### PR TITLE
Fix #200: Dont end up in a locked ui state when somebody leaves.

### DIFF
--- a/Build/Strategic/Strategic_Merc_Handler.cc
+++ b/Build/Strategic/Strategic_Merc_Handler.cc
@@ -385,9 +385,8 @@ void MercsContractIsFinished(SOLDIERTYPE* const pSoldier)
 		{
 			//Send the merc home
 
-			InterruptTime( );
+			InterruptTime();
 			PauseGame();
-			LockPauseState(LOCK_PAUSE_09);
 
 			// Say quote for wishing to leave
 			TacticalCharacterDialogue( pSoldier, QUOTE_NOT_GETTING_PAID );
@@ -399,9 +398,8 @@ void MercsContractIsFinished(SOLDIERTYPE* const pSoldier)
 	}
 	else if( pSoldier->ubWhatKindOfMercAmI == MERC_TYPE__NPC )
 	{
-		InterruptTime( );
+		InterruptTime();
 		PauseGame();
-		LockPauseState(LOCK_PAUSE_10);
 
 		TacticalCharacterDialogue( pSoldier, QUOTE_AIM_SEEN_MIKE );
 


### PR DESCRIPTION
Bitbucket Comments:

@lynxlynxlynx:
While the usefulness of locking is questionable there, wouldn't it be better to just unlock it afterwards? Or does the execution of the dialog happen in the next tick?

@selaux:
I couldn't dig anything particularly insightful from the refactoring history.
