### PR TITLE
fixed #199 (rare boxing crash)

### DIFF
--- a/Build/Tactical/Handle_Items.cc
+++ b/Build/Tactical/Handle_Items.cc
@@ -2308,6 +2308,10 @@ void SoldierGiveItemFromAnimation( SOLDIERTYPE *pSoldier )
 	// Get items from pending data
 
 	// Get objectype and delete
+	if (!pSoldier->pTempObject) {
+		ScreenMsg( MSG_FONT_RED, MSG_DEBUG, L"Attempted to give nonexisting item." );
+		return;
+	}
 	TempObject = *pSoldier->pTempObject;
 	MemFree( pSoldier->pTempObject );
 	pSoldier->pTempObject = NULL;


### PR DESCRIPTION
I've traced the variable and nothing particularly interesting happens. The money transaction works normally and is dumped to the ground just fine with a full inventory.