### PR TITLE
Fix #198: end of meanwhile cutscene crash

### DIFF
--- a/Build/Tactical/Dialogue_Control.cc
+++ b/Build/Tactical/Dialogue_Control.cc
@@ -449,7 +449,7 @@ void HandleDialogue()
 	if (gTacticalStatus.fAutoBandageMode || !d->Execute())
 	{
 		delete d;
-		ghDialogueQ.pop();
+		if(!ghDialogueQ.empty()) ghDialogueQ.pop();
 	}
 }
 


### PR DESCRIPTION
If a cutscene is ended by an NPC action then an extraneous dialogue pop
is executed. This patch adds a check to prevent an empty queue from
being acted on. The true bug may be the return value of Execute and the
correct patch to return the opposite boolean value.