### PR TITLE
Fix `make build-releases`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -690,7 +690,7 @@ build-win-release-on-linux:
 # end users to setup the library.  LGPL allows static linking if we
 # provide source codes for our application.
 MACOS_SDL_STATIC=./_build/lib-SDL-devel-1.2.15-macos-i386
-MACOS_STATIC_CFLAGS_SDL=-arch i386 -I$(MACOS_SDL_STATIC)/include/SDL -D_GNU_SOURCE=1 -D_THREAD_SAFE
+MACOS_STATIC_CFLAGS_SDL=-arch i386 -mmacosx-version-min=10.5 -I$(MACOS_SDL_STATIC)/include/SDL -D_GNU_SOURCE=1 -D_THREAD_SAFE
 MACOS_STATIC_LDFLAGS_SDL=$(MACOS_SDL_STATIC)/lib/libSDLmain.a $(MACOS_SDL_STATIC)/lib/libSDL.a  -Wl,-framework,OpenGL -Wl,-framework,Cocoa -Wl,-framework,ApplicationServices -Wl,-framework,Carbon -Wl,-framework,AudioToolbox -Wl,-framework,AudioUnit -Wl,-framework,IOKit
 build-release-on-mac:
 	-rm -rf $(MAC_RELEASE) $(MAC_RELEASE_ZIP)

--- a/Makefile
+++ b/Makefile
@@ -680,7 +680,7 @@ build-win-release-on-linux:
 	cp _build/distr-files-win-mingw/*.dll $(WIN_RELEASE)
 	cp -R _unittests $(WIN_RELEASE)
 	cp -R externalized $(WIN_RELEASE)
-	cp Changelog $(WIN_RELEASE)/Changelog.txt
+	cp docs/archeology/Changelog $(WIN_RELEASE)/Changelog.txt
 	cp changes.md $(WIN_RELEASE)/changes.md
 	cd $(WIN_RELEASE_BASE_DIR) && zip -r $(WIN_RELEASE_NAME).zip $(WIN_RELEASE_NAME)
 
@@ -701,7 +701,7 @@ build-release-on-mac:
 	cp _build/distr-files-mac/*.txt $(MAC_RELEASE)
 	cp -R _unittests $(MAC_RELEASE)
 	cp -R externalized $(MAC_RELEASE)
-	cp Changelog $(MAC_RELEASE)/Changelog.txt
+	cp docs/archeology/Changelog $(MAC_RELEASE)/Changelog.txt
 	cp changes.md $(MAC_RELEASE)/changes.md
 	cd $(MAC_RELEASE_BASE_DIR) && zip -r $(MAC_RELEASE_NAME).zip $(MAC_RELEASE_NAME)
 


### PR DESCRIPTION
`make build-releases` referenced old paths. Now it works again. I tested the resulting builds on the following configurations and they seem to run fine. Building the Mac release still needs to be tested though and we could consider creating an .app directory structure instead of a common build so it integrates better for OS X users. Then we are ready to do a release.

- Ubuntu 12.04 i386
- Ubuntu 14.04 i386
- Ubuntu 14.04 x64
- OS X 10.11
- OS X 10.9
- Windows 10 x64