### PR TITLE
Mem man cleanup

### DIFF
--- a/sgp/MemMan.cc
+++ b/sgp/MemMan.cc
@@ -14,13 +14,6 @@
 #include "Debug.h"
 #include "slog/slog.h"
 
-#undef _DEBUG // XXX TODO
-
-#ifdef _DEBUG
-//#	define DEBUG_MEM_LEAKS // turns on tracking of every MemAlloc and MemFree!
-#endif
-
-
 #ifdef JA2
 #	include "MouseSystem.h"
 #	include "MessageBoxScreen.h"

--- a/sgp/MemMan.cc
+++ b/sgp/MemMan.cc
@@ -12,7 +12,7 @@
 #include <stdlib.h>
 #include "MemMan.h"
 #include "Debug.h"
-
+#include "slog/slog.h"
 
 #undef _DEBUG // XXX TODO
 
@@ -157,110 +157,6 @@ void* XRealloc(void* const ptr, size_t const size)
 	if (!p) throw std::bad_alloc();
 	return p;
 }
-
-
-#ifdef _DEBUG
-
-PTR MemAllocReal(size_t uiSize, const char* pcFile, INT32 iLine)
-{
-	if (uiSize == 0)
-	{
-		return NULL;
-	}
-
-	if (!fMemManagerInit)
-		DebugMsg(TOPIC_MEMORY_MANAGER, DBG_LEVEL_0, String("MemAlloc: Warning -- Memory manager not initialized -- Line %d in %s", iLine, pcFile));
-
-
-	PTR ptr = _malloc_dbg(uiSize, _NORMAL_BLOCK, pcFile, iLine);
-	if (!ptr)
-	{
-		DebugMsg(TOPIC_MEMORY_MANAGER, DBG_LEVEL_0, String("MemAlloc failed: %d bytes (line %d file %s)", uiSize, iLine, pcFile));
-		throw std::bad_alloc();
-	}
-
-	guiMemTotal   += uiSize;
-	guiMemAlloced += uiSize;
-	MemDebugCounter++;
-
-#ifdef DEBUG_MEM_LEAKS
-	DebugMsg(TOPIC_MEMORY_MANAGER, DBG_LEVEL_1, String("MemAlloc %p: %d bytes (line %d file %s)", ptr, uiSize, iLine, pcFile));
-#endif
-
-	return ptr;
-}
-
-
-void MemFreeReal(PTR ptr, const char* pcFile, INT32 iLine)
-{
-	if (!fMemManagerInit)
-		DebugMsg(TOPIC_MEMORY_MANAGER, DBG_LEVEL_0, String("MemFree: Warning -- Memory manager not initialized -- Line %d in %s", iLine, pcFile));
-
-	if (ptr != NULL)
-	{
-		UINT32 uiSize = _msize(ptr);
-		guiMemTotal -= uiSize;
-		guiMemFreed += uiSize;
-		_free_dbg(ptr, _NORMAL_BLOCK);
-
-#ifdef DEBUG_MEM_LEAKS
-		DebugMsg(TOPIC_MEMORY_MANAGER, DBG_LEVEL_1, String("MemFree  %p: %d bytes (line %d file %s)", ptr, uiSize, iLine, pcFile));
-#endif
-	}
-	else
-	{
-		DebugMsg(TOPIC_MEMORY_MANAGER, DBG_LEVEL_0, String("MemFree ERROR: NULL ptr received (line %d file %s)", iLine, pcFile));
-	}
-
-	/* count even a NULL ptr as a MemFree, not because it's really a memory leak,
-	 * but because it is still an error of some sort (nobody should ever be
-	 * freeing NULL pointers), and this will help in tracking it down if the
-	 * above DebugMsg is not noticed. */
-	MemDebugCounter--;
-}
-
-
-PTR MemReallocReal(PTR ptr, UINT32 uiSize, const char* pcFile, INT32 iLine)
-{
-	if (!fMemManagerInit)
-		DebugMsg(TOPIC_MEMORY_MANAGER, DBG_LEVEL_0, String("MemRealloc: Warning -- Memory manager not initialized -- Line %d in %s", iLine, pcFile));
-
-	UINT32 uiOldSize = 0;
-	if (ptr != NULL)
-	{
-		uiOldSize = _msize(ptr);
-		guiMemTotal -= uiOldSize;
-		guiMemFreed += uiOldSize;
-		MemDebugCounter--;
-	}
-
-	// Note that the ptr changes to ptrNew...
-	PTR ptrNew = _realloc_dbg(ptr, uiSize, _NORMAL_BLOCK, pcFile, iLine);
-	if (ptrNew == NULL)
-	{
-		DebugMsg(TOPIC_MEMORY_MANAGER, DBG_LEVEL_0, String("MemReAlloc failed: ptr %d, %d -> %d bytes (line %d file %s)", ptr, uiOldSize, uiSize, iLine, pcFile));
-		if (uiSize != 0)
-		{
-			// ptr is left untouched, so undo the math above
-			guiMemTotal += uiOldSize;
-			guiMemFreed -= uiOldSize;
-			MemDebugCounter++;
-		}
-		throw std::bad_alloc();
-	}
-
-#ifdef DEBUG_MEM_LEAKS
-	DebugMsg(TOPIC_MEMORY_MANAGER, DBG_LEVEL_1, String("MemRealloc %p: Resizing %d bytes to %d bytes (line %d file %s) - New ptr %p", ptr, uiOldSize, uiSize, iLine, pcFile, ptrNew));
-#endif
-	guiMemTotal   += uiSize;
-	guiMemAlloced += uiSize;
-	MemDebugCounter++;
-
-	return ptrNew;
-}
-
-#endif
-
 
 #ifdef EXTREME_MEMORY_DEBUGGING
 

--- a/sgp/MemMan.cc
+++ b/sgp/MemMan.cc
@@ -12,7 +12,6 @@
 #include <stdlib.h>
 #include "MemMan.h"
 #include "Debug.h"
-#include "slog/slog.h"
 
 #ifdef JA2
 #	include "MouseSystem.h"

--- a/sgp/MemMan.h
+++ b/sgp/MemMan.h
@@ -8,33 +8,32 @@
 
 #include "Types.h"
 
-
 void InitializeMemoryManager(void);
 void ShutdownMemoryManager(void);
 
 // Creates and adds a video object to list
 #if defined EXTREME_MEMORY_DEBUGGING
-/* This is the most effective way to debug memory leaks.  Each memory leak
- * will be recorded in a linked list containing a string referring to the
- * location in code the memory was allocated in addition to the number of
- * occurrences.  The shutdown code will report all unhandled memory with
- * exact location allocated. */
-void DumpMemoryInfoIntoFile(const char* filename, BOOLEAN fAppend);
-#	define MemAlloc(size)        MemAllocXDebug((size), __FILE__, __LINE__)
-#	define MemFree(ptr)          MemFreeXDebug((ptr), __FILE__, __LINE__)
-#	define MemRealloc(ptr, size) MemReallocXDebug((ptr), (size), __FILE__, __LINE__)
-PTR  MemAllocXDebug(size_t size, const char* szCodeString, INT32 iLineNum);
-void MemFreeXDebug(PTR ptr, const char* szCodeString, INT32 iLineNum);
-PTR  MemReallocXDebug(PTR ptr, size_t size, const char* szCodeString, INT32 iLineNum);
+	/* This is the most effective way to debug memory leaks.  Each memory leak
+	 * will be recorded in a linked list containing a string referring to the
+	 * location in code the memory was allocated in addition to the number of
+	 * occurrences.  The shutdown code will report all unhandled memory with
+	 * exact location allocated. */
+	void DumpMemoryInfoIntoFile(const char* filename, BOOLEAN fAppend);
+	void MemFreeXDebug(PTR ptr, const char* szCodeString, INT32 iLineNum);
+	PTR  MemAllocXDebug(size_t size, const char* szCodeString, INT32 iLineNum);
+	PTR  MemReallocXDebug(PTR ptr, size_t size, const char* szCodeString, INT32 iLineNum);
+	#define MemAlloc(size)        MemAllocXDebug((size), __FILE__, __LINE__)
+	#define MemFree(ptr)          MemFreeXDebug((ptr), __FILE__, __LINE__)
+	#define MemRealloc(ptr, size) MemReallocXDebug((ptr), (size), __FILE__, __LINE__)
 #else
-// Release build version
-#		include <stdlib.h>
-#		define MemAlloc(size)        XMalloc((size))
-#		define MemFree(ptr)          free((ptr))
-#		define MemRealloc(ptr, size) XRealloc((ptr), (size))
-void* XMalloc(size_t size);
-void* XRealloc(void* ptr, size_t size);
-#	endif
+	// Release build version
+	#include <stdlib.h>
+	#define MemAlloc(size)        XMalloc((size))
+	#define MemFree(ptr)          free((ptr))
+	#define MemRealloc(ptr, size) XRealloc((ptr), (size))
+	void* XMalloc(size_t size);
+	void* XRealloc(void* ptr, size_t size);
+#endif
 
 static inline void* MallocZ(const size_t n)
 {
@@ -56,7 +55,6 @@ template<typename T> static inline void FreeNull(T*& r) throw()
 #define MALLOCN(type, count)     (type*)MemAlloc(sizeof(type) * (count))
 #define MALLOCNZ(type, count)    (type*)MallocZ(sizeof(type) * (count))
 #define MALLOCZ(type)            (type*)MallocZ(sizeof(type))
-
 #define REALLOC(ptr, type, count) (type*)MemRealloc(ptr, sizeof(type) * (count))
 
-#endif
+#endif /* _MEMMAN_H */

--- a/sgp/MemMan.h
+++ b/sgp/MemMan.h
@@ -27,17 +27,6 @@ PTR  MemAllocXDebug(size_t size, const char* szCodeString, INT32 iLineNum);
 void MemFreeXDebug(PTR ptr, const char* szCodeString, INT32 iLineNum);
 PTR  MemReallocXDebug(PTR ptr, size_t size, const char* szCodeString, INT32 iLineNum);
 #else
-#	if defined _DEBUG && 0 // XXX TODO
-/* This is another debug feature.  Not as sophistocated, but definately not the
- * pig the extreme system is.  This system reports all memory
- * allocations/deallocations in the debug output. */
-#		define MemAlloc(size)        MemAllocReal((size), __FILE__, __LINE__)
-#		define MemFree(ptr)          MemFreeReal((ptr), __FILE__, __LINE__)
-#		define MemRealloc(ptr, size) MemReallocReal((ptr), (size), __FILE__, __LINE__)
-PTR  MemAllocReal(UINT32 size, const char*, INT32);
-void MemFreeReal(PTR ptr, const char*, INT32);
-PTR  MemReallocReal(PTR ptr, UINT32 size, const char*, INT32);
-#	else
 // Release build version
 #		include <stdlib.h>
 #		define MemAlloc(size)        XMalloc((size))
@@ -46,7 +35,6 @@ PTR  MemReallocReal(PTR ptr, UINT32 size, const char*, INT32);
 void* XMalloc(size_t size);
 void* XRealloc(void* ptr, size_t size);
 #	endif
-#endif
 
 static inline void* MallocZ(const size_t n)
 {


### PR DESCRIPTION
Stumbled across this when trying to rework logging. Situtation on Master right now is we have 3 possible Memory-Backends:

- "for release versions" we use a pretty standard wrapper around stdlib
- "_DEBUG" switches on an old implementation that Tron originally marked as to do. It logs some stuff but is broken right now (semms he added the release version to not depend on this one)
- "EXTREME_MEMORY_DEBUGGING" turns on a beast that logs everything that happens with Memory

In this PR, I deleted the _DEBUG variant. The extreme version still compiles but question is whether we need it. I think the widely used stdlib implementation is the way we should go. In the wrapper, we throw exceptions on bad allocations and for me this seems reasonable and enough.

In conclusion, I would vote for removing the extreme version too. We can add more logging to the 'release' variant of course, if anyone wants to. Did anyone ever use the extreme version to debug memory issues?