### PR TITLE
fix an obviously forgotten assignment to bInWater in MovementNoise

### DIFF
--- a/Build/Tactical/OppList.cc
+++ b/Build/Tactical/OppList.cc
@@ -3424,7 +3424,7 @@ UINT8 MovementNoise(SOLDIERTYPE* pSoldier) // XXX TODO000B
 {
  INT32	iStealthSkill, iRoll;
  UINT8	ubMaxVolume, ubVolume, ubBandaged, ubEffLife;
- INT8		bInWater = FALSE;
+ INT8		bInWater = Water( pSoldier->sGridNo );
 
 	if ( pSoldier->bTeam == ENEMY_TEAM )
 	{
@@ -3465,7 +3465,7 @@ UINT8 MovementNoise(SOLDIERTYPE* pSoldier) // XXX TODO000B
 	}
 
 	// if sneaker is moving through water
-	if (Water( pSoldier->sGridNo ) )
+	if ( bInWater )
 	{
 		iStealthSkill -= 10; // 10% penalty
 	}


### PR DESCRIPTION
not obvious here but bInWater is later used again (expand context two times to see it) but would always be false.