### PR TITLE
Debug screens

### DIFF
--- a/Build/Cheats.h
+++ b/Build/Cheats.h
@@ -2,6 +2,7 @@
 #define _CHEATS__H_
 
 #include "Types.h"
+#include "GameState.h"
 
 extern	UINT8			gubCheatLevel;
 
@@ -13,9 +14,9 @@ extern const char * getCheatCode();
 
   // ATE: remove cheats unless we're doing a debug build
 //#ifdef JA2TESTVERSION
-	#define						INFORMATION_CHEAT_LEVEL( )			( gubCheatLevel >= (isGermanVersion() ? 5 : 3) )
+	#define						INFORMATION_CHEAT_LEVEL( )			( (gubCheatLevel >= (isGermanVersion() ? 5 : 3)) || GameState::getInstance()->debugging())
 	#define						CHEATER_CHEAT_LEVEL( )					( gubCheatLevel >= (isGermanVersion() ? 6 : 5) )
-	#define						DEBUG_CHEAT_LEVEL( )					  ( gubCheatLevel >= (isGermanVersion() ? 7 : 6) )
+	#define						DEBUG_CHEAT_LEVEL( )					  ( gubCheatLevel >= (isGermanVersion() ? 7 : 6) || GameState::getInstance()->debugging())
 //#else
 //	#define						INFORMATION_CHEAT_LEVEL( )			( FALSE )
 //	#define						CHEATER_CHEAT_LEVEL( )					( FALSE )

--- a/Build/GameScreen.cc
+++ b/Build/GameScreen.cc
@@ -9,6 +9,7 @@
 #include "SysUtil.h"
 #include "Event_Pump.h"
 #include "Font_Control.h"
+#include "Debug_Pages.h"
 #include "Timer_Control.h"
 #include "Radar_Screen.h"
 #include "Render_Dirty.h"
@@ -118,11 +119,27 @@ void MainGameScreenInit(void)
 
 	// Init Video Overlays
 	// FIRST, FRAMERATE
-	g_fps_overlay = RegisterVideoOverlay(BlitMFont, 0, 0, SMALLFONT1, FONT_MCOLOR_DKGRAY, FONT_MCOLOR_BLACK, L"90");
+	g_fps_overlay = RegisterVideoOverlay(
+          BlitMFont,
+          DEBUG_PAGE_SCREEN_OFFSET_X,
+          DEBUG_PAGE_SCREEN_OFFSET_Y,
+          DEBUG_PAGE_FONT,
+          DEBUG_PAGE_TEXT_COLOR,
+          0,
+          L"90"
+  );
 	EnableVideoOverlay(false, g_fps_overlay);
 
 	// SECOND, PERIOD COUNTER
-	g_counter_period_overlay = RegisterVideoOverlay(BlitMFont, 30, 0, SMALLFONT1, FONT_MCOLOR_DKGRAY, FONT_MCOLOR_BLACK, L"Levelnodes: 100000");
+	g_counter_period_overlay = RegisterVideoOverlay(
+          BlitMFont,
+          DEBUG_PAGE_SCREEN_OFFSET_X,
+          DEBUG_PAGE_SCREEN_OFFSET_Y+DEBUG_PAGE_LINE_HEIGHT,
+          DEBUG_PAGE_FONT,
+          DEBUG_PAGE_TEXT_COLOR,
+          0,
+          L"Levelnodes: 100000"
+  );
 	EnableVideoOverlay(false, g_counter_period_overlay);
 }
 

--- a/Build/GameState.cc
+++ b/Build/GameState.cc
@@ -21,6 +21,10 @@ bool GameState::isEditorMode()
   return (m_mode == GAME_MODE_EDITOR) || (m_mode == GAME_MODE_EDITOR_AUTO);
 }
 
+bool GameState::debugging()
+{
+  return debug;
+}
 
 /** Set editor mode. */
 void GameState::setEditorMode(bool autoLoad)
@@ -28,9 +32,14 @@ void GameState::setEditorMode(bool autoLoad)
   m_mode = autoLoad ? GAME_MODE_EDITOR_AUTO : GAME_MODE_EDITOR;
 }
 
+void GameState::setDebugging(bool enabled) {
+  debug = enabled;
+}
+
 
 /** Private constructor to avoid instantiation. */
 GameState::GameState()
   :m_mode(GAME_MODE_GAME)
 {
+  debug = false;
 }

--- a/Build/GameState.h
+++ b/Build/GameState.h
@@ -25,13 +25,16 @@ public:
 
   /** Set editor mode. */
   void setEditorMode(bool autoLoad);
+  void setDebugging(bool enabled);
 
   /** Check if we are in the editor mode. */
   bool isEditorMode();
+  bool debugging();
 
 private:
 
   GameMode m_mode;
+  bool debug;
 
   /** Private constructor to avoid instantiation. */
   GameState();

--- a/Build/JAScreens.cc
+++ b/Build/JAScreens.cc
@@ -8,6 +8,7 @@
 #include "VSurface.h"
 #include "Input.h"
 #include "Font.h"
+#include "Debug_Pages.h"
 #include "MouseSystem.h"
 #include "Screens.h"
 #include "Font_Control.h"
@@ -428,29 +429,25 @@ void SetDebugRenderHook( RENDER_HOOK pDebugRenderOverride, INT8 ubPage )
 
 static void DefaultDebugPage1(void)
 {
-	SetFont( LARGEFONT1 );
-	gprintf( 0,0,L"DEBUG PAGE ONE" );
+	MPageHeader(L"DEBUG PAGE ONE");
 }
 
 
 static void DefaultDebugPage2(void)
 {
-	SetFont( LARGEFONT1 );
-	gprintf( 0,0,L"DEBUG PAGE TWO" );
+  MPageHeader(L"DEBUG PAGE TWO");
 }
 
 
 static void DefaultDebugPage3(void)
 {
-	SetFont( LARGEFONT1 );
-	gprintf( 0,0,L"DEBUG PAGE THREE" );
+  MPageHeader(L"DEBUG PAGE THREE");
 }
 
 
 static void DefaultDebugPage4(void)
 {
-	SetFont( LARGEFONT1 );
-	gprintf( 0,0,L"DEBUG PAGE FOUR" );
+  MPageHeader(L"DEBUG PAGE FOUR");
 }
 
 

--- a/Build/JAScreens.cc
+++ b/Build/JAScreens.cc
@@ -91,10 +91,10 @@ void DisplayFrameRate( )
 	if ( gbFPSDisplay == SHOW_FULL_FPS )
 	{
 		// FRAME RATE
-		SetVideoOverlayTextF(g_fps_overlay, L"%ld", __min(uiFPS, 1000));
+		SetVideoOverlayTextF(g_fps_overlay, L"FPS: %ld", __min(uiFPS, 1000));
 
 		// TIMER COUNTER
-		SetVideoOverlayTextF(g_counter_period_overlay, L"%ld", __min(giTimerDiag, 1000));
+		SetVideoOverlayTextF(g_counter_period_overlay, L"Game Loop Time: %ld", __min(giTimerDiag, 1000));
 	}
 }
 

--- a/Build/JAScreens.cc
+++ b/Build/JAScreens.cc
@@ -13,6 +13,7 @@
 #include "Screens.h"
 #include "Font_Control.h"
 #include "SysUtil.h"
+#include "RenderWorld.h"
 #include "WorldDef.h"
 #include "EditScreen.h"
 #include "Timer_Control.h"
@@ -338,6 +339,7 @@ static BOOLEAN CheckForAndExitTacticalDebug(void)
 	{
 		FirstTime = TRUE;
 		gfExitDebugScreen = FALSE;
+    gfDoVideoScroll = TRUE;
 		FreeBackgroundRect( guiBackgroundRect );
 		guiBackgroundRect = NO_BGND_RECT;
 		SetRenderHook(NULL);
@@ -369,6 +371,7 @@ ScreenID DebugScreenHandle(void)
 
 	if ( FirstTime )
 	{
+    gfDoVideoScroll = FALSE;
 		FirstTime = FALSE;
 
 		SetRenderHook(DebugRenderHook);

--- a/Build/Tactical/OppList.cc
+++ b/Build/Tactical/OppList.cc
@@ -1,5 +1,5 @@
 #include "Font.h"
-//#include "AI.h"
+#include "Debug_Pages.h"
 #include "Isometric_Utils.h"
 #include "Overhead.h"
 #include "Event_Pump.h"
@@ -2815,95 +2815,47 @@ void RadioSightings(SOLDIERTYPE* const pSoldier, SOLDIERTYPE* const about, UINT8
 
 
 
-#define COLOR1 FONT_MCOLOR_BLACK<<8 | FONT_MCOLOR_LTGREEN
-#define COLOR2 FONT_MCOLOR_BLACK<<8 | FONT_MCOLOR_LTGRAY2
-
-#define DEBUG_FONT FONT14ARIAL
-#define DEBUG_SCREEN_OFFSET_Y 20
-#define DEBUG_SCREEN_OFFSET_X 10
-#define LINE_HEIGHT 15
-#define PAGE_START_Y DEBUG_SCREEN_OFFSET_Y + LINE_HEIGHT
-#define FIRST_COLUMN DEBUG_SCREEN_OFFSET_X
-#define SECOND_COLUMN 300
-#define LABEL_WIDTH 150
-
-#define MPageHeader(...) SetFont(DEBUG_FONT); SetFontColors(COLOR1); mprintf(FIRST_COLUMN, DEBUG_SCREEN_OFFSET_Y, __VA_ARGS__);
-
-static void MHeader(INT32 const x, INT32 const y, wchar_t const* const str)
-{
-  SetFontColors(COLOR1);
-  MPrint(x, y, str);
-  SetFontColors(COLOR2);
-}
-
-
-static void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, INT32 const val)
-{
-  MHeader(x, y, header);
-  mprintf(x+LABEL_WIDTH, y, L"%d", val);
-}
-
-
-static void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, wchar_t const* const val)
-{
-  MHeader(x, y, header);
-  mprintf(x+LABEL_WIDTH, y, L"%ls", val);
-}
-
-
-static void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, void const* const val)
-{
-  MHeader(x, y, header);
-  mprintf(x+LABEL_WIDTH, y, L"%p", val);
-}
-
-static void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, INT32 const val, INT32 const effective_val)
-{
-  MHeader(x, y, header);
-  mprintf(x+LABEL_WIDTH, y, L"%d ( %d )", val, effective_val);
-}
-
 void DebugSoldierPage1()
 {
-  INT32 const h = LINE_HEIGHT;
+  INT32 const h = DEBUG_PAGE_LINE_HEIGHT;
 
 	const SOLDIERTYPE* const s = FindSoldierFromMouse();
 	if (s != NULL)
 	{
 		MPageHeader(L"DEBUG SOLDIER PAGE ONE, GRIDNO %d", s->sGridNo);
 
-    INT32 y = PAGE_START_Y;
+    INT32 y = DEBUG_PAGE_START_Y;
 
-		MPrintStat(FIRST_COLUMN, y += h, L"ID:",   s->ubID);
-		MPrintStat(FIRST_COLUMN, y += h, L"TEAM:", s->bTeam);
-		MPrintStat(FIRST_COLUMN, y += h, L"SIDE:", s->bSide);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"ID:",   s->ubID);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"TEAM:", s->bTeam);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"SIDE:", s->bSide);
 
-		MHeader(FIRST_COLUMN, y +=  h, L"STATUS FLAGS:");
-		mprintf(FIRST_COLUMN+LABEL_WIDTH, y,       L"%x", s->uiStatusFlags);
+		MHeader(DEBUG_PAGE_FIRST_COLUMN, y +=  h, L"STATUS FLAGS:");
+		mprintf(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y,       L"%x", s->uiStatusFlags);
 
-		MPrintStat(FIRST_COLUMN, y += h, L"HUMAN:",    gTacticalStatus.Team[s->bTeam].bHuman);
-		MPrintStat(FIRST_COLUMN, y += h, L"APs:",      s->bActionPoints);
-		MPrintStat(FIRST_COLUMN, y += h, L"Breath:",   s->bBreath);
-		MPrintStat(FIRST_COLUMN, y += h, L"Life:",     s->bLife);
-		MPrintStat(FIRST_COLUMN, y += h, L"LifeMax:",  s->bLifeMax);
-		MPrintStat(FIRST_COLUMN, y += h, L"Bleeding:", s->bBleeding);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"HUMAN:",    gTacticalStatus.Team[s->bTeam].bHuman);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"APs:",      s->bActionPoints);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Breath:",   s->bBreath);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Life:",     s->bLife);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"LifeMax:",  s->bLifeMax);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Bleeding:", s->bBleeding);
 
-		y = PAGE_START_Y;
+		y = DEBUG_PAGE_START_Y;
 
-		MPrintStat(SECOND_COLUMN, y += h, L"Agility:",               s->bAgility,      EffectiveAgility(s));
-		MPrintStat(SECOND_COLUMN, y += h, L"Dexterity:",             s->bDexterity,    EffectiveDexterity(s));
-		MPrintStat(SECOND_COLUMN, y += h, L"Strength:",              s->bStrength);
-		MPrintStat(SECOND_COLUMN, y += h, L"Wisdom:",                s->bWisdom,       EffectiveWisdom(s));
-		MPrintStat(SECOND_COLUMN, y += h, L"Exp Lvl:",               s->bExpLevel,     EffectiveExpLevel(s));
-		MPrintStat(SECOND_COLUMN, y += h, L"Mrksmnship",             s->bMarksmanship, EffectiveMarksmanship(s));
-		MPrintStat(SECOND_COLUMN, y += h, L"Mechanical:",            s->bMechanical);
-		MPrintStat(SECOND_COLUMN, y += h, L"Explosive:",             s->bExplosive);
-		MPrintStat(SECOND_COLUMN, y += h, L"Medical:",               s->bMedical);
-		MPrintStat(SECOND_COLUMN, y += h, L"Drug Effects:",          s->bDrugEffect[0]);
-		MPrintStat(SECOND_COLUMN, y += h, L"Drug Side Effects:",     s->bDrugSideEffect[0]);
-		MPrintStat(SECOND_COLUMN, y += h, L"Booze Effects:",         s->bDrugEffect[1]);
-		MPrintStat(SECOND_COLUMN, y += h, L"Hangover Side Effects:", s->bDrugSideEffect[1]);
-		MPrintStat(SECOND_COLUMN, y += h, L"AI has Keys:",           s->bHasKeys);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"Agility:",               s->bAgility,      EffectiveAgility(s));
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"Dexterity:",             s->bDexterity,    EffectiveDexterity(s));
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"Strength:",              s->bStrength);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"Wisdom:",                s->bWisdom,       EffectiveWisdom(s));
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"Exp Lvl:",               s->bExpLevel,     EffectiveExpLevel(s));
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"Mrksmnship",             s->bMarksmanship, EffectiveMarksmanship(s));
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"Mechanical:",            s->bMechanical);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"Explosive:",             s->bExplosive);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"Medical:",               s->bMedical);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"Drug Effects:",          s->bDrugEffect[0]);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"Drug Side Effects:",     s->bDrugSideEffect[0]);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"Booze Effects:",         s->bDrugEffect[1]);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"Hangover Side Effects:", s->bDrugSideEffect[1]);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"AI has Keys:",           s->bHasKeys);
 	}
 	else if (GetMouseMapPos() != NOWHERE)
 	{
@@ -2925,18 +2877,18 @@ void DebugSoldierPage2()
 		"NORTH"
 	};
 
-	INT32 const h = LINE_HEIGHT;
+	INT32 const h = DEBUG_PAGE_LINE_HEIGHT;
 
 	const SOLDIERTYPE* const s = FindSoldierFromMouse();
 	if (s != NULL)
 	{
 		MPageHeader(L"DEBUG SOLDIER PAGE TWO, GRIDNO %d", s->sGridNo);
 
-		INT32 y = PAGE_START_Y;
+		INT32 y = DEBUG_PAGE_START_Y;
 
-		MPrintStat(FIRST_COLUMN, y += h, L"ID:", s->ubID);
-		MPrintStat(FIRST_COLUMN, y += h, L"Body Type:", s->ubBodyType);
-		MPrintStat(FIRST_COLUMN, y += h, L"Opp Cnt:", s->bOppCnt);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"ID:", s->ubID);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Body Type:", s->ubBodyType);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Opp Cnt:", s->bOppCnt);
 
 		wchar_t const* opp_header;
 		INT8    const* opp_list = s->bOppList;
@@ -2949,43 +2901,43 @@ void DebugSoldierPage2()
 		{
 			opp_header = L"OppList A:";
 		}
-		MHeader(FIRST_COLUMN, y += h, opp_header);
-		mprintf(FIRST_COLUMN+LABEL_WIDTH, y, L"%d %d %d %d %d %d %d %d",
+		MHeader(DEBUG_PAGE_FIRST_COLUMN, y += h, opp_header);
+		mprintf(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, L"%d %d %d %d %d %d %d %d",
 			opp_list[0], opp_list[1], opp_list[2], opp_list[3],
 			opp_list[4], opp_list[5], opp_list[6], opp_list[7]
 		);
 
-		MPrintStat(FIRST_COLUMN, y += h, L"Visible:",     s->bVisible);
-		MPrintStat(FIRST_COLUMN, y += h, L"Direction:",   gzDirectionStr[s->bDirection]);
-		MPrintStat(FIRST_COLUMN, y += h, L"DesDirection", gzDirectionStr[s->bDesiredDirection]);
-		MPrintStat(FIRST_COLUMN, y += h, L"GridNo:",      s->sGridNo);
-		MPrintStat(FIRST_COLUMN, y += h, L"Dest:",        s->sFinalDestination);
-		MPrintStat(FIRST_COLUMN, y += h, L"Path Size:",   s->usPathDataSize);
-		MPrintStat(FIRST_COLUMN, y += h, L"Path Index:",  s->usPathIndex);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Visible:",     s->bVisible);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Direction:",   gzDirectionStr[s->bDirection]);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"DesDirection", gzDirectionStr[s->bDesiredDirection]);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"GridNo:",      s->sGridNo);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Dest:",        s->sFinalDestination);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Path Size:",   s->usPathDataSize);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Path Index:",  s->usPathIndex);
 
-		MHeader(FIRST_COLUMN, y += h, L"First 3 Steps:");
-		mprintf(FIRST_COLUMN+LABEL_WIDTH, y, L"%d %d %d",
+		MHeader(DEBUG_PAGE_FIRST_COLUMN, y += h, L"First 3 Steps:");
+		mprintf(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, L"%d %d %d",
 			s->usPathingData[0],
 			s->usPathingData[1],
 			s->usPathingData[2]
 		);
 
-		MHeader(FIRST_COLUMN, y += h, L"Next 3 Steps:");
-		mprintf(FIRST_COLUMN+LABEL_WIDTH, y, L"%d %d %d",
+		MHeader(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Next 3 Steps:");
+		mprintf(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, L"%d %d %d",
 			s->usPathingData[s->usPathIndex],
 			s->usPathingData[s->usPathIndex + 1],
 			s->usPathingData[s->usPathIndex + 2]
 		);
 
-		MPrintStat(FIRST_COLUMN, y += h, L"FlashInd:",    s->fFlashLocator);
-		MPrintStat(FIRST_COLUMN, y += h, L"ShowInd:",     s->fShowLocator);
-		MPrintStat(FIRST_COLUMN, y += h, L"Main hand:",   ShortItemNames[s->inv[HANDPOS].usItem]);
-		MPrintStat(FIRST_COLUMN, y += h, L"Second hand:", ShortItemNames[s->inv[SECONDHANDPOS].usItem]);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"FlashInd:",    s->fFlashLocator);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"ShowInd:",     s->fShowLocator);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Main hand:",   ShortItemNames[s->inv[HANDPOS].usItem]);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Second hand:", ShortItemNames[s->inv[SECONDHANDPOS].usItem]);
 
 		const GridNo map_pos = GetMouseMapPos();
 		if (map_pos != NOWHERE)
 		{
-			MPrintStat(FIRST_COLUMN, y += h, L"CurrGridNo:", map_pos);
+			MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"CurrGridNo:", map_pos);
 		}
 	}
 	else
@@ -2995,56 +2947,54 @@ void DebugSoldierPage2()
 
 		MPageHeader(L"DEBUG LAND PAGE TWO");
 
-		INT32                    y  = PAGE_START_Y;
+		INT32                    y  = DEBUG_PAGE_START_Y;
 		MAP_ELEMENT const* const me = &gpWorldLevelData[map_pos];
 
-		MPrintStat(FIRST_COLUMN, y += h, L"Land Raised:", me->sHeight);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Land Raised:", me->sHeight);
 
 		LEVELNODE const* const land_head = me->pLandHead;
-		MPrintStat(FIRST_COLUMN, y += h, L"Land Node:", land_head);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Land Node:", land_head);
 		if (land_head != NULL)
 		{
 			UINT16 const idx = land_head->usIndex;
-			MPrintStat(FIRST_COLUMN, y += h, L"Land Node:", idx);
-			MPrintStat(FIRST_COLUMN, y += h, L"Full Land:", gTileDatabase[idx].ubFullTile);
+			MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Land Node:", idx);
+			MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Full Land:", gTileDatabase[idx].ubFullTile);
 		}
 
-		MPrintStat(FIRST_COLUMN, y += h, L"Land St Node:", me->pLandStart);
-		MPrintStat(FIRST_COLUMN, y += h, L"GRIDNO:",       map_pos);
-
-		SetFontColors(COLOR2);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Land St Node:", me->pLandStart);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"GRIDNO:",       map_pos);
 
 		if (me->uiFlags & MAPELEMENT_MOVEMENT_RESERVED)
 		{
-			mprintf(  FIRST_COLUMN+LABEL_WIDTH, y += h, L"Merc: %d",  me->ubReservedSoldierID);
-			MPrint( FIRST_COLUMN, y,      L"RESERVED MOVEMENT FLAG ON:");
+			mprintf(  DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y += h, L"Merc: %d",  me->ubReservedSoldierID);
+			MPrint( DEBUG_PAGE_FIRST_COLUMN, y,      L"RESERVED MOVEMENT FLAG ON:");
 		}
 
 		LEVELNODE const* const node = GetCurInteractiveTile();
 		if (node != NULL)
 		{
-			mprintf(  FIRST_COLUMN+LABEL_WIDTH, y += h, L"Tile: %d", node->usIndex);
-			MPrint( FIRST_COLUMN, y,      L"ON INT TILE");
+			mprintf(  DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y += h, L"Tile: %d", node->usIndex);
+			MPrint( DEBUG_PAGE_FIRST_COLUMN, y,      L"ON INT TILE");
 		}
 
 		if (me->uiFlags & MAPELEMENT_REVEALED)
 		{
-			MPrint(FIRST_COLUMN, y += h, L"REVEALED");
+			MPrint(DEBUG_PAGE_FIRST_COLUMN, y += h, L"REVEALED");
 		}
 
 		if (me->uiFlags & MAPELEMENT_RAISE_LAND_START)
 		{
-			MPrint(FIRST_COLUMN, y += h, L"Land Raise Start");
+			MPrint(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Land Raise Start");
 		}
 
 		if (me->uiFlags & MAPELEMENT_RAISE_LAND_END)
 		{
-			MPrint(FIRST_COLUMN, y += h, L"Raise Land End");
+			MPrint(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Raise Land End");
 		}
 
 		if (gubWorldRoomInfo[map_pos] != NO_ROOM)
 		{
-			MPrintStat(FIRST_COLUMN, y += h, L"Room Number", gubWorldRoomInfo[map_pos]);
+			MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Room Number", gubWorldRoomInfo[map_pos]);
 		}
 
 		if (me->ubExtFlags[0] & MAPELEMENT_EXT_NOBURN_STRUCT)
@@ -3065,96 +3015,96 @@ void DebugSoldierPage3()
 		"BLACK"
 	};
 
-	INT32 const h = LINE_HEIGHT;
+	INT32 const h = DEBUG_PAGE_LINE_HEIGHT;
 
 	const SOLDIERTYPE* const s = FindSoldierFromMouse();
 	if (s != NULL)
 	{
     MPageHeader(L"DEBUG SOLDIER PAGE THREE, GRIDNO %d", s->sGridNo);
 
-		INT32 y = PAGE_START_Y;
+		INT32 y = DEBUG_PAGE_START_Y;
 
-		MPrintStat(FIRST_COLUMN, y += h, L"ID:",     s->ubID);
-		MPrintStat(FIRST_COLUMN, y += h, L"Action:", gzActionStr[s->bAction]);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"ID:",     s->ubID);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Action:", gzActionStr[s->bAction]);
 
 		if (s->uiStatusFlags & SOLDIER_ENEMY)
 		{
-      MPrintStat(FIRST_COLUMN, y += h, L"Alert:", gzAlertStr[s->bAlertStatus]);
+      MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Alert:", gzAlertStr[s->bAlertStatus]);
 		}
 
-		MPrintStat(FIRST_COLUMN, y += h, L"Action Data:", s->usActionData);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Action Data:", s->usActionData);
 
     if (s->uiStatusFlags & SOLDIER_ENEMY)
 		{
-      MPrintStat(FIRST_COLUMN, y += h, L"AIMorale", s->bAIMorale);
+      MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"AIMorale", s->bAIMorale);
 		}
 		else
 		{
-      MPrintStat(FIRST_COLUMN, y += h, L"Morale", s->bMorale);
+      MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Morale", s->bMorale);
 		}
 
-		MPrintStat(FIRST_COLUMN, y += h, L"Delayed Movement:", s->fDelayedMovement);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Delayed Movement:", s->fDelayedMovement);
 
 		if (gubWatchedLocPoints[s->ubID][0] > 0)
 		{
-			mprintf(FIRST_COLUMN, y += h, L"Watch %d/%d for %d pts",
+			mprintf(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Watch %d/%d for %d pts",
 				gsWatchedLoc[s->ubID][0],
 				gbWatchedLocLevel[s->ubID][0],
 				gubWatchedLocPoints[s->ubID][0]
 			);
 		}
 
-		MPrintStat(FIRST_COLUMN, y += h, L"ActionInProg:", s->bActionInProgress);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"ActionInProg:", s->bActionInProgress);
 
 		if (gubWatchedLocPoints[s->ubID][1] > 0)
 		{
-			mprintf(FIRST_COLUMN+LABEL_WIDTH, y += h, L"Watch %d/%d for %d pts",
+			mprintf(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y += h, L"Watch %d/%d for %d pts",
 				gsWatchedLoc[s->ubID][1],
 				gbWatchedLocLevel[s->ubID][1],
 				gubWatchedLocPoints[s->ubID][1]
 			);
 		}
 
-		MPrintStat(FIRST_COLUMN, y += h, L"Last Action:", gzActionStr[s->bLastAction]);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Last Action:", gzActionStr[s->bLastAction]);
 
 		if (gubWatchedLocPoints[s->ubID][2] > 0)
 		{
-			mprintf(FIRST_COLUMN+LABEL_WIDTH, y += h, L"Watch %d/%d for %d pts",
+			mprintf(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y += h, L"Watch %d/%d for %d pts",
 				gsWatchedLoc[s->ubID][2],
 				gbWatchedLocLevel[s->ubID][2],
 				gubWatchedLocPoints[s->ubID][2]
 			);
 		}
 
-		MPrintStat(FIRST_COLUMN, y += h, L"Animation:",   gAnimControl[s->usAnimState].zAnimStr);
-		MPrintStat(FIRST_COLUMN, y += h, L"Getting Hit:", s->fGettingHit);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Animation:",   gAnimControl[s->usAnimState].zAnimStr);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Getting Hit:", s->fGettingHit);
 
 		if (s->ubCivilianGroup != 0)
 		{
-      MPrintStat(FIRST_COLUMN, y += h, L"Civ group", s->ubCivilianGroup);
+      MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Civ group", s->ubCivilianGroup);
 		}
 
-		MPrintStat(FIRST_COLUMN, y += h, L"Suppress pts:",       s->ubSuppressionPoints);
-		MPrintStat(FIRST_COLUMN, y += h, L"Attacker ID:",        SOLDIER2ID(s->attacker));
-		MPrintStat(FIRST_COLUMN, y += h, L"EndAINotCalled:",     s->fTurnInProgress);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Suppress pts:",       s->ubSuppressionPoints);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Attacker ID:",        SOLDIER2ID(s->attacker));
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"EndAINotCalled:",     s->fTurnInProgress);
 
-    y = PAGE_START_Y;
+    y = DEBUG_PAGE_START_Y;
 
-		MPrintStat(SECOND_COLUMN, y += h, L"PrevAnimation:",      gAnimControl[s->usOldAniState].zAnimStr);
-		MPrintStat(SECOND_COLUMN, y += h, L"PrevAniCode:",        gusAnimInst[s->usOldAniState][s->sOldAniCode]);
-		MPrintStat(SECOND_COLUMN, y += h, L"GridNo:",             s->sGridNo);
-		MPrintStat(SECOND_COLUMN, y += h, L"AniCode:",            gusAnimInst[s->usAnimState][s->usAniCode]);
-		MPrintStat(SECOND_COLUMN, y += h, L"No APS To fin Move:", s->fNoAPToFinishMove);
-		MPrintStat(SECOND_COLUMN, y += h, L"Bullets out:",        s->bBulletsLeft);
-		MPrintStat(SECOND_COLUMN, y += h, L"Anim non-int:",       s->fInNonintAnim);
-		MPrintStat(SECOND_COLUMN, y += h, L"RT Anim non-int:",    s->fRTInNonintAnim);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"PrevAnimation:",      gAnimControl[s->usOldAniState].zAnimStr);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"PrevAniCode:",        gusAnimInst[s->usOldAniState][s->sOldAniCode]);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"GridNo:",             s->sGridNo);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"AniCode:",            gusAnimInst[s->usAnimState][s->usAniCode]);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"No APS To fin Move:", s->fNoAPToFinishMove);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"Bullets out:",        s->bBulletsLeft);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"Anim non-int:",       s->fInNonintAnim);
+		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"RT Anim non-int:",    s->fRTInNonintAnim);
 
 		// OPIONION OF SELECTED MERC
 		const SOLDIERTYPE* const sel = GetSelectedMan();
 		if (sel != NULL &&
 				sel->ubProfile < FIRST_NPC && s->ubProfile != NO_PROFILE)
 		{
-			MPrintStat(SECOND_COLUMN, y += h, L"NPC Opinion:", GetProfile(s->ubProfile).bMercOpinion[sel->ubProfile]);
+			MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, L"NPC Opinion:", GetProfile(s->ubProfile).bMercOpinion[sel->ubProfile]);
 		}
 	}
 	else
@@ -3164,40 +3114,40 @@ void DebugSoldierPage3()
 
     MPageHeader(L"DEBUG LAND PAGE THREE");
 
-		INT32 y = PAGE_START_Y;
+		INT32 y = DEBUG_PAGE_START_Y;
 
 		// OK, display door information here.....
 		DOOR_STATUS const* const door = GetDoorStatus(map_pos);
 		if (door == NULL)
 		{
-			MHeader(FIRST_COLUMN, y += h, L"No Door Status");
+			MHeader(DEBUG_PAGE_FIRST_COLUMN, y += h, L"No Door Status");
 		}
 		else
 		{
-			MPrintStat(FIRST_COLUMN, y += h, L"Door Status Found:", map_pos);
+			MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Door Status Found:", map_pos);
 
 			wchar_t const* const door_state =
 				door->ubFlags & DOOR_OPEN ? L"OPEN" : L"CLOSED";
-			MPrintStat(FIRST_COLUMN, y += h, L"Actual Status:", door_state);
+			MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Actual Status:", door_state);
 
 			wchar_t const* const perceived_state =
 				door->ubFlags & DOOR_PERCEIVED_NOTSET ? L"NOT SET" :
 				door->ubFlags & DOOR_PERCEIVED_OPEN   ? L"OPEN"    :
 				                                        L"CLOSED";
-			MPrintStat(FIRST_COLUMN, y += h, L"Perceived Status:", perceived_state);
+			MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Perceived Status:", perceived_state);
 		}
 
 		//Find struct data and se what it says......
 		STRUCTURE const* const structure = FindStructure(map_pos, STRUCTURE_ANYDOOR);
 		if (structure == NULL)
 		{
-			MHeader(FIRST_COLUMN, y += h, L"No Door Struct Data");
+			MHeader(DEBUG_PAGE_FIRST_COLUMN, y += h, L"No Door Struct Data");
 		}
 		else
 		{
 			wchar_t const* const structure_state =
 				structure->fFlags & STRUCTURE_OPEN ? L"OPEN" : L"CLOSED";
-			MPrintStat(FIRST_COLUMN, y += h, L"State:", structure_state);
+			MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"State:", structure_state);
 		}
 	}
 }
@@ -3234,11 +3184,11 @@ static void WriteQuantityAndAttachments(OBJECTTYPE const* o, INT32 const y)
 				wcscat(str, temp);
 			}
 			wcscat(str, L")");
-			mprintf(SECOND_COLUMN, y, str);
+			mprintf(DEBUG_PAGE_SECOND_COLUMN, y, str);
 		}
 		else
 		{
-			mprintf(SECOND_COLUMN, y, L"%d rounds", o->bStatus[0]);
+			mprintf(DEBUG_PAGE_SECOND_COLUMN, y, L"%d rounds", o->bStatus[0]);
 		}
 	}
 	else
@@ -3264,11 +3214,11 @@ static void WriteQuantityAndAttachments(OBJECTTYPE const* o, INT32 const y)
 
 		if (o->ubNumberOfObjects > 1)
 		{ //everything
-			mprintf(SECOND_COLUMN, y, L"%d%%  Qty:  %d%ls", o->bStatus[0], o->ubNumberOfObjects, attachments);
+			mprintf(DEBUG_PAGE_SECOND_COLUMN, y, L"%d%%  Qty:  %d%ls", o->bStatus[0], o->ubNumberOfObjects, attachments);
 		}
 		else
 		{ //condition and attachments
-			mprintf(SECOND_COLUMN, y, L"%d%%%ls", o->bStatus[0], attachments);
+			mprintf(DEBUG_PAGE_SECOND_COLUMN, y, L"%d%%%ls", o->bStatus[0], attachments);
 		}
 	}
 }
@@ -3276,9 +3226,9 @@ static void WriteQuantityAndAttachments(OBJECTTYPE const* o, INT32 const y)
 
 static void PrintItem(INT32 const y, wchar_t const* const header, OBJECTTYPE const* o)
 {
-	MHeader(FIRST_COLUMN, y, header);
+	MHeader(DEBUG_PAGE_FIRST_COLUMN, y, header);
 	if (!o->usItem) return;
-	mprintf(FIRST_COLUMN+LABEL_WIDTH, y, L"%ls", ShortItemNames[o->usItem]);
+	mprintf(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, L"%ls", ShortItemNames[o->usItem]);
 	WriteQuantityAndAttachments(o, y);
 }
 
@@ -3287,15 +3237,15 @@ void DebugSoldierPage4()
 {
 	const SOLDIERTYPE* const s = FindSoldierFromMouse();
 
-  INT32 const h = LINE_HEIGHT;
+  INT32 const h = DEBUG_PAGE_LINE_HEIGHT;
 
 	if (s != NULL)
 	{
 		MPageHeader(L"DEBUG SOLDIER PAGE FOUR, GRIDNO %d", s->sGridNo);
 
-    INT32 y = PAGE_START_Y;
+    INT32 y = DEBUG_PAGE_START_Y;
 
-		MPrintStat(FIRST_COLUMN, y += h, L"Exp. Level:", s->bExpLevel);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Exp. Level:", s->bExpLevel);
 		wchar_t const* sclass;
 		switch (s->ubSoldierClass)
 		{
@@ -3310,7 +3260,7 @@ void DebugSoldierPage4()
 			/* don't care (don't write anything) */
 			default:                            sclass = NULL;               break;
 		}
-		if (sclass) mprintf(SECOND_COLUMN, y, L"%ls", sclass);
+		if (sclass) mprintf(DEBUG_PAGE_SECOND_COLUMN, y, L"%ls", sclass);
 
 		if (s->bTeam != OUR_TEAM)
 		{
@@ -3342,7 +3292,7 @@ void DebugSoldierPage4()
 			y += h;
 			if (node)
 			{
-				mprintf(FIRST_COLUMN, y, L"%ls, %ls, REL EQUIP: %d, REL ATTR: %d",
+				mprintf(DEBUG_PAGE_FIRST_COLUMN, y, L"%ls, %ls, REL EQUIP: %d, REL ATTR: %d",
 					orders, attitude,
 					node->pBasicPlacement->bRelativeEquipmentLevel,
 					node->pBasicPlacement->bRelativeAttributeLevel
@@ -3350,11 +3300,11 @@ void DebugSoldierPage4()
 			}
 			else
 			{
-				mprintf(FIRST_COLUMN, y, L"%ls, %ls", orders, attitude);
+				mprintf(DEBUG_PAGE_FIRST_COLUMN, y, L"%ls, %ls", orders, attitude);
 			}
 		}
 
-		MPrintStat(FIRST_COLUMN, y += h, L"ID:", s->ubID);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, L"ID:", s->ubID);
 
 		PrintItem(y += h, L"HELMETPOS:",     &s->inv[HELMETPOS]);
 		PrintItem(y += h, L"VESTPOS:",       &s->inv[VESTPOS]);

--- a/Build/Tactical/OppList.cc
+++ b/Build/Tactical/OppList.cc
@@ -2818,124 +2818,98 @@ void RadioSightings(SOLDIERTYPE* const pSoldier, SOLDIERTYPE* const about, UINT8
 #define COLOR1 FONT_MCOLOR_BLACK<<8 | FONT_MCOLOR_LTGREEN
 #define COLOR2 FONT_MCOLOR_BLACK<<8 | FONT_MCOLOR_LTGRAY2
 
+#define DEBUG_FONT FONT14ARIAL
+#define DEBUG_SCREEN_OFFSET_Y 20
+#define DEBUG_SCREEN_OFFSET_X 10
 #define LINE_HEIGHT 15
+#define PAGE_START_Y DEBUG_SCREEN_OFFSET_Y + LINE_HEIGHT
+#define FIRST_COLUMN DEBUG_SCREEN_OFFSET_X
+#define SECOND_COLUMN 300
+#define LABEL_WIDTH 150
 
+#define MPageHeader(...) SetFont(DEBUG_FONT); SetFontColors(COLOR1); mprintf(FIRST_COLUMN, DEBUG_SCREEN_OFFSET_Y, __VA_ARGS__);
 
-static void GHeader(INT32 const y, wchar_t const* const str)
+static void MHeader(INT32 const x, INT32 const y, wchar_t const* const str)
 {
-	SetFontShade(LARGEFONT1, FONT_SHADE_GREEN);
-	gprintf(0, y, L"%ls", str);
-	SetFontShade(LARGEFONT1, FONT_SHADE_NEUTRAL);
-}
-
-
-static void GPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, INT32 const val)
-{
-	GHeader(y, header);
-	gprintf(x, y, L"%d", val);
-}
-
-
-static void GPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, char const* const val)
-{
-	GHeader(y, header);
-	gprintf(x, y, L"%hs", val);
-}
-
-
-static void GPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, wchar_t const* const val)
-{
-	GHeader(y, header);
-	gprintf(x, y, L"%ls", val);
-}
-
-
-static void GPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, INT32 const val, INT32 const effective_val)
-{
-	GHeader(y, header);
-	gprintf(x, y, L"%d ( %d )", val, effective_val);
-}
-
-
-void DebugSoldierPage1()
-{
-	INT32 const h = LINE_HEIGHT;
-
-	const SOLDIERTYPE* const s = FindSoldierFromMouse();
-	if (s != NULL)
-	{
-		SetFont(LARGEFONT1);
-		gprintf(0, 0, L"DEBUG SOLDIER PAGE ONE, GRIDNO %d", s->sGridNo);
-
-		INT32 y = h;
-
-		GPrintStat(150, y += h, L"ID:",   s->ubID);
-		GPrintStat(150, y += h, L"TEAM:", s->bTeam);
-		GPrintStat(150, y += h, L"SIDE:", s->bSide);
-
-		GHeader(     y +=  h, L"STATUS FLAGS:");
-		gprintf(150, y,       L"%x", s->uiStatusFlags);
-
-		GPrintStat(150, y += h, L"HUMAN:",    gTacticalStatus.Team[s->bTeam].bHuman);
-		GPrintStat(150, y += h, L"APs:",      s->bActionPoints);
-		GPrintStat(150, y += h, L"Breath:",   s->bBreath);
-		GPrintStat(150, y += h, L"Life:",     s->bLife);
-		GPrintStat(150, y += h, L"LifeMax:",  s->bLifeMax);
-		GPrintStat(150, y += h, L"Bleeding:", s->bBleeding);
-
-		y = h;
-
-		GPrintStat(350, y += h, L"Agility:",               s->bAgility,      EffectiveAgility(s));
-		GPrintStat(350, y += h, L"Dexterity:",             s->bDexterity,    EffectiveDexterity(s));
-		GPrintStat(350, y += h, L"Strength:",              s->bStrength);
-		GPrintStat(350, y += h, L"Wisdom:",                s->bWisdom,       EffectiveWisdom(s));
-		GPrintStat(350, y += h, L"Exp Lvl:",               s->bExpLevel,     EffectiveExpLevel(s));
-		GPrintStat(350, y += h, L"Mrksmnship",             s->bMarksmanship, EffectiveMarksmanship(s));
-		GPrintStat(350, y += h, L"Mechanical:",            s->bMechanical);
-		GPrintStat(350, y += h, L"Explosive:",             s->bExplosive);
-		GPrintStat(350, y += h, L"Medical:",               s->bMedical);
-		GPrintStat(400, y += h, L"Drug Effects:",          s->bDrugEffect[0]);
-		GPrintStat(400, y += h, L"Drug Side Effects:",     s->bDrugSideEffect[0]);
-		GPrintStat(400, y += h, L"Booze Effects:",         s->bDrugEffect[1]);
-		GPrintStat(400, y += h, L"Hangover Side Effects:", s->bDrugSideEffect[1]);
-		GPrintStat(400, y += h, L"AI has Keys:",           s->bHasKeys);
-	}
-	else if (GetMouseMapPos() != NOWHERE)
-	{
-		SetFont(LARGEFONT1);
-		gprintf(0, 0, L"DEBUG LAND PAGE ONE");
-	}
-}
-
-
-static void MHeader(INT32 const y, wchar_t const* const str)
-{
-	SetFontColors(COLOR1);
-	MPrint(0, y, str);
-	SetFontColors(COLOR2);
+  SetFontColors(COLOR1);
+  MPrint(x, y, str);
+  SetFontColors(COLOR2);
 }
 
 
 static void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, INT32 const val)
 {
-	MHeader(y, header);
-	mprintf(x, y, L"%d", val);
+  MHeader(x, y, header);
+  mprintf(x+LABEL_WIDTH, y, L"%d", val);
 }
 
 
 static void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, wchar_t const* const val)
 {
-	MHeader(y, header);
-	mprintf(x, y, L"%ls", val);
+  MHeader(x, y, header);
+  mprintf(x+LABEL_WIDTH, y, L"%ls", val);
 }
 
 
 static void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, void const* const val)
 {
-	MHeader(y, header);
-	mprintf(x, y, L"%p", val);
+  MHeader(x, y, header);
+  mprintf(x+LABEL_WIDTH, y, L"%p", val);
 }
 
+static void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, INT32 const val, INT32 const effective_val)
+{
+  MHeader(x, y, header);
+  mprintf(x+LABEL_WIDTH, y, L"%d ( %d )", val, effective_val);
+}
+
+void DebugSoldierPage1()
+{
+  INT32 const h = LINE_HEIGHT;
+
+	const SOLDIERTYPE* const s = FindSoldierFromMouse();
+	if (s != NULL)
+	{
+		MPageHeader(L"DEBUG SOLDIER PAGE ONE, GRIDNO %d", s->sGridNo);
+
+    INT32 y = PAGE_START_Y;
+
+		MPrintStat(FIRST_COLUMN, y += h, L"ID:",   s->ubID);
+		MPrintStat(FIRST_COLUMN, y += h, L"TEAM:", s->bTeam);
+		MPrintStat(FIRST_COLUMN, y += h, L"SIDE:", s->bSide);
+
+		MHeader(FIRST_COLUMN, y +=  h, L"STATUS FLAGS:");
+		mprintf(FIRST_COLUMN+LABEL_WIDTH, y,       L"%x", s->uiStatusFlags);
+
+		MPrintStat(FIRST_COLUMN, y += h, L"HUMAN:",    gTacticalStatus.Team[s->bTeam].bHuman);
+		MPrintStat(FIRST_COLUMN, y += h, L"APs:",      s->bActionPoints);
+		MPrintStat(FIRST_COLUMN, y += h, L"Breath:",   s->bBreath);
+		MPrintStat(FIRST_COLUMN, y += h, L"Life:",     s->bLife);
+		MPrintStat(FIRST_COLUMN, y += h, L"LifeMax:",  s->bLifeMax);
+		MPrintStat(FIRST_COLUMN, y += h, L"Bleeding:", s->bBleeding);
+
+		y = PAGE_START_Y;
+
+		MPrintStat(SECOND_COLUMN, y += h, L"Agility:",               s->bAgility,      EffectiveAgility(s));
+		MPrintStat(SECOND_COLUMN, y += h, L"Dexterity:",             s->bDexterity,    EffectiveDexterity(s));
+		MPrintStat(SECOND_COLUMN, y += h, L"Strength:",              s->bStrength);
+		MPrintStat(SECOND_COLUMN, y += h, L"Wisdom:",                s->bWisdom,       EffectiveWisdom(s));
+		MPrintStat(SECOND_COLUMN, y += h, L"Exp Lvl:",               s->bExpLevel,     EffectiveExpLevel(s));
+		MPrintStat(SECOND_COLUMN, y += h, L"Mrksmnship",             s->bMarksmanship, EffectiveMarksmanship(s));
+		MPrintStat(SECOND_COLUMN, y += h, L"Mechanical:",            s->bMechanical);
+		MPrintStat(SECOND_COLUMN, y += h, L"Explosive:",             s->bExplosive);
+		MPrintStat(SECOND_COLUMN, y += h, L"Medical:",               s->bMedical);
+		MPrintStat(SECOND_COLUMN, y += h, L"Drug Effects:",          s->bDrugEffect[0]);
+		MPrintStat(SECOND_COLUMN, y += h, L"Drug Side Effects:",     s->bDrugSideEffect[0]);
+		MPrintStat(SECOND_COLUMN, y += h, L"Booze Effects:",         s->bDrugEffect[1]);
+		MPrintStat(SECOND_COLUMN, y += h, L"Hangover Side Effects:", s->bDrugSideEffect[1]);
+		MPrintStat(SECOND_COLUMN, y += h, L"AI has Keys:",           s->bHasKeys);
+	}
+	else if (GetMouseMapPos() != NOWHERE)
+	{
+    MPageHeader(L"DEBUG LAND PAGE ONE");
+	}
+}
 
 void DebugSoldierPage2()
 {
@@ -2956,14 +2930,13 @@ void DebugSoldierPage2()
 	const SOLDIERTYPE* const s = FindSoldierFromMouse();
 	if (s != NULL)
 	{
-		SetFont(LARGEFONT1);
-		gprintf(0, 0, L"DEBUG SOLDIER PAGE TWO, GRIDNO %d", s->sGridNo);
+		MPageHeader(L"DEBUG SOLDIER PAGE TWO, GRIDNO %d", s->sGridNo);
 
-		INT32 y = h;
+		INT32 y = PAGE_START_Y;
 
-		GPrintStat(150, y += h, L"ID:", s->ubID);
-		GPrintStat(150, y += h, L"Body Type:", s->ubBodyType);
-		GPrintStat(150, y += h, L"Opp Cnt:", s->bOppCnt);
+		MPrintStat(FIRST_COLUMN, y += h, L"ID:", s->ubID);
+		MPrintStat(FIRST_COLUMN, y += h, L"Body Type:", s->ubBodyType);
+		MPrintStat(FIRST_COLUMN, y += h, L"Opp Cnt:", s->bOppCnt);
 
 		wchar_t const* opp_header;
 		INT8    const* opp_list = s->bOppList;
@@ -2976,43 +2949,43 @@ void DebugSoldierPage2()
 		{
 			opp_header = L"OppList A:";
 		}
-		GHeader(y += h, opp_header);
-		gprintf(150, y, L"%d %d %d %d %d %d %d %d",
+		MHeader(FIRST_COLUMN, y += h, opp_header);
+		mprintf(FIRST_COLUMN+LABEL_WIDTH, y, L"%d %d %d %d %d %d %d %d",
 			opp_list[0], opp_list[1], opp_list[2], opp_list[3],
 			opp_list[4], opp_list[5], opp_list[6], opp_list[7]
 		);
 
-		GPrintStat(150, y += h, L"Visible:",     s->bVisible);
-		GPrintStat(150, y += h, L"Direction:",   gzDirectionStr[s->bDirection]);
-		GPrintStat(150, y += h, L"DesDirection", gzDirectionStr[s->bDesiredDirection]);
-		GPrintStat(150, y += h, L"GridNo:",      s->sGridNo);
-		GPrintStat(150, y += h, L"Dest:",        s->sFinalDestination);
-		GPrintStat(150, y += h, L"Path Size:",   s->usPathDataSize);
-		GPrintStat(150, y += h, L"Path Index:",  s->usPathIndex);
+		MPrintStat(FIRST_COLUMN, y += h, L"Visible:",     s->bVisible);
+		MPrintStat(FIRST_COLUMN, y += h, L"Direction:",   gzDirectionStr[s->bDirection]);
+		MPrintStat(FIRST_COLUMN, y += h, L"DesDirection", gzDirectionStr[s->bDesiredDirection]);
+		MPrintStat(FIRST_COLUMN, y += h, L"GridNo:",      s->sGridNo);
+		MPrintStat(FIRST_COLUMN, y += h, L"Dest:",        s->sFinalDestination);
+		MPrintStat(FIRST_COLUMN, y += h, L"Path Size:",   s->usPathDataSize);
+		MPrintStat(FIRST_COLUMN, y += h, L"Path Index:",  s->usPathIndex);
 
-		GHeader(y += h, L"First 3 Steps:");
-		gprintf(150, y, L"%d %d %d",
+		MHeader(FIRST_COLUMN, y += h, L"First 3 Steps:");
+		mprintf(FIRST_COLUMN+LABEL_WIDTH, y, L"%d %d %d",
 			s->usPathingData[0],
 			s->usPathingData[1],
 			s->usPathingData[2]
 		);
 
-		GHeader(y += h, L"Next 3 Steps:");
-		gprintf(150, y, L"%d %d %d",
+		MHeader(FIRST_COLUMN, y += h, L"Next 3 Steps:");
+		mprintf(FIRST_COLUMN+LABEL_WIDTH, y, L"%d %d %d",
 			s->usPathingData[s->usPathIndex],
 			s->usPathingData[s->usPathIndex + 1],
 			s->usPathingData[s->usPathIndex + 2]
 		);
 
-		GPrintStat(150, y += h, L"FlashInd:",    s->fFlashLocator);
-		GPrintStat(150, y += h, L"ShowInd:",     s->fShowLocator);
-		GPrintStat(150, y += h, L"Main hand:",   ShortItemNames[s->inv[HANDPOS].usItem]);
-		GPrintStat(150, y += h, L"Second hand:", ShortItemNames[s->inv[SECONDHANDPOS].usItem]);
+		MPrintStat(FIRST_COLUMN, y += h, L"FlashInd:",    s->fFlashLocator);
+		MPrintStat(FIRST_COLUMN, y += h, L"ShowInd:",     s->fShowLocator);
+		MPrintStat(FIRST_COLUMN, y += h, L"Main hand:",   ShortItemNames[s->inv[HANDPOS].usItem]);
+		MPrintStat(FIRST_COLUMN, y += h, L"Second hand:", ShortItemNames[s->inv[SECONDHANDPOS].usItem]);
 
 		const GridNo map_pos = GetMouseMapPos();
 		if (map_pos != NOWHERE)
 		{
-			GPrintStat(150, y += h, L"CurrGridNo:", map_pos);
+			MPrintStat(FIRST_COLUMN, y += h, L"CurrGridNo:", map_pos);
 		}
 	}
 	else
@@ -3020,59 +2993,58 @@ void DebugSoldierPage2()
 		const GridNo map_pos = GetMouseMapPos();
 		if (map_pos == NOWHERE) return;
 
-		SetFont(LARGEFONT1);
-		gprintf(0, 0, L"DEBUG LAND PAGE TWO");
+		MPageHeader(L"DEBUG LAND PAGE TWO");
 
-		INT32                    y  = 0;
+		INT32                    y  = PAGE_START_Y;
 		MAP_ELEMENT const* const me = &gpWorldLevelData[map_pos];
 
-		MPrintStat(150, y += h, L"Land Raised:", me->sHeight);
+		MPrintStat(FIRST_COLUMN, y += h, L"Land Raised:", me->sHeight);
 
 		LEVELNODE const* const land_head = me->pLandHead;
-		MPrintStat(150, y += h, L"Land Node:", land_head);
+		MPrintStat(FIRST_COLUMN, y += h, L"Land Node:", land_head);
 		if (land_head != NULL)
 		{
 			UINT16 const idx = land_head->usIndex;
-			MPrintStat(150, y += h, L"Land Node:", idx);
-			MPrintStat(150, y += h, L"Full Land:", gTileDatabase[idx].ubFullTile);
+			MPrintStat(FIRST_COLUMN, y += h, L"Land Node:", idx);
+			MPrintStat(FIRST_COLUMN, y += h, L"Full Land:", gTileDatabase[idx].ubFullTile);
 		}
 
-		MPrintStat(150, y += h, L"Land St Node:", me->pLandStart);
-		MPrintStat(150, y += h, L"GRIDNO:",       map_pos);
+		MPrintStat(FIRST_COLUMN, y += h, L"Land St Node:", me->pLandStart);
+		MPrintStat(FIRST_COLUMN, y += h, L"GRIDNO:",       map_pos);
 
 		SetFontColors(COLOR2);
 
 		if (me->uiFlags & MAPELEMENT_MOVEMENT_RESERVED)
 		{
-			mprintf(  0, y += h, L"Merc: %d",  me->ubReservedSoldierID);
-			MPrint( 150, y,      L"RESERVED MOVEMENT FLAG ON:");
+			mprintf(  FIRST_COLUMN+LABEL_WIDTH, y += h, L"Merc: %d",  me->ubReservedSoldierID);
+			MPrint( FIRST_COLUMN, y,      L"RESERVED MOVEMENT FLAG ON:");
 		}
 
 		LEVELNODE const* const node = GetCurInteractiveTile();
 		if (node != NULL)
 		{
-			mprintf(  0, y += h, L"Tile: %d", node->usIndex);
-			MPrint( 150, y,      L"ON INT TILE");
+			mprintf(  FIRST_COLUMN+LABEL_WIDTH, y += h, L"Tile: %d", node->usIndex);
+			MPrint( FIRST_COLUMN, y,      L"ON INT TILE");
 		}
 
 		if (me->uiFlags & MAPELEMENT_REVEALED)
 		{
-			MPrint(150, y += h, L"REVEALED");
+			MPrint(FIRST_COLUMN, y += h, L"REVEALED");
 		}
 
 		if (me->uiFlags & MAPELEMENT_RAISE_LAND_START)
 		{
-			MPrint(150, y += h, L"Land Raise Start");
+			MPrint(FIRST_COLUMN, y += h, L"Land Raise Start");
 		}
 
 		if (me->uiFlags & MAPELEMENT_RAISE_LAND_END)
 		{
-			MPrint(150, y += h, L"Raise Land End");
+			MPrint(FIRST_COLUMN, y += h, L"Raise Land End");
 		}
 
 		if (gubWorldRoomInfo[map_pos] != NO_ROOM)
 		{
-			MPrintStat(150, y += h, L"Room Number", gubWorldRoomInfo[map_pos]);
+			MPrintStat(FIRST_COLUMN, y += h, L"Room Number", gubWorldRoomInfo[map_pos]);
 		}
 
 		if (me->ubExtFlags[0] & MAPELEMENT_EXT_NOBURN_STRUCT)
@@ -3098,90 +3070,91 @@ void DebugSoldierPage3()
 	const SOLDIERTYPE* const s = FindSoldierFromMouse();
 	if (s != NULL)
 	{
-		SetFont(LARGEFONT1);
-		gprintf(0, 0, L"DEBUG SOLDIER PAGE THREE, GRIDNO %d", s->sGridNo);
+    MPageHeader(L"DEBUG SOLDIER PAGE THREE, GRIDNO %d", s->sGridNo);
 
-		INT32 y = h;
+		INT32 y = PAGE_START_Y;
 
-		GPrintStat(150, y += h, L"ID:",     s->ubID);
-		GPrintStat(150, y += h, L"Action:", gzActionStr[s->bAction]);
+		MPrintStat(FIRST_COLUMN, y += h, L"ID:",     s->ubID);
+		MPrintStat(FIRST_COLUMN, y += h, L"Action:", gzActionStr[s->bAction]);
 
 		if (s->uiStatusFlags & SOLDIER_ENEMY)
 		{
-			gprintf(350, y, L"Alert %hs", gzAlertStr[s->bAlertStatus]);
+      MPrintStat(FIRST_COLUMN, y += h, L"Alert:", gzAlertStr[s->bAlertStatus]);
 		}
 
-		GPrintStat(150, y += h, L"Action Data:", s->usActionData);
+		MPrintStat(FIRST_COLUMN, y += h, L"Action Data:", s->usActionData);
 
-		if (s->uiStatusFlags & SOLDIER_ENEMY)
+    if (s->uiStatusFlags & SOLDIER_ENEMY)
 		{
-			gprintf(350, y, L"AIMorale %d", s->bAIMorale);
+      MPrintStat(FIRST_COLUMN, y += h, L"AIMorale", s->bAIMorale);
 		}
 		else
 		{
-			gprintf(350, y, L"Morale %d", s->bMorale);
+      MPrintStat(FIRST_COLUMN, y += h, L"Morale", s->bMorale);
 		}
 
-		GPrintStat(150, y += h, L"Delayed Movement:", s->fDelayedMovement);
+		MPrintStat(FIRST_COLUMN, y += h, L"Delayed Movement:", s->fDelayedMovement);
 
 		if (gubWatchedLocPoints[s->ubID][0] > 0)
 		{
-			gprintf(350, y, L"Watch %d/%d for %d pts",
+			mprintf(FIRST_COLUMN, y += h, L"Watch %d/%d for %d pts",
 				gsWatchedLoc[s->ubID][0],
 				gbWatchedLocLevel[s->ubID][0],
 				gubWatchedLocPoints[s->ubID][0]
 			);
 		}
 
-		GPrintStat(150, y += h, L"ActionInProg:", s->bActionInProgress);
+		MPrintStat(FIRST_COLUMN, y += h, L"ActionInProg:", s->bActionInProgress);
 
-		y += h;
 		if (gubWatchedLocPoints[s->ubID][1] > 0)
 		{
-			gprintf(350, y, L"Watch %d/%d for %d pts",
+			mprintf(FIRST_COLUMN+LABEL_WIDTH, y += h, L"Watch %d/%d for %d pts",
 				gsWatchedLoc[s->ubID][1],
 				gbWatchedLocLevel[s->ubID][1],
 				gubWatchedLocPoints[s->ubID][1]
 			);
 		}
 
-		GPrintStat(150, y += h, L"Last Action:", gzActionStr[s->bLastAction]);
+		MPrintStat(FIRST_COLUMN, y += h, L"Last Action:", gzActionStr[s->bLastAction]);
 
 		if (gubWatchedLocPoints[s->ubID][2] > 0)
 		{
-			gprintf(350, y, L"Watch %d/%d for %d pts",
+			mprintf(FIRST_COLUMN+LABEL_WIDTH, y += h, L"Watch %d/%d for %d pts",
 				gsWatchedLoc[s->ubID][2],
 				gbWatchedLocLevel[s->ubID][2],
 				gubWatchedLocPoints[s->ubID][2]
 			);
 		}
 
-		GPrintStat(150, y += h, L"Animation:",   gAnimControl[s->usAnimState].zAnimStr);
-		GPrintStat(150, y += h, L"Getting Hit:", s->fGettingHit);
+		MPrintStat(FIRST_COLUMN, y += h, L"Animation:",   gAnimControl[s->usAnimState].zAnimStr);
+		MPrintStat(FIRST_COLUMN, y += h, L"Getting Hit:", s->fGettingHit);
 
 		if (s->ubCivilianGroup != 0)
 		{
-			gprintf(350, y, L"Civ group %d", s->ubCivilianGroup);
+      MPrintStat(FIRST_COLUMN, y += h, L"Civ group", s->ubCivilianGroup);
 		}
 
-		GPrintStat(150, y += h, L"Suppress pts:",       s->ubSuppressionPoints);
-		GPrintStat(150, y += h, L"Attacker ID:",        SOLDIER2ID(s->attacker));
-		GPrintStat(150, y += h, L"EndAINotCalled:",     s->fTurnInProgress);
-		GPrintStat(150, y += h, L"PrevAnimation:",      gAnimControl[s->usOldAniState].zAnimStr);
-		GPrintStat(150, y += h, L"PrevAniCode:",        gusAnimInst[s->usOldAniState][s->sOldAniCode]);
-		GPrintStat(150, y += h, L"GridNo:",             s->sGridNo);
-		GPrintStat(150, y += h, L"AniCode:",            gusAnimInst[s->usAnimState][s->usAniCode]);
-		GPrintStat(150, y += h, L"No APS To fin Move:", s->fNoAPToFinishMove);
-		GPrintStat(150, y += h, L"Bullets out:",        s->bBulletsLeft);
-		GPrintStat(150, y += h, L"Anim non-int:",       s->fInNonintAnim);
-		GPrintStat(150, y += h, L"RT Anim non-int:",    s->fRTInNonintAnim);
+		MPrintStat(FIRST_COLUMN, y += h, L"Suppress pts:",       s->ubSuppressionPoints);
+		MPrintStat(FIRST_COLUMN, y += h, L"Attacker ID:",        SOLDIER2ID(s->attacker));
+		MPrintStat(FIRST_COLUMN, y += h, L"EndAINotCalled:",     s->fTurnInProgress);
+
+    y = PAGE_START_Y;
+
+		MPrintStat(SECOND_COLUMN, y += h, L"PrevAnimation:",      gAnimControl[s->usOldAniState].zAnimStr);
+		MPrintStat(SECOND_COLUMN, y += h, L"PrevAniCode:",        gusAnimInst[s->usOldAniState][s->sOldAniCode]);
+		MPrintStat(SECOND_COLUMN, y += h, L"GridNo:",             s->sGridNo);
+		MPrintStat(SECOND_COLUMN, y += h, L"AniCode:",            gusAnimInst[s->usAnimState][s->usAniCode]);
+		MPrintStat(SECOND_COLUMN, y += h, L"No APS To fin Move:", s->fNoAPToFinishMove);
+		MPrintStat(SECOND_COLUMN, y += h, L"Bullets out:",        s->bBulletsLeft);
+		MPrintStat(SECOND_COLUMN, y += h, L"Anim non-int:",       s->fInNonintAnim);
+		MPrintStat(SECOND_COLUMN, y += h, L"RT Anim non-int:",    s->fRTInNonintAnim);
 
 		// OPIONION OF SELECTED MERC
 		const SOLDIERTYPE* const sel = GetSelectedMan();
 		if (sel != NULL &&
 				sel->ubProfile < FIRST_NPC && s->ubProfile != NO_PROFILE)
 		{
-			GPrintStat(150, y += h, L"NPC Opinion:", GetProfile(s->ubProfile).bMercOpinion[sel->ubProfile]);
+			MPrintStat(SECOND_COLUMN, y += h, L"NPC Opinion:", GetProfile(s->ubProfile).bMercOpinion[sel->ubProfile]);
 		}
 	}
 	else
@@ -3189,45 +3162,42 @@ void DebugSoldierPage3()
 		const GridNo map_pos = GetMouseMapPos();
 		if (map_pos == NOWHERE) return;
 
-		SetFont(LARGEFONT1);
-		gprintf(0, 0, L"DEBUG LAND PAGE THREE");
+    MPageHeader(L"DEBUG LAND PAGE THREE");
 
-		INT32 y = 0;
+		INT32 y = PAGE_START_Y;
 
 		// OK, display door information here.....
 		DOOR_STATUS const* const door = GetDoorStatus(map_pos);
 		if (door == NULL)
 		{
-			MHeader(y += h, L"No Door Status");
-			y += h * 2;
+			MHeader(FIRST_COLUMN, y += h, L"No Door Status");
 		}
 		else
 		{
-			MPrintStat(150, y += h, L"Door Status Found:", map_pos);
+			MPrintStat(FIRST_COLUMN, y += h, L"Door Status Found:", map_pos);
 
 			wchar_t const* const door_state =
 				door->ubFlags & DOOR_OPEN ? L"OPEN" : L"CLOSED";
-			MPrintStat(200, y += h, L"Actual Status:", door_state);
+			MPrintStat(FIRST_COLUMN, y += h, L"Actual Status:", door_state);
 
 			wchar_t const* const perceived_state =
 				door->ubFlags & DOOR_PERCEIVED_NOTSET ? L"NOT SET" :
 				door->ubFlags & DOOR_PERCEIVED_OPEN   ? L"OPEN"    :
 				                                        L"CLOSED";
-			MPrintStat(200, y += h, L"Perceived Status:", perceived_state);
+			MPrintStat(FIRST_COLUMN, y += h, L"Perceived Status:", perceived_state);
 		}
 
 		//Find struct data and se what it says......
-		y += h;
 		STRUCTURE const* const structure = FindStructure(map_pos, STRUCTURE_ANYDOOR);
 		if (structure == NULL)
 		{
-			MHeader(y, L"No Door Struct Data");
+			MHeader(FIRST_COLUMN, y += h, L"No Door Struct Data");
 		}
 		else
 		{
 			wchar_t const* const structure_state =
 				structure->fFlags & STRUCTURE_OPEN ? L"OPEN" : L"CLOSED";
-			MPrintStat(200, y, L"State:", structure_state);
+			MPrintStat(FIRST_COLUMN, y += h, L"State:", structure_state);
 		}
 	}
 }
@@ -3264,11 +3234,11 @@ static void WriteQuantityAndAttachments(OBJECTTYPE const* o, INT32 const y)
 				wcscat(str, temp);
 			}
 			wcscat(str, L")");
-			gprintf(320, y, str);
+			mprintf(SECOND_COLUMN, y, str);
 		}
 		else
 		{
-			gprintf(320, y, L"%d rounds", o->bStatus[0]);
+			mprintf(SECOND_COLUMN, y, L"%d rounds", o->bStatus[0]);
 		}
 	}
 	else
@@ -3294,11 +3264,11 @@ static void WriteQuantityAndAttachments(OBJECTTYPE const* o, INT32 const y)
 
 		if (o->ubNumberOfObjects > 1)
 		{ //everything
-			gprintf(320, y, L"%d%%  Qty:  %d%ls", o->bStatus[0], o->ubNumberOfObjects, attachments);
+			mprintf(SECOND_COLUMN, y, L"%d%%  Qty:  %d%ls", o->bStatus[0], o->ubNumberOfObjects, attachments);
 		}
 		else
 		{ //condition and attachments
-			gprintf(320, y, L"%d%%%ls", o->bStatus[0], attachments);
+			mprintf(SECOND_COLUMN, y, L"%d%%%ls", o->bStatus[0], attachments);
 		}
 	}
 }
@@ -3306,9 +3276,9 @@ static void WriteQuantityAndAttachments(OBJECTTYPE const* o, INT32 const y)
 
 static void PrintItem(INT32 const y, wchar_t const* const header, OBJECTTYPE const* o)
 {
-	GHeader(y, header);
+	MHeader(FIRST_COLUMN, y, header);
 	if (!o->usItem) return;
-	gprintf(150, y, L"%ls", ShortItemNames[o->usItem]);
+	mprintf(FIRST_COLUMN+LABEL_WIDTH, y, L"%ls", ShortItemNames[o->usItem]);
 	WriteQuantityAndAttachments(o, y);
 }
 
@@ -3316,15 +3286,16 @@ static void PrintItem(INT32 const y, wchar_t const* const header, OBJECTTYPE con
 void DebugSoldierPage4()
 {
 	const SOLDIERTYPE* const s = FindSoldierFromMouse();
+
+  INT32 const h = LINE_HEIGHT;
+
 	if (s != NULL)
 	{
-		SetFont(LARGEFONT1);
-		gprintf(0, 0, L"DEBUG SOLDIER PAGE FOUR, GRIDNO %d", s->sGridNo);
+		MPageHeader(L"DEBUG SOLDIER PAGE FOUR, GRIDNO %d", s->sGridNo);
 
-		INT32 const h = LINE_HEIGHT;
-		INT32       y = h;
+    INT32 y = PAGE_START_Y;
 
-		GPrintStat(150, y += h, L"Exp. Level:", s->bExpLevel);
+		MPrintStat(FIRST_COLUMN, y += h, L"Exp. Level:", s->bExpLevel);
 		wchar_t const* sclass;
 		switch (s->ubSoldierClass)
 		{
@@ -3339,7 +3310,7 @@ void DebugSoldierPage4()
 			/* don't care (don't write anything) */
 			default:                            sclass = NULL;               break;
 		}
-		if (sclass) gprintf(320, y, L"%ls", sclass);
+		if (sclass) mprintf(SECOND_COLUMN, y, L"%ls", sclass);
 
 		if (s->bTeam != OUR_TEAM)
 		{
@@ -3367,12 +3338,11 @@ void DebugSoldierPage4()
 				case CUNNINGAID:  attitude = L"CUNNING AID";  break;
 				default:          attitude = L"UNKNOWN";      break;
 			}
-			SetFontShade(LARGEFONT1, FONT_SHADE_NEUTRAL);
 			SOLDIERINITNODE const* const node = FindSoldierInitNodeBySoldier(*s);
 			y += h;
 			if (node)
 			{
-				gprintf(0, y, L"%ls, %ls, REL EQUIP: %d, REL ATTR: %d",
+				mprintf(FIRST_COLUMN, y, L"%ls, %ls, REL EQUIP: %d, REL ATTR: %d",
 					orders, attitude,
 					node->pBasicPlacement->bRelativeEquipmentLevel,
 					node->pBasicPlacement->bRelativeAttributeLevel
@@ -3380,11 +3350,11 @@ void DebugSoldierPage4()
 			}
 			else
 			{
-				gprintf(0, y, L"%ls, %ls", orders, attitude);
+				mprintf(FIRST_COLUMN, y, L"%ls, %ls", orders, attitude);
 			}
 		}
 
-		GPrintStat(150, y += h, L"ID:", s->ubID);
+		MPrintStat(FIRST_COLUMN, y += h, L"ID:", s->ubID);
 
 		PrintItem(y += h, L"HELMETPOS:",     &s->inv[HELMETPOS]);
 		PrintItem(y += h, L"VESTPOS:",       &s->inv[VESTPOS]);
@@ -3408,8 +3378,7 @@ void DebugSoldierPage4()
 	}
 	else
 	{
-		SetFont(LARGEFONT1);
-		gprintf(0, 0, L"DEBUG LAND PAGE FOUR");
+    MPageHeader(L"DEBUG LAND PAGE FOUR");
 	}
 }
 

--- a/Build/Tactical/Turn_Based_Input.cc
+++ b/Build/Tactical/Turn_Based_Input.cc
@@ -90,10 +90,13 @@
 #include "GameRes.h"
 #include "GameState.h"
 
+#include "slog/slog.h"
 #include "ContentManager.h"
 #include "GameInstance.h"
 #include "Soldier.h"
 #include "policy/GamePolicy.h"
+
+#define DEBUG_CONSOLE_TOPIC "Debug Console"
 
 #ifdef JA2TESTVERSION
 #	include "Ambient_Control.h"
@@ -1463,7 +1466,12 @@ static void HandleModNone(UINT32 const key, UIEventKind* const new_event)
 			break;
 		}
 
-		case 'y': if (INFORMATION_CHEAT_LEVEL()) *new_event = I_LOSDEBUG; break;
+		case 'y':
+      if (INFORMATION_CHEAT_LEVEL()) {
+        SLOGD(DEBUG_CONSOLE_TOPIC, "Entering LOS Debug Mode");
+        *new_event = I_LOSDEBUG;
+      }
+      break;
 		case 'z': if (!gpItemPointer) HandleStealthChangeFromUIKeys();    break;
 
 		case SDLK_INSERT: GoIntoOverheadMap(); break;
@@ -1528,6 +1536,7 @@ static void HandleModNone(UINT32 const key, UIEventKind* const new_event)
 		case SDLK_F11:
 			if (DEBUG_CHEAT_LEVEL())
 			{
+        SLOGD(DEBUG_CONSOLE_TOPIC, "Entering Quest Debug Mode");
 				gsQdsEnteringGridNo = GetMouseMapPos();
 				LeaveTacticalScreen(QUEST_DEBUG_SCREEN);
 			}
@@ -1641,7 +1650,8 @@ static void HandleModCtrl(UINT32 const key, UIEventKind* const new_event)
 		case 'f':
 			if (INFORMATION_CHEAT_LEVEL())
 			{ // Toggle frame rate display
-				gbFPSDisplay = !gbFPSDisplay;
+        SLOGD(DEBUG_CONSOLE_TOPIC, "Toggle FPS Overlay");
+        gbFPSDisplay = !gbFPSDisplay;
 				EnableFPSOverlay(gbFPSDisplay);
 				if (!gbFPSDisplay) SetRenderFlags(RENDER_FLAG_FULL);
 			}
@@ -1729,7 +1739,10 @@ static void HandleModCtrl(UINT32 const key, UIEventKind* const new_event)
 			}
 			break;
 
-		case 'z': if (INFORMATION_CHEAT_LEVEL()) ToggleZBuffer(); break;
+		case 'z':
+      SLOGD(DEBUG_CONSOLE_TOPIC, "Toggling ZBuffer");
+      if (INFORMATION_CHEAT_LEVEL()) ToggleZBuffer();
+      break;
 
 		case SDLK_PAGEUP:
 			// Try to go up towards ground level
@@ -1863,7 +1876,8 @@ static void HandleModAlt(UINT32 const key, UIEventKind* const new_event)
 		case 'm':
 			if (INFORMATION_CHEAT_LEVEL())
 			{
-				*new_event = I_LEVELNODEDEBUG;
+        SLOGD(DEBUG_CONSOLE_TOPIC, "Entering Level Node Debug Mode");
+        *new_event = I_LEVELNODEDEBUG;
 				CountLevelNodes();
 			}
 			break;
@@ -1872,7 +1886,8 @@ static void HandleModAlt(UINT32 const key, UIEventKind* const new_event)
 			if (INFORMATION_CHEAT_LEVEL() && gUIFullTarget)
 			{
 				static UINT16 gQuoteNum = 0;
-				TacticalCharacterDialogue(gUIFullTarget, gQuoteNum++);
+        SLOGD(DEBUG_CONSOLE_TOPIC, "Playing Quote %d", gQuoteNum);
+        TacticalCharacterDialogue(gUIFullTarget, gQuoteNum++);
 			}
 			break;
 
@@ -2317,7 +2332,8 @@ void GetKeyboardInput(UIEventKind* const puiNewEvent)
 			{
 				if ( INFORMATION_CHEAT_LEVEL( ) )
 				{
-					*puiNewEvent = I_SOLDIERDEBUG;
+          SLOGD(DEBUG_CONSOLE_TOPIC, "Entering Soldier and Land Debug Mode");
+          *puiNewEvent = I_SOLDIERDEBUG;
 				}
 			}
 		}

--- a/Build/Tactical/Turn_Based_Input.cc
+++ b/Build/Tactical/Turn_Based_Input.cc
@@ -1925,17 +1925,17 @@ static void HandleModAlt(UINT32 const key, UIEventKind* const new_event)
 		case 't': if (CHEATER_CHEAT_LEVEL()) TeleportSelectedSoldier(); break;
 		case 'u': if (CHEATER_CHEAT_LEVEL()) RefreshSoldier();          break;
 
-#ifdef JA2TESTVERSION
 		case 'v':
 		{
-			gfDoVideoScroll ^= TRUE;
-			wchar_t const* const msg =
-				gfDoVideoScroll ? L"Video Scroll ON" :
-				L"Video Scroll OFF";
-			ScreenMsg(FONT_MCOLOR_LTYELLOW, MSG_INTERFACE, msg);
+      if (DEBUG_CHEAT_LEVEL()) {
+        gfDoVideoScroll ^= TRUE;
+        wchar_t const *const msg =
+                gfDoVideoScroll ? L"Video Scroll ON" :
+                L"Video Scroll OFF";
+        ScreenMsg(FONT_MCOLOR_LTYELLOW, MSG_INTERFACE, msg);
+      }
 			break;
 		}
-#endif
 
 		case 'w':
 			if (CHEATER_CHEAT_LEVEL())

--- a/Build/TileEngine/WorldMan.cc
+++ b/Build/TileEngine/WorldMan.cc
@@ -1,5 +1,6 @@
 #include <stdexcept>
 
+#include "Debug_Pages.h"
 #include "Animation_Data.h"
 #include "Environment.h"
 #include "Font.h"
@@ -28,14 +29,14 @@ static UINT32 guiLNCount[9];
 static const wchar_t gzLevelString[][15] =
 {
 	L"",
-	L"Land    %d",
-	L"Object  %d",
-	L"Struct  %d",
-	L"Shadow  %d",
-	L"Merc    %d",
-	L"Roof    %d",
-	L"Onroof  %d",
-	L"Topmost %d",
+	L"Land",
+	L"Object",
+	L"Struct",
+	L"Shadow",
+	L"Merc",
+	L"Roof",
+	L"Onroof",
+	L"Topmost",
 };
 
 
@@ -75,19 +76,19 @@ void CountLevelNodes(void)
 }
 
 
-#define LINE_HEIGHT 20
 void DebugLevelNodePage(void)
 {
-	SetFont(LARGEFONT1);
-	gprintf(0, 0, L"DEBUG LEVELNODES PAGE 1 OF 1");
+	MPageHeader(L"DEBUG LEVELNODES PAGE 1 OF 1");
+  INT32 y = DEBUG_PAGE_START_Y;
+  INT32 h = DEBUG_PAGE_LINE_HEIGHT;
 
 	for (UINT32 uiLoop = 1; uiLoop < 9; uiLoop++)
 	{
-		gprintf(0, LINE_HEIGHT * (uiLoop + 1), gzLevelString[uiLoop], guiLNCount[uiLoop]);
+		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, gzLevelString[uiLoop], guiLNCount[uiLoop]);
 	}
-	gprintf(0, LINE_HEIGHT * 12, L"%d land nodes in excess of world max (25600)", guiLNCount[1] - WORLD_MAX);
-	gprintf(0, LINE_HEIGHT * 13, L"Total # levelnodes %d, %d bytes each", guiLNCount[0], sizeof(LEVELNODE));
-	gprintf(0, LINE_HEIGHT * 14, L"Total memory for levelnodes %d", guiLNCount[0] * sizeof(LEVELNODE));
+	mprintf(DEBUG_PAGE_FIRST_COLUMN, y += h, L"%d land nodes in excess of world max (25600)", guiLNCount[1] - WORLD_MAX);
+  mprintf(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Total # levelnodes %d, %d bytes each", guiLNCount[0], sizeof(LEVELNODE));
+  mprintf(DEBUG_PAGE_FIRST_COLUMN, y += h, L"Total memory for levelnodes %d", guiLNCount[0] * sizeof(LEVELNODE));
 }
 
 

--- a/Build/Utils/Debug_Pages.cc
+++ b/Build/Utils/Debug_Pages.cc
@@ -1,0 +1,37 @@
+#include "Debug_Pages.h"
+#include "Font.h"
+#include "Font_Control.h"
+
+void MHeader(INT32 const x, INT32 const y, wchar_t const* const str)
+{
+  SetFontColors(DEBUG_PAGE_HEADER_COLOR);
+  MPrint(x, y, str);
+  SetFontColors(DEBUG_PAGE_TEXT_COLOR);
+}
+
+
+void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, INT32 const val)
+{
+  MHeader(x, y, header);
+  mprintf(x+DEBUG_PAGE_LABEL_WIDTH, y, L"%d", val);
+}
+
+
+void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, wchar_t const* const val)
+{
+  MHeader(x, y, header);
+  mprintf(x+DEBUG_PAGE_LABEL_WIDTH, y, L"%ls", val);
+}
+
+
+void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, void const* const val)
+{
+  MHeader(x, y, header);
+  mprintf(x+DEBUG_PAGE_LABEL_WIDTH, y, L"%p", val);
+}
+
+void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, INT32 const val, INT32 const effective_val)
+{
+  MHeader(x, y, header);
+  mprintf(x+DEBUG_PAGE_LABEL_WIDTH, y, L"%d ( %d )", val, effective_val);
+}

--- a/Build/Utils/Debug_Pages.h
+++ b/Build/Utils/Debug_Pages.h
@@ -1,0 +1,26 @@
+#include "Font.h"
+
+#ifndef __DEBUG_PAGES_H
+#define __DEBUG_PAGES_H
+
+#define DEBUG_PAGE_HEADER_COLOR FONT_MCOLOR_BLACK<<8 | FONT_MCOLOR_LTGREEN
+#define DEBUG_PAGE_TEXT_COLOR FONT_MCOLOR_BLACK<<8 | FONT_MCOLOR_LTGRAY2
+
+#define DEBUG_PAGE_FONT FONT14ARIAL
+#define DEBUG_PAGE_SCREEN_OFFSET_Y 20
+#define DEBUG_PAGE_SCREEN_OFFSET_X 10
+#define DEBUG_PAGE_LINE_HEIGHT 15
+#define DEBUG_PAGE_START_Y DEBUG_PAGE_SCREEN_OFFSET_Y + DEBUG_PAGE_LINE_HEIGHT
+#define DEBUG_PAGE_FIRST_COLUMN DEBUG_PAGE_SCREEN_OFFSET_X
+#define DEBUG_PAGE_SECOND_COLUMN 300
+#define DEBUG_PAGE_LABEL_WIDTH 150
+
+#define MPageHeader(...) SetFont(DEBUG_PAGE_FONT); SetFontColors(DEBUG_PAGE_HEADER_COLOR); mprintf(DEBUG_PAGE_FIRST_COLUMN, DEBUG_PAGE_SCREEN_OFFSET_Y, __VA_ARGS__); SetFontColors(DEBUG_PAGE_TEXT_COLOR);
+
+void MHeader(INT32 const x, INT32 const y, wchar_t const* const str);
+void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, INT32 const val);
+void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, wchar_t const* const val);
+void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, void const* const val);
+void MPrintStat(INT32 const x, INT32 const y, wchar_t const* const header, INT32 const val, INT32 const effective_val);
+
+#endif

--- a/Makefile
+++ b/Makefile
@@ -450,6 +450,7 @@ SRCS += Build/Utils/Animated_ProgressBar.cc
 SRCS += Build/Utils/Cinematics.cc
 SRCS += Build/Utils/Cursors.cc
 SRCS += Build/Utils/Debug_Control.cc
+SRCS += Build/Utils/Debug_Pages.cc
 SRCS += Build/Utils/Event_Manager.cc
 SRCS += Build/Utils/Event_Pump.cc
 SRCS += Build/Utils/Font_Control.cc

--- a/sgp/SGP.cc
+++ b/sgp/SGP.cc
@@ -15,6 +15,7 @@
 #include <new>
 
 #include "Button_System.h"
+#include "Cheats.h"
 #include "Debug.h"
 #include "FileMan.h"
 #include "Font.h"
@@ -615,6 +616,7 @@ static BOOLEAN ParseParameters(int argc, char* const argv[], CommandLineParams *
     else if (strcmp(argv[i], "-debug") == 0)
     {
       params->showDebugMessages = true;
+      GameState::getInstance()->setDebugging(true);
     }
     else if (strcmp(argv[i], "-no3btnmouse") == 0)
     {


### PR DESCRIPTION
I enabled some debug screens to be accessible when using the `-debug` parameter.

Tactical Screen
- `F11` for Quest Debug Screen
- `CTRL+f` for FPS Display
- `CTRL+z` to toggle z-buffer
- `ALT+m` for level node debug mode
- `ALT+n` to play quotes of hovered merc
- `q` for soldier and land debug mode
- `y` for struct debug mode

To exit any screen press `q`. To cycle through different pages use pageup and pagedown.

I'm in the progress of making everything look pretty and usable. Progress:
- [x] Quest Debug Screen
- [x] FPS Display
- [x] z-Buffer
- [x] Level Node
- [x] Quotes
- [x] Soldier and Land

Examples:
![screenshot from 2016-03-31 00-15-28](https://cloud.githubusercontent.com/assets/848854/14159359/c16225da-f6d5-11e5-9454-c9e60d24ffa3.png)
![screenshot from 2016-03-31 00-15-39](https://cloud.githubusercontent.com/assets/848854/14159360/c1649fa4-f6d5-11e5-8ed7-67989d7f4448.png)
![screenshot from 2016-03-31 00-18-59](https://cloud.githubusercontent.com/assets/848854/14159433/31a531d4-f6d6-11e5-9ede-b3ffb87df9b6.png)
