### PR TITLE
ApplyScrolling: buffer the top border, so npcs there can be shot in t…

### DIFF
--- a/Build/TileEngine/RenderWorld.cc
+++ b/Build/TileEngine/RenderWorld.cc
@@ -2322,7 +2322,7 @@ static BOOLEAN ApplyScrolling(INT16 sTempRenderCenterX, INT16 sTempRenderCenterY
   // Checking if screen shows areas outside of the map
 	BOOLEAN fOutLeft   = (gsTLX > sTopLeftWorldX);
 	BOOLEAN fOutRight  = (gsTRX < sTopRightWorldX);
-	BOOLEAN fOutTop    = (gsTLY >= sTopLeftWorldY);            /* top of the screen is above top of the map */
+	BOOLEAN fOutTop    = (gsTLY >= sTopLeftWorldY + 62);       /* top of the screen is above top of the map (with padding for headshots) */
 	BOOLEAN fOutBottom = (gsBLY < sBottomLeftWorldY);          /* bottom of the screen is below bottom if the map */
 
   int mapHeight = gsBLY - gsTLY;


### PR DESCRIPTION
…he head #195

roof level automatically offsets, so such cases don't need to be handled separately