### PR TITLE
Fix #201: Add coverity testing via coverity-via-travis branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: cpp
 
+env:
+  global:
+    - secure: "o8hCOxRt+3jpgLHEQgvHSSY5eIAq+yrAprSaOYZ5YZcj0Xztcu/oCbxZ3l9t6arY91yqHDjzyuSJMrLrGigjYIR/Bp26Du9o1MA/j+FmP2I8Uwn1lyBI1hyZtX5Viuktpkcpdfiv52ISbFPnHmJ0JjgsbLqqnGw8Ps2zoYrFlI284d9FxPZJfjt8pzZLBAB77zE0rMKGO1ITRV6FJbG2Wjh5A165gx4yM3UszyA01jVR/ifFItdGfSzJB3UXroFjzxL7TNP9WgQjBEcmup6y7E90PztFGFBVwvBnEHMWwb4Wr8NuFmhMRXbOb5ilw7rwXeeeKBQ2pAShY0A4N5k6Ah6oJcR7+I59eSscnjq0gJVmLkRPUij6RQtL+WgSFQ4EssyTONOelQhEPV4NU5jUleTHES5mFVy8Ndz4gULb9aX/uXRp2aV0fpqDcNnpdZJO1M3upCNxC9X9U3jmQC6MgDElaoyBb4IC1+XDOBq2XbTpLn58IbZUr975S/EIMENXhUl58FohhwuhQMyYqz/C+/A8lOvDQ0v3eOVIqdOgxNuxlAUs3DJAai8xDDVUfYUizcwKNFGo96aD2+eJQ9GeQ1P0uHIzP+BmQidFaZZIVmbEyjVRN8xKIA6TQKQLL0eStm/FHkjMMu3MrfvuDJcJmxcoQQWCFWHKSLGaHLI6xHc="
+
 compiler:
   - gcc
 
@@ -9,9 +13,12 @@ before_install:
 
 script: make SKIP_BUILD_NUMBER_CALC=1 clean && make SKIP_BUILD_NUMBER_CALC=1 all && ./ja2 -unittests
 
-notifications:
-  recipients:
-    - gennady.trafimenkov@gmail.com
-  email:
-    on_success: change
-    on_failure: always
+addons:
+  coverity_scan:
+    project:
+      name: "ja2-stracciatella/ja2-stracciatella"
+      description: "Build submitted via Travis CI"
+    notification_email: github@stefanlau.com
+    build_command_prepend: "make clean"
+    build_command:   "make SKIP_BUILD_NUMBER_CALC=1 all"
+    branch_pattern: coverity-via-travis


### PR DESCRIPTION
This allows us to run a coverity scan every time the coverity-via-travis branch is updated. We should merge this into master though, so we can simply create a PR from master to this branch to get a fresh build. I'm currently waiting for the first build to complete to see if everything works.

We could also create a bot that does that every week.