### PR TITLE
Fixed stack corruption

### DIFF
--- a/Build/Laptop/EMail.cc
+++ b/Build/Laptop/EMail.cc
@@ -53,7 +53,7 @@ struct Page
 
 struct Record
 {
-	wchar_t pRecord[MAIL_STRING_SIZE + 1];
+	wchar_t pRecord[MAIL_STRING_SIZE];
 	Record* Next;
 };
 
@@ -1614,7 +1614,7 @@ static void ClearOutEmailMessageRecordsList(void)
 
 static void AddEmailRecordToList(wchar_t* const text)
 {
-	text[MAIL_STRING_SIZE] = 0;
+	text[MAIL_STRING_SIZE-1] = L'\0';
 	Record* const e = MALLOC(Record);
 	e->Next = NULL;
 	wcscpy(e->pRecord, text);


### PR DESCRIPTION
1, Function "AddEmailRecordToList" is called with parameter "text" which is always an array of length MAIL_STRING_SIZE.
therefore text[MAIL_STRING_SIZE] = 0; causes accessing an array out of bounds.
2, MAIL_STRING_SIZE length of pRecord should be sufficient. Maximum length that is read from data files is MAIL_STRING_SIZE (including trailing zero).