### PR TITLE
Fix #300: Show version number in main menu

### DIFF
--- a/Build/JAScreens.cc
+++ b/Build/JAScreens.cc
@@ -99,7 +99,6 @@ void DisplayFrameRate( )
 	}
 }
 
-
 ScreenID ErrorScreenHandle(void)
 {
   InputAtom  InputEvent;
@@ -166,27 +165,6 @@ ScreenID InitScreenHandle(void)
 	if ( ubCurrentScreen == 0 )
 	{
 		ubCurrentScreen = 1;
-
-		// Init screen
-
-		SetFontAttributes(TINYFONT1, FONT_MCOLOR_WHITE);
-
-		const INT32 x = 10;
-		const INT32 y = SCREEN_HEIGHT;
-
-#ifdef JA2BETAVERSION
-		MPrint(x, y - 60, L"(Beta version error reporting enabled)");
-#endif
-
-#ifdef _DEBUG
-		mprintf(x, y - 50, L"%ls: %hs (Debug %hs)", pMessageStrings[MSG_VERSION], g_version_label, g_version_number);
-#else
-		mprintf(x, y - 50, L"%hs", g_version_label, g_version_number);
-#endif
-
-#ifdef _DEBUG
-		mprintf(x, y - 40, L"SOLDIERTYPE: %d bytes", sizeof(SOLDIERTYPE));
-#endif
 
 		InvalidateScreen( );
 

--- a/Build/MainMenuScreen.cc
+++ b/Build/MainMenuScreen.cc
@@ -3,9 +3,11 @@
 #include "Cursors.h"
 #include "Directories.h"
 #include "English.h"
+#include "Font.h"
 #include "Font_Control.h"
 #include "GameSettings.h"
 #include "GameLoop.h"
+#include "GameVersion.h"
 #include "Input.h"
 #include "JA2_Splash.h"
 #include "JAScreens.h"
@@ -72,6 +74,8 @@ static void ExitMainMenu(void);
 static void HandleMainMenuInput(void);
 static void HandleMainMenuScreen(void);
 static void RenderMainMenu(void);
+static void RenderGameVersion(void);
+static void RenderCopyright(void);
 static void RestoreButtonBackGrounds(void);
 
 
@@ -120,6 +124,8 @@ ScreenID MainMenuScreenHandle(void)
 	{
 		ClearMainMenu();
 		RenderMainMenu();
+    RenderGameVersion();
+    RenderCopyright();
 
 		fInitialRender = FALSE;
 	}
@@ -356,35 +362,16 @@ static void RenderMainMenu(void)
 	BltVideoObject(guiSAVEBUFFER, guiJa2LogoImage,            0, STD_SCREEN_X + 188, STD_SCREEN_Y + 15);
 
 	RestoreExternBackgroundRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
-
-#if defined TESTFOREIGNFONTS
-	UINT16 y = 105;
-#	define TEST_FONT(font) \
-		DrawTextToScreen(#font L": ÄÀÁÂÇËÈÉÊÏÖÒÓÔÜÙÚÛäàáâçëèéêïöòóôüùúûÌì", 0, y, 640, font, FONT_MCOLOR_WHITE, FONT_MCOLOR_BLACK, LEFT_JUSTIFIED); \
-		y += 20;
-	TEST_FONT(LARGEFONT1);
-	TEST_FONT(SMALLFONT1);
-	TEST_FONT(TINYFONT1);
-	TEST_FONT(FONT12POINT1);
-	TEST_FONT(COMPFONT);
-	TEST_FONT(SMALLCOMPFONT);
-	TEST_FONT(MILITARYFONT1);
-	TEST_FONT(FONT10ARIAL);
-	TEST_FONT(FONT14ARIAL);
-	TEST_FONT(FONT12ARIAL);
-	TEST_FONT(FONT10ARIALBOLD);
-	TEST_FONT(BLOCKFONT);
-	TEST_FONT(BLOCKFONT2);
-	TEST_FONT(FONT12ARIALFIXEDWIDTH);
-	TEST_FONT(FONT16ARIAL);
-	TEST_FONT(BLOCKFONTNARROW);
-	TEST_FONT(FONT14HUMANIST);
-#	undef TEST_FONT
-#else
-	DrawTextToScreen(gzCopyrightText, 0, SCREEN_HEIGHT - 15, SCREEN_WIDTH, FONT10ARIAL, FONT_MCOLOR_WHITE, FONT_MCOLOR_BLACK, CENTER_JUSTIFIED);
-#endif
 }
 
+void RenderGameVersion() {
+  SetFontAttributes(FONT10ARIAL, FONT_MCOLOR_WHITE);
+  mprintf(g_ui.m_versionPosition.iX, g_ui.m_versionPosition.iY, L"%hs", g_version_label, g_version_number);
+}
+
+void RenderCopyright() {
+  DrawTextToScreen(gzCopyrightText, 0, SCREEN_HEIGHT - 15, SCREEN_WIDTH, FONT10ARIAL, FONT_MCOLOR_WHITE, FONT_MCOLOR_BLACK, CENTER_JUSTIFIED);
+}
 
 static void RestoreButtonBackGrounds(void)
 {

--- a/Build/UILayout.cc
+++ b/Build/UILayout.cc
@@ -127,6 +127,7 @@ void UILayout::recalculatePositions()
   m_repairPosition.set(         m_stdScreenOffsetX + 160, m_stdScreenOffsetY + 150);
   m_assignmentPosition.set(     m_stdScreenOffsetX + 120, m_stdScreenOffsetY + 150);
   m_squadPosition.set(          m_stdScreenOffsetX + 160, m_stdScreenOffsetY + 150);
+  m_versionPosition.set(        10, m_screenHeight - 15);
 }
 
 /** Get X position of tactical textbox. */

--- a/Build/UILayout.h
+++ b/Build/UILayout.h
@@ -99,6 +99,7 @@ public:
 
   SGPRect               m_wordlClippingRect;
 
+  SGPPoint              m_versionPosition;
   SGPPoint              m_contractPosition;
   SGPPoint              m_attributePosition;
   SGPPoint              m_trainPosition;


### PR DESCRIPTION
Removes it from the splash instead otherwise it looks weird with the copyright fading in.