### PR TITLE
Set CXX_STANDARD for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ endmacro()
 
 project (ja2-stracciatella)
 set(BINARY "ja2")
+set (CMAKE_CXX_STANDARD 98)
 
 ## Versioning
 


### PR DESCRIPTION
- Otherwise compiler will choose language level, which e.g. does not work for me in mingw.