### PR TITLE
Only check retreat conditions for valid sectors

### DIFF
--- a/Build/Strategic/Campaign_Types.h
+++ b/Build/Strategic/Campaign_Types.h
@@ -4,12 +4,15 @@
 #include "Debug.h"
 #include "Types.h"
 
+static inline bool IS_VALID_SECTOR(UINT8 const x, UINT8 const y)
+{
+  return 1 <= x && x <= 16 && 1 <= y && y <= 16;
+}
 
 //Macro to convert sector coordinates (1-16,1-16) to 0-255
 static inline UINT8 SECTOR(UINT8 const x, UINT8 const y)
 {
-	Assert(1 <= x && x <= 16);
-	Assert(1 <= y && y <= 16);
+	Assert(IS_VALID_SECTOR(x, y));
 	return (y - 1) * 16 + x - 1;
 }
 

--- a/Build/Strategic/Strategic_Movement.cc
+++ b/Build/Strategic/Strategic_Movement.cc
@@ -2436,9 +2436,9 @@ BOOLEAN PlayersBetweenTheseSectors(INT16 const sec_src, INT16 const sec_dst, INT
 			continue;
 		}
 
-		INT16 const sec_prev = SECTOR(g.ubPrevX,   g.ubPrevY);
+		INT16 const sec_prev = IS_VALID_SECTOR(g.ubPrevX, g.ubPrevY) ? SECTOR(g.ubPrevX,   g.ubPrevY) : -1;
 		INT16 const sec_cur  = SECTOR(g.ubSectorX, g.ubSectorY);
-		INT16 const sec_next = SECTOR(g.ubNextX,   g.ubNextY);
+		INT16 const sec_next = IS_VALID_SECTOR(g.ubNextX, g.ubNextY) ? SECTOR(g.ubNextY,   g.ubNextY) : -1;
 
 		bool const may_retreat_from_battle =
 			sec_battle == sec_src && sec_cur == sec_src && sec_prev == sec_dst;


### PR DESCRIPTION
E.g. when a group is not moving it does not have a previous sector.

Fixes #356. 