### PR TITLE
Extract easing from DoTransitionFromPreBattleInterfaceToAutoResolve

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/content")
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/internals")
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/policy")
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/ui")
 
 file(GLOB LOCAL_JA2_HEADERS ${CMAKE_CURRENT_SOURCE_DIR} *.h)
 set(LOCAL_JA2_SOURCES

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -1,0 +1,12 @@
+file(GLOB LOCAL_JA2_HEADERS ${CMAKE_CURRENT_SOURCE_DIR} *.h)
+set(JA2_SOURCES
+        ${JA2_SOURCES}
+        ${JA2_LOCAL_HEADERS}
+        ${CMAKE_CURRENT_SOURCE_DIR}/Easings.cc
+        PARENT_SCOPE
+        )
+set(JA2_INCLUDES
+        ${JA2_INCLUDES}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        PARENT_SCOPE
+        )

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -1,8 +1,19 @@
 file(GLOB LOCAL_JA2_HEADERS ${CMAKE_CURRENT_SOURCE_DIR} *.h)
+set(LOCAL_JA2_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/Easings.cc
+        )
+
+if (WITH_UNITTESTS)
+    set(LOCAL_JA2_SOURCES
+            ${LOCAL_JA2_SOURCES}
+            ${CMAKE_CURRENT_SOURCE_DIR}/Easings_unittests.cc
+            )
+endif()
+
 set(JA2_SOURCES
         ${JA2_SOURCES}
-        ${JA2_LOCAL_HEADERS}
-        ${CMAKE_CURRENT_SOURCE_DIR}/Easings.cc
+        ${LOCAL_JA2_HEADERS}
+        ${LOCAL_JA2_SOURCES}
         PARENT_SCOPE
         )
 set(JA2_INCLUDES

--- a/src/ui/Easings.cc
+++ b/src/ui/Easings.cc
@@ -1,0 +1,16 @@
+#include <stdint.h>
+
+#include "sgp/Debug.h"
+
+float EaseInCubic(uint32_t uiStartTime, uint32_t uiEndTime, uint32_t uiCurrentTime) {
+  Assert(uiEndTime >= uiStartTime);
+  Assert(uiCurrentTime <= uiEndTime);
+
+  float fProgress = (float)(uiCurrentTime - uiStartTime) / (float)(uiEndTime - uiStartTime);
+
+  if (fProgress < 0.5) {
+    return 4.0f * fProgress * fProgress * fProgress;
+  } else {
+    return (fProgress - 1.0f) * (2.0f * fProgress - 2.0f) * (2.0f * fProgress - 2.0f) + 1.0f;
+  }
+}

--- a/src/ui/Easings.h
+++ b/src/ui/Easings.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <stdint.h>
+
+float EaseInCubic(uint32_t uiStartTime, uint32_t uiEndTime, uint32_t uiCurrentTime);

--- a/src/ui/Easings_unittests.cc
+++ b/src/ui/Easings_unittests.cc
@@ -1,0 +1,12 @@
+#include "gtest/gtest.h"
+
+#include "Easings.h"
+
+TEST(EasingsTest, easeInCubic)
+{
+  ASSERT_EQ(EaseInCubic(100, 101, 100), 0.0);
+  ASSERT_EQ(EaseInCubic(1000, 1100, 1100), 1.0);
+
+  ASSERT_EQ(EaseInCubic(1000, 1100, 1025), 0.0625);
+  ASSERT_EQ(EaseInCubic(1000, 1100, 1075), 0.9375);
+}


### PR DESCRIPTION
Fixes #381 

- Replace custom easing function with standard cubic one
- Reduce complexity of function