### PR TITLE
Use integer abs function where necessary

### DIFF
--- a/Build/Editor/Cursor_Modes.cc
+++ b/Build/Editor/Cursor_Modes.cc
@@ -249,7 +249,7 @@ static void ForceAreaSelectionWidth(const INT16 sGridX, const INT16 sGridY)
 
 	//compare the region with the anchor and determine if we are going to force size via
 	//height or width depending on the cursor distance from the anchor.
-	if( abs( sGridX - gSelectAnchor.iX ) < abs( sGridY - gSelectAnchor.iY ) )
+	if( ABS( sGridX - gSelectAnchor.iX ) < ABS( sGridY - gSelectAnchor.iY ) )
 	{ //restrict the x axis
 		if( sGridX < gSelectAnchor.iX )
 		{ //to the left

--- a/Build/Editor/SelectWin.cc
+++ b/Build/Editor/SelectWin.cc
@@ -683,8 +683,8 @@ void RenderSelectionWindow( void )
 		GUIButtonRef const button = iSelectWin;
 		if (!button) return;
 
-		if (abs(iStartClickX - button->MouseX()) > 9 ||
-				abs(iStartClickY - (button->MouseY() + iTopWinCutOff - (INT16)g_sel_win_box.y)) > 9)
+		if (ABS(iStartClickX - button->MouseX()) > 9 ||
+				ABS(iStartClickY - (button->MouseY() + iTopWinCutOff - (INT16)g_sel_win_box.y)) > 9)
 		{
 //			iSX = (INT32)iStartClickX;
 //			iEX = (INT32)button->MouseX();

--- a/Build/Editor/Smoothing_Utils.cc
+++ b/Build/Editor/Smoothing_Utils.cc
@@ -33,7 +33,7 @@ UINT16 SearchForWallType( UINT32 iMapIndex )
 		// structure type one tile north, but not one tile south -- so it'll find the correct wall first.
 		for( y = sRadius; y >= -sRadius; y-- ) for( x = -sRadius; x <= sRadius; x++ )
 		{
-			if (abs(x) == sRadius || abs(y) == sRadius)
+			if (ABS(x) == sRadius || ABS(y) == sRadius)
 			{
 				sOffset = y * WORLD_COLS + x;
 				if( !GridNoOnVisibleWorldTile( (INT16)(iMapIndex + sOffset) ) )
@@ -74,7 +74,7 @@ UINT16 SearchForRoofType(UINT32 const map_idx)
 		{
 			for (INT16 x = -radius; x <= radius; ++x)
 			{
-				if (abs(x) != radius && abs(y) != radius) continue;
+				if (ABS(x) != radius && ABS(y) != radius) continue;
 
 				GridNo const grid_no = map_idx + y * WORLD_COLS + x;
 				if (!GridNoOnVisibleWorldTile(grid_no)) continue;

--- a/Build/Laptop/AIMMembers.cc
+++ b/Build/Laptop/AIMMembers.cc
@@ -894,8 +894,8 @@ static void DisplayMercsInventory(MERCPROFILESTRUCT const& p)
 		const ItemModel * item = GCM->getItem(usItem);
 		SGPVObject  const& item_vo  = GetInterfaceGraphicForItem(item);
 		ETRLEObject const& e        = item_vo.SubregionProperties(item->getGraphicNum());
-		INT16       const  sCenX    = x + abs(WEAPONBOX_SIZE_X - 3 - e.usWidth)  / 2 - e.sOffsetX;
-		INT16       const  sCenY    = y + abs(WEAPONBOX_SIZE_Y     - e.usHeight) / 2 - e.sOffsetY;
+		INT16       const  sCenX    = x + ABS(WEAPONBOX_SIZE_X - 3 - e.usWidth)  / 2 - e.sOffsetX;
+		INT16       const  sCenY    = y + ABS(WEAPONBOX_SIZE_Y     - e.usHeight) / 2 - e.sOffsetY;
 
     if(GCM->getGamePolicy()->f_draw_item_shadow)
     {

--- a/Build/Laptop/BobbyRGuns.cc
+++ b/Build/Laptop/BobbyRGuns.cc
@@ -710,7 +710,7 @@ static void DisplayBigItemImage(const ItemModel* item, const UINT16 PosY)
 	//center picture in frame
 	ETRLEObject const& pTrav   = uiImage->SubregionProperties(0);
 	UINT32      const  usWidth = pTrav.usWidth;
-	INT16       const  sCenX   = PosX + abs(int(BOBBYR_GRID_PIC_WIDTH - usWidth)) / 2 - pTrav.sOffsetX;
+	INT16       const  sCenX   = PosX + ABS(BOBBYR_GRID_PIC_WIDTH - usWidth) / 2 - pTrav.sOffsetX;
 	INT16       const  sCenY   = PosY + 8;
 
   if(GCM->getGamePolicy()->f_draw_item_shadow)

--- a/Build/Laptop/Personnel.cc
+++ b/Build/Laptop/Personnel.cc
@@ -1152,8 +1152,8 @@ static void DisplayCharInventory(SOLDIERTYPE const& s)
 
 		SGPVObject  const& gfx   = GetInterfaceGraphicForItem(item);
 		ETRLEObject const& pTrav = gfx.SubregionProperties(item->getGraphicNum());
-		INT16       const  cen_x = PosX + abs(57 - pTrav.usWidth)  / 2 - pTrav.sOffsetX;
-		INT16       const  cen_y = PosY + abs(22 - pTrav.usHeight) / 2 - pTrav.sOffsetY;
+		INT16       const  cen_x = PosX + ABS(57 - pTrav.usWidth)  / 2 - pTrav.sOffsetX;
+		INT16       const  cen_y = PosY + ABS(22 - pTrav.usHeight) / 2 - pTrav.sOffsetY;
 		BltVideoObjectOutline(FRAME_BUFFER, &gfx, item->getGraphicNum(), cen_x, cen_y, SGP_TRANSPARENT);
 
 		SetFontDestBuffer(FRAME_BUFFER);

--- a/Build/Strategic/MapScreen.cc
+++ b/Build/Strategic/MapScreen.cc
@@ -2828,7 +2828,7 @@ static void Teleport()
 	INT16 const sDeltaY = sMapY - s.sSectorY;
 	INT16       sPrevX;
 	INT16       sPrevY;
-	if (abs(sDeltaX) >= abs(sDeltaY))
+	if (ABS(sDeltaX) >= ABS(sDeltaY))
 	{
 		// use East or West
 		if (sDeltaX > 0)

--- a/Build/Strategic/Strategic_AI.cc
+++ b/Build/Strategic/Strategic_AI.cc
@@ -3603,7 +3603,7 @@ static UINT8 SectorDistance(UINT8 ubSectorID1, UINT8 ubSectorID2)
 	ubSectorY1 = (UINT8)SECTORY( ubSectorID1 );
 	ubSectorY2 = (UINT8)SECTORY( ubSectorID2 );
 
-	ubDist = (UINT8)( abs( ubSectorX1 - ubSectorX2 ) + abs( ubSectorY1 - ubSectorY2 ) );
+	ubDist = (UINT8)( ABS( ubSectorX1 - ubSectorX2 ) + ABS( ubSectorY1 - ubSectorY2 ) );
 
 	return ubDist;
 }

--- a/Build/Strategic/Strategic_Movement.cc
+++ b/Build/Strategic/Strategic_Movement.cc
@@ -341,12 +341,12 @@ BOOLEAN GroupBetweenSectorsAndSectorXYIsInDifferentDirection( GROUP *pGroup, UIN
 	if( newDX )
 	{
 		ubNumUnalignedAxes++;
-		newDX /= abs( newDX );
+		newDX /= ABS( newDX );
 	}
 	if( newDY )
 	{
 		ubNumUnalignedAxes++;
-		newDY /= abs( newDY );
+		newDY /= ABS( newDY );
 	}
 
 	// error checking

--- a/Build/Strategic/Strategic_Pathing.cc
+++ b/Build/Strategic/Strategic_Pathing.cc
@@ -125,8 +125,8 @@ static short         trailStratTreedxB = 0;
 (								\
 	(locY = pathQB[ndx].location/MAP_WIDTH),			\
 	(locX = pathQB[ndx].location%MAP_WIDTH),			\
-	(dy = abs(iDestY-locY)),					\
-	(dx = abs(iDestX-locX)),					\
+	(dy = ABS(iDestY-locY)),					\
+	(dx = ABS(iDestX-locX)),					\
 	ESTIMATE						\
 )
 
@@ -135,7 +135,7 @@ static short         trailStratTreedxB = 0;
 #define TOTALCOST(ndx) (pathQB[ndx].costSoFar + pathQB[ndx].costToGo)
 #define XLOC(a) (a%MAP_WIDTH)
 #define YLOC(a) (a/MAP_WIDTH)
-#define LEGDISTANCE(a,b) ( abs( XLOC(b)-XLOC(a) ) + abs( YLOC(b)-YLOC(a) ) )
+#define LEGDISTANCE(a,b) ( ABS( XLOC(b)-XLOC(a) ) + ABS( YLOC(b)-YLOC(a) ) )
 #define FARTHER(ndx,NDX) ( LEGDISTANCE(pathQB[ndx].location,sDestination) > LEGDISTANCE(pathQB[NDX].location,sDestination) )
 
 #define FLAT_STRATEGIC_TRAVEL_TIME		60

--- a/Build/Tactical/Arms_Dealer_Init.cc
+++ b/Build/Tactical/Arms_Dealer_Init.cc
@@ -2299,7 +2299,7 @@ UINT16 CalcValueOfItemToDealer(ArmsDealerID const ubArmsDealer, UINT16 const usI
 	if( !fDealerSelling )
 	{
 		// junk dealer won't buy expensive stuff at all, expensive dealer won't buy junk at all
-		if ( abs( (INT8) ubDealerPriceClass - (INT8) ubItemPriceClass ) == 2 )
+		if ( ABS( (INT8) ubDealerPriceClass - (INT8) ubItemPriceClass ) == 2 )
 		{
 			return( 0 );
 		}

--- a/Build/Tactical/Campaign.cc
+++ b/Build/Tactical/Campaign.cc
@@ -382,7 +382,7 @@ static void ProcessStatChange(MERCPROFILESTRUCT& p, StatKind const ubStat, UINT1
 	{
 		// increment counters that track how often stat changes are being awarded
 		p.usStatChangeChances[ubStat]   += usNumChances;
-		p.usStatChangeSuccesses[ubStat] += abs(sSubPointChange);
+		p.usStatChangeSuccesses[ubStat] += ABS(sSubPointChange);
 	}
 }
 
@@ -1439,7 +1439,7 @@ void AwardExperienceBonusToActiveSquad( UINT8 ubExpBonusType )
 void BuildStatChangeString(wchar_t* const wString, size_t const Length, wchar_t const* const wName, BOOLEAN const fIncrease, INT16 const sPtsChanged, StatKind const ubStat)
 {
 	UINT8 ubStringIndex;
-	UINT16 absPointsChanged = abs( (int)sPtsChanged );
+	UINT16 absPointsChanged = ABS( (int)sPtsChanged );
 
 
 	Assert( sPtsChanged != 0 );

--- a/Build/Tactical/Handle_UI.cc
+++ b/Build/Tactical/Handle_UI.cc
@@ -1874,7 +1874,7 @@ static ScreenID UIHandleMAdjustStanceMode(UI_EVENT* pUIEvent)
 	}
 
 	// Check if delta X has changed alot since last time
-	iPosDiff = abs( (INT32)( usOldMouseY - gusMouseYPos) );
+	iPosDiff = ABS( (INT32)( usOldMouseY - gusMouseYPos) );
 
 	//guiShowUPDownArrows = ARROWS_SHOW_DOWN_BESIDE | ARROWS_SHOW_UP_BESIDE;
 	guiShowUPDownArrows = uiOldShowUPDownArrows;

--- a/Build/Tactical/LOS.cc
+++ b/Build/Tactical/LOS.cc
@@ -3950,7 +3950,7 @@ void MoveBullet(BULLET* const pBullet)
 				// bullets hitting the ground
 				if (pBullet->qCurrZ + pBullet->qIncrZ * iStepsToTravel < qLandHeight)
 				{
-					iStepsToTravel = __min( iStepsToTravel, abs( (pBullet->qCurrZ - qLandHeight) / pBullet->qIncrZ ) );
+					iStepsToTravel = __min( iStepsToTravel, ABS( (pBullet->qCurrZ - qLandHeight) / pBullet->qIncrZ ) );
 					pBullet->qCurrX += pBullet->qIncrX * iStepsToTravel;
 					pBullet->qCurrY += pBullet->qIncrY * iStepsToTravel;
 					pBullet->qCurrZ += pBullet->qIncrZ * iStepsToTravel;

--- a/Build/Tactical/Merc_Hiring.cc
+++ b/Build/Tactical/Merc_Hiring.cc
@@ -478,8 +478,8 @@ static INT16 StrategicPythSpacesAway(INT16 sOrigin, INT16 sDest)
 {
 	INT16 sRows,sCols,sResult;
 
-	sRows = abs((sOrigin / MAP_WORLD_X) - (sDest / MAP_WORLD_X));
-	sCols = abs((sOrigin % MAP_WORLD_X) - (sDest % MAP_WORLD_X));
+	sRows = ABS((sOrigin / MAP_WORLD_X) - (sDest / MAP_WORLD_X));
+	sCols = ABS((sOrigin % MAP_WORLD_X) - (sDest % MAP_WORLD_X));
 
 
 	// apply Pythagoras's theorem for right-handed triangle:

--- a/Build/Tactical/PathAI.cc
+++ b/Build/Tactical/PathAI.cc
@@ -134,7 +134,7 @@ static INT32	iSkipListLevelLimit[8] = {0, 4, 16, 64, 256, 1024, 4192, 16384 };
 #define XLOC(a) (a%MAPWIDTH)
 #define YLOC(a) (a/MAPWIDTH)
 //#define LEGDISTANCE(a,b) ( abs( XLOC(b)-XLOC(a) ) + abs( YLOC(b)-YLOC(a) ) )
-#define LEGDISTANCE( x1, y1, x2, y2 ) ( abs( x2 - x1 ) + abs( y2 - y1 ) )
+#define LEGDISTANCE( x1, y1, x2, y2 ) ( ABS( x2 - x1 ) + ABS( y2 - y1 ) )
 //#define FARTHER(ndx,NDX) ( LEGDISTANCE( ndx->sLocation,sDestination) > LEGDISTANCE(NDX->sLocation,sDestination) )
 #define FARTHER(ndx,NDX) ( ndx->ubLegDistance > NDX->ubLegDistance )
 
@@ -342,8 +342,8 @@ static path_t * pClosedHead;
 
 #define REMAININGCOST(ptr)					\
 (								\
-	(dy = abs(iDestY-iLocY)),					\
-	(dx = abs(iDestX-iLocX)),					\
+	(dy = ABS(iDestY-iLocY)),					\
+	(dx = ABS(iDestX-iLocX)),					\
 	ESTIMATE						\
 )
 /*
@@ -351,8 +351,8 @@ static path_t * pClosedHead;
 (								\
 	(locY = (ptr)->iLocation/MAPWIDTH),			\
 	(locX = (ptr)->iLocation%MAPWIDTH),			\
-	(dy = abs(iDestY-locY)),					\
-	(dx = abs(iDestX-locX)),					\
+	(dy = ABS(iDestY-locY)),					\
+	(dx = ABS(iDestX-locX)),					\
 	ESTIMATE						\
 )
 */

--- a/Build/Tactical/Real_Time_Input.cc
+++ b/Build/Tactical/Real_Time_Input.cc
@@ -240,7 +240,7 @@ static void QueryRTLeftButton(UIEventKind* const puiNewEvent)
 								else
 								{
 									// Have we moved....?
-									if ( abs( gusMouseXPos - gusRubberBandX ) > 10 || abs( gusMouseYPos - gusRubberBandY ) > 10 )
+									if ( ABS( gusMouseXPos - gusRubberBandX ) > 10 || ABS( gusMouseYPos - gusRubberBandY ) > 10 )
 									{
 										gfStartLookingForRubberBanding = FALSE;
 

--- a/Build/Tactical/ShopKeeper_Interface.cc
+++ b/Build/Tactical/ShopKeeper_Interface.cc
@@ -2073,8 +2073,8 @@ static UINT32 DisplayInvSlot(UINT8 const slot_num, UINT16 const item_idx, UINT16
 		const ItemModel * item = GCM->getItem(item_idx);
 		SGPVObject  const& item_vo = GetInterfaceGraphicForItem(item);
 		ETRLEObject const& e       = item_vo.SubregionProperties(item->getGraphicNum());
-		INT16              cen_x   = x + 7 + abs(SKI_INV_WIDTH - 3 - e.usWidth)  / 2 - e.sOffsetX;
-		INT16              cen_y   = y +     abs(SKI_INV_HEIGHT    - e.usHeight) / 2 - e.sOffsetY;
+		INT16              cen_x   = x + 7 + ABS(SKI_INV_WIDTH - 3 - e.usWidth)  / 2 - e.sOffsetX;
+		INT16              cen_y   = y +     ABS(SKI_INV_HEIGHT    - e.usHeight) / 2 - e.sOffsetY;
     if(GCM->getGamePolicy()->f_draw_item_shadow)
     {
       BltVideoObjectOutlineShadow(FRAME_BUFFER, &item_vo, item->getGraphicNum(), cen_x - 2, cen_y + 2);

--- a/Build/Tactical/Soldier_Add.cc
+++ b/Build/Tactical/Soldier_Add.cc
@@ -674,8 +674,8 @@ UINT16 FindGridNoFromSweetSpotWithStructDataFromSoldier(const SOLDIERTYPE* const
 						else
 						{
 							//uiRange = GetRangeInCellCoordsFromGridNoDiff( sSweetGridNo, sGridNo );
-							uiRange = abs((sSweetGridNo / MAXCOL) - (sGridNo / MAXCOL)) +
-								abs((sSweetGridNo % MAXROW) - (sGridNo % MAXROW));
+							uiRange = ABS((sSweetGridNo / MAXCOL) - (sGridNo / MAXCOL)) +
+								ABS((sSweetGridNo % MAXROW) - (sGridNo % MAXROW));
 						}
 
 						if ( uiRange < uiLowestRange || (uiRange == uiLowestRange && PythSpacesAway( pSoldier->sGridNo, sGridNo ) < PythSpacesAway( pSoldier->sGridNo, sLowestGridNo ) ) )

--- a/Build/Tactical/Soldier_Ani.cc
+++ b/Build/Tactical/Soldier_Ani.cc
@@ -943,7 +943,7 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 					{
 						INT16 sDiff = pSoldier->sHeightAdjustment - pSoldier->sDesiredHeight;
 
-						if ( abs( sDiff ) > 4 )
+						if ( ABS( sDiff ) > 4 )
 						{
 							if ( sDiff > 0 )
 							{

--- a/Build/Tactical/Soldier_Create.cc
+++ b/Build/Tactical/Soldier_Create.cc
@@ -2111,8 +2111,8 @@ UINT8 GetPythDistanceFromPalace( INT16 sSectorX, INT16 sSectorY )
 	float fValue = 0.0;
 
 	// grab number of rows and cols
-	sRows = (INT16)(abs((sSectorX) - ( PALACE_SECTOR_X )));
-	sCols = (INT16)(abs((sSectorY) - ( PALACE_SECTOR_Y )));
+	sRows = (INT16)(ABS((sSectorX) - ( PALACE_SECTOR_X )));
+	sCols = (INT16)(ABS((sSectorY) - ( PALACE_SECTOR_Y )));
 
 
 	// apply Pythagoras's theorem for right-handed triangle:

--- a/Build/TacticalAI/AIUtils.cc
+++ b/Build/TacticalAI/AIUtils.cc
@@ -207,7 +207,7 @@ UINT8 ShootingStanceChange( SOLDIERTYPE * pSoldier, ATTACKTYPE * pAttack, INT8 b
 	}
 	for (bLoop = 0; bLoop < 3; bLoop++)
 	{
-		bStanceDiff = abs( bLoop - bStanceNum );
+		bStanceDiff = ABS( bLoop - bStanceNum );
 		if (bStanceDiff == 2 && bAPsAfterAttack < AP_CROUCH + AP_PRONE)
 		{
 			// can't consider this!

--- a/Build/TacticalAI/FindLocations.cc
+++ b/Build/TacticalAI/FindLocations.cc
@@ -1974,7 +1974,7 @@ INT16 FindClosestBoxingRingSpot( SOLDIERTYPE * pSoldier, BOOLEAN fInRing )
 			if ((fInRing  && room == BOXING_RING) ||
 					((!fInRing && room != BOXING_RING) && LegalNPCDestination(pSoldier, sGridNo, IGNORE_PATH, NOWATER, 0)))
 			{
-				iDistance = abs( sXOffset ) + abs( sYOffset );
+				iDistance = ABS( sXOffset ) + ABS( sYOffset );
 				if (iDistance < iClosestDistance && WhoIsThere2(sGridNo, 0) == NULL)
 				{
 					sClosestSpot = sGridNo;

--- a/Build/TacticalAI/Movement.cc
+++ b/Build/TacticalAI/Movement.cc
@@ -719,7 +719,7 @@ INT16 TrackScent( SOLDIERTYPE * pSoldier )
 			for (iXDiff = -RADIUS; iXDiff < (RADIUS + 1); iXDiff += iXIncr)
 			{
 				iGridNo = iStart + iXDiff + iYDiff * WORLD_ROWS;
-				if (abs( iGridNo % WORLD_ROWS - iXStart ) > RADIUS)
+				if (ABS( iGridNo % WORLD_ROWS - iXStart ) > RADIUS)
 				{
 					// wrapped across map!
 					continue;
@@ -737,7 +737,7 @@ INT16 TrackScent( SOLDIERTYPE * pSoldier )
 							ubBestStrength = ubStrength;
 							bDir = atan8( (INT16) iXStart, (INT16) iYStart, (INT16) (iXStart + iXDiff), (INT16) (iYStart + iYDiff) );
 							// now convert it into a difference in degree between it and our current dir
-							ubBestDirDiff = abs( pSoldier->bDirection - bDir );
+							ubBestDirDiff = ABS( pSoldier->bDirection - bDir );
 							if (ubBestDirDiff > 4 ) // dir 0 compared with dir 6, for instance
 							{
 								ubBestDirDiff = 8 - ubBestDirDiff;
@@ -757,7 +757,7 @@ INT16 TrackScent( SOLDIERTYPE * pSoldier )
 								// start by calculating direction to the new gridno
 								bDir = atan8( (INT16) iXStart, (INT16) iYStart, (INT16) (iXStart + iXDiff), (INT16) (iYStart + iYDiff) );
 								// now convert it into a difference in degree between it and our current dir
-								ubDirDiff = abs( pSoldier->bDirection - bDir );
+								ubDirDiff = ABS( pSoldier->bDirection - bDir );
 								if (ubDirDiff > 4 ) // dir 0 compared with dir 6, for instance
 								{
 									ubDirDiff = 8 - ubDirDiff;

--- a/Build/TileEngine/Isometric_Utils.cc
+++ b/Build/TileEngine/Isometric_Utils.cc
@@ -459,8 +459,8 @@ INT16 PythSpacesAway(INT16 sOrigin, INT16 sDest)
 {
 	INT16 sRows,sCols,sResult;
 
-	sRows = abs((sOrigin / MAXCOL) - (sDest / MAXCOL));
-	sCols = abs((sOrigin % MAXROW) - (sDest % MAXROW));
+	sRows = ABS((sOrigin / MAXCOL) - (sDest / MAXCOL));
+	sCols = ABS((sOrigin % MAXROW) - (sDest % MAXROW));
 
 
 	// apply Pythagoras's theorem for right-handed triangle:
@@ -475,8 +475,8 @@ INT16 SpacesAway(INT16 sOrigin, INT16 sDest)
 {
  INT16 sRows,sCols;
 
- sRows = abs((sOrigin / MAXCOL) - (sDest / MAXCOL));
- sCols = abs((sOrigin % MAXROW) - (sDest % MAXROW));
+ sRows = ABS((sOrigin / MAXCOL) - (sDest / MAXCOL));
+ sCols = ABS((sOrigin % MAXROW) - (sDest % MAXROW));
 
 	return( __max( sRows, sCols ) );
 }
@@ -486,8 +486,8 @@ INT16 CardinalSpacesAway(INT16 sOrigin, INT16 sDest)
 {
  INT16 sRows,sCols;
 
- sRows = abs((sOrigin / MAXCOL) - (sDest / MAXCOL));
- sCols = abs((sOrigin % MAXROW) - (sDest % MAXROW));
+ sRows = ABS((sOrigin / MAXCOL) - (sDest / MAXCOL));
+ sCols = ABS((sOrigin % MAXROW) - (sDest % MAXROW));
 
 	return( (INT16)( sRows + sCols ) );
 }
@@ -611,12 +611,12 @@ INT16 QuickestDirection(INT16 origin, INT16 dest)
  if (origin==dest)
      return(0);
 
- if ((abs(origin - dest)) == 4)
+ if ((ABS(origin - dest)) == 4)
      return(1);		// this could be made random
  else
   if (origin > dest)
    {
-    v1 = abs(origin - dest);
+    v1 = ABS(origin - dest);
     v2 = (8 - origin) + dest;
     if (v1 > v2)
        return(1);
@@ -625,7 +625,7 @@ INT16 QuickestDirection(INT16 origin, INT16 dest)
    }
   else
    {
-    v1 = abs(origin - dest);
+    v1 = ABS(origin - dest);
     v2 = (8 - dest) + origin;
     if (v1 > v2)
        return(-1);
@@ -642,12 +642,12 @@ INT16 ExtQuickestDirection(INT16 origin, INT16 dest)
  if (origin==dest)
      return(0);
 
- if ((abs(origin - dest)) == 16)
+ if ((ABS(origin - dest)) == 16)
      return(1);		// this could be made random
  else
   if (origin > dest)
    {
-    v1 = abs(origin - dest);
+    v1 = ABS(origin - dest);
     v2 = (32 - origin) + dest;
     if (v1 > v2)
        return(1);
@@ -656,7 +656,7 @@ INT16 ExtQuickestDirection(INT16 origin, INT16 dest)
    }
   else
    {
-    v1 = abs(origin - dest);
+    v1 = ABS(origin - dest);
     v2 = (32 - dest) + origin;
     if (v1 > v2)
        return(-1);

--- a/Build/TileEngine/Lighting.cc
+++ b/Build/TileEngine/Lighting.cc
@@ -537,9 +537,9 @@ static DOUBLE LinearDistanceDouble(INT16 iX1, INT16 iY1, INT16 iX2, INT16 iY2)
 {
 INT32 iDx, iDy;
 
-	iDx=abs(iX1-iX2);
+	iDx=ABS(iX1-iX2);
 	iDx*=iDx;
-	iDy=abs(iY1-iY2);
+	iDy=ABS(iY1-iY2);
 	iDy*=iDy;
 
 	return(sqrt((DOUBLE)(iDx+iDy)));

--- a/Build/TileEngine/Overhead_Map.cc
+++ b/Build/TileEngine/Overhead_Map.cc
@@ -916,13 +916,13 @@ void CalculateRestrictedMapCoords( INT8 bDirection, INT16 *psX1, INT16 *psY1, IN
 			*psX1 = 0;
 			*psX2 = sEndXS;
 			*psY1 = 0;
-			*psY2 = ( abs( NORMAL_MAP_SCREEN_TY - gsTLY ) / 5 );
+			*psY2 = ( ABS( NORMAL_MAP_SCREEN_TY - gsTLY ) / 5 );
 			break;
 
 		case WEST:
 
 			*psX1 = 0;
-			*psX2 = ( abs( -NORMAL_MAP_SCREEN_X - gsTLX ) / 5 );
+			*psX2 = ( ABS( -NORMAL_MAP_SCREEN_X - gsTLX ) / 5 );
 			*psY1 = 0;
 			*psY2 = sEndYS;
 			break;
@@ -931,13 +931,13 @@ void CalculateRestrictedMapCoords( INT8 bDirection, INT16 *psX1, INT16 *psY1, IN
 
 			*psX1 = 0;
 			*psX2 = sEndXS;
-			*psY1 = ( NORMAL_MAP_SCREEN_HEIGHT - abs( NORMAL_MAP_SCREEN_BY - gsBLY ) ) / 5;
+			*psY1 = ( NORMAL_MAP_SCREEN_HEIGHT - ABS( NORMAL_MAP_SCREEN_BY - gsBLY ) ) / 5;
 			*psY2 = sEndYS;
 			break;
 
 		case EAST:
 
-			*psX1 = ( NORMAL_MAP_SCREEN_WIDTH - abs( NORMAL_MAP_SCREEN_X - gsTRX ) ) / 5;
+			*psX1 = ( NORMAL_MAP_SCREEN_WIDTH - ABS( NORMAL_MAP_SCREEN_X - gsTRX ) ) / 5;
 			*psX2 = sEndXS;
 			*psY1 = 0;
 			*psY2 = sEndYS;

--- a/Build/TileEngine/RenderWorld.cc
+++ b/Build/TileEngine/RenderWorld.cc
@@ -4234,8 +4234,8 @@ static void CalcRenderParameters(INT16 sLeft, INT16 sTop, INT16 sRight, INT16 sB
 
 	// STEP 5 - Determine Deltas for center and find screen values
 	//Make sure these coordinates are multiples of scroll steps
-	const INT16 sOffsetX_W = abs(gsStartPointX_W) - abs(gsStartPointX_M * CELL_X_SIZE);
-	const INT16 sOffsetY_W = abs(gsStartPointY_W) - abs(gsStartPointY_M * CELL_Y_SIZE);
+	const INT16 sOffsetX_W = ABS(gsStartPointX_W) - ABS(gsStartPointX_M * CELL_X_SIZE);
+	const INT16 sOffsetY_W = ABS(gsStartPointY_W) - ABS(gsStartPointY_M * CELL_Y_SIZE);
 
 	INT16 sOffsetX_S;
 	INT16 sOffsetY_S;

--- a/Build/Utils/Sound_Control.cc
+++ b/Build/Utils/Sound_Control.cc
@@ -548,7 +548,7 @@ INT8 SoundDir( INT16 sGridNo )
 
 	sDif = sMiddleX - sScreenX;
 
-	if ( ( sAbsDif = abs( sDif ) ) > 64 )
+	if ( ( sAbsDif = ABS( sDif ) ) > 64 )
   {
 		// OK, NOT the middle.
 
@@ -600,8 +600,8 @@ INT8 SoundVolume( INT8 bInitialVolume, INT16 sGridNo )
 	sDifX = sMiddleX - sScreenX;
 	sDifY = sMiddleY - sScreenY;
 
-	sAbsDifX = abs( sDifX );
-	sAbsDifY = abs( sDifY );
+	sAbsDifX = ABS( sDifX );
+	sAbsDifY = ABS( sDifY );
 
 	if ( sAbsDifX  > 64 || sAbsDifY > 64 )
   {
@@ -781,7 +781,7 @@ static INT8 PositionSoundDir(INT16 sGridNo)
 
 	sDif = sMiddleX - sScreenX;
 
-	if ( ( sAbsDif = abs( sDif ) ) > 64 )
+	if ( ( sAbsDif = ABS( sDif ) ) > 64 )
   {
 		// OK, NOT the middle.
 

--- a/sgp/Types.h
+++ b/sgp/Types.h
@@ -24,6 +24,7 @@
 #define endof(a) ((a) + lengthof(a))
 
 
+#define ABS(a) (UINT16)abs(int(a))
 #define MAX(a, b) __max(a, b)
 #define MIN(a, b) __min(a, b)
 


### PR DESCRIPTION
Follow up of  #388 i replaced all `abs()` that were not explicitly `fabs()` with a macro that does a integer abs.

This seems to fix (at least) the AI deadlocks occuring during enemy turns.