### PR TITLE
Fix issues with text inputs

### DIFF
--- a/Build/Laptop/IMP_Begin_Screen.cc
+++ b/Build/Laptop/IMP_Begin_Screen.cc
@@ -139,10 +139,7 @@ void EnterIMPBeginScreen( void )
 	// render the screen on entry
   RenderIMPBeginScreen( );
 
-  if( !fFinishedCharGeneration )
-	{
-		fFirstIMPAttribTime = TRUE;
-	}
+	fFirstIMPAttribTime = TRUE;
 
 	// create mouse regions
 	CreateIMPBeginScreenMouseRegions( );
@@ -271,19 +268,9 @@ static void BtnIMPBeginScreenDoneCallback(GUI_BUTTON *btn, INT32 reason)
 
 	if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
-		if (fFinishedCharGeneration)
+		if (CheckCharacterInputForEgg())
 		{
-			// simply reviewing name and gender, exit to finish page
-			iCurrentImpPage = IMP_FINISH;
-			fButtonPendingFlag = TRUE;
-			return;
-		}
-		else
-		{
-			if (CheckCharacterInputForEgg())
-			{
-				fEggOnYouFace = TRUE;
-			}
+			fEggOnYouFace = TRUE;
 		}
 
 		// back to mainpage

--- a/Build/Laptop/IMP_Begin_Screen.cc
+++ b/Build/Laptop/IMP_Begin_Screen.cc
@@ -5,31 +5,21 @@
 #include "HImage.h"
 #include "IMP_Begin_Screen.h"
 #include "IMP_MainPage.h"
-#include "IMP_HomePage.h"
+#include "SGPStrings.h"
 #include "IMPVideoObjects.h"
-#include "Local.h"
 #include "Timer_Control.h"
 #include "Render_Dirty.h"
 #include "Cursors.h"
 #include "Laptop.h"
 #include "IMP_Finish.h"
 #include "Text_Input.h"
-#include "MessageBoxScreen.h"
 #include "Soldier_Profile_Type.h"
-#include "IMP_Portraits.h"
 #include "IMP_Attribute_Selection.h"
-#include "English.h"
 #include "Line.h"
-#include "Merc_Hiring.h"
-#include "Game_Clock.h"
 #include "Text.h"
-#include "LaptopSave.h"
-#include "Button_System.h"
 #include "Video.h"
 #include "VSurface.h"
-#include "ScreenIDs.h"
 #include "Font_Control.h"
-#include "UILayout.h"
 
 #if defined JA2BETAVERSION && defined _DEBUG
 #	include "Campaign_Types.h"
@@ -119,7 +109,7 @@ void InitImpBeginScreeenTextInputBoxes() {
 			NAMES_INPUT_HEIGHT,
 			MSYS_PRIORITY_HIGH + 2,
 			pFullName,
-			NAME_LENGTH,
+			NAME_LENGTH-1,
 			INPUTTYPE_FULL_TEXT
 	);
 
@@ -130,7 +120,7 @@ void InitImpBeginScreeenTextInputBoxes() {
 			NAMES_INPUT_HEIGHT,
 			MSYS_PRIORITY_HIGH + 2,
 			pNickName,
-			NICKNAME_LENGTH,
+			8,
 			INPUTTYPE_FULL_TEXT
 	);
 
@@ -208,15 +198,6 @@ void ExitIMPBeginScreen( void )
 	KillTextInputMode();
 
 	wcscpy( pFullName, pFullNameString );
-
-	// is nick name too long?..shorten
-	if( wcslen( pNickNameString ) > 8 )
-	{
-		// null out char 9
-		pNickNameString[ 8 ] = 0;
-	}
-
-
 	wcscpy( pNickName, pNickNameString );
 
 	// set gender
@@ -306,12 +287,14 @@ static void BtnIMPBeginScreenDoneCallback(GUI_BUTTON *btn, INT32 reason)
 		}
 
 		// back to mainpage
+		CopyTrimmedString(pFullNameString, NAME_LENGTH, GetStringFromField(0));
+		CopyTrimmedString(pNickNameString, NICKNAME_LENGTH, GetStringFromField(1));
 
 		// check to see if a name has been selected, if not, do not allow player to proceed with more char generation
-		if (pFullNameString[0] != L'\0' && pFullNameString[0] != L' ' && bGenderFlag != -1)
+		if (wcslen(pFullNameString) != 0 && bGenderFlag != -1)
 		{
 			// valid full name, check to see if nick name
-			if (pNickNameString[0] == '\0' || pNickNameString[0] == L' ')
+			if (wcslen(pNickNameString) == 0)
 			{
 				// no nick name
 				// copy first name to nick name

--- a/Build/Laptop/IMP_HomePage.cc
+++ b/Build/Laptop/IMP_HomePage.cc
@@ -40,8 +40,6 @@ static void BtnIMPAboutUsCallback(GUI_BUTTON *btn, INT32 reason);
 GUIButtonRef giIMPHomePageButton[1];
 static BUTTON_PICS* giIMPHomePageButtonImage[1];
 
-static void CreateIMPHomePageButtons(void);
-
 static void InitImpHomepageTextInputBoxes(void) {
 	InitTextInputMode();
 
@@ -65,94 +63,6 @@ static void InitImpHomepageTextInputBoxes(void) {
 	SetActiveField(0);
 }
 
-void EnterImpHomePage( void )
-{
-	 // load buttons
-   CreateIMPHomePageButtons( );
-
-   InitImpHomepageTextInputBoxes();
-
-	 // render screen once
-	 RenderImpHomePage( );
-}
-
-void RenderImpHomePage( void )
-{
-  // the background
-	RenderProfileBackGround( );
-
-	// the IMP symbol
-	RenderIMPSymbol( 107, 45 );
-
-  // the second button image
-	RenderButton2Image( 134, 314);
-
-	// render the indents
-
-	//activation indents
-	RenderActivationIndent( 257, 328 );
-
-	// the two font page indents
-	RenderFrontPageIndent( 3, 64 );
-  RenderFrontPageIndent( 396,64 );
-
-	RenderAllTextFields();
-}
-
-
-static void RemoveIMPHomePageButtons(void);
-
-
-void ExitImpHomePage( void )
-{
-
-	// remove buttons
-  RemoveIMPHomePageButtons( );
-
-	KillTextInputMode();
-}
-
-static void GetPlayerKeyBoardInputForIMPHomePage(void);
-
-void HandleImpHomePage( void )
-{
-	// handle keyboard input for this screen
-  GetPlayerKeyBoardInputForIMPHomePage( );
-
-	RenderAllTextFields();
-}
-
-static void ProcessPlayerInputActivationString(void);
-
-
-static void GetPlayerKeyBoardInputForIMPHomePage(void)
-{
-	InputAtom					InputEvent;
-	while (DequeueEvent(&InputEvent))
-  {
-		if(	!HandleTextInput( &InputEvent ) && (InputEvent.usEvent == KEY_DOWN || InputEvent.usEvent == KEY_REPEAT || InputEvent.usEvent == KEY_UP ) )
-		{
-		  switch( InputEvent.usParam )
-			{
-				case SDLK_RETURN:
-					if(InputEvent.usEvent == KEY_UP)
-					{
-						// return hit, check to see if current player activation string is a valid one
-						ProcessPlayerInputActivationString( );
-					}
-					break;
-
-				case SDLK_ESCAPE:
-					HandleLapTopESCKey();
-					break;
-
-				default:
-					break;
-			}
-		}
-	}
-}
-
 static void ProcessPlayerInputActivationString(void)
 {
 	wchar_t const* str = GetStringFromField(0);
@@ -173,6 +83,33 @@ static void ProcessPlayerInputActivationString(void)
 	SetActiveField(0);
 }
 
+static void GetPlayerKeyBoardInputForIMPHomePage(void)
+{
+	InputAtom					InputEvent;
+	while (DequeueEvent(&InputEvent))
+	{
+		if(	!HandleTextInput( &InputEvent ) && (InputEvent.usEvent == KEY_DOWN || InputEvent.usEvent == KEY_REPEAT || InputEvent.usEvent == KEY_UP ) )
+		{
+			switch( InputEvent.usParam )
+			{
+				case SDLK_RETURN:
+					if(InputEvent.usEvent == KEY_UP)
+					{
+						// return hit, check to see if current player activation string is a valid one
+						ProcessPlayerInputActivationString( );
+					}
+					break;
+
+				case SDLK_ESCAPE:
+					HandleLapTopESCKey();
+					break;
+
+				default:
+					break;
+			}
+		}
+	}
+}
 
 static void CreateIMPHomePageButtons(void)
 {
@@ -207,4 +144,55 @@ static void BtnIMPAboutUsCallback(GUI_BUTTON *btn, INT32 reason)
 		iCurrentImpPage = IMP_ABOUT_US;
 		fButtonPendingFlag = TRUE;
 	}
+}
+
+void EnterImpHomePage( void )
+{
+	// load buttons
+	CreateIMPHomePageButtons( );
+
+	InitImpHomepageTextInputBoxes();
+
+	// render screen once
+	RenderImpHomePage( );
+}
+
+void RenderImpHomePage( void )
+{
+	// the background
+	RenderProfileBackGround( );
+
+	// the IMP symbol
+	RenderIMPSymbol( 107, 45 );
+
+	// the second button image
+	RenderButton2Image( 134, 314);
+
+	// render the indents
+
+	//activation indents
+	RenderActivationIndent( 257, 328 );
+
+	// the two font page indents
+	RenderFrontPageIndent( 3, 64 );
+	RenderFrontPageIndent( 396,64 );
+
+	RenderAllTextFields();
+}
+
+void ExitImpHomePage( void )
+{
+
+	// remove buttons
+	RemoveIMPHomePageButtons( );
+
+	KillTextInputMode();
+}
+
+void HandleImpHomePage( void )
+{
+	// handle keyboard input for this screen
+	GetPlayerKeyBoardInputForIMPHomePage( );
+
+	RenderAllTextFields();
 }

--- a/Build/Laptop/IMP_HomePage.cc
+++ b/Build/Laptop/IMP_HomePage.cc
@@ -4,25 +4,14 @@
 #include "HImage.h"
 #include "IMP_HomePage.h"
 #include "IMPVideoObjects.h"
-#include "Local.h"
 #include "MessageBoxScreen.h"
 #include "Text.h"
 #include "VObject.h"
-#include "Render_Dirty.h"
 #include "Cursors.h"
 #include "Laptop.h"
-#include "Timer_Control.h"
 #include "Text_Input.h"
 #include "LaptopSave.h"
-#include "Line.h"
-#include "English.h"
-#include "Button_System.h"
-#include "Video.h"
-#include "VSurface.h"
-#include "ScreenIDs.h"
 #include "Font_Control.h"
-#include "UILayout.h"
-
 
 const UINT32 GlowColorsList[] = {
 	FROMRGB(0,   0, 0),
@@ -41,51 +30,51 @@ const UINT32 GlowColorsList[] = {
 static void BtnIMPAboutUsCallback(GUI_BUTTON *btn, INT32 reason);
 
 // position defines
-#define IMP_PLAYER_ACTIVATION_STRING_X LAPTOP_SCREEN_UL_X + 261
-#define IMP_PLAYER_ACTIVATION_STRING_Y LAPTOP_SCREEN_WEB_UL_Y + 336
-#define CURSOR_Y IMP_PLAYER_ACTIVATION_STRING_Y - 5
-
+#define IMP_PLAYER_ACTIVATION_STRING_X LAPTOP_SCREEN_UL_X + 259
+#define IMP_PLAYER_ACTIVATION_STRING_Y LAPTOP_SCREEN_WEB_UL_Y + 330
+#define IMP_PLAYER_ACTIVATION_STRING_WIDTH 99
+#define IMP_PLAYER_ACTIVATION_STRING_HEIGHT 23
+#define IMP_PLAYER_ACTIVATION_STRING_LENGTH 6
 
 // IMP homepage buttons
 GUIButtonRef giIMPHomePageButton[1];
 static BUTTON_PICS* giIMPHomePageButtonImage[1];
 
-// the player activation string
-wchar_t pPlayerActivationString[32];
-
-// position within player activation string
-INT32 iStringPos=0;
-UINT16 uiCursorPosition = IMP_PLAYER_ACTIVATION_STRING_X;
-
-
-// has a new char been added or deleted?
-BOOLEAN fNewCharInActivationString = FALSE;
-
-
 static void CreateIMPHomePageButtons(void);
 
+static void InitImpHomepageTextInputBoxes(void) {
+	InitTextInputMode();
+
+	SetTextInputFont(FONT14ARIAL);
+	Set16BPPTextFieldColor( Get16BPPColor(FROMRGB( 0, 0, 0) ) );
+	SetTextInputRegularColors( FONT_LTGREEN, FONT_BLACK );
+	SetTextInputHilitedColors( FONT_BLACK, FONT_LTGREEN, FONT_LTGREEN  );
+	SetCursorColor( Get16BPPColor(FROMRGB(0, 255, 0) ) );
+
+	AddTextInputField(
+			IMP_PLAYER_ACTIVATION_STRING_X,
+			IMP_PLAYER_ACTIVATION_STRING_Y,
+			IMP_PLAYER_ACTIVATION_STRING_WIDTH,
+			IMP_PLAYER_ACTIVATION_STRING_HEIGHT,
+			MSYS_PRIORITY_HIGH + 2,
+			L"",
+			IMP_PLAYER_ACTIVATION_STRING_LENGTH,
+			INPUTTYPE_FULL_TEXT
+	);
+
+	SetActiveField(0);
+}
 
 void EnterImpHomePage( void )
 {
-   // upon entry to Imp home page
-   memset(pPlayerActivationString, 0, sizeof(pPlayerActivationString));
-
-	 // reset string position
-	 iStringPos =0;
-
-	 // reset activation  cursor position
-   uiCursorPosition = IMP_PLAYER_ACTIVATION_STRING_X;
-
 	 // load buttons
    CreateIMPHomePageButtons( );
+
+   InitImpHomepageTextInputBoxes();
 
 	 // render screen once
 	 RenderImpHomePage( );
 }
-
-
-static void DisplayPlayerActivationString(void);
-
 
 void RenderImpHomePage( void )
 {
@@ -107,9 +96,7 @@ void RenderImpHomePage( void )
 	RenderFrontPageIndent( 3, 64 );
   RenderFrontPageIndent( 396,64 );
 
-
-	// render the  activation string
-	DisplayPlayerActivationString( );
+	RenderAllTextFields();
 }
 
 
@@ -121,107 +108,20 @@ void ExitImpHomePage( void )
 
 	// remove buttons
   RemoveIMPHomePageButtons( );
+
+	KillTextInputMode();
 }
 
-
-static void DisplayActivationStringCursor(void);
 static void GetPlayerKeyBoardInputForIMPHomePage(void);
-
 
 void HandleImpHomePage( void )
 {
-
 	// handle keyboard input for this screen
   GetPlayerKeyBoardInputForIMPHomePage( );
 
-	// has a new char been added to activation string
-  if( fNewCharInActivationString )
-	{
-		// display string
-    DisplayPlayerActivationString( );
-	}
-
-	// render the cursor
-	DisplayActivationStringCursor( );
+	RenderAllTextFields();
 }
 
-
-static void DisplayPlayerActivationString(void)
-{
-
-	// this function will grab the string that the player will enter for activation
-
-	// player gone too far, move back
-	if(iStringPos > 64)
-	{
-		iStringPos = 64;
-	}
-
-	// restore background
-	RenderActivationIndent( 257, 328 );
-
-	SetFontAttributes(FONT14ARIAL, 184);
-	MPrint(IMP_PLAYER_ACTIVATION_STRING_X, IMP_PLAYER_ACTIVATION_STRING_Y, pPlayerActivationString);
-
-	fNewCharInActivationString = FALSE;
-  fReDrawScreenFlag = TRUE;
-}
-
-
-static void DisplayActivationStringCursor(void)
-{
-	// this procdure will draw the activation string cursor on the screen at position cursorx cursory
-	static UINT32 uiBaseTime = 0;
-	UINT32 uiDeltaTime = 0;
-  static UINT32 iCurrentState = 0;
-  static BOOLEAN fIncrement = TRUE;
-
-	if(uiBaseTime == 0)
-	{
-		uiBaseTime = GetJA2Clock();
-	}
-
-	// get difference
-	uiDeltaTime = GetJA2Clock() - uiBaseTime;
-
-	// if difference is long enough, rotate colors
-	if(uiDeltaTime > MIN_GLOW_DELTA)
-  {
-		if( iCurrentState == 10)
-		{
-		  // start rotating downward
-			fIncrement = FALSE;
-		}
-		if( iCurrentState == 0)
-		{
-			// rotate colors upward
-			fIncrement = TRUE;
-		}
-		// if increment upward, increment iCurrentState
-    if(fIncrement)
-		{
-			iCurrentState++;
-		}
-		else
-		{
-			// else downwards
-			iCurrentState--;
-		}
-	  // reset basetime to current clock
-		uiBaseTime = GetJA2Clock( );
-	}
-
-	{ SGPVSurface::Lock l(FRAME_BUFFER);
-		SetClippingRegionAndImageWidth(l.Pitch(), 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
-		// draw line in current state
-		LineDraw(TRUE, uiCursorPosition, CURSOR_Y, uiCursorPosition, CURSOR_Y + CURSOR_HEIGHT, Get16BPPColor(GlowColorsList[iCurrentState]), l.Buffer<UINT16>());
-	}
-
-  InvalidateRegion((UINT16) uiCursorPosition , CURSOR_Y , (UINT16)uiCursorPosition + 1, CURSOR_Y + CURSOR_HEIGHT + 1);
-}
-
-
-static void HandleTextEvent(const InputAtom* Inp);
 static void ProcessPlayerInputActivationString(void);
 
 
@@ -239,116 +139,38 @@ static void GetPlayerKeyBoardInputForIMPHomePage(void)
 					{
 						// return hit, check to see if current player activation string is a valid one
 						ProcessPlayerInputActivationString( );
-
-					  fNewCharInActivationString = TRUE;
 					}
-				break;
+					break;
 
-				case SDLK_ESCAPE: HandleLapTopESCKey(); break;
+				case SDLK_ESCAPE:
+					HandleLapTopESCKey();
+					break;
 
 				default:
-					if(InputEvent.usEvent == KEY_DOWN || InputEvent.usEvent == KEY_REPEAT )
-					{
-						HandleTextEvent(&InputEvent);
-					}
-				break;
-			}
-		}
-	}
-}
-
-
-static void HandleTextEvent(const InputAtom* Inp)
-{
-   // this function checks to see if a letter or a backspace was pressed, if so, either put char to screen
-	 // or delete it
-
-  switch (Inp->usParam)
-	{
-		case SDLK_BACKSPACE:
-			if( iStringPos >= 0 )
-			{
-
-				if( iStringPos > 0 )
-				{
-					// decrement iStringPosition
-					iStringPos-=1;
-				}
-
-				// null out char
-        pPlayerActivationString[iStringPos ] = 0;
-
-				// move back cursor
-        uiCursorPosition = StringPixLength( pPlayerActivationString, FONT14ARIAL ) + IMP_PLAYER_ACTIVATION_STRING_X;
-
-
-
-				// string has been altered, redisplay
-        fNewCharInActivationString = TRUE;
-
-      }
-
-		break;
-
-	  default:
-		{
-			wchar_t Char = Inp->Char;
-			if ((Char >= 'A' && Char <= 'Z') ||
-					(Char >= 'a' && Char <= 'z') ||
-					(Char >= '0' && Char <= '9') ||
-					Char == '_' || Char == '.')
-			{
-				// if the current string position is at max or great, do nothing
-        if( iStringPos >= 6 )
-        {
 					break;
-				}
-				else
-				{
-					if(iStringPos < 0 )
-					{
-						iStringPos = 0;
-					}
-          // valid char, capture and convert to wchar_t
-					pPlayerActivationString[iStringPos] = Char;
-
-					// null out next char position
-					pPlayerActivationString[iStringPos + 1] = 0;
-
-					// move cursor position ahead
-          uiCursorPosition = StringPixLength( pPlayerActivationString, FONT14ARIAL ) + IMP_PLAYER_ACTIVATION_STRING_X;
-
-					// increment string position
-					iStringPos +=1;
-
-				  // string has been altered, redisplay
-          fNewCharInActivationString = TRUE;
-				}
 			}
-			break;
 		}
 	}
 }
-
 
 static void ProcessPlayerInputActivationString(void)
 {
-	wchar_t const* msg;
-	if (wcscmp(pPlayerActivationString, L"XEP624") != 0 &&
-			wcscmp(pPlayerActivationString, L"xep624") != 0)
-	{
-		msg = pImpPopUpStrings[0];
+	wchar_t const* str = GetStringFromField(0);
+	bool stringMatchesCode = wcscmp(str, L"XEP624") == 0 || wcscmp(str, L"xep624") == 0;
+
+	if (stringMatchesCode && !LaptopSaveInfo.fIMPCompletedFlag) {
+		iCurrentImpPage = IMP_MAIN_PAGE;
+		return;
 	}
-	else if (LaptopSaveInfo.fIMPCompletedFlag)
-	{
-		msg = pImpPopUpStrings[6];
-	}
-	else
-	{
-	  iCurrentImpPage = IMP_MAIN_PAGE;
-	  return;
-	}
-	DoLapTopMessageBox(MSG_BOX_IMP_STYLE, msg, LAPTOP_SCREEN, MSG_BOX_FLAG_OK, 0);
+
+	DoLapTopMessageBox(
+			MSG_BOX_IMP_STYLE,
+			stringMatchesCode ? pImpPopUpStrings[6] : pImpPopUpStrings[0],
+			LAPTOP_SCREEN,
+			MSG_BOX_FLAG_OK,
+			0
+	);
+	SetActiveField(0);
 }
 
 

--- a/Build/Laptop/IMP_HomePage.cc
+++ b/Build/Laptop/IMP_HomePage.cc
@@ -13,20 +13,6 @@
 #include "LaptopSave.h"
 #include "Font_Control.h"
 
-const UINT32 GlowColorsList[] = {
-	FROMRGB(0,   0, 0),
-	FROMRGB(0,  25, 0),
-	FROMRGB(0,  50, 0),
-	FROMRGB(0,  75, 0),
-	FROMRGB(0, 100, 0),
-	FROMRGB(0, 125, 0),
-	FROMRGB(0, 150, 0),
-	FROMRGB(0, 175, 0),
-	FROMRGB(0, 200, 0),
-	FROMRGB(0, 225, 0),
-	FROMRGB(0, 255, 0)
-};
-
 static void BtnIMPAboutUsCallback(GUI_BUTTON *btn, INT32 reason);
 
 // position defines

--- a/Build/Laptop/IMP_HomePage.h
+++ b/Build/Laptop/IMP_HomePage.h
@@ -1,16 +1,9 @@
 #ifndef __IMP_HOME_H
 #define __IMP_HOME_H
 
-
-
 void EnterImpHomePage( void );
 void RenderImpHomePage( void );
 void ExitImpHomePage( void );
 void HandleImpHomePage( void );
 
-// minimun glow time
-#define MIN_GLOW_DELTA 100
-#define CURSOR_HEIGHT GetFontHeight( FONT14ARIAL ) + 6
-
-extern const UINT32 GlowColorsList[11];
 #endif

--- a/Build/Utils/Text_Input.cc
+++ b/Build/Utils/Text_Input.cc
@@ -862,6 +862,10 @@ static void SetActiveFieldMouse(MOUSE_REGION const* const r)
 	TEXTINPUTNODE* const n = r->GetUserPtr<TEXTINPUTNODE>();
 	if (n == gpActive) return;
 	// Deselect the current text edit region if applicable, then set the new one.
+	if (gpActive && gpActive->InputCallback) {
+		gpActive->InputCallback(gpActive->ubID, FALSE);
+	}
+
 	RenderInactiveTextFieldNode(gpActive);
 	gpActive = n;
 }
@@ -992,7 +996,7 @@ static void RenderActiveTextField(void)
 	}
 
 	// Draw the blinking ibeam cursor during the on blink period.
-	if (gfEditingText && str && GetJA2Clock() % 1000 < 500)
+	if (gfEditingText && str && GetJA2Clock() % 1000 < TEXT_CURSOR_BLINK_INTERVAL)
 	{
 		INT32          x = n->region.RegionTopLeftX + 2;
 		wchar_t const* c = str;

--- a/Build/Utils/Text_Input.cc
+++ b/Build/Utils/Text_Input.cc
@@ -582,9 +582,18 @@ BOOLEAN HandleTextInput(InputAtom const* const a)
 	// Not in text input mode
 	if (!gfTextInputMode) return FALSE;
 	// Unless we are psycho typers, we only want to process these key events.
-	if (a->usEvent != KEY_DOWN && a->usEvent != KEY_REPEAT) return FALSE;
+	if (a->usEvent != TEXT_INPUT && a->usEvent != KEY_DOWN && a->usEvent != KEY_REPEAT) return FALSE;
 	// Currently in a user field, so return unless TAB is pressed.
 	if (!gfEditingText && a->usParam != SDLK_TAB) return FALSE;
+
+	if (a->usEvent == TEXT_INPUT) {
+		wchar_t const c = a->Char;
+		/* If the key has no character associated, bail out */
+		AssertMsg(c != L'\0', "TEXT_INPUT event sent null character");
+		DeleteHilitedText();
+		HandleRegularInput(c);
+		return TRUE;
+	}
 
 	switch (a->usKeyState)
 	{
@@ -662,7 +671,8 @@ BOOLEAN HandleTextInput(InputAtom const* const a)
 					}
 					break;
 
-				default: goto enter_character;
+				default:
+					return TRUE;
 			}
 			break;
 
@@ -690,14 +700,9 @@ BOOLEAN HandleTextInput(InputAtom const* const a)
 					gubCursorPos = 0;
 					return TRUE;
 
-				default: // Check for typing keys
-enter_character:
-					wchar_t const c = a->Char;
-					/* If the key has no character associated, bail out */
-					if (c == L'\0') return FALSE;
-					DeleteHilitedText();
-					HandleRegularInput(c);
+				default:
 					return TRUE;
+
 			}
 
 		case CTRL_DOWN:

--- a/Build/Utils/Text_Input.cc
+++ b/Build/Utils/Text_Input.cc
@@ -424,6 +424,10 @@ void SetActiveField(UINT8 const id)
 	if (n == gpActive) return;
 	if (!n->fEnabled)  return;
 
+	if (gpActive && gpActive->InputCallback) {
+		gpActive->InputCallback(gpActive->ubID, FALSE);
+	}
+
 	gpActive = n;
 	if (n->szString)
 	{

--- a/Build/Utils/Text_Input.h
+++ b/Build/Utils/Text_Input.h
@@ -3,6 +3,8 @@
 
 #include "Input.h"
 
+#define TEXT_CURSOR_BLINK_INTERVAL 500
+
 //AUTHOR:  Kris Morness
 //Intended for inclusion with SGP.
 

--- a/sgp/Input.cc
+++ b/sgp/Input.cc
@@ -356,7 +356,7 @@ void KeyUp(const SDL_Keysym* KeySym)
 
 void TextInput(const SDL_TextInputEvent* TextEv) {
 	UTF8String utf8String = UTF8String(TextEv->text);
-	QueueKeyEvent(KEY_DOWN, SDLK_UNKNOWN, KMOD_NONE, utf8String.getUTF16()[0]);
+	QueueKeyEvent(TEXT_INPUT, SDLK_UNKNOWN, KMOD_NONE, utf8String.getUTF16()[0]);
 }
 
 

--- a/sgp/Input.h
+++ b/sgp/Input.h
@@ -8,6 +8,7 @@
 #define KEY_DOWN									0x0001
 #define KEY_UP										0x0002
 #define KEY_REPEAT								0x0004
+#define TEXT_INPUT								0x0006
 #define LEFT_BUTTON_DOWN					0x0008
 #define LEFT_BUTTON_UP						0x0010
 #define LEFT_BUTTON_DBL_CLK				0x0020

--- a/sgp/SGPStrings.cc
+++ b/sgp/SGPStrings.cc
@@ -1,4 +1,5 @@
 #include "SGPStrings.h"
+#include "Debug.h"
 
 #if defined(__linux__) || defined(_WIN32)
 
@@ -147,6 +148,87 @@ int WINvswprintf(wchar_t* const s, size_t const n, const wchar_t* const fmt, va_
 	int const ret = _vsnwprintf(s, n, fmt, arg);
 	if (n != 0) s[n - 1] = L'\0'; // _vsnwprintf() does not guarantee NUL termination
 	return ret;
+}
+
+#endif
+
+void CopyTrimmedString(wchar_t* dst, const size_t maxLength, const wchar_t* src) {
+  size_t sourceLength = wcslen(src);
+  wchar_t const* start = src;
+  wchar_t const* end = src + sourceLength - 1;
+
+  while (start[0] == L' ' && start < src + sourceLength) {
+    start++;
+  }
+  while (end[0] == L' ' && end > start) {
+    end--;
+  }
+
+  wcsncpy(dst, start, end - start + 1);
+
+  size_t len = end - start + 1;
+
+  AssertMsg(len < maxLength, "Tried to copy a trimmed string but could not fit the terminating null character");
+
+  dst[len] = 0;
+}
+
+#ifdef WITH_UNITTESTS
+#include "gtest/gtest.h"
+
+TEST(CopyTrimmedString, no_trim)
+{
+  wchar_t dst[16];
+  wchar_t const input[] = L"Don't trim this";
+  wchar_t const expected[] = L"Don't trim this";
+
+  CopyTrimmedString(dst, 16, input);
+  EXPECT_EQ(wcslen(dst), wcslen(expected));
+  EXPECT_EQ(wcscmp(dst, expected), 0);
+}
+
+TEST(CopyTrimmedString, trim_left)
+{
+  wchar_t dst[16];
+  wchar_t const input[] = L"   Left Trim Täst";
+  wchar_t const expected[] = L"Left Trim Täst";
+
+  CopyTrimmedString(dst, 16, input);
+  EXPECT_EQ(wcslen(dst), wcslen(expected));
+  EXPECT_EQ(wcscmp(dst, expected), 0);
+}
+
+TEST(CopyTrimmedString, trim_right)
+{
+  wchar_t dst[16];
+  wchar_t const input[] = L"trimright!!!   ";
+  wchar_t const expected[] = L"trimright!!!";
+
+  CopyTrimmedString(dst, 16, input);
+  EXPECT_EQ(wcslen(dst), wcslen(expected));
+  EXPECT_EQ(wcscmp(dst, expected), 0);
+}
+
+TEST(CopyTrimmedString, trim_both)
+{
+  wchar_t dst[16];
+  wchar_t const input[] = L"   left and right ";
+  wchar_t const expected[] = L"left and right";
+
+  CopyTrimmedString(dst, 16, input);
+  EXPECT_EQ(wcslen(dst), wcslen(expected));
+  EXPECT_EQ(wcscmp(dst, expected), 0);
+}
+
+TEST(CopyTrimmedString, max_length)
+{
+  wchar_t dst[16];
+  wchar_t const input[] = L"   123456789012345 ";
+  wchar_t const expected[] = L"123456789012345";
+
+  CopyTrimmedString(dst, 16, input);
+  EXPECT_EQ(wcslen(dst), wcslen(expected));
+  EXPECT_EQ(wcscmp(dst, expected), 0);
 }
 
 #endif

--- a/sgp/SGPStrings.h
+++ b/sgp/SGPStrings.h
@@ -31,4 +31,6 @@ int WINvswprintf(wchar_t* s, size_t n, const wchar_t* fmt, va_list arg);
 
 #endif
 
+void CopyTrimmedString(wchar_t* dst, const size_t maxLen, const wchar_t* src);
+
 #endif


### PR DESCRIPTION
Closes #419 

This ended up in an almost complete rewrite of the `IMP_HomePage` and `IMP_Begin_Screen` Screens. Basically they had own custom code to handle input fields and keyboard input. I replaced it with inputs from `Text_Input`. Additionally I had to fix that keydown events were not marked as handled anymore, so e.g. pressing one inside an input on the save screen afterwards selected the first save slot. Implications from all of this:
- If a text input is focused, almost all key events are ignored by the respective screens (except for some "chosen" ones)
- The cursors now blink differently on the two mentioned screens than before
- Checkboxes on `Imp_Begin_Screen` now dont get focus anymore when they are hovered over
- Removed ifs that mentioned visiting the `IMP_Begin_Screen` after character creation was finished because I couldn't get to it after doing the questionnaire anymore

I also had a fun idea: Should we add contributors as easter eggs using their github names? We could even create portraits n stuff 😄 
