### PR TITLE
Use current version of gcc on OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,7 +264,7 @@ add_vagrant_build_target(
         "check-compilation-on-openbsd59"
         "openbsd-5.9"
         "all"
-        ""
+        "-DCMAKE_C_COMPILER=egcc -DCMAKE_CXX_COMPILER=eg++"
 )
 
 

--- a/_build/buildboxes/openbsd-5.9/bootstrap.sh
+++ b/_build/buildboxes/openbsd-5.9/bootstrap.sh
@@ -3,4 +3,4 @@
 # installing missing xbase55
 test -f /usr/X11R6/README || (cd /tmp && curl -O http://ftp.openbsd.org/pub/OpenBSD/5.9/amd64/xbase59.tgz && tar -C / -xzphf xbase59.tgz)
 
-pkg_add -v gmake cmake sdl2 boost
+pkg_add -v gmake cmake sdl2 boost g++ gcc


### PR DESCRIPTION
Was using "system" gcc 4.2.1 which does not understand BOMs.