### PR TITLE
Blit main menu backgrounds to frame buffer

### DIFF
--- a/Build/MainMenuScreen.cc
+++ b/Build/MainMenuScreen.cc
@@ -359,10 +359,9 @@ static void CreateDestroyMainMenuButtons(BOOLEAN fCreate)
 
 static void RenderMainMenu(void)
 {
-	BltVideoObject(guiSAVEBUFFER, guiMainMenuBackGroundImage, 0, STD_SCREEN_X,       STD_SCREEN_Y     );
-	BltVideoObject(guiSAVEBUFFER, guiJa2LogoImage,            0, STD_SCREEN_X + 188, STD_SCREEN_Y + 15);
-
-	RestoreExternBackgroundRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
+	BltVideoObject(FRAME_BUFFER, guiMainMenuBackGroundImage, 0, STD_SCREEN_X,       STD_SCREEN_Y     );
+	BltVideoObject(FRAME_BUFFER, guiJa2LogoImage,            0, STD_SCREEN_X + 188, STD_SCREEN_Y + 15);
+	BltVideoSurface(guiSAVEBUFFER, FRAME_BUFFER, 0, 0, NULL);
 }
 
 void RenderGameVersion() {


### PR DESCRIPTION
- Save buffer is restored by the button system, so first we need to blit to frame_buffer (because it is cleared) and then to the save buffer (to be able to restore). Otherwise we would restore from a non-cleared save buffer
- Fixes #72, #106 

Builds 🙂 : http://builds-ja2.stefanlau.com/pull-requests/446/
