### PR TITLE
Fix PR building for non-organization PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - make
   - ./ja2 -unittests
   - if [ "$PUBLISH_BINARY" == "true" ]; then make package; fi
-  - if [ "$PUBLISH_BINARY" == "true" ]; then curl --ftp-create-dirs -T $(echo ja2-stracciatella_*) --ftp-ssl -u $SFTP_USER:$SFTP_PASSWORD ftp://www61.your-server.de/$PUBLISH_DIR/; fi
+  - if [ "$PUBLISH_BINARY" == "true" ] && [ "$SFTP_PASSWORD" != "" ]; then curl --ftp-create-dirs -T $(echo ja2-stracciatella_*) --ftp-ssl -u $SFTP_USER:$SFTP_PASSWORD ftp://www61.your-server.de/$PUBLISH_DIR/; fi
 
 addons:
   coverity_scan:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ test_script:
 after_test:
   - ps: if ("$env:PUBLISH_BINARY" -eq "true") { iex "cmake --build c:\projects\ja2-stracciatella\ci-build --target package" }
   - ps: >
-          if ("$env:PUBLISH_BINARY" -eq "true") {
+          if ("$env:PUBLISH_BINARY" -eq "true" -and (Test-Path Env:\SFTP_PASSWORD)) {
             $binary_path = Get-ChildItem c:\projects\ja2-stracciatella\ci-build\ja2-stracciatella_*.zip;
             iex "curl.exe --ftp-create-dirs -T ${binary_path} --ftp-ssl -u ${env:SFTP_USER}:${env:SFTP_PASSWORD} ftp://www61.your-server.de/${env:PUBLISH_DIR}/"
           }


### PR DESCRIPTION
Solution: Dont try to upload package when no sftp password is set.
Rationale: This is a security issue since a user could create a PR which basically reads sftp credentials and sends them somewhere. This is why secure variables are not set in CI non-orga PR builds.

