### PR TITLE
Check for time accelleration properly when checking for end of turn

### DIFF
--- a/Build/Strategic/Strategic_Turns.cc
+++ b/Build/Strategic/Strategic_Turns.cc
@@ -69,7 +69,7 @@ void HandleStrategicTurn(void)
 		}
 		else
 		{
-			if ( giTimeCompressMode == TIME_COMPRESS_X1 || giTimeCompressMode == TIME_COMPRESS_X0 )
+			if ( !IsTimeBeingCompressed() )
 			{
 				uiCheckTime = NUM_REAL_SEC_PER_TACTICAL_TURN;
 			}

--- a/Build/Tactical/Overhead.cc
+++ b/Build/Tactical/Overhead.cc
@@ -5778,6 +5778,7 @@ static SOLDIERTYPE* InternalReduceAttackBusyCount(SOLDIERTYPE* const pSoldier, c
 SOLDIERTYPE* ReduceAttackBusyCount(SOLDIERTYPE* const attacker, const BOOLEAN fCalledByAttacker)
 {
 	SOLDIERTYPE* const target = (attacker == NULL ? NULL : attacker->target);
+	SLOGD(DEBUG_TAG_OVERHEAD, "Reducing Attack Busy Count of %d", attacker != NULL ? attacker->ubID : -1);
 	return InternalReduceAttackBusyCount(attacker, fCalledByAttacker, target);
 }
 

--- a/Build/TileEngine/Physics.cc
+++ b/Build/TileEngine/Physics.cc
@@ -415,7 +415,6 @@ static BOOLEAN PhysicsUpdateLife(REAL_OBJECT* pObject, float DeltaTime)
 				PlayLocationJA2Sample(pObject->sGridNo, THROW_IMPACT_2, MIDVOLUME, 1);
 			}
 
-			SLOGD(DEBUG_TAG_PHYSICS, "Reducing Attack Busy Count of %d", pObject->owner->ubID);
 			ReduceAttackBusyCount(pObject->owner, FALSE);
 
 			// ATE: Handle end of animation...

--- a/Build/TileEngine/Tile_Animation.cc
+++ b/Build/TileEngine/Tile_Animation.cc
@@ -225,9 +225,8 @@ void DeleteAniTile(ANITILE* const a)
 			}
 
 			// Freeup attacker from explosion
-			SLOGD(DEBUG_TAG_TILES, "Reducing Attack Busy Count of %d", owner->ubID); 
 			ReduceAttackBusyCount(owner, FALSE);
-		}
+    }
 
 
 		if (a->uiFlags & ANITILE_RELEASE_ATTACKER_WHEN_DONE)


### PR DESCRIPTION
Instread of checking for time compression modes manually, we can check if time is being compressed...

Fixes #160 

Also fixes an error with the debug message when there is no owner of the explosion (found when loading the attached savegame)