### PR TITLE
Return NULL from GetSelectedInfo char when no merc is attached to slot

### DIFF
--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -7576,7 +7576,7 @@ SOLDIERTYPE* GetSelectedInfoChar(void)
 	if (bSelectedInfoChar == -1) return NULL;
 	Assert(0 <= bSelectedInfoChar && bSelectedInfoChar < MAX_CHARACTER_COUNT);
 	SOLDIERTYPE* const s = gCharactersList[bSelectedInfoChar].merc;
-	Assert(s != NULL);
+	if (s == NULL) return NULL;
 	Assert(s->bActive);
 	return s;
 }


### PR DESCRIPTION
When merc is leaving the `.merc` member might not be present anymore for the currently selected slot. So we should handle it as if there is no merc currently selected, not throw.

Fixes #462.