### PR TITLE
Build fails if WITH_UNITTESTS is off

### DIFF
--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -314,8 +314,12 @@ int main(int argc, char* argv[])
   }
 
   if (should_run_unittests(params)) {
+#ifdef WITH_UNITTESTS
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
+#else
+    SLOGW(DEBUG_TAG_SGP, "This executable does not include unit tests.");
+#endif
   }
 
   GameVersion version = get_resource_version(params);;


### PR DESCRIPTION
main() contains two calls to functions that are not present when you try to build without unit tests. Additionally it would be possible to completely remove the -unittests command line option in such builds but IMO options that are sometimes present, sometimes not kind of suck.