### PR TITLE
Fix #500: update required cmake version

### DIFF
--- a/rust/CMakeLists.txt
+++ b/rust/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 
 find_package(Cargo 0.9.0 REQUIRED)
 find_package(Rustc 1.8.0 REQUIRED)


### PR DESCRIPTION
`cmake -E env` has only been introduced in CMake 3.1.

This will provide clear error message in case user's CMake is outdated.

Compare https://cmake.org/cmake/help/v3.1/manual/cmake.1.html
and https://cmake.org/cmake/help/v3.0/manual/cmake.1.html