### PR TITLE
[RFC] Shrink gfKeyState

### DIFF
--- a/src/game/Tactical/Merc_Entering.cc
+++ b/src/game/Tactical/Merc_Entering.cc
@@ -452,7 +452,7 @@ void HandleHeliDrop( )
 			guiPendingOverrideEvent = LU_BEGINUILOCK;
 		}
 
-		if (_KeyDown(SDLK_ESCAPE))
+		if (_KeyDown(SDL_SCANCODE_ESCAPE))
 		{
 			// Loop through all mercs not yet placed
 			for ( cnt = gbCurDrop; cnt < gbNumHeliSeatsOccupied; cnt++ )

--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -4920,7 +4920,7 @@ void SetSoldierAniSpeed(SOLDIERTYPE* pSoldier)
 
 	AdjustAniSpeed( pSoldier );
 
-	if (_KeyDown(SDLK_SPACE))
+	if (_KeyDown(SDL_SCANCODE_SPACE))
 	{
 		//pSoldier->sAniDelay = 1000;
 	}

--- a/src/game/Tactical/Turn_Based_Input.cc
+++ b/src/game/Tactical/Turn_Based_Input.cc
@@ -1191,28 +1191,28 @@ void GetPolledKeyboardInput(UIEventKind* puiNewEvent)
 
 	}
 
-	if (_KeyDown(SDLK_DELETE))
+	if (_KeyDown(SDL_SCANCODE_DELETE))
 	{
 		DisplayCoverOfSelectedGridNo( );
 
 		fDeleteDown = TRUE;
 	}
 
-	if (!_KeyDown(SDLK_DELETE) && fDeleteDown)
+	if (!_KeyDown(SDL_SCANCODE_DELETE) && fDeleteDown)
 	{
 		RemoveCoverOfSelectedGridNo();
 
 		fDeleteDown = FALSE;
 	}
 
-	if (_KeyDown(SDLK_END))
+	if (_KeyDown(SDL_SCANCODE_END))
 	{
 		DisplayGridNoVisibleToSoldierGrid( );
 
 		fEndDown = TRUE;
 	}
 
-	if (!_KeyDown(SDLK_END) && fEndDown)
+	if (!_KeyDown(SDL_SCANCODE_END) && fEndDown)
 	{
 		RemoveVisibleGridNoAtSelectedGridNo();
 
@@ -1289,11 +1289,11 @@ static void HandleModNone(UINT32 const key, UIEventKind* const new_event)
 
 		case '-':
 			// If the display cover or line of sight is being displayed
-			if (_KeyDown(SDLK_END) || _KeyDown(SDLK_DELETE))
+			if (_KeyDown(SDL_SCANCODE_END) || _KeyDown(SDL_SCANCODE_DELETE))
 			{
-				if (_KeyDown(SDLK_DELETE))
+				if (_KeyDown(SDL_SCANCODE_DELETE))
 					ChangeSizeOfDisplayCover(gGameSettings.ubSizeOfDisplayCover - 1);
-				if (_KeyDown(SDLK_END))
+				if (_KeyDown(SDL_SCANCODE_END))
 					ChangeSizeOfLOS(gGameSettings.ubSizeOfLOS - 1);
 			}
 			break;
@@ -1320,11 +1320,11 @@ static void HandleModNone(UINT32 const key, UIEventKind* const new_event)
 
 		case '=':
 			//if the display cover or line of sight is being displayed
-			if (_KeyDown(SDLK_END) || _KeyDown(SDLK_DELETE))
+			if (_KeyDown(SDL_SCANCODE_END) || _KeyDown(SDL_SCANCODE_DELETE))
 			{
-				if (_KeyDown(SDLK_DELETE))
+				if (_KeyDown(SDL_SCANCODE_DELETE))
 					ChangeSizeOfDisplayCover(gGameSettings.ubSizeOfDisplayCover + 1);
-				if (_KeyDown(SDLK_END))
+				if (_KeyDown(SDL_SCANCODE_END))
 					ChangeSizeOfLOS(gGameSettings.ubSizeOfLOS + 1);
 			}
 			else if (!(gTacticalStatus.uiFlags & INCOMBAT))
@@ -2855,7 +2855,7 @@ static void CreatePlayerControlledMonster(void)
 	MercCreateStruct.sSectorY         = gWorldSectorY;
 	MercCreateStruct.bSectorZ         = gbWorldSectorZ;
 	//Note:  only gets called if Alt and/or Ctrl isn't pressed!
-	MercCreateStruct.bBodyType        = (_KeyDown(SDLK_INSERT) ? QUEENMONSTER : ADULTFEMALEMONSTER);
+	MercCreateStruct.bBodyType        = (_KeyDown(SDL_SCANCODE_INSERT) ? QUEENMONSTER : ADULTFEMALEMONSTER);
 	MercCreateStruct.bTeam            = CREATURE_TEAM;
 	MercCreateStruct.sInsertionGridNo = usMapPos;
 	RandomizeNewSoldierStats(&MercCreateStruct);

--- a/src/game/TileEngine/RenderWorld.cc
+++ b/src/game/TileEngine/RenderWorld.cc
@@ -2100,10 +2100,10 @@ void ScrollWorld(void)
 		if (!fIgnoreInput)
 		{
 			// Check keys
-			if (_KeyDown(SDLK_UP))    ScrollFlags |= SCROLL_UP;
-			if (_KeyDown(SDLK_DOWN))  ScrollFlags |= SCROLL_DOWN;
-			if (_KeyDown(SDLK_RIGHT)) ScrollFlags |= SCROLL_RIGHT;
-			if (_KeyDown(SDLK_LEFT))  ScrollFlags |= SCROLL_LEFT;
+			if (_KeyDown(SDL_SCANCODE_UP))    ScrollFlags |= SCROLL_UP;
+			if (_KeyDown(SDL_SCANCODE_DOWN))  ScrollFlags |= SCROLL_DOWN;
+			if (_KeyDown(SDL_SCANCODE_RIGHT)) ScrollFlags |= SCROLL_RIGHT;
+			if (_KeyDown(SDL_SCANCODE_LEFT))  ScrollFlags |= SCROLL_LEFT;
 
 			// Do mouse - PUT INTO A TIMER!
 			// Put a counter on starting from mouse, if we have not started already!

--- a/src/sgp/English.h
+++ b/src/sgp/English.h
@@ -1,8 +1,11 @@
 #ifndef __ENGLISH_
 #define __ENGLISH_
 
-#define SHIFT               16
-#define CTRL                17
-#define ALT                 18
+#define SHIFT               ((SDL_Scancode) 503)
+#define CTRL                ((SDL_Scancode) 504)
+#define ALT                 ((SDL_Scancode) 505)
+#define SCANCODE_PLUS       ((SDL_Scancode) 500)
+#define SCANCODE_ASTERISK   ((SDL_Scancode) 501)
+#define SCANCODE_UNDERSCORE ((SDL_Scancode) 502)
 
 #endif

--- a/src/sgp/Input.h
+++ b/src/sgp/Input.h
@@ -69,7 +69,7 @@ void SimulateMouseMovement( UINT32 uiNewXPos, UINT32 uiNewYPos );
 void DequeueAllKeyBoardEvents(void);
 
 
-extern BOOLEAN gfKeyState[SDL_SCANCODE_TO_KEYCODE(SDL_NUM_SCANCODES)]; // TRUE = Pressed, FALSE = Not Pressed
+extern BOOLEAN gfKeyState[SDL_NUM_SCANCODES]; // TRUE = Pressed, FALSE = Not Pressed
 
 extern UINT16    gusMouseXPos;       // X position of the mouse on screen
 extern UINT16    gusMouseYPos;       // y position of the mouse on screen
@@ -77,7 +77,7 @@ extern BOOLEAN   gfLeftButtonState;  // TRUE = Pressed, FALSE = Not Pressed
 extern BOOLEAN   gfRightButtonState; // TRUE = Pressed, FALSE = Not Pressed
 extern BOOLEAN   gfMiddleButtonState;
 
-#define _KeyDown(a)        gfKeyState[(a)]
+#define _KeyDown(a)        gfKeyState[(a)] //The argument has to be a SDL_Scancode
 #define _LeftButtonDown    gfLeftButtonState
 #define _RightButtonDown   gfRightButtonState
 #define _MiddleButtonDown   gfMiddleButtonState


### PR DESCRIPTION
By using SDL_Scancode values instead of SDL_Keycode values to access elements of gfKeyState. Everything else does still use SDL_Keycodes.

Memory usage in main menu:
```
master:             RSS 63 MB, VIRT 1395 MB
shrink_gfKeyState2: RES 58 MB, VIRT  371 MB
```

This has the disadvantage that all _KeyDown() checks have to use SDL_Scancodes, which means that they check the physical position of the key instead of the localized value. On the plus all _KeyDown()s seem to be used for keys that are the same for all (most?) layouts.

**NOTE: I'm not sure if it works on all systems and I haven't even tested very thoroughly on ArchLinux.**