### PR TITLE
catch InvalidEncodingException& in TextInput(...)

### DIFF
--- a/src/sgp/Input.cc
+++ b/src/sgp/Input.cc
@@ -355,8 +355,20 @@ void KeyUp(const SDL_Keysym* KeySym)
 }
 
 void TextInput(const SDL_TextInputEvent* TextEv) {
-	UTF8String utf8String = UTF8String(TextEv->text);
-	QueueKeyEvent(TEXT_INPUT, SDLK_UNKNOWN, KMOD_NONE, utf8String.getUTF16()[0]);
+	try {
+		UTF8String utf8String = UTF8String(TextEv->text);
+		QueueKeyEvent(TEXT_INPUT, SDLK_UNKNOWN, KMOD_NONE, utf8String.getUTF16()[0]);
+	}
+	catch (const InvalidEncodingException&)
+	{
+		// ignore invalid inputs
+		static bool warn = true;
+		if (warn)
+		{
+			SLOGW(DEBUG_TAG_SGP, "Received invalid utf-8 character.");
+			warn = false;
+		}
+	}
 }
 
 


### PR DESCRIPTION
This fixes the crash described in #497.

Although it does not fix the underlying issue, I think it is a good idea to add the `try{} catch{}` because it is very easy to hit a wrong key and lose all game progress.