### PR TITLE
"Fix" exception when attaching ceramic plates to armour

### DIFF
--- a/src/game/Tactical/Items.cc
+++ b/src/game/Tactical/Items.cc
@@ -2002,7 +2002,7 @@ bool AttachObject(SOLDIERTYPE* const s, OBJECTTYPE* const pTargetObj, OBJECTTYPE
 				const ItemModel * tgt_item = GCM->getItem(target.usItem);
 				SoundID const  sound    =
 					tgt_item->isWeapon() ? ATTACH_TO_GUN         :
-					tgt_item->isArmour() ? ATTACH_CERAMIC_PLATES :
+					tgt_item->isArmour() ? NO_SOUND              : // TODO: Fix underlying exception cause
 					tgt_item->isBomb()   ? ATTACH_DETONATOR      :
 					NO_SOUND;
 				if (sound != NO_SOUND) PlayLocationJA2Sample(s->sGridNo, sound, MIDVOLUME, 1);


### PR DESCRIPTION
Current master crashes with the following exception:
```
libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: Opening file 'sounds/ceramic armour insert.wav' failed
```

Guessing it's a missing or misnamed sound file, but as I'm unfamiliar with the codebase it's easier to noop for now, unless someone can point me in the right direction?

Fixes #516 