### PR TITLE
Add try{} catch{} to SoundLoadDisk

### DIFF
--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -14,6 +14,7 @@
 #include "Timer.h"
 #include <SDL.h>
 #include <assert.h>
+#include <stdexcept>
 
 #include "ContentManager.h"
 #include "GameInstance.h"
@@ -548,7 +549,17 @@ static SAMPLETAG* SoundLoadDisk(const char* pFilename)
 {
 	Assert(pFilename != NULL);
 
-	AutoSGPFile hFile(GCM->openGameResForReading(pFilename));
+	AutoSGPFile hFile;
+
+	try
+	{
+		hFile = GCM->openGameResForReading(pFilename);
+	}
+	catch (const std::runtime_error& err)
+	{
+		SLOGE(DEBUG_TAG_SOUND, "SoundLoadDisk: %s", err.what());
+		return NULL;
+	}
 
   // A pessimistic approach as we dont know the decoded size yet
 	UINT32 uiSize = FileGetSize(hFile) * 2;


### PR DESCRIPTION
to prevent crash when a sound is not found.

