### PR TITLE
Shrink gfKeyState (alternative)

### DIFF
--- a/src/sgp/Input.cc
+++ b/src/sgp/Input.cc
@@ -1,3 +1,4 @@
+#include <bitset>
 #include "UTF8String.h"
 #include "Types.h"
 #include "Input.h"
@@ -10,9 +11,8 @@
 
 
 // The gfKeyState table is used to track which of the keys is up or down at any one time. This is used while polling
-// the interface.
-
-BOOLEAN gfKeyState[SDL_SCANCODE_TO_KEYCODE(SDL_NUM_SCANCODES)]; // TRUE = Pressed, FALSE = Not Pressed
+// the interface.  true = pressed, false = not pressed.
+static std::bitset<2 * SDL_NUM_SCANCODES> gfKeyState;
 static BOOLEAN fCursorWasClipped = FALSE;
 static SGPRect gCursorClipRect;
 
@@ -223,6 +223,21 @@ void MouseWheelScroll(const SDL_MouseWheelEvent* WheelEv)
 }
 
 
+// Remap SDL keycodes with bit 30 set to the range 512..1023
+// Necessary to be able to use the keycode as an index for the gfKeyState bitset.
+static SDL_Keycode RemapKeycode(SDL_Keycode const key)
+{
+  return (key & SDLK_SCANCODE_MASK)
+    ? (key & ~SDLK_SCANCODE_MASK) + SDL_NUM_SCANCODES
+    : key;
+}
+
+
+bool _KeyDown(SDL_Keycode const keycode)
+{
+  return gfKeyState[RemapKeycode(keycode)];
+}
+
 
 static void KeyChange(SDL_Keysym const* const key_sym, bool const pressed)
 {
@@ -257,12 +272,12 @@ static void KeyChange(SDL_Keysym const* const key_sym, bool const pressed)
 		case SDLK_KP_ENTER:    key = SDLK_RETURN;                       break;
 
 		default:
-			if (key >= lengthof(gfKeyState)) return;
+			if ((key & ~SDLK_SCANCODE_MASK) >= SDL_NUM_SCANCODES) return;
 			break;
 	}
 
 	UINT     event_type;
-	BOOLEAN& key_state = gfKeyState[key];
+	bool key_state = _KeyDown(key);
 	if (pressed)
 	{
 		event_type = key_state ? KEY_REPEAT : KEY_DOWN;
@@ -272,7 +287,7 @@ static void KeyChange(SDL_Keysym const* const key_sym, bool const pressed)
 		if (!key_state) return;
 		event_type = KEY_UP;
 	}
-	key_state = pressed;
+	gfKeyState[RemapKeycode(key)] = pressed;
 
 	QueueKeyEvent(event_type, key, mod, '\0');
 }
@@ -284,17 +299,17 @@ void KeyDown(const SDL_Keysym* KeySym)
 	{
 		case SDLK_LSHIFT:
 		case SDLK_RSHIFT:
-			_KeyDown(SHIFT) = TRUE;
+			gfKeyState.set(SHIFT);
 			break;
 
 		case SDLK_LCTRL:
 		case SDLK_RCTRL:
-			_KeyDown(CTRL) = TRUE;
+			gfKeyState.set(CTRL);
 			break;
 
 		case SDLK_LALT:
 		case SDLK_RALT:
-			_KeyDown(ALT) = TRUE;
+			gfKeyState.set(ALT);
 			break;
 
 		case SDLK_PRINTSCREEN:
@@ -314,17 +329,17 @@ void KeyUp(const SDL_Keysym* KeySym)
 	{
 		case SDLK_LSHIFT:
 		case SDLK_RSHIFT:
-			_KeyDown(SHIFT) = FALSE;
+			gfKeyState.reset(SHIFT);
 			break;
 
 		case SDLK_LCTRL:
 		case SDLK_RCTRL:
-			_KeyDown(CTRL) = FALSE;
+			gfKeyState.reset(CTRL);
 			break;
 
 		case SDLK_LALT:
 		case SDLK_RALT:
-			_KeyDown(ALT) = FALSE;
+			gfKeyState.reset(ALT);
 			break;
 
 		case SDLK_PRINTSCREEN:

--- a/src/sgp/Input.h
+++ b/src/sgp/Input.h
@@ -69,15 +69,13 @@ void SimulateMouseMovement( UINT32 uiNewXPos, UINT32 uiNewYPos );
 void DequeueAllKeyBoardEvents(void);
 
 
-extern BOOLEAN gfKeyState[SDL_SCANCODE_TO_KEYCODE(SDL_NUM_SCANCODES)]; // TRUE = Pressed, FALSE = Not Pressed
-
 extern UINT16    gusMouseXPos;       // X position of the mouse on screen
 extern UINT16    gusMouseYPos;       // y position of the mouse on screen
 extern BOOLEAN   gfLeftButtonState;  // TRUE = Pressed, FALSE = Not Pressed
 extern BOOLEAN   gfRightButtonState; // TRUE = Pressed, FALSE = Not Pressed
 extern BOOLEAN   gfMiddleButtonState;
 
-#define _KeyDown(a)        gfKeyState[(a)]
+bool _KeyDown(SDL_Keycode);
 #define _LeftButtonDown    gfLeftButtonState
 #define _RightButtonDown   gfRightButtonState
 #define _MiddleButtonDown   gfMiddleButtonState


### PR DESCRIPTION
Alternative to #506 using @momoko-h's code.

Shrink the size of gfKeyState from 1Gb + 512 to 128 bytes

Remap SDL keycodes with bit 30 set to make them usable as gfKeyState indices.