### PR TITLE
Replace reference to non-existing flame animation

### DIFF
--- a/src/game/Tactical/Bullets.cc
+++ b/src/game/Tactical/Bullets.cc
@@ -341,7 +341,10 @@ void AddMissileTrail( BULLET *pBullet, FIXEDPT qCurrX, FIXEDPT qCurrY, FIXEDPT q
 	}
 	else if ( pBullet->usFlags & ( BULLET_FLAG_FLAME ) )
 	{
-		AniParams.zCachedFile = TILECACHEDIR "/flmthr2.sti";
+		// The following line used to reference the non-existing animation
+		// "/flmthr2.sti". This could crash the game if the the unfinished
+		// flamethrower is accessed by cheat codes.
+		AniParams.zCachedFile = TILECACHEDIR "/msle_smk.sti";
 		AniParams.sDelay							= (INT16)( 100 );
 	}
 


### PR DESCRIPTION
with the missile smoke animation.
The missing animation could lead to crashes when accessing
the unfinished flame thrower weapon using cheats.

Resolves a part of the issues mentioned in #521