### PR TITLE
Check if argument of SoundLoadDisk() is an empty string.

### DIFF
--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -549,6 +549,11 @@ static SAMPLETAG* SoundLoadDisk(const char* pFilename)
 {
 	Assert(pFilename != NULL);
 
+	if(pFilename[0] == '\0') {
+		SLOGE(DEBUG_TAG_ASSERTS, "SoundLoadDisk Error: pFilename is an empty string.");
+		return NULL;
+	}
+
 	AutoSGPFile hFile;
 
 	try


### PR DESCRIPTION
Disregard the invalid sound on release builds. Throw on debug builds.

Superficial fix for #528. Obviously the underlying issue should be fixed as well.