### PR TITLE
Fix #540: always show militia dialogues in the same spot

### DIFF
--- a/src/game/MessageBoxScreen.cc
+++ b/src/game/MessageBoxScreen.cc
@@ -582,27 +582,18 @@ void MessageBoxScreenShutdown()
 	gMsgBox.box = 0;
 }
 
-
-static void DoScreenIndependantMessageBoxWithRect(wchar_t const* msg, MessageBoxFlags, MSGBOX_CALLBACK, SGPBox const* centering_rect);
-
-
 // a basic box that don't care what screen we came from
-void DoScreenIndependantMessageBox(wchar_t const* const zString, MessageBoxFlags const usFlags, MSGBOX_CALLBACK const ReturnCallback)
+void DoScreenIndependantMessageBox(wchar_t const* const msg, MessageBoxFlags const flags, MSGBOX_CALLBACK const callback)
 {
 	SGPBox const centering_rect = {0, 0, SCREEN_WIDTH, INV_INTERFACE_START_Y };
-	DoScreenIndependantMessageBoxWithRect(zString, usFlags, ReturnCallback, &centering_rect);
-}
-
-static void DoScreenIndependantMessageBoxWithRect(wchar_t const* const msg, MessageBoxFlags const flags, MSGBOX_CALLBACK const callback, SGPBox const* const centering_rect)
-{
 	switch (ScreenID const screen = guiCurrentScreen)
 	{
 		case AUTORESOLVE_SCREEN:
-		case GAME_SCREEN:        DoMessageBox(                    MSG_BOX_BASIC_STYLE,    msg, screen, flags, callback, centering_rect); break;
-		case LAPTOP_SCREEN:      DoLapTopSystemMessageBoxWithRect(MSG_BOX_LAPTOP_DEFAULT, msg, screen, flags, callback, centering_rect); break;
-		case MAP_SCREEN:         DoMapMessageBoxWithRect(         MSG_BOX_BASIC_STYLE,    msg, screen, flags, callback, centering_rect); break;
-		case OPTIONS_SCREEN:     DoOptionsMessageBoxWithRect(                             msg, screen, flags, callback, centering_rect); break;
-		case SAVE_LOAD_SCREEN:   DoSaveLoadMessageBoxWithRect(                            msg, screen, flags, callback, centering_rect); break;
+		case GAME_SCREEN:        DoMessageBox(                    MSG_BOX_BASIC_STYLE,    msg, screen, flags, callback, &centering_rect); break;
+		case LAPTOP_SCREEN:      DoLapTopSystemMessageBoxWithRect(MSG_BOX_LAPTOP_DEFAULT, msg, screen, flags, callback, &centering_rect); break;
+		case MAP_SCREEN:         DoMapMessageBoxWithRect(         MSG_BOX_BASIC_STYLE,    msg, screen, flags, callback, &centering_rect); break;
+		case OPTIONS_SCREEN:     DoOptionsMessageBoxWithRect(                             msg, screen, flags, callback, &centering_rect); break;
+		case SAVE_LOAD_SCREEN:   DoSaveLoadMessageBoxWithRect(                            msg, screen, flags, callback, &centering_rect); break;
         default:
             break;
 	}

--- a/src/game/MessageBoxScreen.cc
+++ b/src/game/MessageBoxScreen.cc
@@ -593,15 +593,6 @@ void DoScreenIndependantMessageBox(wchar_t const* const zString, MessageBoxFlags
 	DoScreenIndependantMessageBoxWithRect(zString, usFlags, ReturnCallback, &centering_rect);
 }
 
-
-// a basic box that don't care what screen we came from
-void DoLowerScreenIndependantMessageBox(wchar_t const* const zString, MessageBoxFlags const usFlags, MSGBOX_CALLBACK const ReturnCallback)
-{
-	SGPBox const centering_rect = {0, (UINT16)(INV_INTERFACE_START_Y / 2), SCREEN_WIDTH, (UINT16)(INV_INTERFACE_START_Y / 2) };
-	DoScreenIndependantMessageBoxWithRect(zString, usFlags, ReturnCallback, &centering_rect);
-}
-
-
 static void DoScreenIndependantMessageBoxWithRect(wchar_t const* const msg, MessageBoxFlags const flags, MSGBOX_CALLBACK const callback, SGPBox const* const centering_rect)
 {
 	switch (ScreenID const screen = guiCurrentScreen)

--- a/src/game/MessageBoxScreen.h
+++ b/src/game/MessageBoxScreen.h
@@ -91,7 +91,6 @@ extern wchar_t gzUserDefinedButton2[128];
  * pCenteringRect Rect to center in. Can be NULL */
 void DoMessageBox(MessageBoxStyleID, wchar_t const* zString, ScreenID uiExitScreen, MessageBoxFlags, MSGBOX_CALLBACK ReturnCallback, SGPBox const* centering_rect);
 void DoScreenIndependantMessageBox(const wchar_t* zString, MessageBoxFlags, MSGBOX_CALLBACK ReturnCallback);
-void DoLowerScreenIndependantMessageBox(const wchar_t* zString, MessageBoxFlags, MSGBOX_CALLBACK ReturnCallback);
 
 //wrappers for other screens
 void DoMapMessageBoxWithRect(MessageBoxStyleID, wchar_t const* zString, ScreenID uiExitScreen, MessageBoxFlags, MSGBOX_CALLBACK ReturnCallback, SGPBox const* centering_rect);

--- a/src/game/Strategic/Town_Militia.cc
+++ b/src/game/Strategic/Town_Militia.cc
@@ -457,20 +457,6 @@ void HandleInterfaceMessageForCostOfTrainingMilitia( SOLDIERTYPE *pSoldier )
 	}
 }
 
-
-static void DoContinueMilitiaTrainingMessageBox(INT16 const sSectorX, INT16 const sSectorY, wchar_t const* const str, MessageBoxFlags const usFlags, MSGBOX_CALLBACK const ReturnCallback)
-{
-	if( sSectorX <= 10 && sSectorY >= 6 && sSectorY <= 11 )
-	{
-		DoLowerScreenIndependantMessageBox( str, usFlags, ReturnCallback );
-	}
-	else
-	{
-		DoScreenIndependantMessageBox( str, usFlags, ReturnCallback );
-	}
-}
-
-
 // continue training?
 static void HandleInterfaceMessageForContinuingTrainingMilitia(SOLDIERTYPE* const pSoldier)
 {
@@ -493,7 +479,7 @@ static void HandleInterfaceMessageForContinuingTrainingMilitia(SOLDIERTYPE* cons
 	{
 		// loyalty too low to continue training
 		swprintf(sString, lengthof(sString), pMilitiaConfirmStrings[8], pTownNames[GetTownIdForSector(sector)], MIN_RATING_TO_TRAIN_TOWN);
-		DoContinueMilitiaTrainingMessageBox( sSectorX, sSectorY, sString, MSG_BOX_FLAG_OK, CantTrainMilitiaOkBoxCallback );
+		DoScreenIndependantMessageBox( sString, MSG_BOX_FLAG_OK, CantTrainMilitiaOkBoxCallback );
 		return;
 	}
 
@@ -512,7 +498,7 @@ static void HandleInterfaceMessageForContinuingTrainingMilitia(SOLDIERTYPE* cons
 			// town
 			swprintf(sString, lengthof(sString), pMilitiaConfirmStrings[9], pTownNames[bTownId], MIN_RATING_TO_TRAIN_TOWN);
 		}
-		DoContinueMilitiaTrainingMessageBox( sSectorX, sSectorY, sString, MSG_BOX_FLAG_OK, CantTrainMilitiaOkBoxCallback );
+		DoScreenIndependantMessageBox( sString, MSG_BOX_FLAG_OK, CantTrainMilitiaOkBoxCallback );
 		return;
 	}
 
@@ -524,7 +510,7 @@ static void HandleInterfaceMessageForContinuingTrainingMilitia(SOLDIERTYPE* cons
 	{
 		// can't afford to continue training
 		swprintf(sString, lengthof(sString), pMilitiaConfirmStrings[7], giTotalCostOfTraining);
-		DoContinueMilitiaTrainingMessageBox( sSectorX, sSectorY, sString, MSG_BOX_FLAG_OK, CantTrainMilitiaOkBoxCallback );
+		DoScreenIndependantMessageBox( sString, MSG_BOX_FLAG_OK, CantTrainMilitiaOkBoxCallback );
 		return;
 	}
 
@@ -534,7 +520,7 @@ static void HandleInterfaceMessageForContinuingTrainingMilitia(SOLDIERTYPE* cons
 	swprintf( sString, lengthof(sString), pMilitiaConfirmStrings[ 3 ], sStringB, pMilitiaConfirmStrings[ 4 ], giTotalCostOfTraining );
 
 	// ask player whether he'd like to continue training
-	//DoContinueMilitiaTrainingMessageBox( sSectorX, sSectorY, sString, MSG_BOX_FLAG_YESNO, PayMilitiaTrainingYesNoBoxCallback );
+	//DoScreenIndependantMessageBox( sString, MSG_BOX_FLAG_YESNO, PayMilitiaTrainingYesNoBoxCallback );
 	DoMapMessageBox( MSG_BOX_BASIC_STYLE, sString, MAP_SCREEN, MSG_BOX_FLAG_YESNO, PayMilitiaTrainingYesNoBoxCallback );
 }
 


### PR DESCRIPTION
inline the remaining one line function for the sake of clarity