### PR TITLE
Fix rust datadir parsing

### DIFF
--- a/rust/src/stracciatella.rs
+++ b/rust/src/stracciatella.rs
@@ -657,7 +657,15 @@ mod tests {
 
         assert_eq!(super::parse_args(&mut engine_options, input), None);
         unsafe {
-            assert_eq!(str::from_utf8(CStr::from_ptr(super::get_vanilla_data_dir(&engine_options)).to_bytes()).unwrap(), temp_dir.path().to_str().unwrap());
+            let comp = str::from_utf8(CStr::from_ptr(super::get_vanilla_data_dir(&engine_options)).to_bytes()).unwrap();
+            let mut base = String::new();
+
+            // allow /private prefix on mac:
+            if comp.starts_with("/private") {
+                base.push_str("/private");
+            }
+            base.push_str(temp_dir.path().to_str().unwrap());
+            assert_eq!(comp, base);
         }
     }
 

--- a/rust/src/stracciatella.rs
+++ b/rust/src/stracciatella.rs
@@ -193,7 +193,16 @@ fn parse_args(engine_options: &mut EngineOptions, args: Vec<String>) -> Option<S
 
             if let Some(s) = m.opt_str("datadir") {
                 match fs::canonicalize(PathBuf::from(s)) {
-                    Ok(s) => engine_options.vanilla_data_dir = s,
+                    Ok(s) => {
+                        let mut temp = String::from(s.to_str().expect("Should not happen"));
+                        // remove UNC path prefix (Windows)
+                        if temp.starts_with("\\\\") {
+                            temp.drain(..2);
+                            let pos = temp.find("\\").unwrap() + 1;
+                            temp.drain(..pos);
+                        }
+                        engine_options.vanilla_data_dir = PathBuf::from(temp)
+                    },
                     Err(_) => return Some(String::from("Please specify an existing datadir."))
                 };
             }


### PR DESCRIPTION
This should (hopefully) fix the UNC prefix issue on Windows and the `/private` prefix issue on Mac.

Related to #515 and #559.