### PR TITLE
fixing area select not removed if interrupted

### DIFF
--- a/src/game/Tactical/Handle_UI.cc
+++ b/src/game/Tactical/Handle_UI.cc
@@ -3244,7 +3244,8 @@ static INT8 DrawUIMovementPath(SOLDIERTYPE* const pSoldier, UINT16 usMapPos, Mov
 
 			 if ( sGotLocation != NOWHERE )
 			 {
-				 sAPCost += MinAPsToAttack( pSoldier, sAdjustedGridNo, TRUE );
+				 //sAPCost += MinAPsToAttack( pSoldier, sAdjustedGridNo, TRUE );
+				 sAPCost += CalcTotalAPsToAttack(pSoldier, sAdjustedGridNo, TRUE, (pSoldier->bShownAimTime/2));
 				 sAPCost += UIPlotPath(pSoldier, sGotLocation, NO_COPYROUTE, fPlot, pSoldier->usUIMovementMode, pSoldier->bActionPoints);
 
 				 if ( sGotLocation != pSoldier->sGridNo && fGotAdjacent )

--- a/src/game/Tactical/Interface_Control.cc
+++ b/src/game/Tactical/Interface_Control.cc
@@ -561,6 +561,10 @@ void EraseInterfaceMenus( BOOLEAN fIgnoreUIUnLock )
 	PopDownMovementMenu( );
 	PopDownOpenDoorMenu( );
 	DeleteTalkingMenu( );
+
+	// Stop Rubberbanding every time a menu is erased/opened
+	gRubberBandActive = FALSE;
+	ResetMultiSelection();
 }
 
 

--- a/src/game/Tactical/Points.cc
+++ b/src/game/Tactical/Points.cc
@@ -894,7 +894,6 @@ UINT8 CalcTotalAPsToAttack(SOLDIERTYPE* const s, INT16 const grid_no, UINT8 cons
 				ap_cost += s->sWalkToAttackWalkToCost;
 			}
 			ap_cost += MinAPsToAttack(s, adjusted_grid_no, ubAddTurningCost);
-			printf("mincost: %d\n", ap_cost);
 			ap_cost += aim_time;
 			break;
 	}

--- a/src/game/Tactical/Points.cc
+++ b/src/game/Tactical/Points.cc
@@ -894,6 +894,7 @@ UINT8 CalcTotalAPsToAttack(SOLDIERTYPE* const s, INT16 const grid_no, UINT8 cons
 				ap_cost += s->sWalkToAttackWalkToCost;
 			}
 			ap_cost += MinAPsToAttack(s, adjusted_grid_no, ubAddTurningCost);
+			printf("mincost: %d\n", ap_cost);
 			ap_cost += aim_time;
 			break;
 	}
@@ -1116,16 +1117,20 @@ static UINT8 MinAPsToPunch(SOLDIERTYPE const& s, GridNo gridno, bool const add_t
 		{
 			ap += GetAPsToChangeStance(&s, ANIM_CROUCH);
 		}
-		else if (s.sGridNo == gridno)
+		else
 		{
 			ap += GetAPsToChangeStance(&s, ANIM_STAND);
 		}
 	}
 
-	if (add_turning_cost && s.sGridNo == gridno)
+	if (add_turning_cost && s.sGridNo != gridno)
 	{ // Is it the same as he's facing?
 		UINT8 const direction = GetDirectionFromGridNo(gridno, &s);
-		if (direction != s.bDirection) ap += AP_LOOK_STANDING; // ATE: Use standing turn cost
+
+		// Would expect that merc is standing up(2AP) and then looking(1AP)
+		// rather than looking(2AP) and then standing up(2AP)
+		if (direction != s.bDirection && gAnimControl[ s.usAnimState ].ubEndHeight == ANIM_STAND) ap += AP_LOOK_STANDING; // ATE: Use standing turn cost
+		else if(direction != s.bDirection && gAnimControl[ s.usAnimState ].ubEndHeight == ANIM_CROUCH) ap += AP_LOOK_CROUCHED;
 	}
 
 	return ap;


### PR DESCRIPTION
fixing #550. 
I am not that happy with that solution though. I Tried to ignore the next Left-Mousebutton-Up so if you command a merc to open a door/talk to a person/... and hold the button down it would not close the menu after. I wasn't able to do that because the event system in the code is kind of unpredictable.
Maybe the way it works with my commit is enough and not a problem for the user-experience view.