### PR TITLE
Fixing AP-calculations for hand to hand combat[WIP]

### DIFF
--- a/src/game/Tactical/Handle_UI.cc
+++ b/src/game/Tactical/Handle_UI.cc
@@ -3244,9 +3244,11 @@ static INT8 DrawUIMovementPath(SOLDIERTYPE* const pSoldier, UINT16 usMapPos, Mov
 
 			 if ( sGotLocation != NOWHERE )
 			 {
-				 sAPCost += MinAPsToAttack( pSoldier, sAdjustedGridNo, TRUE );
-				 sAPCost += UIPlotPath(pSoldier, sGotLocation, NO_COPYROUTE, fPlot, pSoldier->usUIMovementMode, pSoldier->bActionPoints);
-
+				 //sAPCost += MinAPsToAttack( pSoldier, sAdjustedGridNo, TRUE );
+				 
+				 // method CalcTotalAPsToAttack includes path and minap costs
+				 sAPCost += CalcTotalAPsToAttack(pSoldier, sAdjustedGridNo, TRUE, (pSoldier->bShownAimTime/2));
+ 				 //sAPCost += UIPlotPath(pSoldier, sGotLocation, NO_COPYROUTE, fPlot, pSoldier->usUIMovementMode, pSoldier->bActionPoints);
 				 if ( sGotLocation != pSoldier->sGridNo && fGotAdjacent )
 				 {
 						gfUIHandleShowMoveGrid = TRUE;

--- a/src/game/Tactical/Points.cc
+++ b/src/game/Tactical/Points.cc
@@ -1105,7 +1105,7 @@ static UINT8 MinAPsToPunch(SOLDIERTYPE const& s, GridNo gridno, bool const add_t
 {
 	UINT8	ap = 4;
 
-	if (gridno == NOWHERE) return ap;
+	if (gridno == NOWHERE || s.sGridNo == gridno) return 0;
 
 	if (SOLDIERTYPE const* const tgt = WhoIsThere2(gridno, s.bTargetLevel))
 	{ // On a guy, get his gridno
@@ -1116,18 +1116,40 @@ static UINT8 MinAPsToPunch(SOLDIERTYPE const& s, GridNo gridno, bool const add_t
 		{
 			ap += GetAPsToChangeStance(&s, ANIM_CROUCH);
 		}
-		else if (s.sGridNo == gridno)
+		else
 		{
 			ap += GetAPsToChangeStance(&s, ANIM_STAND);
 		}
 	}
 
-	if (add_turning_cost && s.sGridNo == gridno)
+	if (add_turning_cost)
 	{ // Is it the same as he's facing?
 		UINT8 const direction = GetDirectionFromGridNo(gridno, &s);
-		if (direction != s.bDirection) ap += AP_LOOK_STANDING; // ATE: Use standing turn cost
-	}
 
+		// Would expect that merc is standing up(2AP) and then looking(1AP)
+		// rather than looking(2AP) and then standing up(2AP)
+		// same for proning
+		if (direction != s.bDirection)
+		{
+			// We only add turning costs for enemys in attack range. If we have to
+			// move first turning cost are considered within walking
+			if (s.sWalkToAttackWalkToCost == 0)
+			{
+				if (gAnimControl[ s.usAnimState ].ubEndHeight == ANIM_STAND)
+				{
+					ap += AP_LOOK_STANDING; // ATE: Use standing turn cost
+				}
+				else if (gAnimControl[ s.usAnimState ].ubEndHeight == ANIM_CROUCH)
+				{
+					ap += AP_LOOK_CROUCHED;
+				}
+				else if (gAnimControl[ s.usAnimState ].ubEndHeight == ANIM_PRONE)
+				{
+					ap += AP_LOOK_PRONE;
+				} 
+			}
+		}
+	}
 	return ap;
 }
 

--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -6752,7 +6752,6 @@ void EVENT_SoldierBeginPunchAttack( SOLDIERTYPE *pSoldier, INT16 sGridNo, UINT8 
 {
 	//UINT32 uiMercFlags;
 	UINT8 ubTDirection;
-	BOOLEAN fChangeDirection = FALSE;
 	UINT16	usItem;
 
 	// Get item in hand...
@@ -6771,15 +6770,9 @@ void EVENT_SoldierBeginPunchAttack( SOLDIERTYPE *pSoldier, INT16 sGridNo, UINT8 
 	SOLDIERTYPE* const pTSoldier = WhoIsThere2(pSoldier->sTargetGridNo, pSoldier->bLevel);
 	if (pTSoldier == NULL) return;
 
-	fChangeDirection = TRUE;
-
-
-	if ( fChangeDirection )
-	{
-			// CHANGE DIRECTION AND GOTO ANIMATION NOW
-		EVENT_SetSoldierDesiredDirection( pSoldier, ubDirection );
-		EVENT_SetSoldierDirection( pSoldier, ubDirection );
-	}
+	// CHANGE DIRECTION AND GOTO ANIMATION NOW
+	EVENT_SetSoldierDesiredDirection( pSoldier, ubDirection );
+	EVENT_SetSoldierDirection( pSoldier, ubDirection );
 
 
 	if (HAS_SKILL_TRAIT(pSoldier, MARTIALARTS) && !AreInMeanwhile() && usItem != CROWBAR)


### PR DESCRIPTION
fixing #549 
Weird thing about the AP-Calculation for hand to hand combat is that it expects the MERC to turn first and then switch stance. Which means you can save AP by manually standing up rather than doing it with one attack-click.
		// Would expect that merc is standing up(2AP) and then looking(1AP)
		// rather than looking(2AP) and then standing up(2AP)