### PR TITLE
Selecting Area not resetting after being interrupted by menus

### DIFF
--- a/src/game/Tactical/Interface_Control.cc
+++ b/src/game/Tactical/Interface_Control.cc
@@ -561,6 +561,10 @@ void EraseInterfaceMenus( BOOLEAN fIgnoreUIUnLock )
 	PopDownMovementMenu( );
 	PopDownOpenDoorMenu( );
 	DeleteTalkingMenu( );
+
+	// Stop Rubberbanding every time a menu is erased/opened
+	gRubberBandActive = FALSE;
+	ResetMultiSelection();
 }
 
 


### PR DESCRIPTION
fixing #550. 
I am not that happy with that solution though. I Tried to ignore the next Left-Mousebutton-Up so if you command a merc to open a door/talk to a person/... and hold the button down it would not close the menu after. I wasn't able to do that because the event system in the code is kind of unpredictable.
Maybe the way it works with my commit is enough and not a problem for the user-experience view.