### PR TITLE
fixed wrong animations in some sectors for throwing knifes

### DIFF
--- a/src/game/Tactical/Bullets.cc
+++ b/src/game/Tactical/Bullets.cc
@@ -243,6 +243,18 @@ void UpdateBullets(void)
 							b->pAniTile->sRelativeY	= FIXEDPT_TO_INT32(b->qCurrY);
 							b->pAniTile->pLevelNode->sRelativeZ = CONVERT_HEIGHTUNITS_TO_PIXELS(FIXEDPT_TO_INT32(b->qCurrZ));
 
+							// it seems some sectors deliver wrong depth informationen(Z)
+							// As there only a fixed amount of ways to throw a knife we can
+							// correct the relativeZ value
+							if(b->pAniTile->pLevelNode->sRelativeZ > 160)
+							{
+								b->pAniTile->pLevelNode->sRelativeZ -= 115;
+							}
+							else if(b->pAniTile->pLevelNode->sRelativeZ > 90)
+							{
+								b->pAniTile->pLevelNode->sRelativeZ -= 70;
+							}
+
 							if (b->usFlags & BULLET_FLAG_KNIFE)
 							{
 								b->pShadowAniTile->sRelativeX	= FIXEDPT_TO_INT32(b->qCurrX);


### PR DESCRIPTION
fixes #395 
A little bit hacky because some sectors deliver tripled z positions. As there are only a few ways to throw a knife(ground->ground, roof->ground, roof->roof, ground->roof) we can overcome this problem by decreasing the values while don't affecting gravity or precision. 