### PR TITLE
Attack for 0 AP fix for unreachable enemys

### DIFF
--- a/src/game/Tactical/Handle_UI.cc
+++ b/src/game/Tactical/Handle_UI.cc
@@ -3399,7 +3399,16 @@ bool UIMouseOnValidAttackLocation(SOLDIERTYPE* const s)
 		return false;
 	}
 
-	if (item->getItemClass() == IC_PUNCH) return tgt;
+	if (item->getItemClass() == IC_PUNCH)
+	{
+		// We test again whether the target is reachable
+		if (CalcTotalAPsToAttack(s, tgt->sGridNo, true, 0) == 0)
+		{
+			ScreenMsg( FONT_MCOLOR_LTYELLOW, MSG_UI_FEEDBACK, TacticalStr[ NO_PATH ] );
+			return false;
+		}
+		return tgt;
+	}
 
 	if (item->getItemClass() == IC_MEDKIT)
 	{ // If a guy's here, check if he needs medical help!

--- a/src/game/Tactical/Points.cc
+++ b/src/game/Tactical/Points.cc
@@ -1105,7 +1105,11 @@ static UINT8 MinAPsToPunch(SOLDIERTYPE const& s, GridNo gridno, bool const add_t
 {
 	UINT8	ap = 4;
 
-	if (gridno == NOWHERE) return ap;
+	// We return 0 for invalid attacks; will be handled as impossible
+	if (gridno == NOWHERE)
+	{
+		return 0;
+	}
 
 	if (SOLDIERTYPE const* const tgt = WhoIsThere2(gridno, s.bTargetLevel))
 	{ // On a guy, get his gridno


### PR DESCRIPTION
fixes #192 
If enemys are unreachable due to a blocking door etc. the game puts a message. If you try to right click on the enemys you sometimes receive calculated AP-costs, what can be used with a left click to start an attack for 0AP. Now it checks whether the enemy is reachable.