### PR TITLE
fixed wrong AP calculations while throwing knives[WIP]

### DIFF
--- a/src/game/Tactical/Points.cc
+++ b/src/game/Tactical/Points.cc
@@ -1038,7 +1038,10 @@ UINT8 MinAPsToShootOrStab(SOLDIERTYPE& s, GridNo gridno, bool const add_turning_
 	{
 		if (GCM->getItem(item)->getItemClass() == IC_THROWING_KNIFE)
 		{
-			ap_cost += AP_LOOK_STANDING;
+			//ap_cost += AP_LOOK_STANDING;
+			if (gAnimControl[ s.usAnimState ].ubEndHeight == ANIM_STAND) ap_cost += AP_LOOK_STANDING;
+			else if(gAnimControl[ s.usAnimState ].ubEndHeight == ANIM_CROUCH) ap_cost += AP_LOOK_CROUCHED;
+			else if(gAnimControl[ s.usAnimState ].ubEndHeight == ANIM_PRONE) ap_cost += AP_LOOK_PRONE;
 		}
 		else
 		{

--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -6877,11 +6877,11 @@ void EVENT_SoldierBeginKnifeThrowAttack( SOLDIERTYPE *pSoldier, INT16 sGridNo, U
 	pSoldier->bBulletsLeft = 1;
 	SLOGD(DEBUG_TAG_SOLDIER, "Starting knifethrow attack, bullets left %d", pSoldier->bBulletsLeft);
 
-	EVENT_InitNewSoldierAnim( pSoldier, THROW_KNIFE, 0 , FALSE );
-
 	// CHANGE DIRECTION AND GOTO ANIMATION NOW
 	EVENT_SetSoldierDesiredDirection( pSoldier, ubDirection );
 	EVENT_SetSoldierDirection( pSoldier, ubDirection );
+	// We should throw the knife after turning around
+	EVENT_InitNewSoldierAnim( pSoldier, THROW_KNIFE, 0 , FALSE );
 
 
 	// SET TARGET GRIDNO
@@ -8982,7 +8982,7 @@ static void EnableDisableSoldierLightEffects(BOOLEAN const enable_lights)
 	{
 		if (!s->bInSector)     continue;
 		if (s->bLife < OKLIFE) continue;
-                // att: NO Soldier Lights if in a VEHICLE 
+                // att: NO Soldier Lights if in a VEHICLE
                 if (s->bAssignment == VEHICLE) continue;
 
 		if (enable_lights)


### PR DESCRIPTION
fixes #186 
If the direction of the merc was not right it didn't calculated AP-costs for turning around leading to lower AP-Costs. This happened because in the event-queue for the animations it attacked first then turned around.