### PR TITLE
Fix mouse moving out of the window when in fullscreen mode

### DIFF
--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -99,11 +99,11 @@ void VideoSetFullScreen(const BOOLEAN enable)
 {
 	if (enable)
 	{
-		g_window_flags |= SDL_WINDOW_FULLSCREEN;
+		g_window_flags |= SDL_WINDOW_FULLSCREEN | SDL_WINDOW_INPUT_GRABBED;
 	}
 	else
 	{
-		g_window_flags &= ~SDL_WINDOW_FULLSCREEN;
+		g_window_flags &= ~(SDL_WINDOW_FULLSCREEN | SDL_WINDOW_INPUT_GRABBED);
 	}
 }
 
@@ -113,10 +113,12 @@ void VideoToggleFullScreen(void)
     if (SDL_GetWindowFlags(g_game_window) & SDL_WINDOW_FULLSCREEN)
     {
         SDL_SetWindowFullscreen(g_game_window, 0);
+        SDL_SetWindowGrab(g_game_window, SDL_FALSE);
     }
     else
     {
         SDL_SetWindowFullscreen(g_game_window, SDL_WINDOW_FULLSCREEN);
+        SDL_SetWindowGrab(g_game_window, SDL_TRUE);
     }
 }
 


### PR DESCRIPTION
When the engine is configured to be in fullscreen and the size of the window is smaller than the desktop resolution, the mouse moves out of the window when it goes over the edge. And, if your desktop is, like mine, configured to have focus follow mouse, the game window immediately loses focus, which makes the game pretty much unplayable (or at least, very unpleasant to play.

Now, to avoid this, it's possible to set the size of the window at the same resolution as the desktop but, with the size of today's screens, it makes the objects/characters pretty small.

So, I fixed this by adding the flag SDL_WINDOW_INPUT_GRABBED to the window when it's in fullscreen so the cursor doesn't wander out of the window. And, of course, when switching back and forth to windowed/fullscreen mode, I needed to add a call to SDL_SetWindowGrab to set/unset that flag: if the flag is set when in windowed mode, the cursor can't leave the window, which I think isn't a desirable behavior.

I have only tested that fix on linux (debian sid), by quickly looking around the net it seemed to me that SDL tends to behave differently on different system so I don't know if that patch might bring other unwanted side effects on other systems (and I don't know if the problem was present on other systems either). But since I made that patch for myself to make the engine usable, here it is for you to decide whether or not it should be integrated in the main code base.

Thanks,
Youen