### PR TITLE
preinit dontchargeap to prevent false AP costs

### DIFF
--- a/src/game/Tactical/Handle_UI.cc
+++ b/src/game/Tactical/Handle_UI.cc
@@ -2181,6 +2181,9 @@ static ScreenID UIHandleCAMercShoot(UI_EVENT* pUIEvent)
 {
 	SOLDIERTYPE* const sel = GetSelectedMan();
 	if (sel == NULL) return GAME_SCREEN;
+	// preinit to prevent false ap costs; actions which dont charge turning ap
+	// are coming after this line and put the value to true
+	sel->fDontChargeTurningAPs = FALSE;
 
 	const GridNo usMapPos = GetMouseMapPos();
 	if (usMapPos == NOWHERE) return GAME_SCREEN;


### PR DESCRIPTION
fixes #188 
preinit a value to prevent false ap costs; actions which dont charge turning ap are coming after this line and put the value to true. The assumption should be that every tunring costs ap not the other way round.