### PR TITLE
fixes helicopter collision bug by adding its grids right after the se…

### DIFF
--- a/src/game/Strategic/StrategicMap.cc
+++ b/src/game/Strategic/StrategicMap.cc
@@ -995,6 +995,9 @@ static void EnterSector(INT16 const x, INT16 const y, INT8 const z)
 	GetMapFileName(x, y, z, filename, TRUE);
 	LoadWorld(filename);
 	LoadRadarScreenBitmap(filename);
+	// We have to add the helicopter after the sector is fully loaded
+	// to prevent that the pathfinding doenst consider its collission-grids
+	HandleHelicopterOnGround(true);
 
 	/* ATE: Moved this form above, so that we can have the benefit of changing the
 	 * world BEFORE adding guys to it. */


### PR DESCRIPTION
fixes #317 
I recognized that the collision was correct if you saved a game in B13 and loaded it but if you leave the sector, enter an other one and then return to drassen the helicopter collision was false again.