### PR TITLE
Passive bloodcat ambush fix

### DIFF
--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -1113,6 +1113,14 @@ void LoadSavedGame(UINT8 const save_slot_id)
 	/* The above function LightSetBaseLevel adjusts ALL the level node light
 	 * values including the merc node, we must reset the values */
 	HandlePlayerTogglingLightEffects(FALSE);
+
+	// on loading a gamestate or getting ambushed from the StrategicMap
+	// We have to call this right after loading a saved game for several reasons:
+	// 1. the gubEnemyEncounterCode may be analyzed later so we cant check the
+	// 		ambush code properly
+	// 2. the ai may ignoring the CallAvailableEnemiesTo(...) because it wasn't
+	//		fully analyzed before
+	CallAvailableTeamEnemiesToAmbush(gMapInformation.sCenterGridNo);
 }
 
 

--- a/src/game/Strategic/StrategicMap.cc
+++ b/src/game/Strategic/StrategicMap.cc
@@ -748,18 +748,7 @@ void PrepareLoadedSector()
 		PostSchedules();
 	}
 
-	if( gubEnemyEncounterCode == ENEMY_AMBUSH_CODE || gubEnemyEncounterCode == BLOODCAT_AMBUSH_CODE )
-	{
-		if( gMapInformation.sCenterGridNo != -1 )
-		{
-			CallAvailableEnemiesTo( gMapInformation.sCenterGridNo );
-		}
-		else
-		{
-			SLOGE(DEBUG_TAG_SMAP, "Ambush aborted in sector %c%d -- no center point in map.",
-					gWorldSectorY + 'A' - 1, gWorldSectorX );
-		}
-	}
+	CallAvailableTeamEnemiesToAmbush(gMapInformation.sCenterGridNo);
 
 	if( !( gTacticalStatus.uiFlags & LOADING_SAVED_GAME ) )
 	{

--- a/src/game/TacticalAI/AI.h
+++ b/src/game/TacticalAI/AI.h
@@ -134,6 +134,7 @@ INT8 CalcMorale(SOLDIERTYPE *pSoldier);
 void CallAvailableEnemiesTo(GridNo);
 void CallAvailableKingpinMenTo( INT16 sGridNo );
 void CallAvailableTeamEnemiesTo(GridNo, INT8 team);
+void CallAvailableTeamEnemiesToAmbush(GridNo);
 void CallEldinTo( INT16 sGridNo );
 void CancelAIAction(SOLDIERTYPE* pSoldier);
 void CheckForChangingOrders(SOLDIERTYPE *pSoldier );

--- a/src/game/TacticalAI/Knowledge.cc
+++ b/src/game/TacticalAI/Knowledge.cc
@@ -9,6 +9,7 @@
 #include "Render_Fun.h"
 #include "Soldier_Macros.h"
 #include "Timer_Control.h"
+#include "PreBattle_Interface.h"
 
 
 void CallAvailableEnemiesTo(GridNo grid_no)
@@ -42,6 +43,20 @@ void CallAvailableTeamEnemiesTo(GridNo const grid_no, INT8 const team)
 	}
 }
 
+void CallAvailableTeamEnemiesToAmbush(GridNo const grid_no){
+	if( gubEnemyEncounterCode == ENEMY_AMBUSH_CODE || gubEnemyEncounterCode == BLOODCAT_AMBUSH_CODE )
+	{
+		if( grid_no != -1 )
+		{
+			CallAvailableEnemiesTo( grid_no );
+		}
+		else
+		{
+			SLOGE(DEBUG_TAG_SMAP, "Ambush aborted in sector %c%d -- no center point in map.",
+					gWorldSectorY + 'A' - 1, gWorldSectorX );
+		}
+	}
+}
 
 void CallAvailableKingpinMenTo( INT16 sGridNo )
 {


### PR DESCRIPTION
fixes the first part of #126
I recognized that loading an ambush gamestate could lead to get the wrong statuscode for encounters because they were loaded later. I get around this by calling the enemies to ambush after a gamestate has been fully loaded.
Also I introduced a new method called CallAvailableTeamEnemiesToAmbush to prevent code duplication.