### PR TITLE
checking for existence of subject while climbing

### DIFF
--- a/src/game/Tactical/OppList.cc
+++ b/src/game/Tactical/OppList.cc
@@ -877,6 +877,14 @@ INT16 DistanceVisible(const SOLDIERTYPE* pSoldier, INT8 bFacingDir, INT8 bSubjec
 	INT8	bLightLevel;
 
 	const SOLDIERTYPE* const pSubject = WhoIsThere2(sSubjectGridNo, bLevel);
+  
+       // While the merc is climbing up/down he is shortly on an 
+       // undefined grid_no(NOWHERE) we can't calc anything if this happens so
+       // we check the return of WhoIsThere2 for zero value
+       if (pSubject == 0) 
+       {
+           return( FALSE );
+       }
 
 	if (pSoldier->uiStatusFlags & SOLDIER_MONSTER)
 	{


### PR DESCRIPTION
fixes #402 
While soldiers/mercs were climbing there is a short time in which they have no fixed grid_no. If you use the WhosIsThere method to determine the soldier on that grid_no it returns 0(null). So by checking whether the value is 0 we can overcome the problem of false calculations of visibitily while climbing.