### PR TITLE
Climbing up on a roof now no longer leads to standing up for movement

### DIFF
--- a/src/game/Tactical/Soldier_Ani.cc
+++ b/src/game/Tactical/Soldier_Ani.cc
@@ -272,6 +272,7 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 								ChangeInterfaceLevel( 1 );
 							}
 						}
+						UIHandleSoldierStanceChange(pSoldier, ANIM_CROUCH);
 						HandlePlacingRoofMarker(*pSoldier, true, true);
 					}
 					else


### PR DESCRIPTION
fixes #84 
After reaching the top of a roof we set the ui for that merc to crouching rather than doing nothing and keeping the standing state for movements.