### PR TITLE
Moneycheat added (Laptopview and + key)

### DIFF
--- a/src/game/Laptop/Laptop.cc
+++ b/src/game/Laptop/Laptop.cc
@@ -2840,6 +2840,7 @@ void HandleKeyBoardShortCutsForLapTop(UINT16 usEvent, UINT32 usParam, UINT16 usK
 			break;
 
 		case '=':
+		case '+':
 			if (CHEATER_CHEAT_LEVEL())
 			{
 				// adding money


### PR DESCRIPTION
fixes #426 
In the code there wasn't any handling for the CTRL and + cheat. So added it.
The value for decreasing the money value was 10.000 therefore too low. I increased it to 100.000.

Disclaimer: I have a german keyboard layout.