### PR TITLE
travis: use the apt addon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_install:
   - if [[ "$NIGHTLY_VERSION" != "" ]]; then export PUBLISH_BINARY="true"; export PUBLISH_DIR="nightlies"; export VERSION_TAG="$NIGHTLY_VERSION"; fi
   - if [ "$PUBLISH_BINARY" == "true" ] && [ "$TRAVIS_OS_NAME" == "linux" ]; then export EXTRA_BUILD_SWITCHES="-DCMAKE_INSTALL_PREFIX=/usr -DEXTRA_DATA_DIR=/usr/share/ja2 -DLOCAL_BOOST_LIB=ON"; fi
 
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install cmake make g++ libsdl2-dev libboost-all-dev -y; fi
   - curl -sSf https://static.rust-lang.org/rustup.sh | sh
   - echo "$PUBLISH_BINARY"
   - echo "$PUBLISH_DIR"
@@ -33,6 +32,13 @@ script:
   - if [ "$PUBLISH_BINARY" == "true" ] && [ "$SFTP_PASSWORD" != "" ]; then curl --ftp-create-dirs -T $(echo ja2-stracciatella_*) --ftp-ssl -u $SFTP_USER:$SFTP_PASSWORD ftp://www61.your-server.de/$PUBLISH_DIR/; fi
 
 addons:
+  apt:
+    packages:
+    - cmake
+    - make
+    - g++
+    - libsdl2-dev
+    - libboost-all-dev
   coverity_scan:
     project:
       name: "ja2-stracciatella/ja2-stracciatella"


### PR DESCRIPTION
one sudo less (closer to container-based runs) and fixes this apt dependency problem that recently broke the build:

> The following packages have unmet dependencies:
>  libsdl2-dev : Depends: libegl1-mesa-dev
>                Depends: libgles2-mesa-dev
> E: Unable to correct problems, you have held broken packages.