### PR TITLE
Fixed grenades getting blocked by open doors

### DIFF
--- a/src/game/Tactical/PathAI.cc
+++ b/src/game/Tactical/PathAI.cc
@@ -2511,7 +2511,7 @@ UINT8 InternalDoorTravelCost(const SOLDIERTYPE* pSoldier, INT32 iGridNo, UINT8 u
 
 	if ( IS_TRAVELCOST_DOOR( ubMovementCost ) )
 	{
-		ubReplacementCost = TRAVELCOST_OBSTACLE;
+		ubReplacementCost = ubMovementCost;
 
 		switch( ubMovementCost )
 		{
@@ -2591,6 +2591,7 @@ UINT8 InternalDoorTravelCost(const SOLDIERTYPE* pSoldier, INT32 iGridNo, UINT8 u
 				iDoorGridNo = iGridNo + DirIncrementer[ NORTHWEST ] + DirIncrementer[ WEST ];
 				break;
 			default:
+				ubReplacementCost = TRAVELCOST_OBSTACLE;
 				break;
 		}
 

--- a/src/game/TileEngine/Explosion_Control.cc
+++ b/src/game/TileEngine/Explosion_Control.cc
@@ -1472,8 +1472,8 @@ static void GetRayStopInfo(UINT32 uiNewSpot, UINT8 ubDir, INT8 bLevel, BOOLEAN f
    // Have we hit things like furniture, etc?
 	 if ( Blocking != NOTHING_BLOCKING && !fTravelCostObs )
 	 {
-      // ATE: Tall things should blaock all
-      if ( bStructHeight == 4 )
+      // ATE: Tall things should blaock all; Default wall/door height is 4
+      if ( bStructHeight > 4 )
       {
 				 (*pubKeepGoing) = FALSE;
       }


### PR DESCRIPTION
Fixes #94 
Some defines weren't used for explosion calculations, also the spread of grenades was stopped due to high structureheight which is weird because the default size for doors and walls is 4.