### PR TITLE
Soldiers with enough BP can now stand up properly after being hit by …

### DIFF
--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -7663,7 +7663,7 @@ BOOLEAN InternalIsValidStance(const SOLDIERTYPE* pSoldier, INT8 bDirection, INT8
 
 	if ( pSoldier->bCollapsed )
 	{
-		if ( bNewStance == ANIM_STAND || bNewStance == ANIM_CROUCH )
+		if ((bNewStance == ANIM_STAND || bNewStance == ANIM_CROUCH) && pSoldier->bBreath < OKBREATH)
 		{
 			return( FALSE );
 		}


### PR DESCRIPTION
…a stun grenade

fixes #247
I'm not sure what exactly is the problem in this situation. I opened a pull request for fixing the problem with blood won't standing up. But I'm still unsure whether the issue-creator meant exactly this or whether it's part of the gameplay that someone being hit by a stun grenade can't stand up even with enough BP.

Would like to hear some feedback. :)