### PR TITLE
Fixed error with gas on roof hitting mercs below

### DIFF
--- a/src/game/TileEngine/Explosion_Control.cc
+++ b/src/game/TileEngine/Explosion_Control.cc
@@ -1172,7 +1172,11 @@ static BOOLEAN ExpAffect(const INT16 sBombGridNo, const INT16 sGridNo, const UIN
 			if (pSoldier == NULL) return fRecompileMovementCosts;
 			// someone is here, and they're gonna get hurt
 
-			fRecompileMovementCosts = DishOutGasDamage(pSoldier, pExplosive, sSubsequent, fRecompileMovementCosts, sWoundAmt, sBreathAmt, owner);
+			// only damage if there is smoke/gas on gridno and bLevel
+			if (gpWorldLevelData[pSoldier->sGridNo].ubExtFlags[pSoldier->bLevel] & ANY_SMOKE_EFFECT)
+			{
+			  fRecompileMovementCosts = DishOutGasDamage(pSoldier, pExplosive, sSubsequent, fRecompileMovementCosts, sWoundAmt, sBreathAmt, owner);
+			}
 /*
 		 if (!pSoldier->bActive || !pSoldier->bInSector || !pSoldier->bLife || AM_A_ROBOT( pSoldier ) )
 		 {


### PR DESCRIPTION
Fixes #477 

Preventing damage on the wrong level by rechecking whether there is gas on the grid and height-level, also considering gasmask etc..