### PR TITLE
Copy audio into a buffer of the correct size

### DIFF
--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -623,15 +623,20 @@ static SAMPLETAG* SoundLoadDisk(const char* pFilename)
     };
   }
 
+  UINT32 convertedSize = cvt.len * cvt.len_ratio;
+
   strcpy(s->pName, pFilename);
-  s->n_samples = UINT32(cvt.len * cvt.len_mult / (wavSpec.channels * 2));
+  s->n_samples = UINT32(convertedSize / (wavSpec.channels * 2));
   s->uiFlags     |= SAMPLE_ALLOCATED;
   if (wavSpec.channels != 1) {
     s->uiFlags |= SAMPLE_STEREO;
   }
 
   s->uiInstances  = 0;
-  s->pData = cvt.buf;
+  s->pData = MALLOCN(UINT8, convertedSize);
+  memcpy(s->pData, cvt.buf, convertedSize);
+
+  free(cvt.buf);
 
   IncreaseSoundMemoryUsedBySample(s);
 


### PR DESCRIPTION
This should fix #609. But it comes with a new problem: Performance. Basically everytime a music piece (aka. long sound) is loaded, this results in a tiny hang. Not sure if that was the same before and not sure if we can actually improve performance on this.

Imho it does too many big allocations (one for source wav, one for cvt buffer, one for destination wav). It would probably be better to stream into AudioCVT, with preallocated tiny buffers. I tried this approach already once, but failed implementing it. It's not as simple as it seems, as you have to ensure that you have enough content in the buffers, so the data can be pulled at any time.