### PR TITLE
Laptop: do not show popups when navigating in Bookmarks

### DIFF
--- a/src/game/Laptop/BobbyRGuns.cc
+++ b/src/game/Laptop/BobbyRGuns.cc
@@ -462,6 +462,8 @@ void DisplayItemInfo(UINT32 uiItemClass)
 	if( gusFirstItemIndex == BOBBYR_NO_ITEMS )
 	{
 		if (fExitingLaptopFlag) return;
+		if (gfShowBookmarks)	return;
+		if (fLoadPendingFlag)	return;
 
 		DisableBobbyRButtons();
 


### PR DESCRIPTION
```gfShowBookmarks``` means we clicked onto the Bookmarks button
```fLoadPending``` means we clicked on one of the Bookmarks, leaving to a new site.

In both cases, no pop up about bobbys stock status needs to be shown. Fixes #534 