### PR TITLE
SDL2 2.0.6 Warnings

### DIFF
--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -1,6 +1,9 @@
 ## Dependencies
 
-- SDL 2.0.4 (included for Windows and OS X)
+- SDL2 >= `2.0.4` (version `2.0.4` is included in this repo for Windows and macOS).
+  __WARNING__: There is an issue with SDL in version `2.0.6` that causes segfaults when playing sounds.
+  Please ensure that you run the game with a different version of the SDL2 library otherwise sound will be
+  disabled.
 - boost-filesystem (included with `-DLOCAL_BOOST_LIB=ON`)
 - cmake
 - Rust and Cargo

--- a/src/game/MainMenuScreen.cc
+++ b/src/game/MainMenuScreen.cc
@@ -76,6 +76,7 @@ static void HandleMainMenuInput(void);
 static void HandleMainMenuScreen(void);
 static void RenderMainMenu(void);
 static void RenderGameVersion(void);
+static void RenderSDLVersionWarningIfNeccessary(void);
 static void RenderCopyright(void);
 static void RestoreButtonBackGrounds(void);
 
@@ -127,6 +128,7 @@ ScreenID MainMenuScreenHandle(void)
 		RenderMainMenu();
 		RenderGameVersion();
 		RenderCopyright();
+		RenderSDLVersionWarningIfNeccessary();
 
 		fInitialRender = FALSE;
 	}
@@ -355,6 +357,15 @@ static void RenderMainMenu(void)
 void RenderGameVersion() {
 	SetFontAttributes(FONT10ARIAL, FONT_MCOLOR_WHITE);
 	mprintf(g_ui.m_versionPosition.iX, g_ui.m_versionPosition.iY, L"%hs", g_version_label, g_version_number);
+}
+
+void RenderSDLVersionWarningIfNeccessary() {
+	SDL_version sdl_version_linked;
+	SDL_GetVersion(&sdl_version_linked);
+	if (sdl_version_linked.major == 2 && sdl_version_linked.minor == 0 && sdl_version_linked.patch == 6) {
+		SetFontAttributes(FONT14ARIAL, FONT_MCOLOR_RED);
+		mprintf(0, 0, L"Detected SDL2 2.0.6. Sound disabled. Check ja2.log for more details.");
+	}
 }
 
 void RenderCopyright() {

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -297,6 +297,16 @@ int main(int argc, char* argv[])
 		SoundEnableSound(FALSE);
 	}
 
+	// Disable sound when using SDL2 2.0.6:
+	SDL_version sdl_version_linked;
+	SDL_GetVersion(&sdl_version_linked);
+	if (sdl_version_linked.major == 2 && sdl_version_linked.minor == 0 && sdl_version_linked.patch == 6) {
+		SLOGE(DEBUG_TAG_SGP, "Detected SDL2 2.0.6. Disabled sound.\n"
+							 "This version of SDL2 has a fatal bug in the audio conversion routines.\n"
+							 "Either downgrade to version 2.0.5 or upgrade to version 2.0.7 or later.");
+		SoundEnableSound(FALSE);
+	}
+
 	if (should_start_in_debug_mode(params)) {
 		SLOG_SetLevel(SLOG_DEBUG, SLOG_DEBUG);
 		GameState::getInstance()->setDebugging(true);


### PR DESCRIPTION
Fix (or rather workaround) for #608 

- [x] Disable sound if version 2.0.6 is detected at runtime
- [x] Print error message to console and log file
- [x] Display warning in main menu
- [x] Add warning to `COMPILATION.md`