### PR TITLE
Increase C++ standard to C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endmacro()
 project(ja2-stracciatella)
 set(JA2_BINARY "ja2")
 set(LAUNCHER_BINARY "ja2-launcher")
-set(CMAKE_CXX_STANDARD 98)
+set(CMAKE_CXX_STANDARD 11)
 
 ## Versioning
 

--- a/src/sgp/UTF8String.cc
+++ b/src/sgp/UTF8String.cc
@@ -4,7 +4,7 @@
 // #include <stdio.h>
 
 /** Create object from existing UTF-8 encoded string. */
-UTF8String::UTF8String(const char *utf8Encoded) throw (InvalidEncodingException)
+UTF8String::UTF8String(const char *utf8Encoded)
 	:m_encoded("")
 {
 	std::string value(utf8Encoded);
@@ -20,7 +20,7 @@ UTF8String::UTF8String(const char *utf8Encoded) throw (InvalidEncodingException)
 }
 
 /** Create object from existing UTF-8 encoded string. */
-UTF8String::UTF8String(const uint8_t *utf8Encoded) throw (InvalidEncodingException)
+UTF8String::UTF8String(const uint8_t *utf8Encoded)
 {
 	std::string value((const char*)utf8Encoded);
 	if(utf8::is_valid(value.begin(), value.end()))
@@ -35,14 +35,14 @@ UTF8String::UTF8String(const uint8_t *utf8Encoded) throw (InvalidEncodingExcepti
 }
 
 /** Create object from UTF-16 encoded string. */
-UTF8String::UTF8String(const uint16_t *utf16Encoded) throw (InvalidEncodingException)
+UTF8String::UTF8String(const uint16_t *utf16Encoded)
 {
 	m_encoded = "";
 	append(utf16Encoded);
 }
 
 /** Create object from UTF-32 encoded string. */
-UTF8String::UTF8String(const uint32_t *utf32Encoded) throw (InvalidEncodingException)
+UTF8String::UTF8String(const uint32_t *utf32Encoded)
 {
 	m_encoded = "";
 	append(utf32Encoded);
@@ -129,7 +129,7 @@ size_t UTF8String::getNumBytes() const
 
 
 /** Append UTF16 encoded data to the string. */
-void UTF8String::append(const uint16_t *utf16Encoded) throw (InvalidEncodingException)
+void UTF8String::append(const uint16_t *utf16Encoded)
 {
 	const uint16_t *zeroSearch = utf16Encoded;
 	while(*zeroSearch) zeroSearch++;
@@ -145,7 +145,7 @@ void UTF8String::append(const uint16_t *utf16Encoded) throw (InvalidEncodingExce
 }
 
 /** Append UTF32 encoded data to the string. */
-void UTF8String::append(const uint32_t *utf32Encoded) throw (InvalidEncodingException)
+void UTF8String::append(const uint32_t *utf32Encoded)
 {
 	const uint32_t *zeroSearch = utf32Encoded;
 	while(*zeroSearch) zeroSearch++;

--- a/src/sgp/UTF8String.h
+++ b/src/sgp/UTF8String.h
@@ -52,16 +52,16 @@ class UTF8String
 {
 public:
 	/** Create object from existing UTF-8 encoded string. */
-	UTF8String(const char *utf8Encoded) throw (InvalidEncodingException);
+	UTF8String(const char *utf8Encoded);
 
 	/** Create object from existing UTF-8 encoded string. */
-	UTF8String(const uint8_t *utf8Encoded) throw (InvalidEncodingException);
+	UTF8String(const uint8_t *utf8Encoded);
 
 	/** Create object from UTF-16 encoded string. */
-	UTF8String(const uint16_t *utf16Encoded) throw (InvalidEncodingException);
+	UTF8String(const uint16_t *utf16Encoded);
 
 	/** Create object from UTF-32 encoded string. */
-	UTF8String(const uint32_t *utf32Encoded) throw (InvalidEncodingException);
+	UTF8String(const uint32_t *utf32Encoded);
 
 #ifdef WCHAR_SUPPORT
 	/** Create string from wchar. */
@@ -106,9 +106,8 @@ protected:
 #endif
 
 	/** Append UTF16 encoded data to the string. */
-	void append(const uint16_t *utf16Encoded) throw (InvalidEncodingException);
+	void append(const uint16_t *utf16Encoded);
 
 	/** Append UTF32 encoded data to the string. */
-	void append(const uint32_t *utf32Encoded) throw (InvalidEncodingException);
+	void append(const uint32_t *utf32Encoded);
 };
-


### PR DESCRIPTION
I got annoyed that we cannot use modern C++ features, so I updated the C++ standard we use to C++11.

I removed the `throw` annotations as they are deprecated with C++11. According to the [spec](http://en.cppreference.com/w/cpp/language/noexcept_spec) all the functions are potentially throwing functions so the annotations should not matter.

It now builds for me without warnings. Lets check if it is the same on macOS/Windows.