### PR TITLE
Launcher: change label "JA2 Data Directory" to "JA2 Game Directory"

### DIFF
--- a/src/launcher/StracciatellaLauncher.cc
+++ b/src/launcher/StracciatellaLauncher.cc
@@ -3,58 +3,58 @@
 #include "StracciatellaLauncher.h"
 
 StracciatellaLauncher::StracciatellaLauncher() {
-  { stracciatellaLauncher = new Fl_Double_Window(455, 290, "JA2 Stracciatella Launcher");
+  { stracciatellaLauncher = new Fl_Double_Window(465, 290, "JA2 Stracciatella Launcher");
     stracciatellaLauncher->user_data((void*)(this));
-    { Fl_Group* o = new Fl_Group(-1, 0, 456, 290);
-      { Fl_Group* o = new Fl_Group(5, 10, 440, 65);
+    { Fl_Group* o = new Fl_Group(0, 0, 465, 290);
+      { Fl_Group* o = new Fl_Group(5, 10, 451, 65);
         o->align(Fl_Align(FL_ALIGN_LEFT|FL_ALIGN_INSIDE));
-        { dataDirectoryInput = new Fl_Input(145, 10, 270, 25, "JA2 Data Directory:");
+        { dataDirectoryInput = new Fl_Input(156, 10, 270, 25, "JA2 Game Directory:");
           dataDirectoryInput->align(Fl_Align(132));
         } // Fl_Input* dataDirectoryInput
-        { gameVersionInput = new Fl_Input_Choice(145, 47, 300, 25, "Game Version:");
+        { gameVersionInput = new Fl_Input_Choice(156, 40, 300, 25, "Game Version:");
         } // Fl_Input_Choice* gameVersionInput
-        { browseJa2DirectoryButton = new Fl_Button(420, 10, 25, 25, "...");
+        { browseJa2DirectoryButton = new Fl_Button(431, 10, 25, 25, "...");
         } // Fl_Button* browseJa2DirectoryButton
         o->end();
       } // Fl_Group* o
-      { Fl_Group* o = new Fl_Group(0, 105, 250, 175);
-        { fullscreenCheckbox = new Fl_Check_Button(20, 241, 100, 20, "Fullscreen");
+      { Fl_Group* o = new Fl_Group(6, 105, 250, 175);
+        { fullscreenCheckbox = new Fl_Check_Button(26, 241, 100, 20, "Fullscreen");
           fullscreenCheckbox->down_box(FL_DOWN_BOX);
         } // Fl_Check_Button* fullscreenCheckbox
-        { Fl_Group* o = new Fl_Group(10, 114, 240, 120, "Resolution");
+        { Fl_Group* o = new Fl_Group(16, 114, 240, 120, "Resolution");
           o->box(FL_THIN_DOWN_FRAME);
-          { predefinedResolutionButton = new Fl_Round_Button(20, 124, 100, 20, "Predefined:");
+          { predefinedResolutionButton = new Fl_Round_Button(26, 124, 100, 20, "Predefined:");
             predefinedResolutionButton->down_box(FL_ROUND_DOWN_BOX);
           } // Fl_Round_Button* predefinedResolutionButton
-          { customResolutionButton = new Fl_Round_Button(20, 174, 80, 20, "Custom:");
+          { customResolutionButton = new Fl_Round_Button(26, 174, 80, 20, "Custom:");
             customResolutionButton->down_box(FL_ROUND_DOWN_BOX);
           } // Fl_Round_Button* customResolutionButton
-          { predefinedResolutionInput = new Fl_Input_Choice(40, 144, 180, 25);
+          { predefinedResolutionInput = new Fl_Input_Choice(46, 144, 180, 25);
           } // Fl_Input_Choice* predefinedResolutionInput
-          { customResolutionXInput = new Fl_Value_Input(40, 194, 80, 25);
+          { customResolutionXInput = new Fl_Value_Input(46, 194, 80, 25);
             customResolutionXInput->minimum(640);
             customResolutionXInput->maximum(0);
             customResolutionXInput->value(640);
           } // Fl_Value_Input* customResolutionXInput
-          { customResolutionYInput = new Fl_Value_Input(140, 194, 80, 25);
+          { customResolutionYInput = new Fl_Value_Input(146, 194, 80, 25);
             customResolutionYInput->minimum(480);
             customResolutionYInput->maximum(0);
             customResolutionYInput->value(480);
           } // Fl_Value_Input* customResolutionYInput
-          { new Fl_Box(120, 194, 20, 25, "x");
+          { new Fl_Box(126, 194, 20, 25, "x");
           } // Fl_Box* o
           o->end();
         } // Fl_Group* o
-        { playSoundsCheckbox = new Fl_Check_Button(20, 261, 130, 19, "Play Sounds");
+        { playSoundsCheckbox = new Fl_Check_Button(26, 261, 130, 19, "Play Sounds");
           playSoundsCheckbox->down_box(FL_DOWN_BOX);
           playSoundsCheckbox->value(1);
         } // Fl_Check_Button* playSoundsCheckbox
         o->end();
       } // Fl_Group* o
-      { Fl_Group* o = new Fl_Group(260, 105, 185, 175);
-        { playButton = new Fl_Button(260, 225, 185, 55, "Play Ja2 Stracciatella");
+      { Fl_Group* o = new Fl_Group(270, 105, 186, 175);
+        { playButton = new Fl_Button(270, 225, 185, 55, "Play Ja2 Stracciatella");
         } // Fl_Button* playButton
-        { editorButton = new Fl_Button(260, 190, 185, 25, "Start Map Editor");
+        { editorButton = new Fl_Button(270, 190, 185, 25, "Start Map Editor");
         } // Fl_Button* editorButton
         o->end();
       } // Fl_Group* o

--- a/src/launcher/StracciatellaLauncher.fl
+++ b/src/launcher/StracciatellaLauncher.fl
@@ -8,75 +8,75 @@ class StracciatellaLauncher {open
   } {
     Fl_Window stracciatellaLauncher {
       label {JA2 Stracciatella Launcher} open
-      xywh {719 235 455 290} type Double visible
+      xywh {981 319 465 290} type Double visible
     } {
       Fl_Group {} {open
-        xywh {-1 0 456 290}
+        xywh {0 0 465 290}
       } {
         Fl_Group {} {open
-          xywh {5 10 440 65} align 20
+          xywh {5 10 451 65} align 20
         } {
           Fl_Input dataDirectoryInput {
-            label {JA2 Data Directory:} selected
-            xywh {145 10 270 25} align 132
+            label {JA2 Game Directory:} selected
+            xywh {156 10 270 25} align 132
           }
           Fl_Input_Choice gameVersionInput {
             label {Game Version:} open
-            xywh {145 47 300 25}
+            xywh {156 40 300 25}
           } {}
           Fl_Button browseJa2DirectoryButton {
             label {...}
-            xywh {420 10 25 25}
+            xywh {431 10 25 25}
           }
         }
         Fl_Group {} {open
-          xywh {0 105 250 175}
+          xywh {6 105 250 175}
         } {
           Fl_Check_Button fullscreenCheckbox {
             label Fullscreen
-            xywh {20 241 100 20} down_box DOWN_BOX
+            xywh {26 241 100 20} down_box DOWN_BOX
           }
           Fl_Group {} {
             label Resolution open
-            xywh {10 114 240 120} box THIN_DOWN_FRAME
+            xywh {16 114 240 120} box THIN_DOWN_FRAME
           } {
             Fl_Round_Button predefinedResolutionButton {
               label {Predefined:}
-              xywh {20 124 100 20} down_box ROUND_DOWN_BOX
+              xywh {26 124 100 20} down_box ROUND_DOWN_BOX
             }
             Fl_Round_Button customResolutionButton {
               label {Custom:}
-              xywh {20 174 80 20} down_box ROUND_DOWN_BOX
+              xywh {26 174 80 20} down_box ROUND_DOWN_BOX
             }
             Fl_Input_Choice predefinedResolutionInput {open
-              xywh {40 144 180 25}
+              xywh {46 144 180 25}
             } {}
             Fl_Value_Input customResolutionXInput {
-              xywh {40 194 80 25} minimum 640 maximum 0 value 640
+              xywh {46 194 80 25} minimum 640 maximum 0 value 640
             }
             Fl_Value_Input customResolutionYInput {
-              xywh {140 194 80 25} minimum 480 maximum 0 value 480
+              xywh {146 194 80 25} minimum 480 maximum 0 value 480
             }
             Fl_Box {} {
               label x
-              xywh {120 194 20 25}
+              xywh {126 194 20 25}
             }
           }
           Fl_Check_Button playSoundsCheckbox {
             label {Play Sounds}
-            xywh {20 261 130 19} down_box DOWN_BOX value 1
+            xywh {26 261 130 19} down_box DOWN_BOX value 1
           }
         }
         Fl_Group {} {open
-          xywh {260 105 185 175}
+          xywh {270 105 186 175}
         } {
           Fl_Button playButton {
             label {Play Ja2 Stracciatella}
-            xywh {260 225 185 55}
+            xywh {270 225 185 55}
           }
           Fl_Button editorButton {
             label {Start Map Editor}
-            xywh {260 190 185 25}
+            xywh {270 190 185 25}
           }
         }
       }


### PR DESCRIPTION
Note: This requires some reshuffling of the other widgets as well, because
"Game" needs more space than "Data" for non-monospace fonts.