### PR TITLE
Fix crash during load screen with RUSSIAN data files

### DIFF
--- a/src/game/Utils/_RussianText.cc
+++ b/src/game/Utils/_RussianText.cc
@@ -3798,6 +3798,8 @@ LanguageRes g_LanguageResRussian = {
 	s_rus_str_iron_man_mode_warning,
 	g_eng_str_dead_is_dead_mode_warning,
 	g_eng_str_dead_is_dead_mode_enter_name,
+
+	s_rus_gs_dead_is_dead_mode_tab_name,
 };
 
 


### PR DESCRIPTION
When I'm using RUSSIAN game version, as soon as I try to open load screen, the game crashes. 
Added missing entry s_rus_gs_dead_is_dead_mode_tab_name to g_LanguageResRussian array.
RUSSIAN_GOLD version seems to already have it.