### PR TITLE
Never give an item to an unnamed NPC

### DIFF
--- a/src/game/Tactical/Interface_Items.cc
+++ b/src/game/Tactical/Interface_Items.cc
@@ -3013,9 +3013,19 @@ void DrawItemTileCursor( )
 		// OK, if different than default, change....
 		if ( gfItemPointerDifferentThanDefault )
 		{
-			fGiveItem = !fGiveItem;
+			if (fGiveItem)
+			{
+				// We are targeting a talkable NPC and are using the alternative cursor to
+				// throw instead.
+				fGiveItem = FALSE;
+			}
+			else
+			{
+				// We are using the alternative cursor and the target is not a talkable NPC
+				// Only use the give item cursor if the target is a merc.
+				fGiveItem = GetValidTalkableNPCFromMouse(TRUE, TRUE, FALSE) != NULL;
+			}
 		}
-
 
 		// Get recalc and cursor flags
 		MouseMoveState uiCursorFlags;
@@ -3331,7 +3341,18 @@ BOOLEAN HandleItemPointerClick( UINT16 usMapPos )
 	// OK, if different than default, change....
 	if ( gfItemPointerDifferentThanDefault )
 	{
-		fGiveItem = !fGiveItem;
+		if (fGiveItem)
+		{
+			// We are targeting a talkable NPC and are using the alternative cursor to
+			// throw instead.
+			fGiveItem = FALSE;
+		}
+		else
+		{
+			// We are using the alternative cursor and the target is not a talkable NPC
+			// Only give an item if the target is a merc.
+			fGiveItem = tgt != NULL && IsValidTalkableNPC(tgt, TRUE, TRUE, TRUE);
+		}
 	}
 
 


### PR DESCRIPTION
always throw it.

Without this fix it is possible to give an item to an unnamed NPC via the
alternative cursor mode that can be activated by right clicking while
hovering over the NPC. This causes a softlock that displays the spinning
watch indefinitely.

Fixes issue #694