### PR TITLE
Prevent segmentation fault in CalcChanceToHitGun()

### DIFF
--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -2163,7 +2163,7 @@ UINT32 CalcChanceToHitGun(SOLDIERTYPE *pSoldier, UINT16 sGridNo, UINT8 ubAimTime
 		}
 	}
 
-	if ( !(GCM->getItem(usInHand)->isTwoHanded()) )
+	if (GCM->getItem(usInHand)->isWeapon() && !(GCM->getItem(usInHand)->isTwoHanded()))
 	{
 		// SMGs are treated as pistols for these purpose except there is a -5 penalty;
 		if (GCM->getWeapon(usInHand)->ubWeaponClass == SMGCLASS)


### PR DESCRIPTION
Check if item is a weapon before entering the dual wielding penalty calculation
code.

GCM->getWeapon() returns NULL if the item is not a weapon.

Fixes #495 