### PR TITLE
Collapsing mercs can't kick doors anymore

### DIFF
--- a/src/game/Tactical/Points.cc
+++ b/src/game/Tactical/Points.cc
@@ -464,6 +464,8 @@ BOOLEAN EnoughPoints(const SOLDIERTYPE* pSoldier, INT16 sAPCost, INT16 sBPCost, 
 	if (!(gTacticalStatus.uiFlags & INCOMBAT))
 	{
 		sAPCost = 0;
+		if ( pSoldier->bCollapsed )
+		  return( FALSE );
 	}
 
 	// Get New points


### PR DESCRIPTION
Fixes #476 
In the enoughPoints function there is now a check whether the merc is collapsed in realtime-mode. Weird thing about this function is that there is a sBPCost(BreathPoints) argument which isn't used at all.