### PR TITLE
Allow to load any map version with RUSSIAN resources

### DIFF
--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -2037,11 +2037,6 @@ try
 	FLOAT dMajorMapVersion;
 	FileRead(f, &dMajorMapVersion, sizeof(dMajorMapVersion));
 
-	if(isRussianVersion() && (dMajorMapVersion != 6.00))
-	{
-		throw std::runtime_error("Incompatible major map version");
-	}
-
 	UINT8 ubMinorMapVersion;
 	if (dMajorMapVersion >= 4.00)
 	{
@@ -2281,7 +2276,7 @@ try
 		}
 	}
 
-	if(isRussianVersion())
+	if (dMajorMapVersion == 6.00)
 	{
 		FileSeek(f, 148, FILE_SEEK_FROM_CURRENT);
 	}


### PR DESCRIPTION
Hello.
I did a try to start with mod 'from-russia-with-love' but game surprised me with runtime error in the process of loading map. Soon I realized that russian version is restricted to maps with v6.0. Map A9 from mod has v5.0.
From the other side, I think non-russian versions will fail to load v6.0. So, I made map loading compatibility patch - any map version will be loaded despite language version.