### PR TITLE
fix possible division by zero / SIGFPE

### DIFF
--- a/src/game/Tactical/Interface_Utils.cc
+++ b/src/game/Tactical/Interface_Utils.cc
@@ -214,7 +214,7 @@ void DrawItemUIBarEx(OBJECTTYPE const& o, const UINT8 ubStatus, const INT16 x, c
 	}
 	else if (item->isAmmo())
 	{
-		value = 100 * o.ubShotsLeft[ubStatus] / item->asAmmo()->capacity;
+		value = 100 * o.ubShotsLeft[ubStatus] / (item->asAmmo()->capacity? item->asAmmo()->capacity: 1);
 		if (value > 100) value = 100;
 	}
 	else if (item->isKey())

--- a/src/game/Tactical/ShopKeeper_Interface.cc
+++ b/src/game/Tactical/ShopKeeper_Interface.cc
@@ -2585,7 +2585,7 @@ static FLOAT ItemConditionModifier(UINT16 usItemIndex, INT8 bStatus)
 	if( GCM->getItem(usItemIndex)->getItemClass() == IC_AMMO )
 	{
 		// # bullets left / max magazine capacity
-		dConditionModifier = ( bStatus / (FLOAT) GCM->getItem(usItemIndex)->asAmmo()->capacity);
+		dConditionModifier = bStatus / ((FLOAT) GCM->getItem(usItemIndex)->asAmmo()->capacity? (FLOAT) GCM->getItem(usItemIndex)->asAmmo()->capacity: 1);
 	}
 	else	// non-ammo
 	{

--- a/src/game/Tactical/World_Items.cc
+++ b/src/game/Tactical/World_Items.cc
@@ -328,7 +328,7 @@ void LoadWorldItemsFromMap(HWFILE const f)
 						UINT8 const new_mag_size = replacement->capacity;
 						for (UINT8 i = 0; i != o.ubNumberOfObjects; ++i)
 						{
-							o.bStatus[i] = o.bStatus[i] * new_mag_size / mag_size;
+							o.bStatus[i] = o.bStatus[i] * new_mag_size / (mag_size? mag_size: 1);
 						}
 
 						// then replace item #


### PR DESCRIPTION
A SIGFPE can happen if cycling through items in Alt+w cheat mode. With this change the exception is gone.