### PR TITLE
Use more readable labels in launcher

### DIFF
--- a/rust/src/stracciatella.rs
+++ b/rust/src/stracciatella.rs
@@ -85,14 +85,14 @@ impl FromStr for ResourceVersion {
 impl Display for ResourceVersion {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", match self {
-            &ResourceVersion::DUTCH => "DUTCH",
-            &ResourceVersion::ENGLISH => "ENGLISH",
-            &ResourceVersion::FRENCH => "FRENCH",
-            &ResourceVersion::GERMAN => "GERMAN",
-            &ResourceVersion::ITALIAN => "ITALIAN",
-            &ResourceVersion::POLISH => "POLISH",
-            &ResourceVersion::RUSSIAN => "RUSSIAN",
-            &ResourceVersion::RUSSIAN_GOLD => "RUSSIAN_GOLD",
+            &ResourceVersion::DUTCH => "Dutch",
+            &ResourceVersion::ENGLISH => "English",
+            &ResourceVersion::FRENCH => "French",
+            &ResourceVersion::GERMAN => "German",
+            &ResourceVersion::ITALIAN => "Italian",
+            &ResourceVersion::POLISH => "Polish",
+            &ResourceVersion::RUSSIAN => "Russian",
+            &ResourceVersion::RUSSIAN_GOLD => "Russian (Gold)",
         })
     }
 }
@@ -122,9 +122,9 @@ impl FromStr for ScalingQuality {
 impl Display for ScalingQuality {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", match self {
-            &ScalingQuality::LINEAR => "LINEAR",
-            &ScalingQuality::NEAR_PERFECT => "NEAR_PERFECT",
-            &ScalingQuality::PERFECT => "PERFECT",
+            &ScalingQuality::LINEAR => "Linear Interpolation",
+            &ScalingQuality::NEAR_PERFECT => "Near perfect with oversampling",
+            &ScalingQuality::PERFECT => "Pixel perfect centered",
         })
     }
 }
@@ -550,13 +550,8 @@ pub extern fn get_resource_version(ptr: *const EngineOptions) -> ResourceVersion
 }
 
 #[no_mangle]
-pub extern fn set_resource_version(ptr: *mut EngineOptions, res_ptr: *const c_char) -> () {
-    let c_str = unsafe { CStr::from_ptr(res_ptr) };
-    let version = c_str.to_str().unwrap();
-
-    if let Ok(v) = ResourceVersion::from_str(version) {
-        unsafe_from_ptr_mut!(ptr).resource_version = v
-    }
+pub extern fn set_resource_version(ptr: *mut EngineOptions, res: ResourceVersion) -> () {
+    unsafe_from_ptr_mut!(ptr).resource_version = res;
 }
 
 #[no_mangle]
@@ -585,13 +580,14 @@ pub fn get_scaling_quality(ptr: *const EngineOptions) -> ScalingQuality {
 }
 
 #[no_mangle]
-pub fn set_scaling_quality(ptr: *mut EngineOptions, res_ptr: *const c_char) -> () {
-    let c_str = unsafe { CStr::from_ptr(res_ptr) };
-    let quality = c_str.to_str().unwrap();
+pub extern fn get_scaling_quality_string(quality: ScalingQuality) -> *mut c_char {
+    let c_str_home = CString::new(quality.to_string()).unwrap();
+    c_str_home.into_raw()
+}
 
-    if let Ok(q) = ScalingQuality::from_str(quality) {
-        unsafe_from_ptr_mut!(ptr).scaling_quality = q
-    }
+#[no_mangle]
+pub fn set_scaling_quality(ptr: *mut EngineOptions, scaling_quality: ScalingQuality) -> () {
+        unsafe_from_ptr_mut!(ptr).scaling_quality = scaling_quality
 }
 
 
@@ -1109,14 +1105,14 @@ r##"{
 
     #[test]
     fn get_resource_version_string_should_return_the_correct_resource_version_string() {
-        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::DUTCH), "DUTCH");
-        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::ENGLISH), "ENGLISH");
-        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::FRENCH), "FRENCH");
-        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::GERMAN), "GERMAN");
-        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::ITALIAN), "ITALIAN");
-        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::POLISH), "POLISH");
-        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::RUSSIAN), "RUSSIAN");
-        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::RUSSIAN_GOLD), "RUSSIAN_GOLD");
+        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::DUTCH), "Dutch");
+        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::ENGLISH), "English");
+        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::FRENCH), "French");
+        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::GERMAN), "German");
+        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::ITALIAN), "Italian");
+        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::POLISH), "Polish");
+        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::RUSSIAN), "Russian");
+        assert_chars_eq!(super::get_resource_version_string(super::ResourceVersion::RUSSIAN_GOLD), "Russian (Gold)");
 
     }
 

--- a/src/externalized/RustInterface.h
+++ b/src/externalized/RustInterface.h
@@ -16,7 +16,7 @@ extern "C" {
 	extern UINT16 get_resolution_y(const engine_options_t *);
 	extern void set_resolution(const engine_options_t *, UINT16, UINT16);
 	extern GameVersion get_resource_version(const engine_options_t *);
-	extern void set_resource_version(const engine_options_t *, const char *);
+	extern void set_resource_version(const engine_options_t *, GameVersion);
 	extern char * get_resource_version_string(GameVersion);
 	extern void free_rust_string(char *);
 	extern bool should_show_help(const engine_options_t *);
@@ -24,7 +24,8 @@ extern "C" {
 	extern bool should_run_editor(const engine_options_t *);
 	extern bool should_start_in_fullscreen(const engine_options_t *);
 	extern VideoScaleQuality get_scaling_quality(const engine_options_t *);
-	extern void set_scaling_quality(const engine_options_t *, const char *);
+	extern char * get_scaling_quality_string(VideoScaleQuality);
+	extern void set_scaling_quality(const engine_options_t *, VideoScaleQuality);
 	extern void set_start_in_fullscreen(const engine_options_t *, bool);
 	extern bool should_start_in_window(const engine_options_t *);
 	extern bool should_start_in_debug_mode(const engine_options_t *);

--- a/src/launcher/Launcher.h
+++ b/src/launcher/Launcher.h
@@ -13,9 +13,6 @@ public:
 	int writeJsonFile();
 private:
 	std::string exePath;
-	std::string helpString;
-	std::vector< std::pair<int, int> > predefinedResolutions;
-	std::vector< std::pair<const char*, const char*> > scalingModes;
 	engine_options_t* engine_options;
 
 	void populateChoices();

--- a/src/launcher/StracciatellaLauncher.cc
+++ b/src/launcher/StracciatellaLauncher.cc
@@ -3,7 +3,7 @@
 #include "StracciatellaLauncher.h"
 
 StracciatellaLauncher::StracciatellaLauncher() {
-  { stracciatellaLauncher = new Fl_Double_Window(465, 329, "JA2 Stracciatella Launcher");
+  { stracciatellaLauncher = new Fl_Double_Window(465, 325, "JA2 Stracciatella Launcher");
     stracciatellaLauncher->user_data((void*)(this));
     { Fl_Group* o = new Fl_Group(0, 0, 465, 318);
       { Fl_Group* o = new Fl_Group(5, 10, 451, 65);
@@ -11,8 +11,9 @@ StracciatellaLauncher::StracciatellaLauncher() {
         { dataDirectoryInput = new Fl_Input(156, 10, 270, 25, "JA2 Game Directory:");
           dataDirectoryInput->align(Fl_Align(132));
         } // Fl_Input* dataDirectoryInput
-        { gameVersionInput = new Fl_Input_Choice(156, 40, 300, 25, "Game Version:");
-        } // Fl_Input_Choice* gameVersionInput
+        { gameVersionInput = new Fl_Choice(156, 40, 300, 25, "Game Version:");
+          gameVersionInput->down_box(FL_BORDER_BOX);
+        } // Fl_Choice* gameVersionInput
         { browseJa2DirectoryButton = new Fl_Button(431, 10, 25, 25, "...");
         } // Fl_Button* browseJa2DirectoryButton
         o->end();

--- a/src/launcher/StracciatellaLauncher.fl
+++ b/src/launcher/StracciatellaLauncher.fl
@@ -20,7 +20,7 @@ class StracciatellaLauncher {open
             label {JA2 Game Directory:}
             xywh {156 10 270 25} align 132
           }
-          Fl_Input_Choice gameVersionInput {
+          Fl_Choice gameVersionInput {
             label {Game Version:} open
             xywh {156 40 300 25}
           } {}

--- a/src/launcher/StracciatellaLauncher.h
+++ b/src/launcher/StracciatellaLauncher.h
@@ -6,20 +6,20 @@
 #include <FL/Fl_Double_Window.H>
 #include <FL/Fl_Group.H>
 #include <FL/Fl_Input.H>
-#include <FL/Fl_Input_Choice.H>
+#include <FL/Fl_Choice.H>
 #include <FL/Fl_Button.H>
 #include <FL/Fl_Check_Button.H>
 #include <FL/Fl_Round_Button.H>
+#include <FL/Fl_Input_Choice.H>
 #include <FL/Fl_Value_Input.H>
 #include <FL/Fl_Box.H>
-#include <FL/Fl_Choice.H>
 
 class StracciatellaLauncher {
 public:
   StracciatellaLauncher();
   Fl_Double_Window *stracciatellaLauncher;
   Fl_Input *dataDirectoryInput;
-  Fl_Input_Choice *gameVersionInput;
+  Fl_Choice *gameVersionInput;
   Fl_Button *browseJa2DirectoryButton;
   Fl_Check_Button *fullscreenCheckbox;
   Fl_Round_Button *predefinedResolutionButton;


### PR DESCRIPTION
Uses `Russian` instead of `RUSSIAN`. 