### PR TITLE
Added brightness/gamma setting to ja2.json. closes #709

### DIFF
--- a/assets/distr-files-linux/ja2_manpage
+++ b/assets/distr-files-linux/ja2_manpage
@@ -20,6 +20,11 @@ Path to vanilla data
 \fB\-res WxH\fR
 Screen resolution, e.g. 800x600. Default value is 640x480
 .TP
+\fB\-brightness GAMMA\fR
+Screen brightness (gamma multiplier) value to set where 0.0 is completely dark and 1.0 is normal brightness. Default value is 1.0
+.br
+NOTE: some video drivers do not support setting the gamma value and this option may not have any effect in those cases
+.TP
 \fB\-resversion VERSION\fR
 Version of the game resources.
 Possible values are: DUTCH, ENGLISH, FRENCH, GERMAN, ITALIAN, POLISH, RUSSIAN, RUSSIAN_GOLD.

--- a/src/externalized/RustInterface.h
+++ b/src/externalized/RustInterface.h
@@ -15,6 +15,8 @@ extern "C" {
 	extern UINT16 get_resolution_x(const engine_options_t *);
 	extern UINT16 get_resolution_y(const engine_options_t *);
 	extern void set_resolution(const engine_options_t *, UINT16, UINT16);
+	extern FLOAT get_brightness(const engine_options_t *);
+	extern void set_brightness(const engine_options_t *, FLOAT);
 	extern GameVersion get_resource_version(const engine_options_t *);
 	extern void set_resource_version(const engine_options_t *, GameVersion);
 	extern char * get_resource_version_string(GameVersion);

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -336,6 +336,8 @@ int main(int argc, char* argv[])
 
 	VideoScaleQuality scalingQuality = get_scaling_quality(params);
 
+	FLOAT brightness = get_brightness(params);
+
 	////////////////////////////////////////////////////////////
 
 	SDL_Init(SDL_INIT_VIDEO);
@@ -412,7 +414,7 @@ int main(int argc, char* argv[])
 		SLOGI(DEBUG_TAG_SGP,"------------------------------------------------------------------------------");
 	}
 
-		free_engine_options(params);
+	free_engine_options(params);
 
 	std::vector<std::string> libraries = cm->getListOfGameResources();
 	cm->initGameResouces(configFolderPath, libraries);
@@ -428,6 +430,7 @@ int main(int argc, char* argv[])
 
 		SLOGD(DEBUG_TAG_SGP, "Initializing Video Manager");
 		InitializeVideoManager(scalingQuality);
+		VideoSetBrightness(brightness);
 
 		SLOGD(DEBUG_TAG_SGP, "Initializing Video Object Manager");
 		InitializeVideoObjectManager();

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -121,6 +121,11 @@ void VideoToggleFullScreen(void)
 	}
 }
 
+void VideoSetBrightness(float brightness)
+{
+	SDL_SetWindowBrightness(g_game_window, brightness);
+}
+
 
 static void GetRGBDistribution();
 

--- a/src/sgp/Video.h
+++ b/src/sgp/Video.h
@@ -26,6 +26,8 @@ void         GetPrimaryRGBDistributionMasks(UINT32* RedBitMask, UINT32* GreenBit
 void         EndFrameBufferRender(void);
 void         PrintScreen(void);
 
+void VideoSetBrightness(float brightness);
+
 /* Toggle between fullscreen and window mode after initialising the video
  * manager */
 void VideoToggleFullScreen(void);


### PR DESCRIPTION
As the title says. It allows to set brightness value so it corrects the gamma in game.