### PR TITLE
Fixed crash due to assertion in Strategic_AI::MoveSAIGroupToSector()

### DIFF
--- a/src/game/Strategic/Strategic_AI.cc
+++ b/src/game/Strategic/Strategic_AI.cc
@@ -963,15 +963,21 @@ static BOOLEAN HandlePlayerGroupNoticedByPatrolGroup(const GROUP* const pPlayerG
 	usOffensePoints = pEnemyGroup->pEnemyGroup->ubNumAdmins * 2 +
 										pEnemyGroup->pEnemyGroup->ubNumTroops * 4 +
 										pEnemyGroup->pEnemyGroup->ubNumElites * 6;
-	if( PlayerForceTooStrong( ubSectorID, usOffensePoints, &usDefencePoints ) )
+
+	const UINT8 playerSector = pPlayerGroup->ubNextX
+			? SECTOR(pPlayerGroup->ubNextX, pPlayerGroup->ubNextY)
+			: SECTOR(pPlayerGroup->ubSectorX, pPlayerGroup->ubSectorY);
+
+	if(PlayerForceTooStrong(ubSectorID, usOffensePoints, &usDefencePoints)
+	   || SectorInfo[playerSector].ubGarrisonID != NO_GARRISON)
 	{
-		RequestAttackOnSector( ubSectorID, usDefencePoints );
+		RequestAttackOnSector(ubSectorID, usDefencePoints);
 		return FALSE;
 	}
 	//For now, automatically attack.
 	if( pPlayerGroup->ubNextX )
 	{
-		MoveSAIGroupToSector( &pEnemyGroup, (UINT8)SECTOR( pPlayerGroup->ubNextX, pPlayerGroup->ubNextY ), DIRECT, PURSUIT );
+		MoveSAIGroupToSector( &pEnemyGroup, playerSector, DIRECT, PURSUIT );
 
 		SLOGD(DEBUG_TAG_SAI, "Enemy group at %c%d detected player group at %c%d and is moving to intercept them at %c%d.",
 					pEnemyGroup->ubSectorY + 'A' - 1, pEnemyGroup->ubSectorX,
@@ -980,7 +986,7 @@ static BOOLEAN HandlePlayerGroupNoticedByPatrolGroup(const GROUP* const pPlayerG
 	}
 	else
 	{
-		MoveSAIGroupToSector( &pEnemyGroup, (UINT8)SECTOR( pPlayerGroup->ubSectorX, pPlayerGroup->ubSectorY ), DIRECT, PURSUIT );
+		MoveSAIGroupToSector( &pEnemyGroup, playerSector, DIRECT, PURSUIT );
 
 		SLOGD(DEBUG_TAG_SAI, "Enemy group at %c%d detected player group at %c%d and is moving to intercept them at %c%d.",
 					pEnemyGroup->ubSectorY + 'A' - 1, pEnemyGroup->ubSectorX,


### PR DESCRIPTION
When enemy patrol group notices player group in section with garrison, Strategic_AI::HandlePlayerGroupNoticedByPatrolGroup() will send enemy group in PURSUIT and it will cause crash because of following assertion failure in Strategic_AI::MoveSAIGroupToSector():
```
/* Make sure that the group isn't moving into a garrison sector. These sectors
 * should be using ASSAULT intentions! */
Assert(intention != PURSUIT || SectorInfo[sector].ubGarrisonID == NO_GARRISON);
```

Have attached the [SaveGame07.zip](https://github.com/ja2-stracciatella/ja2-stracciatella/files/2508869/SaveGame07.zip) that will cause the crash by advancing the time for few seconds. You have to retry it few times so RNG will trigger enemy patrol notice.
