### PR TITLE
Fixed delay after stealing items from another merc.

### DIFF
--- a/src/game/Tactical/Soldier_Ani.cc
+++ b/src/game/Tactical/Soldier_Ani.cc
@@ -489,6 +489,13 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 					//CODE: FOR A NON-INTERRUPTABLE SCRIPT - SIGNAL DONE
 					pSoldier->fInNonintAnim = FALSE;
 
+					if (pSoldier->usAnimState == STEAL_ITEM) {
+						SLOGD(DEBUG_TAG_SOLDIER,
+							"Reducing attacker busy count..., CODE FROM ANIMATION %hs ( %d )",
+							gAnimControl[pSoldier->usAnimState].zAnimStr, pSoldier->usAnimState);
+						ReduceAttackBusyCount(pSoldier, FALSE);
+					}
+
 					// ATE: if it's the begin cower animation, unset ui, cause it could
 					// be from player changin stance
 					if ( pSoldier->usAnimState == START_COWER )

--- a/src/game/Tactical/Soldier_Ani.cc
+++ b/src/game/Tactical/Soldier_Ani.cc
@@ -490,8 +490,7 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 					pSoldier->fInNonintAnim = FALSE;
 
 					if (pSoldier->usAnimState == STEAL_ITEM) {
-						SLOGD(DEBUG_TAG_SOLDIER,
-							"Reducing attacker busy count..., CODE FROM ANIMATION %hs ( %d )",
+						SLOGD("Reducing attacker busy count..., CODE FROM ANIMATION %hs ( %d )",
 							gAnimControl[pSoldier->usAnimState].zAnimStr, pSoldier->usAnimState);
 						ReduceAttackBusyCount(pSoldier, FALSE);
 					}


### PR DESCRIPTION
After merc does steal action on another merc, animation is started and busy count is increased but is never decreased, so ui gets locked for 25 seconds until the lock timeout expires.
This fixes that so as soon as animation finishes attack busy count get decreased, and when it reaches zero UI leaves wait state as it should.