### PR TITLE
Fixed game starting completely dark.

### DIFF
--- a/rust/src/stracciatella.rs
+++ b/rust/src/stracciatella.rs
@@ -164,8 +164,7 @@ pub struct EngineOptions {
     mods: Vec<String>,
     #[serde(rename ="res", serialize_with = "serialize_resolution", deserialize_with = "deserialize_resolution")]
     resolution: (u16, u16),
-    #[serde(default)]
-    brightness: (f32),
+    brightness: f32,
     #[serde(rename = "resversion")]
     resource_version: ResourceVersion,
     #[serde(skip)]


### PR DESCRIPTION
When starting game directly without ja2-launcher and no brightness setting defined in json or command line it would default to 0.0, and whole screen would turn completely dark.

I'd appreciate if someone with more experience in rust and serde_json would check this to confirm this is correct solution. Apparently serde(default) would set this value to 0.0 instead of using what was defined here: https://github.com/ja2-stracciatella/ja2-stracciatella/blob/master/rust/src/stracciatella.rs#L196

I thought serde(default) is just supposed to add line to json if not present using the default value from that line... apparently not.

Edit: this was introduced by changes from my pull request #734 