### PR TITLE
Modularize rust code

### DIFF
--- a/rust/src/config/cli.rs
+++ b/rust/src/config/cli.rs
@@ -1,0 +1,191 @@
+use std::fs;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use getopts::Options;
+
+use EngineOptions;
+use Resolution;
+use VanillaVersion;
+
+#[cfg(not(windows))]
+static DATA_DIR_OPTION_EXAMPLE: &'static str = "/opt/ja2";
+
+#[cfg(windows)]
+static DATA_DIR_OPTION_EXAMPLE: &'static str = "C:\\JA2";
+
+pub struct Cli {
+    args: Vec<String>,
+    options: Options
+}
+
+impl Cli {
+    pub fn from_args(args: &[String]) -> Self {
+        let mut opts = Options::new();
+
+        opts.long_only(true);
+        opts.optmulti(
+            "",
+            "datadir",
+            "Set path for data directory",
+            DATA_DIR_OPTION_EXAMPLE
+        );
+        opts.optmulti(
+            "",
+            "mod",
+            "Start one of the game modifications. MOD_NAME is the name of modification, e.g. 'from-russia-with-love. See mods folder for possible options'.",
+            "MOD_NAME"
+        );
+        opts.optopt(
+            "",
+            "res",
+            "Screen resolution, e.g. 800x600. Default value is 640x480",
+            "WIDTHxHEIGHT"
+        );
+        opts.optopt(
+            "",
+            "brightness",
+            "Screen brightness (gamma multiplier) value to set where 0.0 is completely dark and 1.0 is normal brightness. Default value is 1.0",
+            "GAMMA_VALUE"
+        );
+        opts.optopt(
+            "",
+            "resversion",
+            "Version of the game resources. Possible values: DUTCH, ENGLISH, FRENCH, GERMAN, ITALIAN, POLISH, RUSSIAN, RUSSIAN_GOLD. Default value is ENGLISH. RUSSIAN is for BUKA Agonia Vlasty release. RUSSIAN_GOLD is for Gold release",
+            "RUSSIAN_GOLD"
+        );
+        opts.optflag(
+            "",
+            "unittests",
+            "Perform unit tests. E.g. 'ja2.exe -unittests --gtest_output=\"xml:report.xml\" --gtest_repeat=2'");
+        opts.optflag(
+            "",
+            "editor",
+            "Start the map editor (Editor.slf is required)"
+        );
+        opts.optflag(
+            "",
+            "fullscreen",
+            "Start the game in the fullscreen mode"
+        );
+        opts.optflag(
+            "",
+            "nosound",
+            "Turn the sound and music off"
+        );
+        opts.optflag(
+            "",
+            "window",
+            "Start the game in a window"
+        );
+        opts.optflag(
+            "",
+            "debug",
+            "Enable Debug Mode"
+        );
+        opts.optflag(
+            "",
+            "help",
+            "print this help menu"
+        );
+
+        Cli {
+            args: args.to_vec(),
+            options: opts
+        }
+    }
+
+    pub fn apply_to_engine_options(&self, engine_options: &mut EngineOptions) -> Result<(), String> {
+        match self.options.parse(&self.args[1..]) {
+            Ok(m) => {
+                if !m.free.is_empty() {
+                    return Err(format!("Unknown arguments: '{}'.", m.free.join(" ")));
+                }
+
+                if let Some(s) = m.opt_str("datadir") {
+                    match fs::canonicalize(PathBuf::from(s)) {
+                        Ok(s) => {
+                            let mut temp = String::from(s.to_str().expect("Should not happen"));
+                            // remove UNC path prefix (Windows)
+                            if temp.starts_with("\\\\") {
+                                temp.drain(..2);
+                                let pos = temp.find('\\').unwrap() + 1;
+                                temp.drain(..pos);
+                            }
+                            engine_options.vanilla_data_dir = PathBuf::from(temp)
+                        },
+                        Err(_) => return Err(String::from("Please specify an existing datadir."))
+                    };
+                }
+
+                if !m.opt_strs("mod").is_empty() {
+                    engine_options.mods = m.opt_strs("mod");
+                }
+
+                if let Some(s) = m.opt_str("res") {
+                    match Resolution::from_str(&s) {
+                        Ok(res) => {
+                            engine_options.resolution = res;
+                        },
+                        Err(s) => return Err(s)
+                    }
+                }
+
+                if let Some(s) = m.opt_str("brightness") {
+                    match s.parse::<f32>() {
+                        Ok(val) => {
+                            engine_options.brightness = val;
+                        },
+                        Err(_e) => return Err(String::from("Incorrect brightness value."))
+                    }
+                }
+
+                if let Some(s) = m.opt_str("resversion") {
+                    match VanillaVersion::from_str(&s) {
+                        Ok(resource_version) => {
+                            engine_options.resource_version = resource_version
+                        },
+                        Err(s) => return Err(s)
+                    }
+                }
+
+                if m.opt_present("help") {
+                    engine_options.show_help = true;
+                }
+
+
+                if m.opt_present("unittests") {
+                    engine_options.run_unittests = true;
+                }
+
+                if m.opt_present("editor") {
+                    engine_options.run_editor = true;
+                }
+
+                if m.opt_present("fullscreen") {
+                    engine_options.start_in_fullscreen = true;
+                }
+
+                if m.opt_present("nosound") {
+                    engine_options.start_without_sound = true;
+                }
+
+                if m.opt_present("window") {
+                    engine_options.start_in_window = true;
+                }
+
+                if m.opt_present("debug") {
+                    engine_options.start_in_debug_mode = true;
+                }
+
+                Ok(())
+            }
+            Err(f) => Err(f.to_string())
+        }
+    }
+
+    pub fn usage() -> String {
+        let cli = Cli::from_args(&[]);
+        cli.options.usage("Usage: ja2 [options]")
+    }
+}

--- a/rust/src/config/engine_options.rs
+++ b/rust/src/config/engine_options.rs
@@ -1,0 +1,69 @@
+use std::path::PathBuf;
+
+use Resolution;
+use ScalingQuality;
+use VanillaVersion;
+
+#[derive(Debug, PartialEq)]
+pub struct EngineOptions {
+    pub stracciatella_home: PathBuf,
+    pub vanilla_data_dir: PathBuf,
+    pub mods: Vec<String>,
+    pub resolution: Resolution,
+    pub brightness: f32,
+    pub resource_version: VanillaVersion,
+    pub show_help: bool,
+    pub run_unittests: bool,
+    pub run_editor: bool,
+    pub start_in_fullscreen: bool,
+    pub start_in_window: bool,
+	pub scaling_quality: ScalingQuality,
+    pub start_in_debug_mode: bool,
+    pub start_without_sound: bool,
+}
+
+impl Default for EngineOptions {
+    fn default() -> EngineOptions {
+        EngineOptions {
+            stracciatella_home: PathBuf::from(""),
+            vanilla_data_dir: PathBuf::from(""),
+            mods: vec!(),
+            resolution: Resolution::default(),
+            brightness: 1.0,
+            resource_version: VanillaVersion::ENGLISH,
+            show_help: false,
+            run_unittests: false,
+            run_editor: false,
+            start_in_fullscreen: false,
+            start_in_window: true,
+			scaling_quality: ScalingQuality::default(),
+            start_in_debug_mode: false,
+            start_without_sound: false,
+        }
+    }
+}
+
+impl EngineOptions {
+    pub fn from_home_and_args(stracciatella_home: &PathBuf, args: &[String]) -> Result<EngineOptions, String> {
+        use ensure_json_config_existence;
+        use parse_json_config;
+        use parse_args;
+
+        ensure_json_config_existence(stracciatella_home)?;
+
+        let mut engine_options = parse_json_config(&stracciatella_home)?;
+
+        engine_options.stracciatella_home = stracciatella_home.clone();
+
+        match parse_args(&mut engine_options, args) {
+            None => Ok(()),
+            Some(str) => Err(str)
+        }?;
+
+        if engine_options.vanilla_data_dir == PathBuf::from("") {
+            return Err(String::from("Vanilla data directory has to be set either in config file or per command line switch"))
+        }
+
+        Ok(engine_options)
+    }
+}

--- a/rust/src/config/ja2_json.rs
+++ b/rust/src/config/ja2_json.rs
@@ -1,0 +1,130 @@
+use std::error::Error;
+use std::fs;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use Resolution;
+use VanillaVersion;
+use ScalingQuality;
+use EngineOptions;
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Ja2JsonContent {
+    data_dir: Option<PathBuf>,
+    mods: Option<Vec<String>>,
+    res: Option<Resolution>,
+    brightness: Option<f32>,
+    resversion: Option<VanillaVersion>,
+    fullscreen: Option<bool>,
+    scaling: Option<ScalingQuality>,
+    debug: Option<bool>,
+    nosound: Option<bool>,
+}
+
+pub struct Ja2Json {
+    path: PathBuf
+}
+
+fn build_json_config_location(stracciatella_home: &PathBuf) -> PathBuf {
+    let mut path = PathBuf::from(stracciatella_home);
+    path.push("ja2.json");
+    path
+}
+
+impl Ja2Json {
+    pub fn from_stracciatella_home(stracciatella_home: &PathBuf) -> Self {
+        let path = build_json_config_location(stracciatella_home);
+        return Ja2Json { path: path };
+    }
+
+    pub fn get_content(&self) -> Result<Ja2JsonContent, String> {
+        File::open(&self.path)
+            .map_err(|s| format!("Error reading ja2.json config file: {}", s.description()))
+            .and_then(|f| serde_json::from_reader(f).map_err(|s| format!("Error parsing ja2.json config file: {}", s)))
+    }
+
+    pub fn apply_to_engine_options(&self, engine_options: &mut EngineOptions) -> Result<(), String> {
+        macro_rules! copy_to {
+            ($from: expr, $to: expr) => { if let Some(v) = $from { $to = v; } }
+        }
+
+        let content = self.get_content()?;
+
+        copy_to!(content.data_dir, engine_options.vanilla_data_dir);
+        copy_to!(content.mods, engine_options.mods);
+        copy_to!(content.res, engine_options.resolution);
+        copy_to!(content.brightness, engine_options.brightness);
+        copy_to!(content.resversion, engine_options.resource_version);
+        copy_to!(content.fullscreen, engine_options.start_in_fullscreen);
+        copy_to!(content.scaling, engine_options.scaling_quality);
+        copy_to!(content.debug, engine_options.start_in_debug_mode);
+        copy_to!(content.nosound, engine_options.start_without_sound);
+
+        Ok(())
+    }
+
+    pub fn write(&self, engine_options: &EngineOptions) -> Result<(), String> {
+        macro_rules! copy_to {
+            ($from: expr, $to: expr) => { $to = Some($from.clone()); }
+        }
+
+        let mut content = Ja2JsonContent {
+            data_dir: None,
+            mods: None,
+            res: None,
+            brightness: None,
+            resversion: None,
+            fullscreen: None,
+            scaling: None,
+            debug: None,
+            nosound: None,
+        };
+
+        copy_to!(engine_options.vanilla_data_dir, content.data_dir);
+        copy_to!(engine_options.mods, content.mods);
+        copy_to!(engine_options.resolution, content.res);
+        copy_to!(engine_options.brightness, content.brightness);
+        copy_to!(engine_options.resource_version, content.resversion);
+        copy_to!(engine_options.start_in_fullscreen, content.fullscreen);
+        copy_to!(engine_options.scaling_quality, content.scaling);
+        copy_to!(engine_options.start_in_debug_mode, content.debug);
+        copy_to!(engine_options.start_without_sound, content.nosound);
+
+
+        let json = serde_json::to_string_pretty(&content).map_err(|s| format!("Error creating contents of ja2.json config file: {}", s.description()))?;
+        let mut f = File::create(&self.path).map_err(|s| format!("Error creating ja2.json config file: {}", s.description()))?;
+
+        f.write_all(json.as_bytes()).map_err(|s| format!("Error creating ja2.json config file: {}", s.description()))
+    }
+
+    pub fn ensure_existence(&self) -> Result<(), String> {
+        #[cfg(not(windows))]
+        static DEFAULT_JSON_CONTENT: &'static str = r##"{
+            "help": "Put the directory to your original ja2 installation into the line below",
+            "data_dir": "/some/place/where/the/data/is"
+        }"##;
+        #[cfg(windows)]
+        static DEFAULT_JSON_CONTENT: &'static str = r##"{
+            "help": "Put the directory to your original ja2 installation into the line below. Make sure to use double backslashes.",
+            "data_dir": "C:\\Program Files\\Jagged Alliance 2"
+        }"##;
+
+        let parent = self.path.parent();
+        if let Some(p) = parent {
+            if !p.exists() {
+                fs::create_dir_all(p).map_err(|why| format!("Error creating {:?}: {:?}", p, why.kind()))?;
+            }
+        }
+
+        if !self.path.exists() {
+            let mut f = File::create(&self.path).map_err(|why| format!("Error creating {:?}: {:?}", self.path, why.kind()))?;
+            f.write_all(DEFAULT_JSON_CONTENT.as_bytes()).map_err(|why| format!("Error writing {:?}: {:?}", self.path, why.kind()))?;
+        }
+
+        Ok(())
+    }
+}

--- a/rust/src/config/mod.rs
+++ b/rust/src/config/mod.rs
@@ -1,7 +1,9 @@
 mod scaling_quality;
 mod vanilla_version;
 mod resolution;
+mod ja2_json;
 
 pub use self::scaling_quality::ScalingQuality;
 pub use self::vanilla_version::VanillaVersion;
 pub use self::resolution::Resolution;
+pub use self::ja2_json::Ja2Json;

--- a/rust/src/config/mod.rs
+++ b/rust/src/config/mod.rs
@@ -1,5 +1,7 @@
 mod scaling_quality;
 mod vanilla_version;
+mod resolution;
 
 pub use self::scaling_quality::ScalingQuality;
 pub use self::vanilla_version::VanillaVersion;
+pub use self::resolution::Resolution;

--- a/rust/src/config/mod.rs
+++ b/rust/src/config/mod.rs
@@ -1,0 +1,3 @@
+mod scaling_quality;
+
+pub use self::scaling_quality::ScalingQuality;

--- a/rust/src/config/mod.rs
+++ b/rust/src/config/mod.rs
@@ -1,3 +1,5 @@
 mod scaling_quality;
+mod vanilla_version;
 
 pub use self::scaling_quality::ScalingQuality;
+pub use self::vanilla_version::VanillaVersion;

--- a/rust/src/config/mod.rs
+++ b/rust/src/config/mod.rs
@@ -2,8 +2,10 @@ mod scaling_quality;
 mod vanilla_version;
 mod resolution;
 mod ja2_json;
+mod cli;
 
 pub use self::scaling_quality::ScalingQuality;
 pub use self::vanilla_version::VanillaVersion;
 pub use self::resolution::Resolution;
 pub use self::ja2_json::Ja2Json;
+pub use self::cli::Cli;

--- a/rust/src/config/mod.rs
+++ b/rust/src/config/mod.rs
@@ -3,9 +3,14 @@ mod vanilla_version;
 mod resolution;
 mod ja2_json;
 mod cli;
+mod stracciatella_home;
+
+mod engine_options;
 
 pub use self::scaling_quality::ScalingQuality;
 pub use self::vanilla_version::VanillaVersion;
 pub use self::resolution::Resolution;
 pub use self::ja2_json::Ja2Json;
 pub use self::cli::Cli;
+pub use self::engine_options::EngineOptions;
+pub use self::stracciatella_home::find_stracciatella_home;

--- a/rust/src/config/resolution.rs
+++ b/rust/src/config/resolution.rs
@@ -1,0 +1,55 @@
+use std::str::FromStr;
+use std::fmt;
+use std::fmt::Display;
+use std::default::Default;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub struct Resolution(pub u16, pub u16);
+
+impl FromStr for Resolution {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut resolutions = s.split('x').filter_map(|r_str| r_str.parse::<u16>().ok());
+
+        match (resolutions.next(), resolutions.next()) {
+            (Some(x), Some(y)) => Ok(Resolution(x, y)),
+            _ => Err(String::from("Incorrect resolution format, should be WIDTHxHEIGHT."))
+        }
+    }
+}
+
+impl Display for Resolution {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}x{}", self.0, self.1)
+    }
+}
+
+impl Serialize for Resolution {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{}", self))
+    }
+}
+
+impl<'de> Deserialize<'de> for Resolution {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let deserialized_string = String::deserialize(deserializer)?;
+        Resolution::from_str(&deserialized_string).map_err(serde::de::Error::custom)
+    }
+}
+
+impl Default for Resolution {
+    fn default() -> Self {
+        Resolution(640, 480)
+    }
+}

--- a/rust/src/config/scaling_quality.rs
+++ b/rust/src/config/scaling_quality.rs
@@ -1,0 +1,44 @@
+use std::str::FromStr;
+use std::fmt;
+use std::fmt::Display;
+use std::default::Default;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub enum ScalingQuality {
+    LINEAR,
+    NEAR_PERFECT,
+    PERFECT,
+}
+
+impl FromStr for ScalingQuality {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "LINEAR" => Ok(ScalingQuality::LINEAR),
+            "NEAR_PERFECT" => Ok(ScalingQuality::NEAR_PERFECT),
+            "PERFECT" => Ok(ScalingQuality::PERFECT),
+            _ => Err(format!("Scaling quality {} is unknown", s))
+        }
+    }
+}
+
+impl Display for ScalingQuality {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", match self {
+            ScalingQuality::LINEAR => "Linear Interpolation",
+            ScalingQuality::NEAR_PERFECT => "Near perfect with oversampling",
+            ScalingQuality::PERFECT => "Pixel perfect centered",
+        })
+    }
+}
+
+impl Default for ScalingQuality {
+    fn default() -> ScalingQuality {
+        ScalingQuality::PERFECT
+    }
+}

--- a/rust/src/config/stracciatella_home.rs
+++ b/rust/src/config/stracciatella_home.rs
@@ -1,0 +1,21 @@
+use dirs;
+use std::path::PathBuf;
+
+pub fn find_stracciatella_home() -> Result<PathBuf, String> {
+    #[cfg(not(windows))]
+    let base = dirs::home_dir();
+    #[cfg(windows)]
+    let base = dirs::document_dir();
+    #[cfg(not(windows))]
+    let dir = ".ja2";
+    #[cfg(windows)]
+    let dir = "JA2";
+
+    match base {
+        Some(mut path) => {
+            path.push(dir);
+            Ok(path)
+        },
+        None => Err(String::from("Could not find home directory")),
+    }
+}

--- a/rust/src/config/vanilla_version.rs
+++ b/rust/src/config/vanilla_version.rs
@@ -1,0 +1,52 @@
+use std::str::FromStr;
+use std::fmt;
+use std::fmt::Display;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub enum VanillaVersion {
+    DUTCH,
+    ENGLISH,
+    FRENCH,
+    GERMAN,
+    ITALIAN,
+    POLISH,
+    RUSSIAN,
+    RUSSIAN_GOLD,
+}
+
+impl FromStr for VanillaVersion {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "DUTCH" => Ok(VanillaVersion::DUTCH),
+            "ENGLISH" => Ok(VanillaVersion::ENGLISH),
+            "FRENCH" => Ok(VanillaVersion::FRENCH),
+            "GERMAN" => Ok(VanillaVersion::GERMAN),
+            "ITALIAN" => Ok(VanillaVersion::ITALIAN),
+            "POLISH" => Ok(VanillaVersion::POLISH),
+            "RUSSIAN" => Ok(VanillaVersion::RUSSIAN),
+            "RUSSIAN_GOLD" => Ok(VanillaVersion::RUSSIAN_GOLD),
+            _ => Err(format!("Resource version {} is unknown", s))
+        }
+    }
+}
+
+impl Display for VanillaVersion {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", match self {
+            VanillaVersion::DUTCH => "Dutch",
+            VanillaVersion::ENGLISH => "English",
+            VanillaVersion::FRENCH => "French",
+            VanillaVersion::GERMAN => "German",
+            VanillaVersion::ITALIAN => "Italian",
+            VanillaVersion::POLISH => "Polish",
+            VanillaVersion::RUSSIAN => "Russian",
+            VanillaVersion::RUSSIAN_GOLD => "Russian (Gold)",
+        })
+    }
+}

--- a/rust/src/stracciatella.rs
+++ b/rust/src/stracciatella.rs
@@ -28,6 +28,10 @@ use serde::Serialize;
 use getopts::Options;
 use libc::{size_t, c_char};
 
+mod config;
+
+pub use config::ScalingQuality;
+
 #[cfg(not(windows))]
 static DATA_DIR_OPTION_EXAMPLE: &'static str = "/opt/ja2";
 #[cfg(not(windows))]
@@ -87,38 +91,6 @@ impl Display for ResourceVersion {
             ResourceVersion::POLISH => "Polish",
             ResourceVersion::RUSSIAN => "Russian",
             ResourceVersion::RUSSIAN_GOLD => "Russian (Gold)",
-        })
-    }
-}
-
-#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
-#[repr(C)]
-#[allow(non_camel_case_types)]
-pub enum ScalingQuality {
-    LINEAR,
-    NEAR_PERFECT,
-    PERFECT,
-}
-
-impl FromStr for ScalingQuality {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "LINEAR" => Ok(ScalingQuality::LINEAR),
-            "NEAR_PERFECT" => Ok(ScalingQuality::NEAR_PERFECT),
-            "PERFECT" => Ok(ScalingQuality::PERFECT),
-            _ => Err(format!("Scaling quality {} is unknown", s))
-        }
-    }
-}
-
-impl Display for ScalingQuality {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", match self {
-            ScalingQuality::LINEAR => "Linear Interpolation",
-            ScalingQuality::NEAR_PERFECT => "Near perfect with oversampling",
-            ScalingQuality::PERFECT => "Pixel perfect centered",
         })
     }
 }
@@ -193,7 +165,7 @@ impl Default for EngineOptions {
             run_editor: false,
             start_in_fullscreen: false,
             start_in_window: true,
-			scaling_quality: ScalingQuality::PERFECT,
+			scaling_quality: ScalingQuality::default(),
             start_in_debug_mode: false,
             start_without_sound: false,
         }

--- a/src/game/GameRes.h
+++ b/src/game/GameRes.h
@@ -12,7 +12,7 @@
 #include "StringEncodingTypes.h"
 
 /** List of supported game versions (localizations). */
-using GameVersion = ResourceVersion;
+using GameVersion = VanillaVersion;
 
 enum MultiLanguageGraphic
 {


### PR DESCRIPTION
This is part of a multi-step refactoring i want to make. It basically extracts functionality into separate modules without touching the external interface. Next step would be to migrate tests to their respective modules and introduce an integration test from C++ using gtest.

The overall goal is for `stracciatella.rs` to only contain the ffi bindings.