### PR TITLE
Removed silly camo kit addition

### DIFF
--- a/src/game/Laptop/IMP_Confirm.cc
+++ b/src/game/Laptop/IMP_Confirm.cc
@@ -364,11 +364,6 @@ static void GiveItemsToPC(UINT8 ubProfileId)
 	{
 		MakeProfileInvItemAnySlot(p, COMBAT_KNIFE, 100, 1);
 	}
-
-	if (HasSkillTrait(p, CAMOUFLAGED))
-	{
-		MakeProfileInvItemAnySlot(p, CAMOUFLAGEKIT, 100, 1);
-	}
 }
 
 


### PR DESCRIPTION
There's a silly piece of code in IMP character generation.
If the character is CAMOUFLAGED they get a camo kit.
First, CAMOUFLAGED characters don't need camo kits, this is entirely useless for them.
Second, one can't create a CAMOUFLAGED IMP so this is dead code.