### PR TITLE
Fixed bug when picking up items during combat doesn't deduct APs

### DIFF
--- a/src/game/Tactical/Handle_Items.cc
+++ b/src/game/Tactical/Handle_Items.cc
@@ -1321,6 +1321,11 @@ void SoldierGetItemFromWorld(SOLDIERTYPE* const s, const INT32 iItemIndex, const
 		}
 	}
 
+	if (!gfDontChargeAPsToPickup)
+	{
+		DeductPoints(s, AP_PICKUP_ITEM, 0);
+	}
+
 	gpTempSoldier = s;
 	gsTempGridno  = sGridNo;
 	SetCustomizableTimerCallbackAndDelay(1000, CheckForPickedOwnership, TRUE);


### PR DESCRIPTION
Should fix #790.
Also fix #763.