### PR TITLE
SoundMan

### DIFF
--- a/src/sgp/Smack_Stub.cc
+++ b/src/sgp/Smack_Stub.cc
@@ -48,7 +48,6 @@ void SmackPrintFlickInfo(unsigned long width, unsigned long height, UCHAR8 scale
 UINT32 SmackGetAudio(const smk SmkObj, UCHAR8** audiobuffer)
 {
 	UINT32 audiolen = 0;
-	UINT32 i, index;
 	UCHAR8* paudio;
 
 	if (!audiobuffer)
@@ -154,7 +153,7 @@ Smack* SmackOpen(SGPFile* FileHandle, UINT32 Flags, UINT32 ExtraFlag)
 	flickinfo->FramesPerSecond = usf;
 	audiobuffer = NULL;
 	audiolen = SmackGetAudio(flickinfo->Smacker, &audiobuffer);
-	if (audiobuffer != NULL);
+	if (audiobuffer != NULL)
 	{
 		//SmackWriteAudio( audiobuffer, audiolen); // are getting right audio data?
 		// shoot and forget... audiobuffer should be freed by SoundMan

--- a/src/sgp/Smack_Stub.cc
+++ b/src/sgp/Smack_Stub.cc
@@ -156,7 +156,7 @@ Smack* SmackOpen(SGPFile* FileHandle, UINT32 Flags, UINT32 ExtraFlag)
 	if (audiobuffer != NULL)
 	{
 		//SmackWriteAudio( audiobuffer, audiolen); // are getting right audio data?
-		// shoot and forget... audiobuffer should be freed by SoundMan
+		// shoot and forget...
 		flickinfo->SoundTag = SoundPlayFromSmackBuff(a_channels[SMKTRACK], a_depth[SMKTRACK], a_rate[SMKTRACK], audiobuffer, audiolen, MAXVOLUME, 64, 1, NULL, NULL);
 		MemFree(audiobuffer);
 	}

--- a/src/sgp/Smack_Stub.cc
+++ b/src/sgp/Smack_Stub.cc
@@ -160,6 +160,10 @@ Smack* SmackOpen(SGPFile* FileHandle, UINT32 Flags, UINT32 ExtraFlag)
 		flickinfo->SoundTag = SoundPlayFromSmackBuff(a_channels[SMKTRACK], a_depth[SMKTRACK], a_rate[SMKTRACK], audiobuffer, audiolen, MAXVOLUME, 64, 1, NULL, NULL);
 		MemFree(audiobuffer);
 	}
+	else
+	{
+		flickinfo->SoundTag = SOUND_ERROR;
+	}
 	SmkVideoSwitch  (flickinfo->Smacker, ENABLE);
 	if ((smk_first(flickinfo->Smacker) < 0))
 	{
@@ -238,7 +242,7 @@ void SmackClose(Smack* Smk)
 {
 	if(!Smk)
 		return;
-	if(!SoundStop(Smk->SoundTag))
+	if(Smk->SoundTag != SOUND_ERROR && !SoundStop(Smk->SoundTag))
 		printf("Error in SmackClose SoundStop\n");
 	free(Smk->SmackerInMemory);
 	smk_close(Smk->Smacker); // closes and frees Smacker Object and file

--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -680,7 +680,6 @@ static SAMPLETAG* SoundLoadDisk(const char* pFilename)
 	SDL_AudioSpec wavSpec;
 	Uint32 wavLength;
 	Uint8 *wavBuffer;
-	SDL_AudioCVT cvt;
 
 	if (SDL_LoadWAV_RW(rwOps, 0,  &wavSpec, &wavBuffer, &wavLength) == NULL) {
 		SLOGE(DEBUG_TAG_SOUND, "SoundLoadDisk Error: Error loading file \"%s\"- %s", pFilename, SDL_GetError());

--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -216,7 +216,11 @@ UINT32 SoundPlayFromSmackBuff(UINT8 channels, UINT8 depth, UINT32 rate, UINT8* p
 	if (pbuffer == NULL) return SOUND_ERROR;
 	if (size == 0) return SOUND_ERROR;
 
-	if (depth == 16) format = AUDIO_S16LSB;
+	//Originaly Sound Blaster could only play mono unsigned 8-bit PCM data.
+	//Later it became capable of playing 16-bit audio data, but needed to be signed and LSB.
+	//They were the de facto standard so I'm assuming smacker uses the same.
+	if (depth == 8) format = AUDIO_U8;
+	else if (depth == 16) format = AUDIO_S16LSB;
 	else return SOUND_ERROR;
 
 	SAMPLETAG* s = SoundLoadBuffer(format, channels, rate, pbuffer, size);

--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -64,6 +64,12 @@ enum
 #define SOUND_DEFAULT_THRESH ( 2 * 1024 * 1024) // size for sample to be double-buffered
 #define SOUND_DEFAULT_STREAM (64 * 1024)        // double-buffered buffer size
 
+// The audio device will be opened with the following values
+#define SOUND_FREQ      44100
+#define SOUND_FORMAT    AUDIO_S16SYS
+#define SOUND_CHANNELS  2
+#define SOUND_SAMPLES   1024
+
 // Struct definition for sample slots in the cache
 // Holds the regular sample data, as well as the data for the random samples
 struct SAMPLETAG
@@ -777,7 +783,7 @@ static SOUNDTAG* SoundGetChannelByID(UINT32 uiSoundID)
 
 static void SoundCallback(void* userdata, Uint8* stream, int len)
 {
-	INT32  mix[ gTargetAudioSpec.samples ];
+	INT32  mix[ SOUND_SAMPLES ];
 
 	Assert(len * 2 == sizeof(mix));
 
@@ -863,10 +869,10 @@ static BOOLEAN SoundInitHardware(void)
 {
 	SDL_InitSubSystem(SDL_INIT_AUDIO);
 
-	gTargetAudioSpec.freq     = 44100;
-	gTargetAudioSpec.format   = AUDIO_S16SYS;
-	gTargetAudioSpec.channels = 2;
-	gTargetAudioSpec.samples  = 1024;
+	gTargetAudioSpec.freq     = SOUND_FREQ;
+	gTargetAudioSpec.format   = SOUND_FORMAT;
+	gTargetAudioSpec.channels = SOUND_CHANNELS;
+	gTargetAudioSpec.samples  = SOUND_SAMPLES;
 	gTargetAudioSpec.callback = SoundCallback;
 	gTargetAudioSpec.userdata = NULL;
 

--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -794,6 +794,7 @@ static SOUNDTAG* SoundGetChannelByID(UINT32 uiSoundID)
 
 static void SoundCallback(void* userdata, Uint8* stream, int len)
 {
+	// INT16 data is being mixed as INT32, so it needs to be double the length of the stream
 	if ( guiMixLength < len * 2 )
 	{
 		guiMixLength = len * 2;
@@ -867,9 +868,9 @@ mixing:
 		}
 	}
 
-	// Clip sounds
+	// Clip sounds and fill the stream
 	INT16* Stream = (INT16*)stream;
-	UINT32 uiEnd = guiMixLength / sizeof(gMixBuffer[0]);
+	UINT32 uiEnd = len / sizeof(Stream[0]);
 	for (UINT32 i = 0; i < uiEnd; ++i)
 	{
 		if (gMixBuffer[i] >= INT16_MAX)     Stream[i] = INT16_MAX;

--- a/src/sgp/SoundMan.h
+++ b/src/sgp/SoundMan.h
@@ -20,7 +20,7 @@ void InitializeSoundManager(void);
 void ShutdownSoundManager(void);
 
 
-UINT32 SoundPlayFromBuffer(INT16* pbuffer, UINT32 size, UINT32 volume, UINT32 pan, UINT32 loop, void (*end_callback)(void*), void* data);
+UINT32 SoundPlayFromSmackBuff(UINT8 channels, UINT8 depth, UINT32 rate, UINT8* pbuffer, UINT32 size, UINT32 volume, UINT32 pan, UINT32 loop, void (*end_callback)(void*), void* data);
 
 
 /* Starts a sample playing. If the sample is not loaded in the cache, it will


### PR DESCRIPTION
I heard a flinch-inducing sound one time while using a shotgun. >.<

After inspecting the code I found that the sound mixing code can overflow/underflow, which is the probable cause of that terrible sound, so I went ahead and made a fix (avoid overflow/underflow and add clipping).
~~I'm not sure if VC allows this kind of array (mix in SoundCallback), someone else will need to test it.~~

After that I noticed out-of-date comments about changing the sound frequency in smacker code and a couple of other minor issues, so I reworked the way sound samples are created from buffers.

While adding sound clipping I wanted to change the format to AUDIO_F32SYS, but decided to ask first.
Can I change the format?
It doubles the amount of memory needed by the samples, it avoids the need of a separate mix buffer and it simplifies other ways of handling sound that would be clipped.