### PR TITLE
fixed clang Warnings

### DIFF
--- a/src/game/GameInitOptionsScreen.cc
+++ b/src/game/GameInitOptionsScreen.cc
@@ -177,7 +177,7 @@ static void GetGIOScreenUserInput(void);
 static void RestoreGIOButtonBackGrounds(void);
 static void DoneFadeOutForExitGameInitOptionScreen(void);
 static void DisplayMessageToUserAboutGameDifficulty(void);
-static void DisplayMessageToUserAboutDeadIsDeadSaveScreen(const wchar_t, MSGBOX_CALLBACK);
+static void DisplayMessageToUserAboutDeadIsDeadSaveScreen(const wchar_t*, MSGBOX_CALLBACK);
 static void ConfirmGioDifSettingMessageBoxCallBack(MessageBoxReturnValue);
 static BOOLEAN DisplayMessageToUserAboutIronManMode(void);
 static void ConfirmGioIronManMessageBoxCallBack(MessageBoxReturnValue);

--- a/src/game/Laptop/Laptop.cc
+++ b/src/game/Laptop/Laptop.cc
@@ -1294,6 +1294,9 @@ static void ExitLaptopMode(LaptopMode uiMode)
 		case LAPTOP_MODE_FILES:                    ExitFiles();             break;
 		case LAPTOP_MODE_EMAIL:                    ExitEmail();             break;
 		case LAPTOP_MODE_BROKEN_LINK:              ExitBrokenLink();        break;
+
+		// nothing to do for other subwindows
+		default: break;
 	}
 
 	if (uiMode != LAPTOP_MODE_NONE && uiMode < LAPTOP_MODE_WWW)

--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -8102,7 +8102,8 @@ void SoldierCollapse( SOLDIERTYPE *pSoldier )
 
 	if (pSoldier->uiStatusFlags & SOLDIER_ENEMY)
 	{
-		if (!gTacticalStatus.bPanicTriggerIsAlarm && gTacticalStatus.the_chosen_one == pSoldier)
+		INT8 bPanicTrigger = ClosestPanicTrigger(pSoldier);
+		if (!gTacticalStatus.bPanicTriggerIsAlarm[bPanicTrigger] && gTacticalStatus.the_chosen_one == pSoldier)
 		{
 			// replace this guy as the chosen one!
 			gTacticalStatus.the_chosen_one = NULL;

--- a/src/game/TileEngine/Explosion_Control.cc
+++ b/src/game/TileEngine/Explosion_Control.cc
@@ -100,9 +100,6 @@ BOOLEAN                      gfExplosionQueueActive      = FALSE;
 static BOOLEAN      gfExplosionQueueMayHaveChangedSight = FALSE;
 static SOLDIERTYPE* gPersonToSetOffExplosions           = 0;
 
-static INT16 gsTempActionGridNo = NOWHERE;
-
-
 #define NUM_EXPLOSION_SLOTS 100
 static EXPLOSIONTYPE gExplosionData[NUM_EXPLOSION_SLOTS];
 

--- a/src/game/Utils/Font_Control.cc
+++ b/src/game/Utils/Font_Control.cc
@@ -93,7 +93,6 @@ void ShutdownFonts(void)
 // Set shades for fonts
 void SetFontShade(SGPFont const font, FontShade const shade)
 {
-	CHECKV(0 <= shade && shade < 16);
 	font->CurrentShade(shade);
 }
 

--- a/src/game/Utils/Music_Control.cc
+++ b/src/game/Utils/Music_Control.cc
@@ -306,6 +306,8 @@ static void StartMusicBasedOnMode(void)
 				next = MUSIC_TACTICAL_CREATURE_BATTLE;
 			}
 			break;
+		default: // ignore other modes
+			break;
 	}
 
 	switch (gubMusicMode) {
@@ -318,6 +320,8 @@ static void StartMusicBasedOnMode(void)
 			break;
 		case MUSIC_TACTICAL_DEFEAT:
 			gbDeathSongCount++;
+			break;
+		default: // ignore other modes
 			break;
 	}
 

--- a/src/game/Utils/Sound_Control.cc
+++ b/src/game/Utils/Sound_Control.cc
@@ -327,25 +327,6 @@ static char const* const szAmbientEffects[NUM_AMBIENTS] =
 	SOUNDSDIR "/night_bird3.wav"
 };
 
-static UINT8 const AmbientVols[NUM_AMBIENTS] =
-{
-	25,		// lightning 1
-	25,		// lightning 2
-	10,		// rain 1
-	25,		// bird 1
-	25,		// bird 2
-	10,		// crickets 1
-	10,		// crickets 2
-	25,		// cricket 1
-	25,		// cricket 2
-	25,		// owl 1
-	25,		// owl 2
-	25,		// owl 3
-	25,		// night bird 1
-	25		// night bird 2
-};
-
-
 void ShutdownJA2Sound(void)
 {
 	SoundStopAll();

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -496,7 +496,7 @@ int main(int argc, char* argv[])
 	return EXIT_SUCCESS;
 }
 
-static void convertDialogQuotesToJson(const DefaultContentManager *cm,
+/*static void convertDialogQuotesToJson(const DefaultContentManager *cm,
 					STRING_ENC_TYPE encType,
 					const char *dialogFile, const char *outputFile)
 {
@@ -510,4 +510,4 @@ static void convertDialogQuotesToJson(const DefaultContentManager *cm,
 		quotes[i] = NULL;
 	}
 	JsonUtility::writeToFile(outputFile, quotes_str);
-}
+}*/

--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -113,10 +113,9 @@ struct SOUNDTAG
 };
 
 static size_t GetSampleSize(const SAMPLETAG* const s);
-static const UINT32 guiSoundDefaultVolume  = MAXVOLUME;
 static const UINT32 guiSoundMemoryLimit    = SOUND_DEFAULT_MEMORY; // Maximum memory used for sounds
 static       UINT32 guiSoundMemoryUsed     = 0;                    // Memory currently in use
-static const UINT32 guiSoundCacheThreshold = SOUND_DEFAULT_THRESH; // Double-buffered threshold
+//static const UINT32 guiSoundCacheThreshold = SOUND_DEFAULT_THRESH; // Double-buffered threshold
 static void IncreaseSoundMemoryUsedBySample(SAMPLETAG *sample) { guiSoundMemoryUsed += sample->n_samples * GetSampleSize(sample); }
 static void DecreaseSoundMemoryUsedBySample(SAMPLETAG *sample) { guiSoundMemoryUsed -= sample->n_samples * GetSampleSize(sample); }
 


### PR DESCRIPTION
also has a small vanilla ai bugfix included.

-Wall generates more-than-my-screen-buffer-full of extra warnings and I haven't tried -Wextra. I think we should clean it up and use -Werror for debug builds.

The spammer was ENUM_BITSET, which looks useless and random sampling of the users show no uses of the functions. Can probably be outright killed... It turns out that's tricky. While there are some useless users, converting to an old school templated class enum (the cxx11 keyword doesn't help — we need the methods) only almost worked. I couldn't get the bool operator to work, while the rest seemed fine. The simplest way out is to not use the enums as types in the first place.

Then there's the:
- ubLoop = ubLoop FIXME in LOS.cc:3472 (https://github.com/figment/JA2-1.13/commit/3b3ecaf2997d080a1f4442516abdb3eafe7f53d3 just removed it)
- TrashMapTile(), MapOptimize() FIXME (introduced by ja2s)
