### PR TITLE
Add some rust doc comments to exported things from rust/src/config

### DIFF
--- a/rust/src/config/cli.rs
+++ b/rust/src/config/cli.rs
@@ -1,3 +1,5 @@
+//! This module contains code to read command line arguments for the ja2 executable
+
 use std::fs;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -14,12 +16,17 @@ static DATA_DIR_OPTION_EXAMPLE: &'static str = "/opt/ja2";
 #[cfg(windows)]
 static DATA_DIR_OPTION_EXAMPLE: &'static str = "C:\\JA2";
 
+/// Handles command line parameters for executables
+///
+/// Encapsulates the Cli arguments definition and the actual Cli arguments
+/// passed to the executable
 pub struct Cli {
     args: Vec<String>,
     options: Options
 }
 
 impl Cli {
+    /// Constructor to create Cli instance from command line arguments
     pub fn from_args(args: &[String]) -> Self {
         let mut opts = Options::new();
 
@@ -95,6 +102,7 @@ impl Cli {
         }
     }
 
+    /// Apply current arguments to EngineOptions struct
     pub fn apply_to_engine_options(&self, engine_options: &mut EngineOptions) -> Result<(), String> {
         match self.options.parse(&self.args[1..]) {
             Ok(m) => {
@@ -184,6 +192,7 @@ impl Cli {
         }
     }
 
+    /// Get command line usage string
     pub fn usage() -> String {
         let cli = Cli::from_args(&[]);
         cli.options.usage("Usage: ja2 [options]")

--- a/rust/src/config/engine_options.rs
+++ b/rust/src/config/engine_options.rs
@@ -4,21 +4,36 @@ use crate::Resolution;
 use crate::ScalingQuality;
 use crate::VanillaVersion;
 
+/// Struct that is used to store the engines configuration parameters
 #[derive(Debug, PartialEq)]
 pub struct EngineOptions {
+    /// Path to configuration directory in the users home directory
     pub stracciatella_home: PathBuf,
+    /// Path to the vanilla game directory
     pub vanilla_data_dir: PathBuf,
+    /// List of enabled mods
     pub mods: Vec<String>,
+    /// Resolution the game will start in
     pub resolution: Resolution,
+    /// Gamma correction parameter
     pub brightness: f32,
+    /// Vanilla game version that the user is in posession of
     pub resource_version: VanillaVersion,
+    /// Whether to show help on startup and exit
     pub show_help: bool,
+    /// Whether to run unittests on startup and exit
     pub run_unittests: bool,
+    /// Wether to run the editor instead of the game itself
     pub run_editor: bool,
+    /// Whether to start the game in fullscreen
     pub start_in_fullscreen: bool,
+    /// Whether to start the game in windowed mode
     pub start_in_window: bool,
+    /// Scaling quality that is used when scaling up game resources
 	pub scaling_quality: ScalingQuality,
+    /// Whether to start in debug mode
     pub start_in_debug_mode: bool,
+    /// Whether to enable sound
     pub start_without_sound: bool,
 }
 
@@ -44,6 +59,10 @@ impl Default for EngineOptions {
 }
 
 impl EngineOptions {
+    /// Construct an EngineOptions instance from home directory and Cli arguments
+    ///
+    /// Takes Cli arguments and JSON configuration file into account. It will also
+    /// create a default JSON configuration file if it does not exist yet.
     pub fn from_home_and_args(stracciatella_home: &PathBuf, args: &[String]) -> Result<EngineOptions, String> {
         use crate::ensure_json_config_existence;
         use crate::parse_json_config;

--- a/rust/src/config/engine_options.rs
+++ b/rust/src/config/engine_options.rs
@@ -7,7 +7,7 @@ use crate::VanillaVersion;
 /// Struct that is used to store the engines configuration parameters
 #[derive(Debug, PartialEq)]
 pub struct EngineOptions {
-    /// Path to configuration directory in the users home directory
+    /// Path to configuration directory in the user's home directory
     pub stracciatella_home: PathBuf,
     /// Path to the vanilla game directory
     pub vanilla_data_dir: PathBuf,

--- a/rust/src/config/ja2_json.rs
+++ b/rust/src/config/ja2_json.rs
@@ -25,6 +25,7 @@ pub struct Ja2JsonContent {
     nosound: Option<bool>,
 }
 
+/// Struct to handle interactions with the JSON configuration file
 pub struct Ja2Json {
     path: PathBuf
 }
@@ -36,17 +37,19 @@ fn build_json_config_location(stracciatella_home: &PathBuf) -> PathBuf {
 }
 
 impl Ja2Json {
+    /// Construct a Ja2Json instance from the stracciatella home directory
     pub fn from_stracciatella_home(stracciatella_home: &PathBuf) -> Self {
         let path = build_json_config_location(stracciatella_home);
         Ja2Json { path }
     }
 
-    pub fn get_content(&self) -> Result<Ja2JsonContent, String> {
+    fn get_content(&self) -> Result<Ja2JsonContent, String> {
         File::open(&self.path)
             .map_err(|s| format!("Error reading ja2.json config file: {}", s.description()))
             .and_then(|f| serde_json::from_reader(f).map_err(|s| format!("Error parsing ja2.json config file: {}", s)))
     }
 
+    /// Apply current JSON file contents to EngineOptions struct
     pub fn apply_to_engine_options(&self, engine_options: &mut EngineOptions) -> Result<(), String> {
         macro_rules! copy_to {
             ($from: expr, $to: expr) => { if let Some(v) = $from { $to = v; } }
@@ -67,6 +70,7 @@ impl Ja2Json {
         Ok(())
     }
 
+    /// Write current contents of EngineOptions to JSON configuration file
     pub fn write(&self, engine_options: &EngineOptions) -> Result<(), String> {
         macro_rules! copy_to {
             ($from: expr, $to: expr) => { $to = Some($from.clone()); }
@@ -101,6 +105,7 @@ impl Ja2Json {
         f.write_all(json.as_bytes()).map_err(|s| format!("Error creating ja2.json config file: {}", s.description()))
     }
 
+    /// Ensures that the JSON configuration file exists and write a default one if it doesn't
     pub fn ensure_existence(&self) -> Result<(), String> {
         #[cfg(not(windows))]
         static DEFAULT_JSON_CONTENT: &'static str = r##"{

--- a/rust/src/config/mod.rs
+++ b/rust/src/config/mod.rs
@@ -1,3 +1,5 @@
+//! This module contains code to configure the ja2-stracciatella engine
+
 mod scaling_quality;
 mod vanilla_version;
 mod resolution;

--- a/rust/src/config/resolution.rs
+++ b/rust/src/config/resolution.rs
@@ -7,6 +7,7 @@ use serde::Deserializer;
 use serde::Serialize;
 use serde::Serializer;
 
+/// Struct that contains a specific resolution for the game
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub struct Resolution(pub u16, pub u16);
 

--- a/rust/src/config/scaling_quality.rs
+++ b/rust/src/config/scaling_quality.rs
@@ -5,12 +5,16 @@ use std::default::Default;
 use serde::Deserialize;
 use serde::Serialize;
 
+/// Enum used to specify scaling quality for scaling up graphics
 #[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
 #[repr(C)]
 #[allow(non_camel_case_types)]
 pub enum ScalingQuality {
+    /// Use linear interpolation
     LINEAR,
+    /// Use nearest neighbor interpolation
     NEAR_PERFECT,
+    /// Scale up to the nearest multiple of 640x480 and use nearest neighbor interpolation
     PERFECT,
 }
 

--- a/rust/src/config/stracciatella_home.rs
+++ b/rust/src/config/stracciatella_home.rs
@@ -1,6 +1,7 @@
 use dirs;
 use std::path::PathBuf;
 
+/// Find ja2 stracciatella configuration directory inside the users home directory
 pub fn find_stracciatella_home() -> Result<PathBuf, String> {
     #[cfg(not(windows))]
     let base = dirs::home_dir();

--- a/rust/src/config/stracciatella_home.rs
+++ b/rust/src/config/stracciatella_home.rs
@@ -1,7 +1,7 @@
 use dirs;
 use std::path::PathBuf;
 
-/// Find ja2 stracciatella configuration directory inside the users home directory
+/// Find ja2 stracciatella configuration directory inside the user's home directory
 pub fn find_stracciatella_home() -> Result<PathBuf, String> {
     #[cfg(not(windows))]
     let base = dirs::home_dir();

--- a/rust/src/config/vanilla_version.rs
+++ b/rust/src/config/vanilla_version.rs
@@ -4,17 +4,26 @@ use std::fmt::Display;
 use serde::Deserialize;
 use serde::Serialize;
 
+/// Enum for the vanilla game version that is used to run the game
 #[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
 #[repr(C)]
 #[allow(non_camel_case_types)]
 pub enum VanillaVersion {
+    // Dutch Version
     DUTCH,
+    // English Version
     ENGLISH,
+    // French Version
     FRENCH,
+    // German Version
     GERMAN,
+    // Italian Version
     ITALIAN,
+    // Polish Version
     POLISH,
+    // Russian Version (“BUKA Agonia Vlasty” release)
     RUSSIAN,
+    // Russian Version ("Gold" release)
     RUSSIAN_GOLD,
 }
 


### PR DESCRIPTION
I really liked the adding of doc comments in #820, so I added comments to all exported things in `rust/src/config`. This should give a better overview over what exists in rust code and the responsibilities of the individual modules.

To see the current docs you can run `cargo doc && firefox target/doc/stracciatella/index.html` in the `rust` subdirectory (adapt for your favorite other browser :wink:)