### PR TITLE
Multiple mods + launcher

### DIFF
--- a/rust/src/stracciatella.rs
+++ b/rust/src/stracciatella.rs
@@ -141,6 +141,18 @@ pub unsafe extern fn get_mod(ptr: *const EngineOptions, index: u32) -> *mut c_ch
 }
 
 #[no_mangle]
+pub unsafe extern fn clear_mods(ptr: *mut EngineOptions) {
+    unsafe_from_ptr_mut!(ptr).mods.clear();
+}
+
+#[no_mangle]
+pub unsafe extern fn push_mod(ptr: *mut EngineOptions, name: *const c_char) {
+    assert!(!name.is_null());
+    let name = unsafe { CStr::from_ptr(name) }.to_str().unwrap().to_owned();
+    unsafe_from_ptr_mut!(ptr).mods.push(name);
+}
+
+#[no_mangle]
 pub unsafe extern fn get_resolution_x(ptr: *const EngineOptions) -> u16 {
     unsafe_from_ptr!(ptr).resolution.0
 }

--- a/rust/src/stracciatella.rs
+++ b/rust/src/stracciatella.rs
@@ -305,17 +305,7 @@ pub unsafe extern "C" fn guess_resource_version(
 /// Returns the path to game.json.
 #[no_mangle]
 pub unsafe extern "C" fn get_game_json_path() -> *mut c_char {
-    let mut path = PathBuf::new();
-    let extra_data_dir = option_env!("EXTRA_DATA_DIR");
-    if extra_data_dir.is_some() && extra_data_dir.unwrap().len() > 0 {
-        // use dir defined at compile time
-        path.push(extra_data_dir.unwrap());
-    } else if let Ok(exe) = env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            // use the directory of the executable
-            path.push(dir);
-        }
-    }
+    let mut path = get_assets_dir();
     path.push("externalized/game.json");
     let path: String = path.to_string_lossy().into();
     return CString::new(path).unwrap().into_raw();
@@ -386,6 +376,79 @@ pub extern "C" fn check_if_relative_path_exists(
         buf.push(component);
     }
     return buf.exists();
+}
+
+/// Returns a list of available mods.
+#[no_mangle]
+pub extern "C" fn get_available_mods() -> *mut VecCString {
+    let mut path = get_assets_dir();
+    path.push("mods");
+    if let Ok(entries) = path.read_dir() {
+        let mods: Vec<_> = entries
+            .filter_map(|x| x.ok()) // DirEntry
+            .filter_map(|x| {
+                if let Ok(metadata) = x.metadata() {
+                    if metadata.is_dir() {
+                        return x.file_name().into_string().ok();
+                    }
+                }
+                None
+            }) // String
+            .filter_map(|x| CString::new(x.as_bytes().to_owned()).ok()) // CString
+            .collect();
+        VecCString::from_vec(mods).into_ptr()
+    } else {
+        VecCString::new().into_ptr()
+    }
+}
+
+pub struct VecCString {
+    inner: Vec<CString>
+}
+
+impl VecCString {
+    pub fn new() -> Self {
+        Self { inner: Vec::new() }
+    }
+    pub fn from_vec(vec: Vec<CString>) -> Self {
+        Self { inner: vec }
+    }
+    pub fn into_ptr(self) -> *mut VecCString {
+        Box::into_raw(Box::new(self))
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn vec_c_string_delete(vec: *mut VecCString) {
+    assert!(!vec.is_null());
+    unsafe { Box::from_raw(vec) };
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn vec_c_string_len(vec: *mut VecCString) -> size_t {
+    unsafe_from_ptr!(vec).inner.len()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn vec_c_string_get(vec: *mut VecCString, index: size_t) -> *mut c_char {
+    unsafe_from_ptr!(vec).inner[index].clone().into_raw()
+}
+
+/// Returns the path to the assets directory.
+/// It contains mods and externalized subdirectories.
+fn get_assets_dir() -> PathBuf {
+    let mut path = PathBuf::new();
+    let extra_data_dir = option_env!("EXTRA_DATA_DIR");
+    if extra_data_dir.is_some() && extra_data_dir.unwrap().len() > 0 {
+        // use dir defined at compile time
+        path.push(extra_data_dir.unwrap());
+    } else if let Ok(exe) = env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            // use the directory of the executable
+            path.push(dir);
+        }
+    }
+    path
 }
 
 #[cfg(test)]

--- a/src/externalized/ModPackContentManager.h
+++ b/src/externalized/ModPackContentManager.h
@@ -10,8 +10,8 @@ class ModPackContentManager : public DefaultContentManager
 {
 public:
 	ModPackContentManager(GameVersion gameVersion,
-				const std::string &modName,
-				const std::string &modResFolder,
+				const std::vector<std::string> &modNames,
+				const std::vector<std::string> &modResFolders,
 				const std::string &configFolder,
 				const std::string &gameResRootPath,
 				const std::string &externalizedDataPath);
@@ -31,7 +31,7 @@ public:
 	virtual UTF8String* loadDialogQuoteFromFile(const char* filename, int quote_number);
 
 protected:
-	std::string m_modName;
-	std::string m_modResFolder;
+	std::vector<std::string> m_modNames;
+	std::vector<std::string> m_modResFolders;
 	std::map<std::string, std::vector<std::string> > m_dialogQuotesMap;
 };

--- a/src/launcher/Launcher.h
+++ b/src/launcher/Launcher.h
@@ -31,6 +31,10 @@ private:
 	static void widgetChanged(Fl_Widget* widget, void* userdata);
 	static void reloadJa2Json(Fl_Widget* widget, void* userdata);
 	static void saveJa2Json(Fl_Widget* widget, void* userdata);
+	static void addMod(Fl_Widget* widget, void* userdata);
+	static void moveUpMods(Fl_Widget* widget, void* userdata);
+	static void moveDownMods(Fl_Widget* widget, void* userdata);
+	static void removeMods(Fl_Widget* widget, void* userdata);
 };
 
 #endif //JA2_LAUNCHER_H_H

--- a/src/launcher/StracciatellaLauncher.cc
+++ b/src/launcher/StracciatellaLauncher.cc
@@ -39,7 +39,21 @@ StracciatellaLauncher::StracciatellaLauncher() {
           } // Fl_Button* guessVersionButton
           o->end();
         } // Fl_Group* o
-        { Fl_Group* o = new Fl_Group(10, 160, 445, 130, "resizable");
+        { Fl_Group* o = new Fl_Group(10, 160, 445, 105);
+          { modsCheckBrowser = new Fl_Check_Browser(20, 175, 315, 80, "Mods:");
+            modsCheckBrowser->align(Fl_Align(FL_ALIGN_TOP_LEFT));
+          } // Fl_Check_Browser* modsCheckBrowser
+          { addModMenuButton = new Fl_Menu_Button(345, 175, 100, 20, "Add");
+          } // Fl_Menu_Button* addModMenuButton
+          { moveDownModsButton = new Fl_Button(345, 215, 100, 20, "Move down");
+          } // Fl_Button* moveDownModsButton
+          { moveUpModsButton = new Fl_Button(345, 195, 100, 20, "Move up");
+          } // Fl_Button* moveUpModsButton
+          { removeModsButton = new Fl_Button(345, 235, 100, 20, "Remove");
+          } // Fl_Button* removeModsButton
+          o->end();
+        } // Fl_Group* o
+        { Fl_Group* o = new Fl_Group(10, 265, 445, 25, "resizable");
           o->labeltype(FL_NO_LABEL);
           o->align(Fl_Align(FL_ALIGN_TOP|FL_ALIGN_INSIDE));
           o->end();

--- a/src/launcher/StracciatellaLauncher.fl
+++ b/src/launcher/StracciatellaLauncher.fl
@@ -55,8 +55,32 @@ class StracciatellaLauncher {open
             }
           }
           Fl_Group {} {
-            label resizable open
-            xywh {10 160 445 130} labeltype NO_LABEL align 17 resizable
+            xywh {10 160 445 105}
+          } {
+            Fl_Check_Browser modsCheckBrowser {
+              label {Mods:}
+              xywh {20 175 315 80} align 5
+            }
+            Fl_Menu_Button addModMenuButton {
+              label Add
+              xywh {345 175 100 20}
+            } {}
+            Fl_Button moveDownModsButton {
+              label {Move down}
+              xywh {345 215 100 20}
+            }
+            Fl_Button moveUpModsButton {
+              label {Move up}
+              xywh {345 195 100 20}
+            }
+            Fl_Button removeModsButton {
+              label Remove
+              xywh {345 235 100 20}
+            }
+          }
+          Fl_Group {} {
+            label resizable
+            xywh {10 265 445 25} labeltype NO_LABEL align 17 resizable
           } {}
         }
         Fl_Group {} {

--- a/src/launcher/StracciatellaLauncher.h
+++ b/src/launcher/StracciatellaLauncher.h
@@ -9,10 +9,11 @@
 #include <FL/Fl_Button.H>
 #include <FL/Fl_Input.H>
 #include <FL/Fl_Choice.H>
+#include <FL/Fl_Check_Browser.H>
+#include <FL/Fl_Menu_Button.H>
 #include <FL/Fl_Output.H>
 #include <FL/Fl_Value_Input.H>
 #include <FL/Fl_Box.H>
-#include <FL/Fl_Menu_Button.H>
 #include <FL/Fl_Check_Button.H>
 
 class StracciatellaLauncher {
@@ -25,6 +26,11 @@ public:
   Fl_Button *browseJa2DirectoryButton;
   Fl_Choice *gameVersionInput;
   Fl_Button *guessVersionButton;
+  Fl_Check_Browser *modsCheckBrowser;
+  Fl_Menu_Button *addModMenuButton;
+  Fl_Button *moveDownModsButton;
+  Fl_Button *moveUpModsButton;
+  Fl_Button *removeModsButton;
   Fl_Output *gameSettingsOutput;
   Fl_Choice *scalingModeChoice;
   Fl_Value_Input *resolutionXInput;

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -380,12 +380,21 @@ int main(int argc, char* argv[])
 
 	if(get_number_of_mods(params) > 0)
 	{
-		char* rustModName = get_mod(params, 0);
-		std::string modName = std::string(rustModName);
-		free_rust_string(rustModName);
-		std::string modResFolder = FileMan::joinPaths(FileMan::joinPaths(FileMan::joinPaths(extraDataDir, "mods"), modName), "data");
+		std::vector<std::string> modNames;
+		std::vector<std::string> modResFolders;
+		auto n = get_number_of_mods(params);
+		printf("%d\n", n);
+		for (auto i = 0; i < n; ++i)
+		{
+			char* rustModName = get_mod(params, i);
+			std::string modName(rustModName);
+			free_rust_string(rustModName);
+			std::string modResFolder = FileMan::joinPaths(FileMan::joinPaths(FileMan::joinPaths(extraDataDir, "mods"), modName), "data");
+			modNames.emplace_back(modName);
+			modResFolders.emplace_back(modResFolder);
+		}
 		cm = new ModPackContentManager(version,
-						modName, modResFolder, configFolderPath,
+						modNames, modResFolders, configFolderPath,
 						gameResRootPath, externalizedDataPath);
 		SLOGI(DEBUG_TAG_SGP,"------------------------------------------------------------------------------");
 		SLOGI(DEBUG_TAG_SGP,"JA2 Home Dir:                  '%s'", configFolderPath.c_str());
@@ -395,9 +404,12 @@ int main(int argc, char* argv[])
 		SLOGI(DEBUG_TAG_SGP,"Tilecache directory:           '%s'", cm->getTileDir().c_str());
 		SLOGI(DEBUG_TAG_SGP,"Saved games directory:         '%s'", cm->getSavedGamesFolder().c_str());
 		SLOGI(DEBUG_TAG_SGP,"------------------------------------------------------------------------------");
-		SLOGI(DEBUG_TAG_SGP,"MOD name:                      '%s'", modName.c_str());
-		SLOGI(DEBUG_TAG_SGP,"MOD resource directory:        '%s'", modResFolder.c_str());
-		SLOGI(DEBUG_TAG_SGP,"------------------------------------------------------------------------------");
+		for (auto i = 0; i < n; ++i)
+		{
+			SLOGI(DEBUG_TAG_SGP,"MOD name:                      '%s'", modNames[i].c_str());
+			SLOGI(DEBUG_TAG_SGP,"MOD resource directory:        '%s'", modResFolders[i].c_str());
+			SLOGI(DEBUG_TAG_SGP,"------------------------------------------------------------------------------");
+		}
 	}
 	else
 	{

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -378,12 +378,11 @@ int main(int argc, char* argv[])
 
 	DefaultContentManager *cm;
 
-	if(get_number_of_mods(params) > 0)
+	auto n = get_number_of_mods(params);
+	if(n > 0)
 	{
 		std::vector<std::string> modNames;
 		std::vector<std::string> modResFolders;
-		auto n = get_number_of_mods(params);
-		printf("%d\n", n);
 		for (auto i = 0; i < n; ++i)
 		{
 			char* rustModName = get_mod(params, i);


### PR DESCRIPTION
The launcher can edit the mods in `ja2.json`.
The game can use multiple mods. (order matters)

Launcher screenshot:
![mods](https://user-images.githubusercontent.com/1009600/61595193-08d02100-abec-11e9-82a6-f1ac273a1518.png)
Those checkboxes are for selecting which mods you want to move up/move down/remove.

Addresses most of #321 