### PR TITLE
Use normalized unicode in rust

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7,6 +7,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +123,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "caseless"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -307,6 +324,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "nodrop"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,9 +472,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "remove_dir_all"
@@ -507,6 +549,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "spin"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +563,7 @@ name = "stracciatella"
 version = "0.1.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "caseless 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbindgen 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -530,6 +578,7 @@ dependencies = [
  "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -606,6 +655,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +674,19 @@ dependencies = [
 name = "typenum"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ucd-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "unicode-width"
@@ -631,6 +701,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "utf8-ranges"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -669,6 +744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
+"checksum aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "36b7aa1ccb7d7ea3f437cf025a2ab1c47cc6c1bc9fc84918ff449def12f5e282"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
@@ -683,6 +759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
+"checksum caseless 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "808dab3318747be122cb31d36de18d4d1c81277a76f8332a02b81a3d73463d7f"
 "checksum cbindgen 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7e19db9a3892c88c74cbbdcd218196068a928f1b60e736c448b13a1e81f277"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
@@ -707,6 +784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c275b6ad54070ac2d665eef9197db647b32239c9d244bfb6f041a766d00da5b3"
 "checksum md-5 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a18af3dcaf2b0219366cdb4e2af65a6101457b415c3d1a5c71dd9c2b7c77b9c8"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
+"checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
@@ -724,7 +802,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
+"checksum regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6b23da8dfd98a84bd7e08700190a5d9f7d2d38abd4369dd1dae651bc40bfd2cc"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
+"checksum regex-syntax 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5485bf1523a9ed51c4964273f22f63f24e31632adb5dad134f488f86a3875c"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
@@ -732,6 +812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "d46b3dfedb19360a74316866cef04687cd4d6a70df8e6a506c63512790769b72"
 "checksum serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "c22a0820adfe2f257b098714323563dd06426502abbbce4f51b72ef544c5027f"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
+"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d960b829a55e56db167e861ddb43602c003c7be0bee1d345021703fac2fb7c"
@@ -741,11 +822,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
+"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+"checksum ucd-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa9b3b49edd3468c0e6565d85783f51af95212b6fa3986a5500954f00b460874"
+"checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
+"checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,6 +35,8 @@ byteorder = "1.3.1"
 hex = "0.3.2"
 digest = "0.8.0"
 md-5 = "0.8.0"
+unicode-normalization = "0.1"
+caseless = "0.2"
 
 [dependencies.clap]
 optional = true

--- a/rust/src/stracciatella.rs
+++ b/rust/src/stracciatella.rs
@@ -26,6 +26,7 @@ pub mod res;
 pub mod file_formats;
 pub mod librarydb;
 pub mod c;
+pub mod unicode;
 
 pub use crate::config::ScalingQuality;
 pub use crate::config::VanillaVersion;

--- a/rust/src/stracciatella.rs
+++ b/rust/src/stracciatella.rs
@@ -35,6 +35,7 @@ use crate::config::Ja2Json;
 use crate::config::Cli;
 use crate::config::EngineOptions;
 use crate::config::find_stracciatella_home;
+use crate::unicode::Nfc;
 
 fn parse_args(engine_options: &mut EngineOptions, args: &[String]) -> Option<String> {
     let cli = Cli::from_args(args);
@@ -354,18 +355,19 @@ pub extern "C" fn check_if_relative_path_exists(
     let base: PathBuf = unsafe { CStr::from_ptr(unsafe_from_ptr!(base)) }.to_string_lossy().into_owned().into();
     let path: PathBuf = unsafe { CStr::from_ptr(unsafe_from_ptr!(path)) }.to_string_lossy().into_owned().into();
     let mut buf = base;
+    if !caseless {
+        buf.push(path);
+        return buf.exists();
+    }
     'outer: for component in path.components() {
         match component {
             Component::Normal(os_str) => {
-                if caseless {
-                    let want_ascii_lowercase = os_str.to_string_lossy().to_ascii_lowercase();
-                    let result = buf.read_dir();
-                    if let Ok(entries) = result {
-                        for result in entries {
-                            if let Ok(entry) = result {
-                                let file_name = entry.file_name();
-                                let have_ascii_lowercase = file_name.to_string_lossy().to_ascii_lowercase();
-                                if want_ascii_lowercase == have_ascii_lowercase {
+                if let Some(want_caseless) = os_str.to_str().map(|x| Nfc::caseless(x)) {
+                    if let Ok(entries) = buf.read_dir() {
+                        for entry in entries.filter_map(|x| x.ok()) {
+                            let file_name = entry.file_name();
+                            if let Some(have_caseless) = file_name.to_str().map(|x| Nfc::caseless(x)) {
+                                if want_caseless == have_caseless {
                                     buf.push(file_name);
                                     continue 'outer;
                                 }

--- a/rust/src/unicode.rs
+++ b/rust/src/unicode.rs
@@ -1,0 +1,197 @@
+//! Correct unicode handling.
+//!
+//! Correct unicode is hard, I'll spare you the gory details...
+//! This module adds a slight runtime speed cost and a considerable binary size cost.
+//! Uses the crates [`unicode-normalization`] and [`caseless`].
+//!
+//! In javascript [`String.prototype.normalize()`] defaults to NFC so we use it too.
+//!
+//! We use the default `String` order, which is probably not correct unicode order.
+//!
+//!
+//! # Normalization
+//!
+//! Two unicode strings with different bytes can be considered equal.
+//! Normalizing makes them have the same bytes as long as the same normalization form is used.
+//!
+//! We use [canonical equivalence] to ensure characters have the same visual appearance and behavior.
+//!
+//! There is a runtime space-time tradeoff between the two canonical [normalization forms]:
+//!  * NFD = more string space, less normalization time (decomposition)
+//!  * NFC = less string space, more normalization time (decomposition + composition)
+//!
+//!
+//! # Partial strings
+//!
+//! A concatenated string must be normalized even if the original strings were normalized.
+//!
+//! I'm not sure, but utf8 substrings are probably normalized if the original was normalized.
+//!
+//!
+//! # Ordering
+//!
+//! Should depend on the locale.
+//!
+//!
+//! # Case sensitive
+//!
+//! Compare normalized strings.
+//!
+//!
+//! # Case insensitive
+//!
+//! Compare caseless normalized strings.
+//!
+//! To get a caseless string we must normalize, then get a caseless representation with [case folding] and normalize again.
+//!
+//!
+//! [`caseless`]: https://crates.io/crates/caseless
+//! [`unicode-normalization`]: https://crates.io/crates/unicode-normalization
+//! [`String.prototype.normalize()`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
+//! [canonical equivalence]: http://www.unicode.org/reports/tr15/#Canon_Compat_Equivalence
+//! [normalization forms]: http://www.unicode.org/reports/tr15/#Norm_Forms
+//! [case folding]: https://www.w3.org/International/wiki/Case_folding
+#![allow(dead_code)]
+
+use std::fmt;
+use std::ops;
+
+use caseless::Caseless;
+use unicode_normalization::{is_nfc, UnicodeNormalization};
+
+/// A unicode string normalized with NFC.
+///
+/// Can be used transparently as a `&str`.
+/// The inner `String` is private to ensure it remains normalized.
+/// Uses default `String` order, which is probably not correct unicode order.
+#[derive(Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Nfc {
+    inner: String,
+}
+
+impl Nfc {
+    /// Creates a normalized string.
+    pub fn from_str(s: &str) -> Self {
+        if is_nfc(s) {
+            let string = s.to_owned();
+            Self { inner: string }
+        } else {
+            let string = s.chars().nfc().collect();
+            Self { inner: string }
+        }
+    }
+
+    /// Creates a normalized caseless string.
+    pub fn caseless(s: &str) -> Self {
+        let string = s.chars().nfc().default_case_fold().nfc().collect();
+        Self { inner: string }
+    }
+
+    /// Creates a normalized path string.
+    /// Converts '\\' to '/'.
+    pub fn path(s: &str) -> Self {
+        if is_nfc(s) && !s.contains('\\') {
+            let string = s.to_owned();
+            Self { inner: string }
+        } else {
+            let string = s
+                .chars()
+                .map(|x| if x == '\\' { '/' } else { x })
+                .nfc()
+                .collect();
+            Self { inner: string }
+        }
+    }
+
+    /// Creates a normalized caseless path string.
+    /// Converts '\\' to '/'.
+    pub fn caseless_path(s: &str) -> Self {
+        let string = s
+            .chars()
+            .map(|x| if x == '\\' { '/' } else { x })
+            .nfc()
+            .default_case_fold()
+            .nfc()
+            .collect();
+        Self { inner: string }
+    }
+
+    /// Match `String::as_str()`.
+    pub fn as_str(&self) -> &str {
+        &self.inner
+    }
+}
+
+impl AsRef<[u8]> for Nfc {
+    fn as_ref(&self) -> &[u8] {
+        self.inner.as_bytes()
+    }
+}
+
+impl AsRef<str> for Nfc {
+    fn as_ref(&self) -> &str {
+        &self.inner
+    }
+}
+
+/// Converts to a normalized string.
+impl From<&str> for Nfc {
+    fn from(s: &str) -> Self {
+        Nfc::from_str(s)
+    }
+}
+
+/// Converts to a normalized string.
+/// Consumes the original string.
+impl From<String> for Nfc {
+    fn from(string: String) -> Self {
+        if is_nfc(&string) {
+            Self { inner: string }
+        } else {
+            let string = string.chars().nfc().collect();
+            Self { inner: string }
+        }
+    }
+}
+
+/// Unwraps the inner string.
+impl Into<String> for Nfc {
+    fn into(self) -> String {
+        self.inner
+    }
+}
+
+/// Inherits all the methods of `str`.
+impl ops::Deref for Nfc {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.inner
+    }
+}
+
+/// Adds a string.
+impl ops::Add<&str> for Nfc {
+    type Output = Self;
+
+    fn add(self, other: &str) -> Self {
+        let string = self.inner.chars().chain(other.chars()).nfc().collect();
+        Self { inner: string }
+    }
+}
+
+/// Matches the inner string.
+impl fmt::Display for Nfc {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let display: &fmt::Display = &self.inner;
+        display.fmt(f)
+    }
+}
+
+/// Matches the inner string.
+impl fmt::Debug for Nfc {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let debug: &fmt::Debug = &self.inner;
+        debug.fmt(f)
+    }
+}


### PR DESCRIPTION
Reference: #835

Is was using ascii caseless comparisons in the rustified LibraryDB.
It was decided that unicode caseless comparisons should be used.
Other code needs it too so I made the changes here instead of the original PR.

This PR introduces a `unicode::Nfc` struct that ensures the string is normalized and can be used for comparisons, caseless or not.