### PR TITLE
Rework Random

### DIFF
--- a/src/game/Editor/EditScreen.cc
+++ b/src/game/Editor/EditScreen.cc
@@ -495,7 +495,7 @@ static void SetBackgroundTexture(void)
 		RemoveAllLandsOfTypeRange( cnt, FIRSTTEXTURE, DEEPWATERTEXTURE );
 
 		// Add level
-		usIndex = (UINT16)(rand( ) % 10 );
+		usIndex = (UINT16)Random(10);
 
 		// Adjust for type
 		usIndex += gTileTypeStartIndex[ gCurrentBackground ];
@@ -1441,7 +1441,7 @@ static void HandleKeyboardShortcuts(void)
 								RemoveAllRoofsOfTypeRange( i, FIRSTTEXTURE, LASTITEM );
 								RemoveAllOnRoofsOfTypeRange( i, FIRSTTEXTURE, LASTITEM );
 								RemoveAllShadowsOfTypeRange( i, FIRSTROOF, LASTSLANTROOF );
-								usRoofIndex = 9 + ( rand() % 3 );
+								usRoofIndex = 9 + Random(3);
 								UINT16 usTileIndex = GetTileIndexFromTypeSubIndex(usRoofType, usRoofIndex);
 								AddRoofToHead( i, usTileIndex );
 							}

--- a/src/game/Editor/Edit_Sys.cc
+++ b/src/game/Editor/Edit_Sys.cc
@@ -416,7 +416,7 @@ UINT16 GetRandomIndexByRange( UINT16 usRangeStart, UINT16 usRangeEnd )
 			usNumInPickList++;
 		}
 	}
-	return ( usNumInPickList ) ? usPickList[ rand() % usNumInPickList ] : 0xffff;
+	return ( usNumInPickList ) ? usPickList[ Random(usNumInPickList) ] : 0xffff;
 }
 
 
@@ -700,7 +700,7 @@ static BOOLEAN PasteExistingTexture(UINT32 iMapIndex, UINT16 usIndex)
 	DeleteAllLandLayers( iMapIndex );
 
 	// ADD BASE LAND AT LEAST!
-	usNewIndex = (UINT16)(rand( ) % 10 );
+	usNewIndex = (UINT16)Random(10);
 
 	// Adjust for type
 	usNewIndex += gTileTypeStartIndex[ gCurrentBackground ];
@@ -773,7 +773,7 @@ static BOOLEAN SetLowerLandIndexWithRadius(INT32 iMapIndex, UINT32 uiNewType, UI
 						AddToUndoList( iMapIndex );
 
 						// Force middle one to NOT smooth, and set to random 'full' tile
-						usTemp = ( rand( ) % 10 ) + 1;
+						usTemp = Random(10) + 1;
 						UINT16 NewTile = GetTileIndexFromTypeSubIndex(uiNewType, usTemp);
 						SetLandIndex(iNewIndex, NewTile, uiNewType);
 					}
@@ -782,7 +782,7 @@ static BOOLEAN SetLowerLandIndexWithRadius(INT32 iMapIndex, UINT32 uiNewType, UI
 						AddToUndoList( iMapIndex );
 
 						// Force middle one to NOT smooth, and set to random 'full' tile
-						usTemp = ( rand( ) % 10 ) + 1;
+						usTemp = Random(10) + 1;
 						UINT16 NewTile = GetTileIndexFromTypeSubIndex(uiNewType, usTemp);
 						SetLandIndex(iNewIndex, NewTile, uiNewType);
 					}

--- a/src/game/Editor/EditorTerrain.cc
+++ b/src/game/Editor/EditorTerrain.cc
@@ -21,6 +21,7 @@
 #include "Cursor_Modes.h"
 #include "English.h"
 #include "UILayout.h"
+#include "Random.h"
 
 
 BOOLEAN gfShowTerrainTileButtons;
@@ -187,7 +188,7 @@ void ChooseWeightedTerrainTile()
 	{ //Not in the weighted mode.  CurrentPaste will already contain the selected tile.
 		return;
 	}
-	sRandomNum = rand() % usTotalWeight;
+	sRandomNum = Random(usTotalWeight);
 	for( x = 0; x < NUM_TERRAIN_TILE_REGIONS; x++ )
 	{
 		usWeight = ubTerrainTileButtonWeight[ x ];

--- a/src/game/Editor/NewSmooth.cc
+++ b/src/game/Editor/NewSmooth.cc
@@ -378,7 +378,7 @@ UINT16 PickAWallPiece( UINT16 usWallPieceType )
 	if (usWallPieceType < NUM_WALL_TYPES)
 	{
 		usVariants = gbWallTileLUT[ usWallPieceType ][ 0 ];
-		usVariantChosen = ( rand() % usVariants ) + 1;
+		usVariantChosen = Random(usVariants) + 1;
 		usWallPieceChosen = gbWallTileLUT[ usWallPieceType ][ usVariantChosen ];
 	}
 	return usWallPieceChosen;
@@ -591,7 +591,7 @@ void RebuildRoofUsingFloorInfo(INT32 const map_idx, UINT16 roof_type)
 		bottom          ? BOTTOM_ROOF_INDEX      :
 		left            ? LEFT_ROOF_INDEX        :
 		right           ? RIGHT_ROOF_INDEX       :
-		CENTER_ROOF_BASE_INDEX + rand() % CENTER_ROOF_VARIANTS;
+		CENTER_ROOF_BASE_INDEX + Random(CENTER_ROOF_VARIANTS);
 	UINT16 const tile_idx = GetTileIndexFromTypeSubIndex(roof_type, roof_idx);
 	AddRoofToHead(map_idx, tile_idx);
 	// If the editor view roofs is off, then the new roofs need to be hidden.
@@ -628,7 +628,7 @@ void RebuildRoof(UINT32 const map_idx, UINT16 roof_type)
 		bottom           ? BOTTOM_ROOF_INDEX      :
 		left             ? LEFT_ROOF_INDEX        :
 		right            ? RIGHT_ROOF_INDEX       :
-		CENTER_ROOF_BASE_INDEX + rand() % CENTER_ROOF_VARIANTS;
+		CENTER_ROOF_BASE_INDEX + Random(CENTER_ROOF_VARIANTS);
 	UINT16 const tile_idx = GetTileIndexFromTypeSubIndex(roof_type, roof_idx);
 	AddRoofToHead(map_idx, tile_idx);
 	// If the editor view roofs is off, then the new roofs need to be hidden.

--- a/src/game/Editor/Smooth.cc
+++ b/src/game/Editor/Smooth.cc
@@ -6,6 +6,7 @@
 #include "Structure_Wrap.h"
 #include "Exit_Grids.h"
 #include "Editor_Undo.h"
+#include "Random.h"
 
 
 INT16 gbSmoothStruct[] =
@@ -198,7 +199,7 @@ void SmoothTerrain(int gridno, int origType, UINT16 *piNewTile, BOOLEAN fForceSm
 					*piNewTile = NO_TILE;
 					return;
 				}
-				uiTempIndex = rand() % pSmoothStruct[ cnt + 1 ];
+				uiTempIndex = Random(pSmoothStruct[ cnt + 1 ]);
 				land = pSmoothStruct[ cnt + 2 + uiTempIndex ];
 				fFound = TRUE;
 			} while( FALSE );
@@ -216,7 +217,7 @@ void SmoothTerrain(int gridno, int origType, UINT16 *piNewTile, BOOLEAN fForceSm
 		}
 		// this is a "full" tile, so randomize between the
 		// five available tiles
-		land = (rand( ) % 10 ) + 1;
+		land = Random(10) + 1;
 	}
 	*piNewTile = GetTileIndexFromTypeSubIndex(origType, land);
 }
@@ -479,7 +480,7 @@ static void SmoothWaterTerrain(int gridno, int origType, UINT16* piNewTile, BOOL
 					*piNewTile = NO_TILE;
 					return;
 				}
-				uiTempIndex = rand() % pSmoothStruct[ cnt + 1 ];
+				uiTempIndex = Random(pSmoothStruct[ cnt + 1 ]);
 				land = pSmoothStruct[ cnt + 2 + uiTempIndex ];
 				fFound = TRUE;
 			} while( FALSE );
@@ -495,7 +496,7 @@ static void SmoothWaterTerrain(int gridno, int origType, UINT16* piNewTile, BOOL
 				*piNewTile = NO_TILE;
 				return;
 			}
-			land = (rand( ) % 10 ) + 1;
+			land = Random(10) + 1;
 	}
 	*piNewTile = GetTileIndexFromTypeSubIndex(origType, land);
 }

--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -2451,7 +2451,7 @@ void NewWorld()
 	for (INT32 cnt = 0; cnt != WORLD_MAX; ++cnt)
 	{
 		// Set land index
-		UINT16 const idx = rand() % 10;
+		UINT16 const idx = Random(10);
 		AddLandToHead(cnt, idx);
 	}
 

--- a/src/sgp/Random.cc
+++ b/src/sgp/Random.cc
@@ -1,69 +1,89 @@
 #include "Random.h"
-#include <stdlib.h>
-#include <time.h>
 
+#include <chrono>
+#include <random>
+
+/// Pseudo-random number engine.
+static std::mt19937 gRandomEngine;
+
+/// Uniform distribution in the range [0,UINT32_MAX].
+static std::uniform_int_distribution<UINT32> guiDistribution(0, UINT32_MAX);
+
+// Pregenerated pseudo-random numbers.
 UINT32 guiPreRandomIndex = 0;
 UINT32 guiPreRandomNums[ MAX_PREGENERATED_NUMS ];
 
+/// Pre-generated pseudo-random number engine.
+struct PreRandomEngine {
+	typedef UINT32 result_type;
+	static constexpr result_type min() { return 0; }
+	static constexpr result_type max() { return UINT32_MAX; }
+	result_type operator()()
+	{
+		// Extract the current pregenerated number
+		UINT32 uiNum = guiPreRandomNums[ guiPreRandomIndex ];
+
+		// Replace the current pregenerated number with a new one.
+		// NOTE the original code has this commented out in the name of optimization.
+		guiPreRandomNums[ guiPreRandomIndex ] = guiDistribution(gRandomEngine);
+
+		// Go to the next index.
+		guiPreRandomIndex++;
+		if (guiPreRandomIndex >= (UINT32)MAX_PREGENERATED_NUMS)
+			guiPreRandomIndex = 0;
+		return uiNum;
+	}
+};
+static PreRandomEngine gPreRandomEngine;
+
 void InitializeRandom(void)
 {
-	// Seed the random-number generator with current time so that
-	// the numbers will be different every time we run.
-	srand( (unsigned) time(NULL) );
-	//Pregenerate all of the random numbers.
-	for( guiPreRandomIndex = 0; guiPreRandomIndex < MAX_PREGENERATED_NUMS; guiPreRandomIndex++ )
+	// Seed the pseudo-random number engine with the current time
+	// so that the numbers will be different every time we run.
+	UINT32 uiSeed1 = std::chrono::system_clock::now().time_since_epoch().count();
+
+	// Also try to seed the pseudo-random number engine with a non-deterministic
+	// random number (entropy is 0 when not available).
+	std::random_device randomDevice;
+	UINT32 uiSeed2 = guiDistribution(randomDevice);
+
+	std::seed_seq seed = { uiSeed1, uiSeed2 };
+	gRandomEngine = std::mt19937(seed);
+
+	// Pregenerate random numbers.
+	for (guiPreRandomIndex = 0; guiPreRandomIndex < MAX_PREGENERATED_NUMS; ++guiPreRandomIndex)
 	{
-		guiPreRandomNums[ guiPreRandomIndex ] = rand();
+		guiPreRandomNums[ guiPreRandomIndex ] = guiDistribution(gRandomEngine);
 	}
 	guiPreRandomIndex = 0;
 }
 
-// Returns a pseudo-random integer between 0 and uiRange
+/// Returns a pseudo-random integer in the range [0,uiRange).
+/// Returns 0 if no range is given (not an error).
 UINT32 Random(UINT32 uiRange)
 {
-	UINT32 x;
-	// Always return 0, if no range given (it's not an error)
-	if (uiRange == 0)
-		return(0);
-	/* Ensures a correct average value by actually limiting the possible
-	 * set of values to the largest multiple of uiRange and
-	 * discarding [largest multiple of uiRange beneath RAND_MAX,RAND_MAX].
-	 * The rather complex limitation ensures a correct behaviour even
-	 * for very large (close to RAND_MAX) values of uiRange.
-	 */
-	do { x = rand(); } while ( x >= (((RAND_MAX - uiRange + 1)/uiRange+1)*uiRange));
-	return x % uiRange;
+	if (!uiRange)
+		return 0;
+	std::uniform_int_distribution<UINT32> distribution(0, uiRange - 1);
+	return distribution(gRandomEngine);
 }
 
-BOOLEAN Chance( UINT32 uiChance )
+BOOLEAN Chance(UINT32 uiChance)
 {
 	return Random(100) < uiChance;
 }
 
-UINT32 PreRandom( UINT32 uiRange )
+/// Returns a pregenerated pseudo-random integer in the range [0,uiRange).
+/// Returns 0 if no range is given (not an error).
+UINT32 PreRandom(UINT32 uiRange)
 {
-	UINT32 uiNum;
-	if( !uiRange )
+	if (!uiRange)
 		return 0;
-	//Extract the current pregenerated number
-	/* HACK0007 Stop PreRandom always returning 0 or 1
-	 * without ensuring an equal distribution, which
-	 * would be a rather complex task with pregenerated randoms
-	 */
-	uiNum = guiPreRandomNums[ guiPreRandomIndex ] % uiRange;
-	//Replace the current pregenerated number with a new one.
-
-	//This was removed in the name of optimization.  Uncomment if you hate recycling.
-	//guiPreRandomNums[ guiPreRandomIndex ] = rand();
-
-	//Go to the next index.
-	guiPreRandomIndex++;
-	if( guiPreRandomIndex >= (UINT32)MAX_PREGENERATED_NUMS )
-		guiPreRandomIndex = 0;
-	return uiNum;
+	std::uniform_int_distribution<UINT32> distribution(0, uiRange - 1);
+	return distribution(gPreRandomEngine);
 }
 
-BOOLEAN PreChance( UINT32 uiChance )
+BOOLEAN PreChance(UINT32 uiChance)
 {
 	return PreRandom(100) < uiChance;
 }


### PR DESCRIPTION
1. Use C++ facilities to generate uniform pseudo-random integer numbers.
2. Replace leftover uses of `rand()` with `Random`.
3. Add game policy to allow not recycling prerandom numbers.
    Vanilla had this commented out in the name of optimization, but today computers are much more powerful and this is not a hot path so I don't see value in this optimization.

This PR is based on the opposite view of #777.
For me non-uniform pseudo-random numbers is a bug (`PreRandom` was not uniform) and issue #777 is not a bug.