### PR TITLE
Fix "enough money to extend life ensurance" test.

### DIFF
--- a/src/game/Strategic/Merc_Contract.cc
+++ b/src/game/Strategic/Merc_Contract.cc
@@ -293,7 +293,7 @@ BOOLEAN MercContractHandling(SOLDIERTYPE* const s, UINT8 const ubDesiredAction)
 
 		HandleImportantMercQuote(s, QUOTE_ACCEPT_CONTRACT_RENEWAL);
 
-		if (iCostOfInsurance > LaptopSaveInfo.iCurrentBalance)
+		if (iCostOfInsurance > LaptopSaveInfo.iCurrentBalance - contract_charge)
 		{
 			HandleNotifyPlayerCantAffordInsurance();
 


### PR DESCRIPTION
The contract hasn't been renewed yet.
It needs to compare against the balance after contract renewal.

Fixes #93