### PR TITLE
Add note about rustup and cross-compilation

### DIFF
--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -45,6 +45,12 @@ cmake -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain-mingw.cmake path/to/source
 make
 ```
 
+If you are using rustup, you might need to add the x86_64-pc-windows-gnu target to the rust toolchain before compiling.
+
+```
+rustup target add x86_64-pc-windows-gnu
+```
+
 ## Build on macOS
 
 ```

--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -45,10 +45,18 @@ cmake -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain-mingw.cmake path/to/source
 make
 ```
 
-If you are using rustup, you might need to add the x86_64-pc-windows-gnu target to the rust toolchain before compiling.
+If you are using rustup, you might need to add the MinGW target to the rust toolchain before compiling.
+
+When building for 64-bit:
 
 ```
 rustup target add x86_64-pc-windows-gnu
+```
+
+When building for 32-bit:
+
+```
+rustup target add i686-pc-windows-gnu
 ```
 
 ## Build on macOS


### PR DESCRIPTION
Got some errors about a missing "core" crate for rust when compiling on Debian for Windows, this fix solved the issue. Originally mentioned in https://github.com/ja2-stracciatella/ja2-stracciatella/issues/726