### PR TITLE
Reorganize rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,11 @@ before_install:
   - if [[ "$TRAVIS_MINGW" == "true" ]]; then
       rustup target add x86_64-pc-windows-gnu;
     fi
+  - rustup component add rustfmt
 
   - cargo -V
   - rustc -V
+  - cargo fmt -- -V
   - cmake --version
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       fakeroot -v;
@@ -80,6 +82,7 @@ script:
       sudo make install;
     fi
   - cd ../rust
+  - cargo fmt -- --check;
   - if [ "$TRAVIS_MINGW" != "true" ]; then
       cargo test;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,12 @@ before_install:
       rustup target add x86_64-pc-windows-gnu;
     fi
   - rustup component add rustfmt
+  - rustup component add clippy
 
   - cargo -V
   - rustc -V
   - cargo fmt -- -V
+  - cargo clippy -- -V
   - cmake --version
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       fakeroot -v;
@@ -83,6 +85,7 @@ script:
     fi
   - cd ../rust
   - cargo fmt -- --check;
+  - cargo clippy --all-targets --all-features -- -D warnings;
   - if [ "$TRAVIS_MINGW" != "true" ]; then
       cargo test;
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,10 +66,12 @@ install:
   - cmd: curl -sSf -o rustup-init.exe https://win.rustup.rs/
   - cmd: rustup-init.exe -y --default-toolchain %RUSTUP_TOOLCHAIN%
   - cmd: set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - cmd: rustup.exe component add rustfmt
 
   - cmd: echo "%RUSTUP_TOOLCHAIN%"
   - cmd: rustc -V
   - cmd: cargo -V
+  - cmd: cargo fmt -- -V
   - cmd: cmake --version
 
 before_build:
@@ -82,6 +84,7 @@ build_script:
 
 test_script:
   - cmd: cd ..\rust
+  - cmd: cargo fmt -- --check
   - cmd: cargo test
   - cmd: cd ..\ci-build
   - cmd: cd %BUILD_TYPE%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,11 +67,13 @@ install:
   - cmd: rustup-init.exe -y --default-toolchain %RUSTUP_TOOLCHAIN%
   - cmd: set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - cmd: rustup.exe component add rustfmt
+  - cmd: rustup.exe component add clippy
 
   - cmd: echo "%RUSTUP_TOOLCHAIN%"
   - cmd: rustc -V
   - cmd: cargo -V
   - cmd: cargo fmt -- -V
+  - cmd: cargo clippy -- -V
   - cmd: cmake --version
 
 before_build:
@@ -85,6 +87,7 @@ build_script:
 test_script:
   - cmd: cd ..\rust
   - cmd: cargo fmt -- --check
+  - cmd: cargo clippy --all-targets --all-features -- -D warnings
   - cmd: cargo test
   - cmd: cd ..\ci-build
   - cmd: cd %BUILD_TYPE%

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,23 +1,28 @@
 extern crate cbindgen;
 
-use std::path;
 use std::env;
 use std::fs;
+use std::path;
 
 fn main() {
     let crate_dir = path::PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
-    let default_header_path = crate_dir.join("stracciatella.h").into_os_string().into_string().unwrap();
+    let default_header_path = crate_dir
+        .join("stracciatella.h")
+        .into_os_string()
+        .into_string()
+        .unwrap();
     let header_env = env::var("HEADER_LOCATION").unwrap_or(default_header_path);
     let header_path = path::PathBuf::from(&header_env);
     let header_dir = header_path.parent().unwrap();
-    let config = cbindgen::Config::from_file("cbindgen.toml").expect("Failed to read `cbindgen.toml`!");
+    let config =
+        cbindgen::Config::from_file("cbindgen.toml").expect("Failed to read `cbindgen.toml`!");
 
     fs::create_dir_all(&header_dir).unwrap();
 
     cbindgen::Builder::new()
-      .with_crate(crate_dir)
-      .with_config(config)
-      .generate()
-      .expect("Unable to generate bindings")
-      .write_to_file(&header_path);
+        .with_crate(crate_dir)
+        .with_config(config)
+        .generate()
+        .expect("Unable to generate bindings")
+        .write_to_file(&header_path);
 }

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,25 +1,24 @@
-extern crate cbindgen;
-
 use std::env;
 use std::fs;
-use std::path;
+use std::path::PathBuf;
+
+use cbindgen::{Builder, Config};
 
 fn main() {
-    let crate_dir = path::PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let crate_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let default_header_path = crate_dir
         .join("stracciatella.h")
         .into_os_string()
         .into_string()
         .unwrap();
     let header_env = env::var("HEADER_LOCATION").unwrap_or(default_header_path);
-    let header_path = path::PathBuf::from(&header_env);
+    let header_path = PathBuf::from(&header_env);
     let header_dir = header_path.parent().unwrap();
-    let config =
-        cbindgen::Config::from_file("cbindgen.toml").expect("Failed to read `cbindgen.toml`!");
+    let config = Config::from_file("cbindgen.toml").expect("Failed to read `cbindgen.toml`!");
 
     fs::create_dir_all(&header_dir).unwrap();
 
-    cbindgen::Builder::new()
+    Builder::new()
         .with_crate(crate_dir)
         .with_config(config)
         .generate()

--- a/rust/src/bin_resource_pack.rs
+++ b/rust/src/bin_resource_pack.rs
@@ -141,7 +141,7 @@ fn subcommand_create(matches: &ArgMatches) {
             if paths.len() > 1 {
                 graceful_error(&format!("Too many data dirs found {:?}", paths));
             }
-            if paths.len() == 0 {
+            if paths.is_empty() {
                 graceful_error(&format!("Data dir not found in {:?}", gamedir));
             }
             let path = paths.remove(0);

--- a/rust/src/bin_resource_pack.rs
+++ b/rust/src/bin_resource_pack.rs
@@ -15,15 +15,16 @@ mod file_formats;
 mod res;
 mod unicode;
 
-use res::{ResourcePackBuilder, ResourcePropertiesExt};
-use unicode::Nfc;
-
-use clap::{crate_version, App, Arg, ArgMatches, SubCommand};
-use serde_json;
 use std::fmt::Debug;
 use std::fs;
 use std::path::PathBuf;
 use std::process;
+
+use clap::{crate_version, App, Arg, ArgMatches, SubCommand};
+use serde_json;
+
+use crate::res::{ResourcePackBuilder, ResourcePropertiesExt};
+use crate::unicode::Nfc;
 
 /// Entry point of the resource-pack executable.
 fn main() {

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -1,0 +1,260 @@
+//! This module contains the C interface for [`stracciatella::config`].
+//!
+//! [`stracciatella::config`]: ../../config/index.html
+
+use std::ptr;
+
+use crate::c::common::*;
+use crate::config::{
+    find_stracciatella_home, Cli, EngineOptions, Ja2Json, Resolution, ScalingQuality,
+    VanillaVersion,
+};
+
+/// Creates `EngineOptions` with the provided command line arguments.
+/// Loads values from `(stracciatella_home)/ja2.json`, creating it if it does not exist.
+/// The caller is responsible for the returned memory.
+#[no_mangle]
+pub extern "C" fn create_engine_options(
+    array: *const *const c_char,
+    length: size_t,
+) -> *mut EngineOptions {
+    let args: Vec<String> = unsafe_slice(array, length)
+        .iter()
+        .map(|&x| str_from_c_str_or_panic(unsafe_c_str(x)).to_owned())
+        .collect();
+
+    match find_stracciatella_home().and_then(|x| EngineOptions::from_home_and_args(&x, &args)) {
+        Ok(engine_options) => {
+            if engine_options.show_help {
+                print!("{}", Cli::usage());
+            }
+            into_ptr(engine_options)
+        }
+        Err(msg) => {
+            println!("{}", msg);
+            ptr::null_mut()
+        }
+    }
+}
+
+/// Writes `EngineOptions` to `(stracciatella_home)/ja2.json`.
+/// Returns true on success, false otherwise.
+#[no_mangle]
+pub extern "C" fn write_engine_options(ptr: *mut EngineOptions) -> bool {
+    let engine_options = unsafe_mut(ptr);
+    let ja2_json = Ja2Json::from_stracciatella_home(&engine_options.stracciatella_home);
+    ja2_json.write(&engine_options).is_ok()
+}
+
+/// Deletes `EngineOptions`.
+#[no_mangle]
+pub extern "C" fn free_engine_options(ptr: *mut EngineOptions) {
+    let _drop_me = from_ptr(ptr);
+}
+
+/// Gets the `EngineOptions.stracciatella_home` path.
+/// The caller is responsible for the returned memory.
+#[no_mangle]
+pub extern "C" fn get_stracciatella_home(ptr: *const EngineOptions) -> *mut c_char {
+    let engine_options = unsafe_ref(ptr);
+    let stracciatella_home = c_string_from_path_or_panic(&engine_options.stracciatella_home);
+    stracciatella_home.into_raw()
+}
+
+/// Gets the `EngineOptions.vanilla_game_dir` path.
+/// The caller is responsible for the returned memory.
+#[no_mangle]
+pub extern "C" fn get_vanilla_game_dir(ptr: *const EngineOptions) -> *mut c_char {
+    let engine_options = unsafe_ref(ptr);
+    let vanilla_game_dir = c_string_from_path_or_panic(&engine_options.vanilla_game_dir);
+    vanilla_game_dir.into_raw()
+}
+
+/// Sets the `EngineOptions.vanilla_game_dir` path.
+#[no_mangle]
+pub extern "C" fn set_vanilla_game_dir(ptr: *mut EngineOptions, game_dir_ptr: *const c_char) {
+    let engine_options = unsafe_mut(ptr);
+    let vanilla_game_dir = path_from_c_str_or_panic(unsafe_c_str(game_dir_ptr));
+    engine_options.vanilla_game_dir = vanilla_game_dir.to_owned();
+}
+
+/// Gets the length of `EngineOptions.mods`.
+#[no_mangle]
+pub extern "C" fn get_number_of_mods(ptr: *const EngineOptions) -> u32 {
+    let engine_options = unsafe_ref(ptr);
+    engine_options.mods.len() as u32
+}
+
+/// Gets the target index of `EngineOptions.mods`.
+/// The caller is responsible for the returned memory.
+#[no_mangle]
+pub extern "C" fn get_mod(ptr: *const EngineOptions, index: u32) -> *mut c_char {
+    let engine_options = unsafe_ref(ptr);
+    match engine_options.mods.get(index as usize) {
+        Some(str_mod) => {
+            let c_str_mod = c_string_from_str(&str_mod);
+            c_str_mod.into_raw()
+        }
+        None => {
+            let len = engine_options.mods.len();
+            panic!("Invalid mod index {}, len = {}", index, len);
+        }
+    }
+}
+
+/// Clears `EngineOptions.mods`.
+#[no_mangle]
+pub extern "C" fn clear_mods(ptr: *mut EngineOptions) {
+    let engine_options = unsafe_mut(ptr);
+    engine_options.mods.clear();
+}
+
+/// Adds a mod to `EngineOptions.mods`.
+#[no_mangle]
+pub extern "C" fn push_mod(ptr: *mut EngineOptions, name: *const c_char) {
+    let engine_options = unsafe_mut(ptr);
+    let name = str_from_c_str_or_panic(unsafe_c_str(name)).to_owned();
+    engine_options.mods.push(name);
+}
+
+/// Gets the width of `EngineOptions.resolution`.
+#[no_mangle]
+pub extern "C" fn get_resolution_x(ptr: *const EngineOptions) -> u16 {
+    let engine_options = unsafe_ref(ptr);
+    engine_options.resolution.0
+}
+
+/// Gets the height of `EngineOptions.resolution`.
+#[no_mangle]
+pub extern "C" fn get_resolution_y(ptr: *const EngineOptions) -> u16 {
+    let engine_options = unsafe_ref(ptr);
+    engine_options.resolution.1
+}
+
+/// Sets `EngineOptions.resolution`.
+#[no_mangle]
+pub extern "C" fn set_resolution(ptr: *mut EngineOptions, x: u16, y: u16) {
+    let engine_options = unsafe_mut(ptr);
+    engine_options.resolution = Resolution(x, y);
+}
+
+/// Gets `EngineOptions.brightness`.
+#[no_mangle]
+pub extern "C" fn get_brightness(ptr: *const EngineOptions) -> f32 {
+    let engine_options = unsafe_ref(ptr);
+    engine_options.brightness
+}
+
+/// Sets `EngineOptions.brightness`.
+#[no_mangle]
+pub extern "C" fn set_brightness(ptr: *mut EngineOptions, brightness: f32) {
+    let engine_options = unsafe_mut(ptr);
+    engine_options.brightness = brightness
+}
+
+/// Gets `EngineOptions.resource_version`.
+#[no_mangle]
+pub extern "C" fn get_resource_version(ptr: *const EngineOptions) -> VanillaVersion {
+    let engine_options = unsafe_ref(ptr);
+    engine_options.resource_version
+}
+
+/// Sets `EngineOptions.resource_version`.
+#[no_mangle]
+pub extern "C" fn set_resource_version(ptr: *mut EngineOptions, res: VanillaVersion) {
+    let engine_options = unsafe_mut(ptr);
+    engine_options.resource_version = res;
+}
+
+/// Gets `EngineOptions.run_unittests`.
+#[no_mangle]
+pub extern "C" fn should_run_unittests(ptr: *const EngineOptions) -> bool {
+    let engine_options = unsafe_ref(ptr);
+    engine_options.run_unittests
+}
+
+/// Gets `EngineOptions.show_help`.
+#[no_mangle]
+pub extern "C" fn should_show_help(ptr: *const EngineOptions) -> bool {
+    let engine_options = unsafe_ref(ptr);
+    engine_options.show_help
+}
+
+/// Gets `EngineOptions.run_editor`.
+#[no_mangle]
+pub extern "C" fn should_run_editor(ptr: *const EngineOptions) -> bool {
+    let engine_options = unsafe_ref(ptr);
+    engine_options.run_editor
+}
+
+/// Gets `EngineOptions.start_in_fullscreen`.
+#[no_mangle]
+pub extern "C" fn should_start_in_fullscreen(ptr: *const EngineOptions) -> bool {
+    let engine_options = unsafe_ref(ptr);
+    engine_options.start_in_fullscreen
+}
+
+/// Sets `EngineOptions.start_in_fullscreen`.
+#[no_mangle]
+pub extern "C" fn set_start_in_fullscreen(ptr: *mut EngineOptions, val: bool) {
+    let engine_options = unsafe_mut(ptr);
+    engine_options.start_in_fullscreen = val
+}
+
+/// Gets `EngineOptions.scaling_quality`.
+#[no_mangle]
+pub extern "C" fn get_scaling_quality(ptr: *const EngineOptions) -> ScalingQuality {
+    let engine_options = unsafe_ref(ptr);
+    engine_options.scaling_quality
+}
+
+/// Sets `EngineOptions.scaling_quality`.
+#[no_mangle]
+pub extern "C" fn set_scaling_quality(ptr: *mut EngineOptions, scaling_quality: ScalingQuality) {
+    let engine_options = unsafe_mut(ptr);
+    engine_options.scaling_quality = scaling_quality
+}
+
+/// Gets `EngineOptions.start_in_window`.
+#[no_mangle]
+pub extern "C" fn should_start_in_window(ptr: *const EngineOptions) -> bool {
+    let engine_options = unsafe_ref(ptr);
+    engine_options.start_in_window
+}
+
+/// Gets `EngineOptions.start_in_debug_mode`.
+#[no_mangle]
+pub extern "C" fn should_start_in_debug_mode(ptr: *const EngineOptions) -> bool {
+    let engine_options = unsafe_ref(ptr);
+    engine_options.start_in_debug_mode
+}
+
+/// Gets `EngineOptions.start_without_sound`.
+#[no_mangle]
+pub extern "C" fn should_start_without_sound(ptr: *const EngineOptions) -> bool {
+    let engine_options = unsafe_ref(ptr);
+    engine_options.start_without_sound
+}
+
+/// Sets `EngineOptions.start_without_sound`.
+#[no_mangle]
+pub extern "C" fn set_start_without_sound(ptr: *mut EngineOptions, val: bool) {
+    let engine_options = unsafe_mut(ptr);
+    engine_options.start_without_sound = val
+}
+
+/// Gets the string representation of the `ScalingQuality` value.
+/// The caller is responsible for the returned memory.
+#[no_mangle]
+pub extern "C" fn get_scaling_quality_string(quality: ScalingQuality) -> *mut c_char {
+    let c_string = c_string_from_str(&quality.to_string());
+    c_string.into_raw()
+}
+
+/// Gets the string represntation of the `VanillaVersion` value.
+/// The caller is responsible for the returned memory.
+#[no_mangle]
+pub extern "C" fn get_resource_version_string(version: VanillaVersion) -> *mut c_char {
+    let c_string = c_string_from_str(&version.to_string());
+    c_string.into_raw()
+}

--- a/rust/src/c/librarydb.rs
+++ b/rust/src/c/librarydb.rs
@@ -2,7 +2,8 @@
 //!
 //! [`stracciatella::librarydb`]: ../../librarydb/index.html
 
-use std::io::{self, Read, Seek, SeekFrom};
+use std::io;
+use std::io::{Read, Seek, SeekFrom};
 
 use crate::c::common::*;
 use crate::librarydb::{LibraryDB, LibraryFile};

--- a/rust/src/c/logger.rs
+++ b/rust/src/c/logger.rs
@@ -3,9 +3,8 @@
 //! [`stracciatella::logger`]: ../../logger/index.html
 
 use crate::c::common::*;
-use crate::logger::Logger;
-
 pub use crate::logger::LogLevel;
+use crate::logger::Logger;
 
 /// Initializes the logger
 #[no_mangle]

--- a/rust/src/c/misc.rs
+++ b/rust/src/c/misc.rs
@@ -112,9 +112,7 @@ pub extern "C" fn check_if_relative_path_exists(
                 if let Ok(entries) = buf.read_dir() {
                     for entry in entries.filter_map(|x| x.ok()) {
                         let file_name = entry.file_name();
-                        if let Some(have_caseless) =
-                            file_name.to_str().map(|x| Nfc::caseless(x))
-                        {
+                        if let Some(have_caseless) = file_name.to_str().map(|x| Nfc::caseless(x)) {
                             if want_caseless == have_caseless {
                                 buf.push(file_name);
                                 continue 'outer;

--- a/rust/src/c/misc.rs
+++ b/rust/src/c/misc.rs
@@ -1,0 +1,249 @@
+//! This module contains miscellaneous code for C.
+//!
+//! The code in this module is not associated with any module in particular.
+
+use std::ffi::CString;
+use std::path::{Component, PathBuf};
+use std::ptr;
+
+use crate::c::common::*;
+use crate::config::find_stracciatella_home;
+use crate::get_assets_dir;
+use crate::unicode::Nfc;
+
+/// Converts the launcher executable path to the game executable path.
+/// The executable is assumed to be in the same directory as the launcher.
+/// The caller is responsible for the returned memory.
+#[no_mangle]
+pub extern "C" fn find_ja2_executable(launcher_path_ptr: *const c_char) -> *mut c_char {
+    let launcher_path = str_from_c_str_or_panic(unsafe_c_str(launcher_path_ptr));
+    let is_exe = launcher_path.to_lowercase().ends_with(".exe");
+    let end_of_executable_slice = launcher_path.len() - if is_exe { 13 } else { 9 };
+    let mut executable_path = String::from(&launcher_path[0..end_of_executable_slice]);
+
+    if is_exe {
+        executable_path.push_str(if is_exe { ".exe" } else { "" });
+    }
+
+    let c_string = c_string_from_str(&executable_path);
+    c_string.into_raw()
+}
+
+/// Deletes a CString.
+/// The caller is no longer responsible for the memory.
+#[no_mangle]
+pub extern "C" fn free_rust_string(s: *mut c_char) {
+    if s.is_null() {
+        return;
+    }
+    unsafe { CString::from_raw(s) };
+}
+
+/// Guesses the resource version from the contents of the game directory.
+/// Returns a VanillaVersion value if it was sucessful, -1 otherwise.
+#[no_mangle]
+pub extern "C" fn guess_resource_version(gamedir: *const c_char) -> c_int {
+    let path = str_from_c_str_or_panic(unsafe_c_str(gamedir));
+    let logged = crate::guess::guess_vanilla_version(&path);
+    let mut result = -1;
+    if let Some(version) = logged.vanilla_version {
+        result = version as c_int;
+    }
+    return result;
+}
+
+/// Returns the path to game.json.
+/// The caller is responsible for the returned memory.
+#[no_mangle]
+pub extern "C" fn get_game_json_path() -> *mut c_char {
+    let mut path = get_assets_dir();
+    path.push("externalized/game.json");
+    let path: String = path.to_string_lossy().into();
+    return CString::new(path).unwrap().into_raw();
+}
+
+/// Finds a path relative to the stracciatella home directory.
+/// If path is null, it finds the stracciatella home directory.
+/// If test_exists is true, it makes sure the path exists.
+/// The caller is responsible for the returned memory.
+#[no_mangle]
+pub extern "C" fn find_path_from_stracciatella_home(
+    path: *const c_char,
+    test_exists: bool,
+) -> *mut c_char {
+    if let Ok(mut path_buf) = find_stracciatella_home() {
+        if !path.is_null() {
+            let s = str_from_c_str_or_panic(unsafe_c_str(path));
+            path_buf.push(&s);
+        }
+        if test_exists && !path_buf.exists() {
+            return ptr::null_mut(); // path not found
+        } else {
+            match path_buf.canonicalize() {
+                Ok(p) => path_buf = p,
+                _ => {}
+            }
+            let s: String = path_buf.to_string_lossy().into();
+            return CString::new(s).unwrap().into_raw(); // path found
+        }
+    } else {
+        return ptr::null_mut(); // no home
+    }
+}
+
+/// Returns true if it was able to find path relative to base.
+/// Makes caseless searches one component at a time.
+#[no_mangle]
+pub extern "C" fn check_if_relative_path_exists(
+    base: *const c_char,
+    path: *const c_char,
+    caseless: bool,
+) -> bool {
+    let base: PathBuf = path_from_c_str_or_panic(unsafe_c_str(base)).to_owned();
+    let path: PathBuf = path_from_c_str_or_panic(unsafe_c_str(path)).to_owned();
+    let mut buf = base;
+    if !caseless {
+        buf.push(path);
+        return buf.exists();
+    }
+    'outer: for component in path.components() {
+        match component {
+            Component::Normal(os_str) => {
+                if let Some(want_caseless) = os_str.to_str().map(|x| Nfc::caseless(x)) {
+                    if let Ok(entries) = buf.read_dir() {
+                        for entry in entries.filter_map(|x| x.ok()) {
+                            let file_name = entry.file_name();
+                            if let Some(have_caseless) =
+                                file_name.to_str().map(|x| Nfc::caseless(x))
+                            {
+                                if want_caseless == have_caseless {
+                                    buf.push(file_name);
+                                    continue 'outer;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        buf.push(component);
+    }
+    return buf.exists();
+}
+
+/// Returns a list of available mods.
+/// The caller is responsible for the returned memory.
+#[no_mangle]
+pub extern "C" fn get_available_mods() -> *mut VecCString {
+    let mut path = get_assets_dir();
+    path.push("mods");
+    if let Ok(entries) = path.read_dir() {
+        let mods: Vec<_> = entries
+            .filter_map(|x| x.ok()) // DirEntry
+            .filter_map(|x| {
+                if let Ok(metadata) = x.metadata() {
+                    if metadata.is_dir() {
+                        return x.file_name().into_string().ok();
+                    }
+                }
+                None
+            }) // String
+            .filter_map(|x| CString::new(x.as_bytes().to_owned()).ok()) // CString
+            .collect();
+        into_ptr(VecCString::from_vec(mods))
+    } else {
+        into_ptr(VecCString::new())
+    }
+}
+
+/// A wrapper around `Vec<CString>` for C.
+pub struct VecCString {
+    inner: Vec<CString>,
+}
+
+impl VecCString {
+    pub fn new() -> Self {
+        Self { inner: Vec::new() }
+    }
+    pub fn from_vec(vec: Vec<CString>) -> Self {
+        Self { inner: vec }
+    }
+}
+
+/// Deletes the vector.
+#[no_mangle]
+pub extern "C" fn vec_c_string_delete(vec: *mut VecCString) {
+    let _drop_me = from_ptr(vec);
+}
+
+/// Returns the vector length.
+#[no_mangle]
+pub extern "C" fn vec_c_string_len(vec: *mut VecCString) -> size_t {
+    let vec = unsafe_ref(vec);
+    vec.inner.len()
+}
+
+/// Returns the string at the target index.
+/// The caller is responsible for the returned memory.
+#[no_mangle]
+pub extern "C" fn vec_c_string_get(vec: *mut VecCString, index: size_t) -> *mut c_char {
+    let vec = unsafe_ref(vec);
+    vec.inner[index].clone().into_raw()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CString;
+    use std::fs;
+
+    use crate::c::common::*;
+    use crate::c::misc::free_rust_string;
+
+    #[test]
+    fn find_ja2_executable_should_determine_game_path_from_launcher_path() {
+        macro_rules! t {
+            ($path:expr, $expected:expr) => {
+                let path = c_string_from_str($path);
+                let got = super::find_ja2_executable(path.as_ptr());
+                assert_eq!(str_from_c_str_or_panic(unsafe_c_str(got)), $expected);
+                free_rust_string(got);
+            };
+        }
+        t!("/home/test/ja2-launcher", "/home/test/ja2");
+        t!(
+            "C:\\\\home\\\\test\\\\ja2-launcher.exe",
+            "C:\\\\home\\\\test\\\\ja2.exe"
+        );
+        t!("ja2-launcher", "ja2");
+        t!("ja2-launcher.exe", "ja2.exe");
+        t!("JA2-LAUNCHER.EXE", "JA2.exe");
+    }
+
+    #[test]
+    fn check_if_relative_path_exists() {
+        let temp_dir = tempdir::TempDir::new("ja2-tests").unwrap();
+        fs::create_dir_all(temp_dir.path().join("foo/bar")).unwrap();
+
+        macro_rules! t {
+            ($path:expr, $caseless:expr, $expected:expr) => {
+                let base = CString::new(temp_dir.path().to_str().unwrap()).unwrap();
+                let path = CString::new($path).unwrap();
+                assert_eq!(
+                    super::check_if_relative_path_exists(base.as_ptr(), path.as_ptr(), $caseless),
+                    $expected
+                );
+            };
+        }
+        t!("baz", false, false);
+        t!("baz", true, false);
+        t!("foo", false, true);
+        t!("foo", true, true);
+        t!("foo/bar", false, true);
+        t!("foo/bar", true, true);
+        t!("foo/BAR", true, true);
+        t!("FOO/BAR", true, true);
+        t!("FOO/bar", true, true);
+        t!("FOO", true, true);
+    }
+}

--- a/rust/src/c/mod.rs
+++ b/rust/src/c/mod.rs
@@ -28,6 +28,12 @@ pub(crate) mod common {
     //! C can send a pointer that has already been freed.
     //! C can send a pointer that is being used in a different thread.
     //! Only null pointers can be detected safely, the rest can't be checked in rust.
+    //!
+    //! When you declare a function unsafe you automatically get an unsafe body (disables safety checks).
+    //! All `pub extern "C"` functions that receive a pointer from C are unsafe.
+    //! We want the safety checks so we DO NOT declare them unsafe.
+    //! Hopefully in the future there will be a way for unsafe functions to get a safe body.
+    //! See https://github.com/rust-lang/rfcs/pull/2585
     #![allow(dead_code)]
 
     pub use libc::{c_char, c_int, size_t};

--- a/rust/src/c/mod.rs
+++ b/rust/src/c/mod.rs
@@ -3,6 +3,7 @@
 pub mod config;
 pub mod librarydb;
 pub mod logger;
+pub mod misc;
 
 pub mod error {
     //! This module contains error handling code for C.
@@ -167,7 +168,7 @@ pub(crate) mod common {
 mod tests {
     use crate::c::common::*;
     use crate::c::error::*;
-    use crate::free_rust_string;
+    use crate::c::misc::free_rust_string;
     use std::cell::RefCell;
     use std::ffi::{CStr, CString};
     use std::path::Path;

--- a/rust/src/c/mod.rs
+++ b/rust/src/c/mod.rs
@@ -1,5 +1,6 @@
 //! This module and it's submodules contains code for C.
 
+pub mod config;
 pub mod librarydb;
 pub mod logger;
 

--- a/rust/src/c/mod.rs
+++ b/rust/src/c/mod.rs
@@ -39,11 +39,12 @@ pub(crate) mod common {
     //! See https://github.com/rust-lang/rfcs/pull/2585
     #![allow(dead_code)]
 
-    pub use libc::{c_char, c_int, size_t};
     use std::cell::RefCell;
     use std::ffi::{CStr, CString};
     use std::path::Path;
     use std::slice;
+
+    pub use libc::{c_char, c_int, size_t};
 
     thread_local!(
         /// A thread local error for C.
@@ -166,12 +167,13 @@ pub(crate) mod common {
 
 #[cfg(test)]
 mod tests {
-    use crate::c::common::*;
-    use crate::c::error::*;
-    use crate::c::misc::free_rust_string;
     use std::cell::RefCell;
     use std::ffi::{CStr, CString};
     use std::path::Path;
+
+    use crate::c::common::*;
+    use crate::c::error::*;
+    use crate::c::misc::free_rust_string;
 
     #[test]
     fn test_pointers() {

--- a/rust/src/c/mod.rs
+++ b/rust/src/c/mod.rs
@@ -27,6 +27,7 @@ pub(crate) mod common {
     //! All pointers that come from C are unsafe.
     //! C can send a pointer that has already been freed.
     //! C can send a pointer that is being used in a different thread.
+    //! C can send a pointer that is a different type of data (another struct or a number).
     //! Only null pointers can be detected safely, the rest can't be checked in rust.
     //!
     //! When you declare a function unsafe you automatically get an unsafe body (disables safety checks).

--- a/rust/src/config/cli.rs
+++ b/rust/src/config/cli.rs
@@ -4,8 +4,8 @@ use std::fs;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use log::warn;
 use getopts::Options;
+use log::warn;
 
 use crate::config::EngineOptions;
 use crate::config::Resolution;
@@ -23,7 +23,7 @@ static GAME_DIR_OPTION_EXAMPLE: &'static str = "C:\\JA2";
 /// passed to the executable
 pub struct Cli {
     args: Vec<String>,
-    options: Options
+    options: Options,
 }
 
 impl Cli {
@@ -36,13 +36,13 @@ impl Cli {
             "",
             "datadir", // TODO remove this deprecated option in version >= 0.18
             "Set path for the vanilla game directory. DEPRECATED use -gamedir instead.",
-            GAME_DIR_OPTION_EXAMPLE
+            GAME_DIR_OPTION_EXAMPLE,
         );
         opts.optmulti(
             "",
             "gamedir",
             "Set path for the vanilla game directory",
-            GAME_DIR_OPTION_EXAMPLE
+            GAME_DIR_OPTION_EXAMPLE,
         );
         opts.optmulti(
             "",
@@ -54,7 +54,7 @@ impl Cli {
             "",
             "res",
             "Screen resolution, e.g. 800x600. Default value is 640x480",
-            "WIDTHxHEIGHT"
+            "WIDTHxHEIGHT",
         );
         opts.optopt(
             "",
@@ -75,42 +75,25 @@ impl Cli {
         opts.optflag(
             "",
             "editor",
-            "Start the map editor (Editor.slf is required)"
+            "Start the map editor (Editor.slf is required)",
         );
-        opts.optflag(
-            "",
-            "fullscreen",
-            "Start the game in the fullscreen mode"
-        );
-        opts.optflag(
-            "",
-            "nosound",
-            "Turn the sound and music off"
-        );
-        opts.optflag(
-            "",
-            "window",
-            "Start the game in a window"
-        );
-        opts.optflag(
-            "",
-            "debug",
-            "Enable Debug Mode"
-        );
-        opts.optflag(
-            "",
-            "help",
-            "print this help menu"
-        );
+        opts.optflag("", "fullscreen", "Start the game in the fullscreen mode");
+        opts.optflag("", "nosound", "Turn the sound and music off");
+        opts.optflag("", "window", "Start the game in a window");
+        opts.optflag("", "debug", "Enable Debug Mode");
+        opts.optflag("", "help", "print this help menu");
 
         Cli {
             args: args.to_vec(),
-            options: opts
+            options: opts,
         }
     }
 
     /// Apply current arguments to EngineOptions struct
-    pub fn apply_to_engine_options(&self, engine_options: &mut EngineOptions) -> Result<(), String> {
+    pub fn apply_to_engine_options(
+        &self,
+        engine_options: &mut EngineOptions,
+    ) -> Result<(), String> {
         match self.options.parse(&self.args[1..]) {
             Ok(m) => {
                 if !m.free.is_empty() {
@@ -118,7 +101,9 @@ impl Cli {
                 }
 
                 if m.opt_str("datadir").is_some() {
-                    warn!("The `datadir` command line argument is deprecated, use `gamedir` instead");
+                    warn!(
+                        "The `datadir` command line argument is deprecated, use `gamedir` instead"
+                    );
                 }
 
                 if let Some(s) = m.opts_str(&["gamedir".to_owned(), "datadir".to_owned()]) {
@@ -132,8 +117,8 @@ impl Cli {
                                 temp.drain(..pos);
                             }
                             engine_options.vanilla_game_dir = PathBuf::from(temp)
-                        },
-                        Err(_) => return Err(String::from("Please specify an existing gamedir."))
+                        }
+                        Err(_) => return Err(String::from("Please specify an existing gamedir.")),
                     };
                 }
 
@@ -145,8 +130,8 @@ impl Cli {
                     match Resolution::from_str(&s) {
                         Ok(res) => {
                             engine_options.resolution = res;
-                        },
-                        Err(s) => return Err(s)
+                        }
+                        Err(s) => return Err(s),
                     }
                 }
 
@@ -154,24 +139,21 @@ impl Cli {
                     match s.parse::<f32>() {
                         Ok(val) => {
                             engine_options.brightness = val;
-                        },
-                        Err(_e) => return Err(String::from("Incorrect brightness value."))
+                        }
+                        Err(_e) => return Err(String::from("Incorrect brightness value.")),
                     }
                 }
 
                 if let Some(s) = m.opt_str("resversion") {
                     match VanillaVersion::from_str(&s) {
-                        Ok(resource_version) => {
-                            engine_options.resource_version = resource_version
-                        },
-                        Err(s) => return Err(s)
+                        Ok(resource_version) => engine_options.resource_version = resource_version,
+                        Err(s) => return Err(s),
                     }
                 }
 
                 if m.opt_present("help") {
                     engine_options.show_help = true;
                 }
-
 
                 if m.opt_present("unittests") {
                     engine_options.run_unittests = true;
@@ -199,7 +181,7 @@ impl Cli {
 
                 Ok(())
             }
-            Err(f) => Err(f.to_string())
+            Err(f) => Err(f.to_string()),
         }
     }
 

--- a/rust/src/config/cli.rs
+++ b/rust/src/config/cli.rs
@@ -7,9 +7,7 @@ use std::str::FromStr;
 use getopts::Options;
 use log::warn;
 
-use crate::config::EngineOptions;
-use crate::config::Resolution;
-use crate::config::VanillaVersion;
+use crate::config::{EngineOptions, Resolution, VanillaVersion};
 
 #[cfg(not(windows))]
 static GAME_DIR_OPTION_EXAMPLE: &'static str = "/opt/ja2";

--- a/rust/src/config/cli.rs
+++ b/rust/src/config/cli.rs
@@ -7,9 +7,9 @@ use std::str::FromStr;
 use log::warn;
 use getopts::Options;
 
-use crate::EngineOptions;
-use crate::Resolution;
-use crate::VanillaVersion;
+use crate::config::EngineOptions;
+use crate::config::Resolution;
+use crate::config::VanillaVersion;
 
 #[cfg(not(windows))]
 static GAME_DIR_OPTION_EXAMPLE: &'static str = "/opt/ja2";

--- a/rust/src/config/engine_options.rs
+++ b/rust/src/config/engine_options.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 
-use crate::config::Resolution;
-use crate::config::ScalingQuality;
-use crate::config::VanillaVersion;
+use crate::config::{Resolution, ScalingQuality, VanillaVersion};
+use crate::{ensure_json_config_existence, parse_args, parse_json_config};
 
 /// Struct that is used to store the engines configuration parameters
 #[derive(Debug, PartialEq)]
@@ -67,10 +66,6 @@ impl EngineOptions {
         stracciatella_home: &PathBuf,
         args: &[String],
     ) -> Result<EngineOptions, String> {
-        use crate::ensure_json_config_existence;
-        use crate::parse_args;
-        use crate::parse_json_config;
-
         ensure_json_config_existence(stracciatella_home)?;
 
         let mut engine_options = parse_json_config(&stracciatella_home)?;

--- a/rust/src/config/engine_options.rs
+++ b/rust/src/config/engine_options.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
-use crate::Resolution;
-use crate::ScalingQuality;
-use crate::VanillaVersion;
+use crate::config::Resolution;
+use crate::config::ScalingQuality;
+use crate::config::VanillaVersion;
 
 /// Struct that is used to store the engines configuration parameters
 #[derive(Debug, PartialEq)]

--- a/rust/src/config/engine_options.rs
+++ b/rust/src/config/engine_options.rs
@@ -30,7 +30,7 @@ pub struct EngineOptions {
     /// Whether to start the game in windowed mode
     pub start_in_window: bool,
     /// Scaling quality that is used when scaling up game resources
-	pub scaling_quality: ScalingQuality,
+    pub scaling_quality: ScalingQuality,
     /// Whether to start in debug mode
     pub start_in_debug_mode: bool,
     /// Whether to enable sound
@@ -42,7 +42,7 @@ impl Default for EngineOptions {
         EngineOptions {
             stracciatella_home: PathBuf::from(""),
             vanilla_game_dir: PathBuf::from(""),
-            mods: vec!(),
+            mods: vec![],
             resolution: Resolution::default(),
             brightness: 1.0,
             resource_version: VanillaVersion::ENGLISH,
@@ -51,7 +51,7 @@ impl Default for EngineOptions {
             run_editor: false,
             start_in_fullscreen: false,
             start_in_window: true,
-			scaling_quality: ScalingQuality::default(),
+            scaling_quality: ScalingQuality::default(),
             start_in_debug_mode: false,
             start_without_sound: false,
         }
@@ -63,10 +63,13 @@ impl EngineOptions {
     ///
     /// Takes Cli arguments and JSON configuration file into account. It will also
     /// create a default JSON configuration file if it does not exist yet.
-    pub fn from_home_and_args(stracciatella_home: &PathBuf, args: &[String]) -> Result<EngineOptions, String> {
+    pub fn from_home_and_args(
+        stracciatella_home: &PathBuf,
+        args: &[String],
+    ) -> Result<EngineOptions, String> {
         use crate::ensure_json_config_existence;
-        use crate::parse_json_config;
         use crate::parse_args;
+        use crate::parse_json_config;
 
         ensure_json_config_existence(stracciatella_home)?;
 
@@ -76,11 +79,11 @@ impl EngineOptions {
 
         match parse_args(&mut engine_options, args) {
             None => Ok(()),
-            Some(str) => Err(str)
+            Some(str) => Err(str),
         }?;
 
         if engine_options.vanilla_game_dir == PathBuf::from("") {
-            return Err(String::from("Vanilla data directory has to be set either in config file or per command line switch"))
+            return Err(String::from("Vanilla data directory has to be set either in config file or per command line switch"));
         }
 
         Ok(engine_options)

--- a/rust/src/config/ja2_json.rs
+++ b/rust/src/config/ja2_json.rs
@@ -4,15 +4,15 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
+use log::warn;
 use serde::Deserialize;
 use serde::Serialize;
-use log::warn;
 
-use crate::json;
-use crate::config::Resolution;
-use crate::config::VanillaVersion;
-use crate::config::ScalingQuality;
 use crate::config::EngineOptions;
+use crate::config::Resolution;
+use crate::config::ScalingQuality;
+use crate::config::VanillaVersion;
+use crate::json;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Ja2JsonContent {
@@ -31,7 +31,7 @@ pub struct Ja2JsonContent {
 
 /// Struct to handle interactions with the JSON configuration file
 pub struct Ja2Json {
-    path: PathBuf
+    path: PathBuf,
 }
 
 fn build_json_config_location(stracciatella_home: &PathBuf) -> PathBuf {
@@ -54,9 +54,16 @@ impl Ja2Json {
     }
 
     /// Apply current JSON file contents to EngineOptions struct
-    pub fn apply_to_engine_options(&self, engine_options: &mut EngineOptions) -> Result<(), String> {
+    pub fn apply_to_engine_options(
+        &self,
+        engine_options: &mut EngineOptions,
+    ) -> Result<(), String> {
         macro_rules! copy_to {
-            ($from: expr, $to: expr) => { if let Some(v) = $from { $to = v; } }
+            ($from: expr, $to: expr) => {
+                if let Some(v) = $from {
+                    $to = v;
+                }
+            };
         }
 
         let content = self.get_content()?;
@@ -82,7 +89,9 @@ impl Ja2Json {
     /// Write current contents of EngineOptions to JSON configuration file
     pub fn write(&self, engine_options: &EngineOptions) -> Result<(), String> {
         macro_rules! copy_to {
-            ($from: expr, $to: expr) => { $to = Some($from.clone()); }
+            ($from: expr, $to: expr) => {
+                $to = Some($from.clone());
+            };
         }
 
         let mut content = Ja2JsonContent {
@@ -108,10 +117,13 @@ impl Ja2Json {
         copy_to!(engine_options.start_in_debug_mode, content.debug);
         copy_to!(engine_options.start_without_sound, content.nosound);
 
-        let json = json::ser::to_string(&content).map_err(|x| format!("Error creating contents of ja2.json config file: {}", x))?;
-        let mut f = File::create(&self.path).map_err(|s| format!("Error creating ja2.json config file: {}", s.description()))?;
+        let json = json::ser::to_string(&content)
+            .map_err(|x| format!("Error creating contents of ja2.json config file: {}", x))?;
+        let mut f = File::create(&self.path)
+            .map_err(|s| format!("Error creating ja2.json config file: {}", s.description()))?;
 
-        f.write_all(json.as_bytes()).map_err(|s| format!("Error creating ja2.json config file: {}", s.description()))
+        f.write_all(json.as_bytes())
+            .map_err(|s| format!("Error creating ja2.json config file: {}", s.description()))
     }
 
     /// Ensures that the JSON configuration file exists and write a default one if it doesn't
@@ -130,13 +142,16 @@ impl Ja2Json {
         let parent = self.path.parent();
         if let Some(p) = parent {
             if !p.exists() {
-                fs::create_dir_all(p).map_err(|why| format!("Error creating {:?}: {:?}", p, why.kind()))?;
+                fs::create_dir_all(p)
+                    .map_err(|why| format!("Error creating {:?}: {:?}", p, why.kind()))?;
             }
         }
 
         if !self.path.exists() {
-            let mut f = File::create(&self.path).map_err(|why| format!("Error creating {:?}: {:?}", self.path, why.kind()))?;
-            f.write_all(DEFAULT_JSON_CONTENT.as_bytes()).map_err(|why| format!("Error writing {:?}: {:?}", self.path, why.kind()))?;
+            let mut f = File::create(&self.path)
+                .map_err(|why| format!("Error creating {:?}: {:?}", self.path, why.kind()))?;
+            f.write_all(DEFAULT_JSON_CONTENT.as_bytes())
+                .map_err(|why| format!("Error writing {:?}: {:?}", self.path, why.kind()))?;
         }
 
         Ok(())

--- a/rust/src/config/ja2_json.rs
+++ b/rust/src/config/ja2_json.rs
@@ -5,13 +5,9 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use log::warn;
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-use crate::config::EngineOptions;
-use crate::config::Resolution;
-use crate::config::ScalingQuality;
-use crate::config::VanillaVersion;
+use crate::config::{EngineOptions, Resolution, ScalingQuality, VanillaVersion};
 use crate::json;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]

--- a/rust/src/config/ja2_json.rs
+++ b/rust/src/config/ja2_json.rs
@@ -9,10 +9,10 @@ use serde::Serialize;
 use log::warn;
 
 use crate::json;
-use crate::Resolution;
-use crate::VanillaVersion;
-use crate::ScalingQuality;
-use crate::EngineOptions;
+use crate::config::Resolution;
+use crate::config::VanillaVersion;
+use crate::config::ScalingQuality;
+use crate::config::EngineOptions;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Ja2JsonContent {

--- a/rust/src/config/mod.rs
+++ b/rust/src/config/mod.rs
@@ -1,18 +1,17 @@
 //! This module contains code to configure the ja2-stracciatella engine
 
-mod scaling_quality;
-mod vanilla_version;
-mod resolution;
-mod ja2_json;
 mod cli;
-mod stracciatella_home;
-
 mod engine_options;
+mod ja2_json;
+mod resolution;
+mod scaling_quality;
+mod stracciatella_home;
+mod vanilla_version;
 
-pub use self::scaling_quality::ScalingQuality;
-pub use self::vanilla_version::VanillaVersion;
-pub use self::resolution::Resolution;
-pub use self::ja2_json::Ja2Json;
 pub use self::cli::Cli;
 pub use self::engine_options::EngineOptions;
+pub use self::ja2_json::Ja2Json;
+pub use self::resolution::Resolution;
+pub use self::scaling_quality::ScalingQuality;
 pub use self::stracciatella_home::find_stracciatella_home;
+pub use self::vanilla_version::VanillaVersion;

--- a/rust/src/config/resolution.rs
+++ b/rust/src/config/resolution.rs
@@ -1,11 +1,9 @@
-use serde::Deserialize;
-use serde::Deserializer;
-use serde::Serialize;
-use serde::Serializer;
 use std::default::Default;
 use std::fmt;
 use std::fmt::Display;
 use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Struct that contains a specific resolution for the game
 #[derive(Debug, PartialEq, Copy, Clone)]

--- a/rust/src/config/resolution.rs
+++ b/rust/src/config/resolution.rs
@@ -1,11 +1,11 @@
-use std::str::FromStr;
-use std::fmt;
-use std::fmt::Display;
-use std::default::Default;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
 use serde::Serializer;
+use std::default::Default;
+use std::fmt;
+use std::fmt::Display;
+use std::str::FromStr;
 
 /// Struct that contains a specific resolution for the game
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -19,7 +19,9 @@ impl FromStr for Resolution {
 
         match (resolutions.next(), resolutions.next()) {
             (Some(x), Some(y)) => Ok(Resolution(x, y)),
-            _ => Err(String::from("Incorrect resolution format, should be WIDTHxHEIGHT."))
+            _ => Err(String::from(
+                "Incorrect resolution format, should be WIDTHxHEIGHT.",
+            )),
         }
     }
 }

--- a/rust/src/config/scaling_quality.rs
+++ b/rust/src/config/scaling_quality.rs
@@ -1,9 +1,9 @@
-use std::str::FromStr;
-use std::fmt;
-use std::fmt::Display;
-use std::default::Default;
 use serde::Deserialize;
 use serde::Serialize;
+use std::default::Default;
+use std::fmt;
+use std::fmt::Display;
+use std::str::FromStr;
 
 /// Enum used to specify scaling quality for scaling up graphics
 #[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
@@ -26,18 +26,22 @@ impl FromStr for ScalingQuality {
             "LINEAR" => Ok(ScalingQuality::LINEAR),
             "NEAR_PERFECT" => Ok(ScalingQuality::NEAR_PERFECT),
             "PERFECT" => Ok(ScalingQuality::PERFECT),
-            _ => Err(format!("Scaling quality {} is unknown", s))
+            _ => Err(format!("Scaling quality {} is unknown", s)),
         }
     }
 }
 
 impl Display for ScalingQuality {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", match self {
-            ScalingQuality::LINEAR => "Linear Interpolation",
-            ScalingQuality::NEAR_PERFECT => "Near perfect with oversampling",
-            ScalingQuality::PERFECT => "Pixel perfect centered",
-        })
+        write!(
+            f,
+            "{}",
+            match self {
+                ScalingQuality::LINEAR => "Linear Interpolation",
+                ScalingQuality::NEAR_PERFECT => "Near perfect with oversampling",
+                ScalingQuality::PERFECT => "Pixel perfect centered",
+            }
+        )
     }
 }
 

--- a/rust/src/config/scaling_quality.rs
+++ b/rust/src/config/scaling_quality.rs
@@ -1,9 +1,9 @@
-use serde::Deserialize;
-use serde::Serialize;
 use std::default::Default;
 use std::fmt;
 use std::fmt::Display;
 use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
 
 /// Enum used to specify scaling quality for scaling up graphics
 #[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]

--- a/rust/src/config/stracciatella_home.rs
+++ b/rust/src/config/stracciatella_home.rs
@@ -16,7 +16,7 @@ pub fn find_stracciatella_home() -> Result<PathBuf, String> {
         Some(mut path) => {
             path.push(dir);
             Ok(path)
-        },
+        }
         None => Err(String::from("Could not find home directory")),
     }
 }

--- a/rust/src/config/stracciatella_home.rs
+++ b/rust/src/config/stracciatella_home.rs
@@ -1,5 +1,6 @@
-use dirs;
 use std::path::PathBuf;
+
+use dirs;
 
 /// Find ja2 stracciatella configuration directory inside the user's home directory
 pub fn find_stracciatella_home() -> Result<PathBuf, String> {

--- a/rust/src/config/vanilla_version.rs
+++ b/rust/src/config/vanilla_version.rs
@@ -1,8 +1,8 @@
-use std::str::FromStr;
-use std::fmt;
-use std::fmt::Display;
 use serde::Deserialize;
 use serde::Serialize;
+use std::fmt;
+use std::fmt::Display;
+use std::str::FromStr;
 
 /// Enum for the vanilla game version that is used to run the game
 #[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
@@ -40,22 +40,26 @@ impl FromStr for VanillaVersion {
             "POLISH" => Ok(VanillaVersion::POLISH),
             "RUSSIAN" => Ok(VanillaVersion::RUSSIAN),
             "RUSSIAN_GOLD" => Ok(VanillaVersion::RUSSIAN_GOLD),
-            _ => Err(format!("Resource version {} is unknown", s))
+            _ => Err(format!("Resource version {} is unknown", s)),
         }
     }
 }
 
 impl Display for VanillaVersion {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", match self {
-            VanillaVersion::DUTCH => "Dutch",
-            VanillaVersion::ENGLISH => "English",
-            VanillaVersion::FRENCH => "French",
-            VanillaVersion::GERMAN => "German",
-            VanillaVersion::ITALIAN => "Italian",
-            VanillaVersion::POLISH => "Polish",
-            VanillaVersion::RUSSIAN => "Russian",
-            VanillaVersion::RUSSIAN_GOLD => "Russian (Gold)",
-        })
+        write!(
+            f,
+            "{}",
+            match self {
+                VanillaVersion::DUTCH => "Dutch",
+                VanillaVersion::ENGLISH => "English",
+                VanillaVersion::FRENCH => "French",
+                VanillaVersion::GERMAN => "German",
+                VanillaVersion::ITALIAN => "Italian",
+                VanillaVersion::POLISH => "Polish",
+                VanillaVersion::RUSSIAN => "Russian",
+                VanillaVersion::RUSSIAN_GOLD => "Russian (Gold)",
+            }
+        )
     }
 }

--- a/rust/src/config/vanilla_version.rs
+++ b/rust/src/config/vanilla_version.rs
@@ -1,8 +1,8 @@
-use serde::Deserialize;
-use serde::Serialize;
 use std::fmt;
 use std::fmt::Display;
 use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
 
 /// Enum for the vanilla game version that is used to run the game
 #[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]

--- a/rust/src/file_formats/slf.rs
+++ b/rust/src/file_formats/slf.rs
@@ -58,7 +58,6 @@
 
 use std::io::ErrorKind::{InvalidData, InvalidInput};
 use std::io::{Cursor, Error, Read, Result, Seek, SeekFrom, Write};
-
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
@@ -442,7 +441,7 @@ mod tests {
     use std::fmt::Debug;
     use std::io::Cursor;
 
-    use super::{
+    use crate::file_formats::slf::{
         SlfEntry, SlfEntryState, SlfHeader, ENTRY_BYTES, HEADER_BYTES, UNIX_EPOCH_AS_FILETIME,
     };
 

--- a/rust/src/guess.rs
+++ b/rust/src/guess.rs
@@ -79,6 +79,7 @@ impl Percentages {
 }
 
 impl From<&MatchResourcesResult> for Percentages {
+    #[allow(clippy::cast_lossless)]
     fn from(result: &MatchResourcesResult) -> Self {
         let number_of_resources = result.number_of_resources;
         let count_differences =

--- a/rust/src/guess.rs
+++ b/rust/src/guess.rs
@@ -1,7 +1,5 @@
 //! This module contains code to guess Vanillaversion with resource packs.
 
-use log::{error, info};
-use rayon::prelude::*;
 use std::collections::HashSet;
 use std::convert::From;
 use std::error::Error;
@@ -12,6 +10,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+use log::{error, info};
+use rayon::prelude::*;
 use serde_json;
 
 use crate::config::VanillaVersion;
@@ -473,10 +473,12 @@ impl From<serde_json::Error> for GuessError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::fs;
     use std::io::Write;
+
     use tempdir::TempDir;
+
+    use crate::guess::*;
 
     fn build_data_dir_with_resources(resources: Vec<(PathBuf, Vec<u8>)>) -> TempDir {
         let tmp_dir = TempDir::new("ja2-test-guess").unwrap();

--- a/rust/src/guess.rs
+++ b/rust/src/guess.rs
@@ -81,9 +81,8 @@ impl Percentages {
 impl From<&MatchResourcesResult> for Percentages {
     fn from(result: &MatchResourcesResult) -> Self {
         let number_of_resources = result.number_of_resources;
-        let count_differences = |filter: &Fn(&&Difference) -> bool| {
-            result.differences.iter().filter(filter).count()
-        };
+        let count_differences =
+            |filter: &Fn(&&Difference) -> bool| result.differences.iter().filter(filter).count();
         let num_only_in_datadir = count_differences(&|d| match d {
             Difference::OnlyExistsInDataDir(_, _) => true,
             _ => false,

--- a/rust/src/json.rs
+++ b/rust/src/json.rs
@@ -41,9 +41,11 @@ pub mod ser {
     //!
     //! [`serde_json`]: https://crates.io/crates/serde_json
 
-    use super::skip;
     use serde::Serialize;
-    use serde_json::{self, Value};
+    use serde_json;
+    use serde_json::Value;
+
+    use crate::json::skip;
 
     /// Converts a value to a string containing json.
     ///
@@ -258,7 +260,7 @@ pub mod skip {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::json::*;
 
     #[test]
     fn test_json_with_comments() {

--- a/rust/src/librarydb.rs
+++ b/rust/src/librarydb.rs
@@ -28,7 +28,8 @@ use std::cmp;
 use std::collections::HashSet;
 use std::fmt;
 use std::fs::File;
-use std::io::{self, Seek, SeekFrom};
+use std::io;
+use std::io::{Seek, SeekFrom};
 use std::ops;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex, MutexGuard, RwLock};
@@ -391,8 +392,8 @@ pub mod tests {
 
     use tempdir::TempDir;
 
-    use super::*;
     use crate::file_formats::slf::{SlfEntry, SlfEntryState, SlfHeader};
+    use crate::librarydb::*;
 
     fn make_slf(dir: &Path, name: &str, library_path: &str, entry_paths: &[&str]) -> PathBuf {
         let header = SlfHeader {

--- a/rust/src/logger.rs
+++ b/rust/src/logger.rs
@@ -6,12 +6,12 @@
 //!
 //! [`stracciatella::c::logger`]: ../c/logger/index.html
 
-use log::{Log, Metadata, Level, set_max_level, LevelFilter, Record, logger, set_boxed_logger};
-use simplelog::{CombinedLogger, TermLogger, WriteLogger, Config, TerminalMode};
+use log::{logger, set_boxed_logger, set_max_level, Level, LevelFilter, Log, Metadata, Record};
+use simplelog::{CombinedLogger, Config, TermLogger, TerminalMode, WriteLogger};
 use std::fs::File;
 use std::path::Path;
-use std::sync::atomic::Ordering;
 use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 
 static GLOBAL_LOG_LEVEL: AtomicUsize = AtomicUsize::new(LogLevel::Info as usize);
 

--- a/rust/src/logger.rs
+++ b/rust/src/logger.rs
@@ -6,12 +6,12 @@
 //!
 //! [`stracciatella::c::logger`]: ../c/logger/index.html
 
-use log::{logger, set_boxed_logger, set_max_level, Level, LevelFilter, Log, Metadata, Record};
-use simplelog::{CombinedLogger, Config, TermLogger, TerminalMode, WriteLogger};
 use std::fs::File;
 use std::path::Path;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use log::{logger, set_boxed_logger, set_max_level, Level, LevelFilter, Log, Metadata, Record};
+use simplelog::{CombinedLogger, Config, TermLogger, TerminalMode, WriteLogger};
 
 static GLOBAL_LOG_LEVEL: AtomicUsize = AtomicUsize::new(LogLevel::Info as usize);
 

--- a/rust/src/res.rs
+++ b/rust/src/res.rs
@@ -557,9 +557,8 @@ mod tests {
     use crate::res::{Resource, ResourcePropertiesExt};
 
     #[test]
-    fn property_value_compatibility() {
+    fn property_value_compatibility_boolean() {
         let mut resource = Resource::default();
-        // boolean
         resource.set_property("p", true);
         assert!(resource.get_bool("p").is_some());
         assert!(resource.get_str("p").is_none());
@@ -567,7 +566,11 @@ mod tests {
         assert!(resource.get_u64("p").is_none());
         assert!(resource.get_f64("p").is_none());
         assert_eq!(resource.get_bool("p").unwrap(), true);
-        // string
+    }
+
+    #[test]
+    fn property_value_compatibility_string() {
+        let mut resource = Resource::default();
         resource.set_property("p", "foo");
         assert!(resource.get_bool("p").is_none());
         assert!(resource.get_str("p").is_some());
@@ -575,7 +578,11 @@ mod tests {
         assert!(resource.get_u64("p").is_none());
         assert!(resource.get_f64("p").is_none());
         assert_eq!(resource.get_str("p").unwrap(), "foo");
-        // universal number
+    }
+
+    #[test]
+    fn property_value_compatibility_universal_number() {
+        let mut resource = Resource::default();
         resource.set_property("p", 0);
         assert!(resource.get_bool("p").is_none());
         assert!(resource.get_str("p").is_none());
@@ -583,7 +590,12 @@ mod tests {
         assert!(resource.get_u64("p").is_some());
         assert!(resource.get_f64("p").is_some());
         assert_eq!(resource.get_i64("p").unwrap(), 0);
-        // floating point number
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn property_value_compatibility_floating_point_number() {
+        let mut resource = Resource::default();
         resource.set_property("p", 0.5);
         assert!(resource.get_bool("p").is_none());
         assert!(resource.get_str("p").is_none());
@@ -591,7 +603,11 @@ mod tests {
         assert!(resource.get_u64("p").is_none());
         assert!(resource.get_f64("p").is_some());
         assert_eq!(resource.get_f64("p").unwrap(), 0.5);
-        // negative number
+    }
+
+    #[test]
+    fn property_value_compatibility_negative_number() {
+        let mut resource = Resource::default();
         resource.set_property("p", -1);
         assert!(resource.get_bool("p").is_none());
         assert!(resource.get_str("p").is_none());
@@ -599,7 +615,11 @@ mod tests {
         assert!(resource.get_u64("p").is_none());
         assert!(resource.get_f64("p").is_some());
         assert_eq!(resource.get_i64("p").unwrap(), -1);
-        // big number
+    }
+
+    #[test]
+    fn property_value_compatibility_big_number() {
+        let mut resource = Resource::default();
         resource.set_property("p", u64::max_value());
         assert!(resource.get_bool("p").is_none());
         assert!(resource.get_str("p").is_none());
@@ -619,12 +639,13 @@ mod tests {
         use md5::Md5;
 
         fn data_for_hasher() -> Vec<u8> {
-            return "A quick brown fox jumps over the lazy dog"
+            "A quick brown fox jumps over the lazy dog"
                 .repeat(1_000_000)
                 .as_bytes()
-                .to_vec();
+                .to_vec()
         }
 
+        #[allow(clippy::cast_lossless)]
         fn print_hasher_result(name: &str, time: Duration, size: usize, hash: &[u8]) {
             let secs = time.as_secs() as f64 + time.subsec_nanos() as f64 / 1_000_000_000f64;
             let mib = size as f64 / 1_000_000f64;

--- a/rust/src/res.rs
+++ b/rust/src/res.rs
@@ -59,14 +59,12 @@ use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
 
-use serde::{Deserialize, Serialize};
-use serde_json::{json, Map, Value};
-
 use digest::Digest;
 use hex;
 use md5::Md5;
-
 use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
 
 use crate::file_formats::slf::{SlfEntryState, SlfHeader};
 use crate::unicode::Nfc;
@@ -556,7 +554,7 @@ impl ResourcePropertiesExt for Resource {
 
 #[cfg(test)]
 mod tests {
-    use super::{Resource, ResourcePropertiesExt};
+    use crate::res::{Resource, ResourcePropertiesExt};
 
     #[test]
     fn property_value_compatibility() {

--- a/rust/src/res.rs
+++ b/rust/src/res.rs
@@ -164,7 +164,7 @@ impl Resource {
     fn new(path: &str) -> Self {
         let mut resource = Resource::default();
         resource.path = path.to_owned();
-        return resource;
+        resource
     }
 }
 
@@ -172,28 +172,28 @@ impl ResourcePackBuilder {
     // Constructor.
     #[allow(dead_code)]
     pub fn new() -> Self {
-        return Self::default();
+        Self::default()
     }
 
     /// Adds archive contents.
     #[allow(dead_code)]
     pub fn with_archive(&mut self, extension: &str) -> &mut Self {
         self.with_archives.push(extension.into());
-        return self;
+        self
     }
 
     /// Adds file sizes.
     #[allow(dead_code)]
     pub fn with_file_size(&mut self) -> &mut Self {
         self.with_file_size = true;
-        return self;
+        self
     }
 
     /// Adds a hash algorithm.
     #[allow(dead_code)]
     pub fn with_hash(&mut self, algorithm: &str) -> &mut Self {
         self.with_hashes.push(algorithm.into());
-        return self;
+        self
     }
 
     /// Adds a directory or an archive.
@@ -206,7 +206,7 @@ impl ResourcePackBuilder {
         }
         let tuple = (base.to_owned(), path.to_owned());
         self.with_paths.push_back(tuple);
-        return self;
+        self
     }
 
     /// Returns a resource pack or an error.
@@ -259,7 +259,7 @@ impl ResourcePackBuilder {
 
         let pack = self.pack.to_owned();
         self.pack = ResourcePack::default();
-        return Ok(pack);
+        Ok(pack)
     }
 
     /// Adds the contents of an OS directory.
@@ -295,7 +295,7 @@ impl ResourcePackBuilder {
         }
         let extension = lowercase_extension(path);
         let wants_archive = self.with_archives.binary_search(&extension).is_ok();
-        let wants_hashes = self.with_hashes.len() > 0;
+        let wants_hashes = !self.with_hashes.is_empty();
         if wants_archive || wants_hashes {
             let data = std::fs::read(path)?;
             if wants_archive {
@@ -312,7 +312,7 @@ impl ResourcePackBuilder {
             }
         }
         resources.push(resource);
-        return Ok(resources);
+        Ok(resources)
     }
 
     // Adds the contents of a SLF archive.
@@ -337,7 +337,7 @@ impl ResourcePackBuilder {
                 if self.with_file_size {
                     resource.set_property("file_size", entry.length);
                 }
-                let wants_hashes = self.with_hashes.len() > 0;
+                let wants_hashes = !self.with_hashes.is_empty();
                 if wants_hashes {
                     let from = entry.offset as usize;
                     let to = from + entry.length as usize;
@@ -348,7 +348,7 @@ impl ResourcePackBuilder {
             .collect();
         let resources = resources?;
         slf.set_property("archive_slf_num_resources", resources.len());
-        return Ok(resources);
+        Ok(resources)
     }
 
     /// Adds hashes of the resource data.
@@ -361,7 +361,7 @@ impl ResourcePackBuilder {
             let prop = "hash_".to_owned() + algorithm;
             resource.set_property(&prop, hash);
         }
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -376,10 +376,10 @@ pub enum ResourceError {
 
 impl Error for ResourceError {
     fn description(&self) -> &str {
-        return match self {
+        match self {
             ResourceError::Text(desc) => desc,
             ResourceError::IoError(err) => err.description(),
-        };
+        }
     }
 }
 
@@ -412,7 +412,7 @@ impl FSIterator {
     fn new(path: &Path) -> Self {
         let mut all_files = Self::default();
         all_files.with(path.to_owned());
-        return all_files;
+        all_files
     }
 
     /// Adds a path to the iterator.
@@ -467,7 +467,7 @@ fn resource_path(base: &Path, path: &Path) -> Result<Nfc, ResourceError> {
             None => Err(format!("{:?} contains invalid utf8", resource_path).into()),
         };
     }
-    return Err(format!("{:?} is not a prefix of {:?}", base, path).into());
+    Err(format!("{:?} is not a prefix of {:?}", base, path).into())
 }
 
 /// Trait the adds shortcuts for properties.
@@ -480,27 +480,27 @@ pub trait ResourcePropertiesExt {
 
     /// Removes a property and returns the old value.
     fn remove_property(&mut self, name: &str) -> Option<Value> {
-        return self.properties_mut().remove(name);
+        self.properties_mut().remove(name)
     }
 
     /// Sets the value of a property and returns the old value.
     fn set_property<T: Serialize>(&mut self, name: &str, value: T) -> Option<Value> {
-        return self.properties_mut().insert(name.to_owned(), json!(value));
+        self.properties_mut().insert(name.to_owned(), json!(value))
     }
 
     /// Gets the value of a property.
     fn get_property(&self, name: &str) -> Option<&Value> {
-        return self.properties().get(name);
+        self.properties().get(name)
     }
 
     /// Gets the value of a bool property.
     fn get_bool(&self, name: &str) -> Option<bool> {
-        return self.get_property(name).and_then(|v| v.as_bool());
+        self.get_property(name).and_then(|v| v.as_bool())
     }
 
     /// Gets the value of a string property.
     fn get_str(&self, name: &str) -> Option<&str> {
-        return self.get_property(name).and_then(|v| v.as_str());
+        self.get_property(name).and_then(|v| v.as_str())
     }
 
     /// Gets the value of an array of strings property.
@@ -515,42 +515,42 @@ pub trait ResourcePropertiesExt {
             }
             return Some(strings);
         }
-        return None;
+        None
     }
 
     /// Gets the signed integer value of a number property.
     fn get_i64(&self, name: &str) -> Option<i64> {
-        return self.get_property(name).and_then(|v| v.as_i64());
+        self.get_property(name).and_then(|v| v.as_i64())
     }
 
     /// Gets the unsigned integer value of a number property.
     fn get_u64(&self, name: &str) -> Option<u64> {
-        return self.get_property(name).and_then(|v| v.as_u64());
+        self.get_property(name).and_then(|v| v.as_u64())
     }
 
     /// Gets the floating-point value of a number property.
     fn get_f64(&self, name: &str) -> Option<f64> {
-        return self.get_property(name).and_then(|v| v.as_f64());
+        self.get_property(name).and_then(|v| v.as_f64())
     }
 }
 
 impl ResourcePropertiesExt for ResourcePack {
     fn properties(&self) -> &Map<String, Value> {
-        return &self.properties;
+        &self.properties
     }
 
     fn properties_mut(&mut self) -> &mut Map<String, Value> {
-        return &mut self.properties;
+        &mut self.properties
     }
 }
 
 impl ResourcePropertiesExt for Resource {
     fn properties(&self) -> &Map<String, Value> {
-        return &self.properties;
+        &self.properties
     }
 
     fn properties_mut(&mut self) -> &mut Map<String, Value> {
-        return &mut self.properties;
+        &mut self.properties
     }
 }
 

--- a/rust/src/stracciatella.rs
+++ b/rust/src/stracciatella.rs
@@ -54,7 +54,6 @@ fn get_assets_dir() -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use std::env;
     use std::fs;
     use std::fs::File;
     use std::io::prelude::*;
@@ -439,7 +438,7 @@ mod tests {
     fn find_stracciatella_home_should_find_the_correct_stracciatella_home_path_on_unixlike() {
         let mut engine_options = EngineOptions::default();
         engine_options.stracciatella_home = find_stracciatella_home().unwrap();
-        let expected = format!("{}/.ja2", env::var("HOME").unwrap());
+        let expected = format!("{}/.ja2", std::env::var("HOME").unwrap());
 
         assert_eq!(engine_options.stracciatella_home, Path::new(&expected));
     }

--- a/rust/src/stracciatella.rs
+++ b/rust/src/stracciatella.rs
@@ -263,7 +263,7 @@ mod tests {
         f.write_all(contents).unwrap();
         f.sync_all().unwrap();
 
-        return dir;
+        dir
     }
 
     #[test]

--- a/rust/src/stracciatella.rs
+++ b/rust/src/stracciatella.rs
@@ -12,7 +12,6 @@ pub mod unicode;
 
 use std::default::Default;
 use std::path::PathBuf;
-use std::str;
 
 use crate::config::{Cli, EngineOptions, Ja2Json};
 

--- a/rust/src/stracciatella.rs
+++ b/rust/src/stracciatella.rs
@@ -30,7 +30,6 @@ use crate::config::Resolution;
 use crate::config::Ja2Json;
 use crate::config::Cli;
 use crate::config::EngineOptions;
-use crate::config::find_stracciatella_home;
 
 fn parse_args(engine_options: &mut EngineOptions, args: &[String]) -> Option<String> {
     let cli = Cli::from_args(args);
@@ -57,7 +56,7 @@ pub fn parse_json_config(stracciatella_home: &PathBuf) -> Result<EngineOptions, 
 fn get_assets_dir() -> PathBuf {
     let mut path = PathBuf::new();
     let extra_data_dir = option_env!("EXTRA_DATA_DIR");
-    if extra_data_dir.is_some() && extra_data_dir.unwrap().len() > 0 {
+    if extra_data_dir.is_some() && !extra_data_dir.unwrap().is_empty() {
         // use dir defined at compile time
         path.push(extra_data_dir.unwrap());
     } else if let Ok(exe) = env::current_exe() {
@@ -80,6 +79,7 @@ mod tests {
     use std::io::prelude::*;
     use std::env;
 
+    use crate::config::find_stracciatella_home;
     use super::*;
 
     #[test]

--- a/rust/src/stracciatella.rs
+++ b/rust/src/stracciatella.rs
@@ -1,18 +1,4 @@
 #![crate_type = "lib"]
-//https://github.com/rust-lang/rfcs/pull/2585
-#![allow(unused_unsafe)]
-
-extern crate dirs;
-extern crate getopts;
-extern crate libc;
-extern crate serde;
-extern crate serde_derive;
-extern crate serde_json;
-
-use std::default::Default;
-use std::env;
-use std::path::PathBuf;
-use std::str;
 
 pub mod c;
 pub mod config;
@@ -24,9 +10,11 @@ pub mod logger;
 pub mod res;
 pub mod unicode;
 
-use crate::config::Cli;
-use crate::config::EngineOptions;
-use crate::config::Ja2Json;
+use std::default::Default;
+use std::path::PathBuf;
+use std::str;
+
+use crate::config::{Cli, EngineOptions, Ja2Json};
 
 fn parse_args(engine_options: &mut EngineOptions, args: &[String]) -> Option<String> {
     let cli = Cli::from_args(args);
@@ -55,7 +43,7 @@ fn get_assets_dir() -> PathBuf {
     if extra_data_dir.is_some() && !extra_data_dir.unwrap().is_empty() {
         // use dir defined at compile time
         path.push(extra_data_dir.unwrap());
-    } else if let Ok(exe) = env::current_exe() {
+    } else if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
             // use the directory of the executable
             path.push(dir);
@@ -66,18 +54,16 @@ fn get_assets_dir() -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    extern crate regex;
-    extern crate tempdir;
-
     use std::env;
     use std::fs;
     use std::fs::File;
     use std::io::prelude::*;
     use std::path::Path;
 
-    use super::*;
-    use crate::config::find_stracciatella_home;
-    use crate::config::VanillaVersion;
+    use tempdir;
+
+    use crate::config::{find_stracciatella_home, VanillaVersion};
+    use crate::*;
 
     #[test]
     fn parse_args_should_abort_on_unknown_arguments() {
@@ -461,7 +447,7 @@ mod tests {
     #[test]
     #[cfg(windows)]
     fn find_stracciatella_home_should_find_the_correct_stracciatella_home_path_on_windows() {
-        use self::regex::Regex;
+        use regex::Regex;
 
         let mut engine_options = EngineOptions::default();
         engine_options.stracciatella_home = find_stracciatella_home().unwrap();

--- a/rust/src/stracciatella.rs
+++ b/rust/src/stracciatella.rs
@@ -24,9 +24,6 @@ pub mod librarydb;
 pub mod c;
 pub mod unicode;
 
-pub use crate::config::ScalingQuality;
-pub use crate::config::VanillaVersion;
-use crate::config::Resolution;
 use crate::config::Ja2Json;
 use crate::config::Cli;
 use crate::config::EngineOptions;
@@ -80,6 +77,7 @@ mod tests {
     use std::env;
 
     use crate::config::find_stracciatella_home;
+    use crate::config::VanillaVersion;
     use super::*;
 
     #[test]

--- a/rust/src/unicode.rs
+++ b/rust/src/unicode.rs
@@ -70,17 +70,6 @@ pub struct Nfc {
 }
 
 impl Nfc {
-    /// Creates a normalized string.
-    pub fn from_str(s: &str) -> Self {
-        if is_nfc(s) {
-            let string = s.to_owned();
-            Self { inner: string }
-        } else {
-            let string = s.chars().nfc().collect();
-            Self { inner: string }
-        }
-    }
-
     /// Creates a normalized caseless string.
     pub fn caseless(s: &str) -> Self {
         let string = s.chars().nfc().default_case_fold().nfc().collect();
@@ -134,10 +123,15 @@ impl AsRef<str> for Nfc {
     }
 }
 
-/// Converts to a normalized string.
 impl From<&str> for Nfc {
     fn from(s: &str) -> Self {
-        Nfc::from_str(s)
+        if is_nfc(s) {
+            let string = s.to_owned();
+            Self { inner: string }
+        } else {
+            let string = s.chars().nfc().collect();
+            Self { inner: string }
+        }
     }
 }
 


### PR DESCRIPTION
Tasks:
-  [x] C code is contained inside module `c`
 - [x] figure out and fix dependencies of module `config`
 - [x] everything is formatted with rustfmt
 - [x] check formatting with travis/appveyor
 - [x] fix [clippy](https://github.com/rust-lang/rust-clippy) lints
 - [x] check clippy lints with travis/appveyor

Postponed:
 - split rust code into subcrates (lib, bin, C static lib)

A different PR:
- rename C functions