### PR TITLE
Rewrite guessing vanilla version

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -201,6 +201,45 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +256,11 @@ dependencies = [
  "redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "either"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "failure"
@@ -342,6 +386,14 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "memoffset"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +413,14 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -466,6 +526,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +622,14 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +637,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "scoped_threadpool"
 version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scopeguard"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -614,6 +722,7 @@ dependencies = [
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "md-5 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -829,8 +938,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
+"checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
+"checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
+"checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
+"checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+"checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
@@ -848,9 +962,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum md-5 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a18af3dcaf2b0219366cdb4e2af65a6101457b415c3d1a5c71dd9c2b7c77b9c8"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
+"checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
+"checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
@@ -863,6 +979,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "615e683324e75af5d43d8f7a39ffe3ee4a9dc42c5c701167a71dc59c3a493aca"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+"checksum rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a4b0186e22767d5b9738a05eab7c6ac90b15db17e5b5f9bd87976dd7d89a10a4"
+"checksum rayon-core 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbe0df8435ac0c397d467b6cad6d25543d06e8a019ef3f6af3c384597515bd2"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
@@ -872,8 +990,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5485bf1523a9ed51c4964273f22f63f24e31632adb5dad134f488f86a3875c"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
+"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
+"checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
+"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "d46b3dfedb19360a74316866cef04687cd4d6a70df8e6a506c63512790769b72"
 "checksum serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "c22a0820adfe2f257b098714323563dd06426502abbbce4f51b72ef544c5027f"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -39,6 +39,7 @@ unicode-normalization = "0.1"
 caseless = "0.2"
 log = "0.4"
 simplelog = "0.6"
+rayon = "1.1.0"
 
 [dependencies.clap]
 optional = true

--- a/rust/src/guess.rs
+++ b/rust/src/guess.rs
@@ -161,6 +161,14 @@ impl Guess {
             }
         }
 
+        info!(
+            "Number of language specific files: {} Dutch, {} German, {} Italian, {} Polish, {} Russian",
+            num_dutch,
+            num_german,
+            num_italian,
+            num_polish,
+            num_russian
+        );
         let version = match (num_dutch, num_german, num_italian, num_polish, num_russian) {
             (n, 0, 0, 0, 0) if n > 0 => Some(VanillaVersion::DUTCH),
             (0, n, 0, 0, 0) if n > 0 => Some(VanillaVersion::GERMAN),

--- a/rust/src/guess.rs
+++ b/rust/src/guess.rs
@@ -302,8 +302,7 @@ impl Guess {
     /// Read resource pack json
     fn get_pack(&self, path: &Path) -> GuessResult<ResourcePack> {
         let f = File::open(&path)?;
-        let mut pack: ResourcePack = serde_json::from_reader(f)?;
-        pack.resources = sorted_resources(pack.resources);
+        let pack: ResourcePack = serde_json::from_reader(f)?;
         Ok(pack)
     }
 
@@ -363,7 +362,6 @@ impl Guess {
             .into_iter()
             .filter(move |r| common_paths.contains(&get_compared_path(r)))
             .collect();
-        let resources = sorted_resources(resources);
 
         let file_comparison_result = resources.iter().flat_map(|resource| {
             let pack_resource = pack
@@ -417,19 +415,6 @@ fn is_json_file(path: &Path) -> bool {
         return false;
     }
     path.extension().unwrap_or(&OsString::new()).to_str() == Some("json")
-}
-
-fn sorted_resources(mut resources: Vec<Resource>) -> Vec<Resource> {
-    resources.sort_unstable_by(|a, b| {
-        if a.path == b.path {
-            let a_path = a.get_str("archive_path").unwrap_or("");
-            let b_path = b.get_str("archive_path").unwrap_or("");
-            a_path.cmp(b_path)
-        } else {
-            a.path.cmp(&b.path)
-        }
-    });
-    resources
 }
 
 #[derive(Debug)]

--- a/rust/src/guess.rs
+++ b/rust/src/guess.rs
@@ -196,6 +196,7 @@ impl Guess {
             .get_pack_paths()?
             .par_iter()
             .map(|path| self.compare_pack(datadir, path))
+            // Collect results and bail on first error found
             .collect::<Result<Vec<_>, _>>()?;
 
         let (best_version, best_difference) = results.iter().fold(

--- a/rust/src/guess.rs
+++ b/rust/src/guess.rs
@@ -1,8 +1,7 @@
 //! This module contains code to guess Vanillaversion with resource packs.
 
 use log::{error, info};
-use rayon::iter::IntoParallelRefIterator;
-use rayon::iter::ParallelIterator;
+use rayon::prelude::*;
 use std::collections::HashSet;
 use std::convert::From;
 use std::error::Error;

--- a/rust/src/guess.rs
+++ b/rust/src/guess.rs
@@ -82,29 +82,29 @@ impl Percentages {
 impl From<&MatchResourcesResult> for Percentages {
     fn from(result: &MatchResourcesResult) -> Self {
         let number_of_resources = result.number_of_resources;
-        let count_differences = |filter: Box<Fn(&&Difference) -> bool>| {
+        let count_differences = |filter: &Fn(&&Difference) -> bool| {
             result.differences.iter().filter(filter).count()
         };
-        let num_only_in_datadir = count_differences(Box::new(|d| match d {
+        let num_only_in_datadir = count_differences(&|d| match d {
             Difference::OnlyExistsInDataDir(_, _) => true,
             _ => false,
-        }));
+        });
         let percentage_only_in_datadir = num_only_in_datadir as f64 / number_of_resources as f64;
-        let num_only_in_pack = count_differences(Box::new(|d| match d {
+        let num_only_in_pack = count_differences(&|d| match d {
             Difference::OnlyExistsInPack(_, _) => true,
             _ => false,
-        }));
+        });
         let percentage_only_in_pack = num_only_in_pack as f64 / number_of_resources as f64;
-        let num_file_size_mismatch = count_differences(Box::new(|d| match d {
+        let num_file_size_mismatch = count_differences(&|d| match d {
             Difference::FileSizeMismatch(_, _, _) => true,
             _ => false,
-        }));
+        });
         let percentage_file_size_mismatch =
             num_file_size_mismatch as f64 / number_of_resources as f64;
-        let num_hash_mismatch = count_differences(Box::new(|d| match d {
+        let num_hash_mismatch = count_differences(&|d| match d {
             Difference::HashMismatch(_, _, _, _) => true,
             _ => false,
-        }));
+        });
         let percentage_hash_mismatch = num_hash_mismatch as f64 / number_of_resources as f64;
         let total = percentage_only_in_datadir
             + percentage_only_in_pack

--- a/rust/src/res.rs
+++ b/rust/src/res.rs
@@ -84,34 +84,6 @@ pub struct ResourcePack {
     pub resources: Vec<Resource>,
 }
 
-impl ResourcePack {
-    fn get_enabled_properties(&self) -> impl Iterator<Item = &String> {
-        self.properties
-            .iter()
-            .filter(|(_, v)| v.as_bool() == Some(true))
-            .map(|(k, _)| k)
-    }
-
-    pub fn has_file_size(&self) -> bool {
-        self.get_enabled_properties()
-            .any(|k| k.as_str() == "with_file_size")
-    }
-
-    pub fn get_hashes(&self) -> HashSet<String> {
-        self.get_enabled_properties()
-            .filter(|k| k.starts_with("with_hash_"))
-            .map(|k| k["with_hash_".len()..].to_owned())
-            .collect()
-    }
-
-    pub fn get_archives(&self) -> HashSet<String> {
-        self.get_enabled_properties()
-            .filter(|k| k.starts_with("with_archive_"))
-            .map(|k| k["with_archive_".len()..].to_owned())
-            .collect()
-    }
-}
-
 /// A resource in the pack.
 ///
 /// A resource always maps to raw data, which can be a file or data inside an archive.
@@ -143,12 +115,46 @@ pub struct ResourcePackBuilder {
 }
 
 impl ResourcePack {
-    // Constructor.
+    /// Constructor.
     #[allow(dead_code)]
     fn new(name: &str) -> Self {
         let mut pack = ResourcePack::default();
         pack.name = name.to_owned();
-        return pack;
+        pack
+    }
+
+    /// Get properties that are enabled (true)
+    #[allow(dead_code)]
+    fn get_enabled_properties(&self) -> impl Iterator<Item = &String> {
+        self.properties
+            .iter()
+            .filter(|(_, v)| v.as_bool() == Some(true))
+            .map(|(k, _)| k)
+    }
+
+    /// Returns wether the resource pack has been built with file sizes
+    #[allow(dead_code)]
+    pub fn has_file_size(&self) -> bool {
+        self.get_enabled_properties()
+            .any(|k| k.as_str() == "with_file_size")
+    }
+
+    /// Returns the hashes that are used in the resource pack
+    #[allow(dead_code)]
+    pub fn get_hashes(&self) -> HashSet<String> {
+        self.get_enabled_properties()
+            .filter(|k| k.starts_with("with_hash_"))
+            .map(|k| k["with_hash_".len()..].to_owned())
+            .collect()
+    }
+
+    /// Returns which archives were inspected when building the resource pack
+    #[allow(dead_code)]
+    pub fn get_archives(&self) -> HashSet<String> {
+        self.get_enabled_properties()
+            .filter(|k| k.starts_with("with_archive_"))
+            .map(|k| k["with_archive_".len()..].to_owned())
+            .collect()
     }
 }
 

--- a/rust/src/res.rs
+++ b/rust/src/res.rs
@@ -52,7 +52,7 @@
 //!  * `hash_{algorithm}` (string) - hash of the specified algorithm
 //!
 
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::convert::From;
 use std::error::Error;
 use std::fmt;
@@ -82,6 +82,34 @@ pub struct ResourcePack {
 
     /// The resources in this pack.
     pub resources: Vec<Resource>,
+}
+
+impl ResourcePack {
+    fn get_enabled_properties(&self) -> impl Iterator<Item = &String> {
+        self.properties
+            .iter()
+            .filter(|(_, v)| v.as_bool() == Some(true))
+            .map(|(k, _)| k)
+    }
+
+    pub fn has_file_size(&self) -> bool {
+        self.get_enabled_properties()
+            .any(|k| k.as_str() == "with_file_size")
+    }
+
+    pub fn get_hashes(&self) -> HashSet<String> {
+        self.get_enabled_properties()
+            .filter(|k| k.starts_with("with_hash_"))
+            .map(|k| k["with_hash_".len()..].to_owned())
+            .collect()
+    }
+
+    pub fn get_archives(&self) -> HashSet<String> {
+        self.get_enabled_properties()
+            .filter(|k| k.starts_with("with_archive_"))
+            .map(|k| k["with_archive_".len()..].to_owned())
+            .collect()
+    }
 }
 
 /// A resource in the pack.

--- a/rust/src/res.rs
+++ b/rust/src/res.rs
@@ -202,35 +202,54 @@ impl ResourcePackBuilder {
             let prop = "with_hash_".to_owned() + algorithm;
             self.pack.set_property(&prop, true);
         }
-        while self.with_paths.len() > 0 {
-            let (base, path) = self.with_paths.pop_front().unwrap();
-            let metadata = path.metadata()?;
-            if metadata.is_file() {
-                self.add_file(&base, &path)?;
-            } else if metadata.is_dir() {
-                self.add_dir_contents(&base, &path)?;
-            }
-        }
+
+        let resources: Result<Vec<Vec<Resource>>, ResourceError> = self
+            .with_paths
+            .iter()
+            .map(|paths| {
+                let (base, path) = paths;
+                let metadata = path.metadata()?;
+                if metadata.is_file() {
+                    self.get_resources_for_file(&base, &path)
+                } else if metadata.is_dir() {
+                    self.get_resources_for_dir(&base, &path)
+                } else {
+                    Ok(vec![])
+                }
+            })
+            .collect();
+        let mut resources: Vec<_> = resources?.into_iter().flat_map(|r| r).collect();
+        self.pack.resources.append(&mut resources);
+
         let pack = self.pack.to_owned();
         self.pack = ResourcePack::default();
         return Ok(pack);
     }
 
     /// Adds the contents of an OS directory.
-    fn add_dir_contents(&mut self, base: &Path, dir: &Path) -> Result<(), ResourceError> {
-        for path in FSIterator::new(dir) {
-            self.add_file(&base, &path)?;
-        }
-        return Ok(());
+    fn get_resources_for_dir(
+        &self,
+        base: &Path,
+        dir: &Path,
+    ) -> Result<Vec<Resource>, ResourceError> {
+        let resources: Result<Vec<Vec<Resource>>, _> = FSIterator::new(dir)
+            .map(|file| self.get_resources_for_file(base, &file))
+            .collect();
+        Ok(resources?.into_iter().flat_map(|r| r).collect())
     }
 
     /// Adds an OS file as a resource.
-    fn add_file(&mut self, base: &Path, path: &Path) -> Result<(), ResourceError> {
+    fn get_resources_for_file(
+        &self,
+        base: &Path,
+        path: &Path,
+    ) -> Result<Vec<Resource>, ResourceError> {
         // must have a valid resource path
+        let mut resources = vec![];
         let resource_path = resource_path(base, path)?;
         if resource_path.to_ascii_lowercase().starts_with("temp/") {
             // the game can create/modify/remove files in the temp folder, ignore it
-            return Ok(());
+            return Ok(resources);
         }
         let mut resource = Resource::new(&resource_path);
         if self.with_file_size {
@@ -243,7 +262,10 @@ impl ResourcePackBuilder {
             let data = std::fs::read(path)?;
             if wants_archive {
                 match extension.as_str() {
-                    "slf" => self.add_slf_contents(&mut resource, &data)?,
+                    "slf" => {
+                        let mut slf_resources = self.get_resources_for_slf(&mut resource, &data)?;
+                        resources.append(&mut slf_resources);
+                    }
                     _ => panic!(), // execute() must be fixed
                 }
             }
@@ -251,18 +273,24 @@ impl ResourcePackBuilder {
                 self.add_hashes(&mut resource, &data)?;
             }
         }
-        self.pack.resources.push(resource);
-        return Ok(());
+        resources.push(resource);
+        return Ok(resources);
     }
 
     // Adds the contents of a SLF archive.
-    fn add_slf_contents(&mut self, slf: &mut Resource, data: &[u8]) -> Result<(), ResourceError> {
+    fn get_resources_for_slf(
+        &self,
+        slf: &mut Resource,
+        data: &[u8],
+    ) -> Result<Vec<Resource>, ResourceError> {
         slf.set_property("archive_slf", true);
-        let mut num_resources = 0;
         let mut input = io::Cursor::new(&data);
         let header = SlfHeader::from_input(&mut input)?;
-        for entry in header.entries_from_input(&mut input)? {
-            if entry.state == SlfEntryState::Ok {
+        let entries = header.entries_from_input(&mut input)?;
+        let resources: Result<Vec<Resource>, ResourceError> = entries
+            .iter()
+            .filter(|entry| entry.state == SlfEntryState::Ok)
+            .map(|entry| {
                 let mut resource = Resource::default();
                 let path = header.library_path.clone() + &entry.file_path;
                 resource.path = path.replace("\\", "/");
@@ -277,16 +305,16 @@ impl ResourcePackBuilder {
                     let to = from + entry.length as usize;
                     self.add_hashes(&mut resource, &data[from..to])?;
                 }
-                self.pack.resources.push(resource);
-                num_resources += 1;
-            }
-        }
-        slf.set_property("archive_slf_num_resources", num_resources);
-        return Ok(());
+                Ok(resource)
+            })
+            .collect();
+        let resources = resources?;
+        slf.set_property("archive_slf_num_resources", resources.len());
+        return Ok(resources);
     }
 
     /// Adds hashes of the resource data.
-    fn add_hashes(&mut self, resource: &mut Resource, data: &[u8]) -> Result<(), ResourceError> {
+    fn add_hashes(&self, resource: &mut Resource, data: &[u8]) -> Result<(), ResourceError> {
         for algorithm in &self.with_hashes {
             let hash = match algorithm.as_str() {
                 "md5" => hex::encode(Md5::digest(&data)),


### PR DESCRIPTION
This rewrites guessing vanilla version to some degree. Motivation for the change is mostly that I think it never worked as intended on my machine (because of not matching paths case insensitively). I found the logic hard to follow as well. 

### Major Changes
- When building resource packs, resources are now read in parallel using rayon
- Iterators and HashMap are used instead of for loops
- Case insensitivity has been introduced
- When comparing resource packs, we first check for language specific resources (e.g. `german` subdirectory), this is just faster (at least on my machine) and less error prone. It will return a game version if ONLY files for this version are found
- We compare resource packs second, in parallel. We calculate percentages for each resource pack, e.g. how many files are missing in data dir that are in the resource pack. We then use the minimal mismatching game version

### Todo

- [x] Use `Nfc` for resource path