### PR TITLE
Fix warning C4099

### DIFF
--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -14,7 +14,7 @@
 
 #include "rapidjson/document.h"
 
-class LibraryDB;
+struct LibraryDB;
 
 class DefaultContentManager : public ContentManager, public IGameDataLoader
 {


### PR DESCRIPTION
Reference #857

The AppVeyor console had this warning:
```
warning C4099: 'LibraryDB': type name first seen using 'struct' now seen using 'class'
```
