### PR TITLE
Fix warning C4566

### DIFF
--- a/src/game/Tactical/LoadSaveMercProfile_unittest.cc
+++ b/src/game/Tactical/LoadSaveMercProfile_unittest.cc
@@ -1,4 +1,4 @@
-﻿// -*-coding: utf-8-with-signature-unix;-*-
+// -*-coding: utf-8-unix;-*-
 
 #include "gtest/gtest.h"
 

--- a/src/sgp/LoadSaveData_unittest.cc
+++ b/src/sgp/LoadSaveData_unittest.cc
@@ -1,4 +1,4 @@
-﻿// -*-coding: utf-8-with-signature-unix;-*-
+// -*-coding: utf-8-unix;-*-
 
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
Reference #857

The AppVeyor console had warnings like this:
```
warning C4566: character represented by universal-character-name '\u0412' cannot be represented in the current code page (1252)
```

Visual Studio supports UTF-8, but it must not have a BOM.