### PR TITLE
Set the source and execution charset to utf-8 in MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,11 @@ set(EXTERNAL_PROJECT_CMAKE_ARGS
     -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=${CMAKE_FIND_ROOT_PATH_MODE_INCLUDE}
 )
 
+if(MSVC)
+	# set the source and execution charset
+	add_compile_options("/utf-8")
+endif()
+
 ## Build
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "")


### PR DESCRIPTION
Continuation of #867

@lynxlynxlynx better let the tests finish before merging from now on >.<
Even if it works for me, it might not work in the builders, like what happened here.