### PR TITLE
Rename C-rust interface

### DIFF
--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -140,7 +140,7 @@ pub extern "C" fn EngineOptions_setResolution(ptr: *mut EngineOptions, x: u16, y
 
 /// Gets `EngineOptions.brightness`.
 #[no_mangle]
-pub extern "C" fn get_brightness(ptr: *const EngineOptions) -> f32 {
+pub extern "C" fn EngineOptions_getBrightness(ptr: *const EngineOptions) -> f32 {
     let engine_options = unsafe_ref(ptr);
     engine_options.brightness
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -104,7 +104,7 @@ pub extern "C" fn EngineOptions_getMod(ptr: *const EngineOptions, index: u32) ->
 
 /// Clears `EngineOptions.mods`.
 #[no_mangle]
-pub extern "C" fn clear_mods(ptr: *mut EngineOptions) {
+pub extern "C" fn EngineOptions_clearMods(ptr: *mut EngineOptions) {
     let engine_options = unsafe_mut(ptr);
     engine_options.mods.clear();
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -265,7 +265,7 @@ mod tests {
 
     use crate::c::common::*;
     use crate::c::config::*;
-    use crate::c::misc::free_rust_string;
+    use crate::c::misc::CString_destroy;
     use crate::config::{EngineOptions, Resolution};
     use crate::parse_json_config;
     use crate::tests::write_temp_folder_with_ja2_json;
@@ -322,7 +322,7 @@ mod tests {
             ($version:expr, $expected:expr) => {
                 let got = VanillaVersion_toString($version);
                 assert_eq!(str_from_c_str_or_panic(unsafe_c_str(got)), $expected);
-                free_rust_string(got);
+                CString_destroy(got);
             };
         }
         t!(VanillaVersion::DUTCH, "Dutch");

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -80,7 +80,7 @@ pub extern "C" fn EngineOptions_setVanillaGameDir(ptr: *mut EngineOptions, game_
 
 /// Gets the length of `EngineOptions.mods`.
 #[no_mangle]
-pub extern "C" fn get_number_of_mods(ptr: *const EngineOptions) -> u32 {
+pub extern "C" fn EngineOptions_getModsLength(ptr: *const EngineOptions) -> u32 {
     let engine_options = unsafe_ref(ptr);
     engine_options.mods.len() as u32
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -14,11 +14,11 @@ use crate::config::{
 /// Loads values from `(stracciatella_home)/ja2.json`, creating it if it does not exist.
 /// The caller is responsible for the returned memory.
 #[no_mangle]
-pub extern "C" fn create_engine_options(
-    array: *const *const c_char,
+pub extern "C" fn EngineOptions_create(
+    args: *const *const c_char,
     length: size_t,
 ) -> *mut EngineOptions {
-    let args: Vec<String> = unsafe_slice(array, length)
+    let args: Vec<String> = unsafe_slice(args, length)
         .iter()
         .map(|&x| str_from_c_str_or_panic(unsafe_c_str(x)).to_owned())
         .collect();

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -203,7 +203,7 @@ pub extern "C" fn EngineOptions_setStartInFullscreen(ptr: *mut EngineOptions, va
 
 /// Gets `EngineOptions.scaling_quality`.
 #[no_mangle]
-pub extern "C" fn get_scaling_quality(ptr: *const EngineOptions) -> ScalingQuality {
+pub extern "C" fn EngineOptions_getScalingQuality(ptr: *const EngineOptions) -> ScalingQuality {
     let engine_options = unsafe_ref(ptr);
     engine_options.scaling_quality
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -182,7 +182,7 @@ pub extern "C" fn EngineOptions_shouldShowHelp(ptr: *const EngineOptions) -> boo
 
 /// Gets `EngineOptions.run_editor`.
 #[no_mangle]
-pub extern "C" fn should_run_editor(ptr: *const EngineOptions) -> bool {
+pub extern "C" fn EngineOptions_shouldRunEditor(ptr: *const EngineOptions) -> bool {
     let engine_options = unsafe_ref(ptr);
     engine_options.run_editor
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -111,7 +111,7 @@ pub extern "C" fn EngineOptions_clearMods(ptr: *mut EngineOptions) {
 
 /// Adds a mod to `EngineOptions.mods`.
 #[no_mangle]
-pub extern "C" fn push_mod(ptr: *mut EngineOptions, name: *const c_char) {
+pub extern "C" fn EngineOptions_pushMod(ptr: *mut EngineOptions, name: *const c_char) {
     let engine_options = unsafe_mut(ptr);
     let name = str_from_c_str_or_panic(unsafe_c_str(name)).to_owned();
     engine_options.mods.push(name);

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -238,7 +238,7 @@ pub extern "C" fn EngineOptions_shouldStartWithoutSound(ptr: *const EngineOption
 
 /// Sets `EngineOptions.start_without_sound`.
 #[no_mangle]
-pub extern "C" fn set_start_without_sound(ptr: *mut EngineOptions, val: bool) {
+pub extern "C" fn EngineOptions_setStartWithoutSound(ptr: *mut EngineOptions, val: bool) {
     let engine_options = unsafe_mut(ptr);
     engine_options.start_without_sound = val
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -147,7 +147,7 @@ pub extern "C" fn EngineOptions_getBrightness(ptr: *const EngineOptions) -> f32 
 
 /// Sets `EngineOptions.brightness`.
 #[no_mangle]
-pub extern "C" fn set_brightness(ptr: *mut EngineOptions, brightness: f32) {
+pub extern "C" fn EngineOptions_setBrightness(ptr: *mut EngineOptions, brightness: f32) {
     let engine_options = unsafe_mut(ptr);
     engine_options.brightness = brightness
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -119,7 +119,7 @@ pub extern "C" fn EngineOptions_pushMod(ptr: *mut EngineOptions, name: *const c_
 
 /// Gets the width of `EngineOptions.resolution`.
 #[no_mangle]
-pub extern "C" fn get_resolution_x(ptr: *const EngineOptions) -> u16 {
+pub extern "C" fn EngineOptions_getResolutionX(ptr: *const EngineOptions) -> u16 {
     let engine_options = unsafe_ref(ptr);
     engine_options.resolution.0
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -88,7 +88,7 @@ pub extern "C" fn EngineOptions_getModsLength(ptr: *const EngineOptions) -> u32 
 /// Gets the target index of `EngineOptions.mods`.
 /// The caller is responsible for the returned memory.
 #[no_mangle]
-pub extern "C" fn get_mod(ptr: *const EngineOptions, index: u32) -> *mut c_char {
+pub extern "C" fn EngineOptions_getMod(ptr: *const EngineOptions, index: u32) -> *mut c_char {
     let engine_options = unsafe_ref(ptr);
     match engine_options.mods.get(index as usize) {
         Some(str_mod) => {

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -231,7 +231,7 @@ pub extern "C" fn EngineOptions_shouldStartInDebugMode(ptr: *const EngineOptions
 
 /// Gets `EngineOptions.start_without_sound`.
 #[no_mangle]
-pub extern "C" fn should_start_without_sound(ptr: *const EngineOptions) -> bool {
+pub extern "C" fn EngineOptions_shouldStartWithoutSound(ptr: *const EngineOptions) -> bool {
     let engine_options = unsafe_ref(ptr);
     engine_options.start_without_sound
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -72,7 +72,7 @@ pub extern "C" fn EngineOptions_getVanillaGameDir(ptr: *const EngineOptions) -> 
 
 /// Sets the `EngineOptions.vanilla_game_dir` path.
 #[no_mangle]
-pub extern "C" fn set_vanilla_game_dir(ptr: *mut EngineOptions, game_dir_ptr: *const c_char) {
+pub extern "C" fn EngineOptions_setVanillaGameDir(ptr: *mut EngineOptions, game_dir_ptr: *const c_char) {
     let engine_options = unsafe_mut(ptr);
     let vanilla_game_dir = path_from_c_str_or_panic(unsafe_c_str(game_dir_ptr));
     engine_options.vanilla_game_dir = vanilla_game_dir.to_owned();

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -64,7 +64,7 @@ pub extern "C" fn EngineOptions_getStracciatellaHome(ptr: *const EngineOptions) 
 /// Gets the `EngineOptions.vanilla_game_dir` path.
 /// The caller is responsible for the returned memory.
 #[no_mangle]
-pub extern "C" fn get_vanilla_game_dir(ptr: *const EngineOptions) -> *mut c_char {
+pub extern "C" fn EngineOptions_getVanillaGameDir(ptr: *const EngineOptions) -> *mut c_char {
     let engine_options = unsafe_ref(ptr);
     let vanilla_game_dir = c_string_from_path_or_panic(&engine_options.vanilla_game_dir);
     vanilla_game_dir.into_raw()

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -246,7 +246,7 @@ pub extern "C" fn EngineOptions_setStartWithoutSound(ptr: *mut EngineOptions, va
 /// Gets the string representation of the `ScalingQuality` value.
 /// The caller is responsible for the returned memory.
 #[no_mangle]
-pub extern "C" fn get_scaling_quality_string(quality: ScalingQuality) -> *mut c_char {
+pub extern "C" fn ScalingQuality_toString(quality: ScalingQuality) -> *mut c_char {
     let c_string = c_string_from_str(&quality.to_string());
     c_string.into_raw()
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -254,7 +254,7 @@ pub extern "C" fn ScalingQuality_toString(quality: ScalingQuality) -> *mut c_cha
 /// Gets the string represntation of the `VanillaVersion` value.
 /// The caller is responsible for the returned memory.
 #[no_mangle]
-pub extern "C" fn get_resource_version_string(version: VanillaVersion) -> *mut c_char {
+pub extern "C" fn VanillaVersion_toString(version: VanillaVersion) -> *mut c_char {
     let c_string = c_string_from_str(&version.to_string());
     c_string.into_raw()
 }
@@ -317,10 +317,10 @@ mod tests {
     }
 
     #[test]
-    fn get_resource_version_string_should_return_the_correct_resource_version_string() {
+    fn vanilla_version_to_string_should_return_the_correct_resource_version_string() {
         macro_rules! t {
             ($version:expr, $expected:expr) => {
-                let got = get_resource_version_string($version);
+                let got = VanillaVersion_toString($version);
                 assert_eq!(str_from_c_str_or_panic(unsafe_c_str(got)), $expected);
                 free_rust_string(got);
             };

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -133,7 +133,7 @@ pub extern "C" fn EngineOptions_getResolutionY(ptr: *const EngineOptions) -> u16
 
 /// Sets `EngineOptions.resolution`.
 #[no_mangle]
-pub extern "C" fn set_resolution(ptr: *mut EngineOptions, x: u16, y: u16) {
+pub extern "C" fn EngineOptions_setResolution(ptr: *mut EngineOptions, x: u16, y: u16) {
     let engine_options = unsafe_mut(ptr);
     engine_options.resolution = Resolution(x, y);
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -168,7 +168,7 @@ pub extern "C" fn EngineOptions_setResourceVersion(ptr: *mut EngineOptions, res:
 
 /// Gets `EngineOptions.run_unittests`.
 #[no_mangle]
-pub extern "C" fn should_run_unittests(ptr: *const EngineOptions) -> bool {
+pub extern "C" fn EngineOptions_shouldRunUnittests(ptr: *const EngineOptions) -> bool {
     let engine_options = unsafe_ref(ptr);
     engine_options.run_unittests
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -210,7 +210,7 @@ pub extern "C" fn EngineOptions_getScalingQuality(ptr: *const EngineOptions) -> 
 
 /// Sets `EngineOptions.scaling_quality`.
 #[no_mangle]
-pub extern "C" fn set_scaling_quality(ptr: *mut EngineOptions, scaling_quality: ScalingQuality) {
+pub extern "C" fn EngineOptions_setScalingQuality(ptr: *mut EngineOptions, scaling_quality: ScalingQuality) {
     let engine_options = unsafe_mut(ptr);
     engine_options.scaling_quality = scaling_quality
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -48,7 +48,7 @@ pub extern "C" fn EngineOptions_write(ptr: *mut EngineOptions) -> bool {
 
 /// Deletes `EngineOptions`.
 #[no_mangle]
-pub extern "C" fn free_engine_options(ptr: *mut EngineOptions) {
+pub extern "C" fn EngineOptions_destroy(ptr: *mut EngineOptions) {
     let _drop_me = from_ptr(ptr);
 }
 

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -154,7 +154,7 @@ pub extern "C" fn EngineOptions_setBrightness(ptr: *mut EngineOptions, brightnes
 
 /// Gets `EngineOptions.resource_version`.
 #[no_mangle]
-pub extern "C" fn get_resource_version(ptr: *const EngineOptions) -> VanillaVersion {
+pub extern "C" fn EngineOptions_getResourceVersion(ptr: *const EngineOptions) -> VanillaVersion {
     let engine_options = unsafe_ref(ptr);
     engine_options.resource_version
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -189,7 +189,7 @@ pub extern "C" fn EngineOptions_shouldRunEditor(ptr: *const EngineOptions) -> bo
 
 /// Gets `EngineOptions.start_in_fullscreen`.
 #[no_mangle]
-pub extern "C" fn should_start_in_fullscreen(ptr: *const EngineOptions) -> bool {
+pub extern "C" fn EngineOptions_shouldStartInFullscreen(ptr: *const EngineOptions) -> bool {
     let engine_options = unsafe_ref(ptr);
     engine_options.start_in_fullscreen
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -196,7 +196,7 @@ pub extern "C" fn EngineOptions_shouldStartInFullscreen(ptr: *const EngineOption
 
 /// Sets `EngineOptions.start_in_fullscreen`.
 #[no_mangle]
-pub extern "C" fn set_start_in_fullscreen(ptr: *mut EngineOptions, val: bool) {
+pub extern "C" fn EngineOptions_setStartInFullscreen(ptr: *mut EngineOptions, val: bool) {
     let engine_options = unsafe_mut(ptr);
     engine_options.start_in_fullscreen = val
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -40,7 +40,7 @@ pub extern "C" fn EngineOptions_create(
 /// Writes `EngineOptions` to `(stracciatella_home)/ja2.json`.
 /// Returns true on success, false otherwise.
 #[no_mangle]
-pub extern "C" fn write_engine_options(ptr: *mut EngineOptions) -> bool {
+pub extern "C" fn EngineOptions_write(ptr: *mut EngineOptions) -> bool {
     let engine_options = unsafe_mut(ptr);
     let ja2_json = Ja2Json::from_stracciatella_home(&engine_options.stracciatella_home);
     ja2_json.write(&engine_options).is_ok()
@@ -279,7 +279,7 @@ mod tests {
         engine_options.stracciatella_home = stracciatella_home.clone();
         engine_options.resolution = Resolution(100, 100);
 
-        assert_eq!(write_engine_options(&mut engine_options), true);
+        assert_eq!(EngineOptions_write(&mut engine_options), true);
 
         let got_engine_options = parse_json_config(&stracciatella_home).unwrap();
 
@@ -296,7 +296,7 @@ mod tests {
         engine_options.stracciatella_home = stracciatella_home.clone();
         engine_options.resolution = Resolution(100, 100);
 
-        write_engine_options(&mut engine_options);
+        EngineOptions_write(&mut engine_options);
 
         let config_file_contents = fs::read_to_string(stracciatella_json).unwrap();
 

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -217,7 +217,7 @@ pub extern "C" fn EngineOptions_setScalingQuality(ptr: *mut EngineOptions, scali
 
 /// Gets `EngineOptions.start_in_window`.
 #[no_mangle]
-pub extern "C" fn should_start_in_window(ptr: *const EngineOptions) -> bool {
+pub extern "C" fn EngineOptions_shouldStartInWindow(ptr: *const EngineOptions) -> bool {
     let engine_options = unsafe_ref(ptr);
     engine_options.start_in_window
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -224,7 +224,7 @@ pub extern "C" fn EngineOptions_shouldStartInWindow(ptr: *const EngineOptions) -
 
 /// Gets `EngineOptions.start_in_debug_mode`.
 #[no_mangle]
-pub extern "C" fn should_start_in_debug_mode(ptr: *const EngineOptions) -> bool {
+pub extern "C" fn EngineOptions_shouldStartInDebugMode(ptr: *const EngineOptions) -> bool {
     let engine_options = unsafe_ref(ptr);
     engine_options.start_in_debug_mode
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -126,7 +126,7 @@ pub extern "C" fn EngineOptions_getResolutionX(ptr: *const EngineOptions) -> u16
 
 /// Gets the height of `EngineOptions.resolution`.
 #[no_mangle]
-pub extern "C" fn get_resolution_y(ptr: *const EngineOptions) -> u16 {
+pub extern "C" fn EngineOptions_getResolutionY(ptr: *const EngineOptions) -> u16 {
     let engine_options = unsafe_ref(ptr);
     engine_options.resolution.1
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -161,7 +161,7 @@ pub extern "C" fn EngineOptions_getResourceVersion(ptr: *const EngineOptions) ->
 
 /// Sets `EngineOptions.resource_version`.
 #[no_mangle]
-pub extern "C" fn set_resource_version(ptr: *mut EngineOptions, res: VanillaVersion) {
+pub extern "C" fn EngineOptions_setResourceVersion(ptr: *mut EngineOptions, res: VanillaVersion) {
     let engine_options = unsafe_mut(ptr);
     engine_options.resource_version = res;
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -55,7 +55,7 @@ pub extern "C" fn EngineOptions_destroy(ptr: *mut EngineOptions) {
 /// Gets the `EngineOptions.stracciatella_home` path.
 /// The caller is responsible for the returned memory.
 #[no_mangle]
-pub extern "C" fn get_stracciatella_home(ptr: *const EngineOptions) -> *mut c_char {
+pub extern "C" fn EngineOptions_getStracciatellaHome(ptr: *const EngineOptions) -> *mut c_char {
     let engine_options = unsafe_ref(ptr);
     let stracciatella_home = c_string_from_path_or_panic(&engine_options.stracciatella_home);
     stracciatella_home.into_raw()

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -72,7 +72,10 @@ pub extern "C" fn EngineOptions_getVanillaGameDir(ptr: *const EngineOptions) -> 
 
 /// Sets the `EngineOptions.vanilla_game_dir` path.
 #[no_mangle]
-pub extern "C" fn EngineOptions_setVanillaGameDir(ptr: *mut EngineOptions, game_dir_ptr: *const c_char) {
+pub extern "C" fn EngineOptions_setVanillaGameDir(
+    ptr: *mut EngineOptions,
+    game_dir_ptr: *const c_char,
+) {
     let engine_options = unsafe_mut(ptr);
     let vanilla_game_dir = path_from_c_str_or_panic(unsafe_c_str(game_dir_ptr));
     engine_options.vanilla_game_dir = vanilla_game_dir.to_owned();
@@ -210,7 +213,10 @@ pub extern "C" fn EngineOptions_getScalingQuality(ptr: *const EngineOptions) -> 
 
 /// Sets `EngineOptions.scaling_quality`.
 #[no_mangle]
-pub extern "C" fn EngineOptions_setScalingQuality(ptr: *mut EngineOptions, scaling_quality: ScalingQuality) {
+pub extern "C" fn EngineOptions_setScalingQuality(
+    ptr: *mut EngineOptions,
+    scaling_quality: ScalingQuality,
+) {
     let engine_options = unsafe_mut(ptr);
     engine_options.scaling_quality = scaling_quality
 }

--- a/rust/src/c/config.rs
+++ b/rust/src/c/config.rs
@@ -175,7 +175,7 @@ pub extern "C" fn EngineOptions_shouldRunUnittests(ptr: *const EngineOptions) ->
 
 /// Gets `EngineOptions.show_help`.
 #[no_mangle]
-pub extern "C" fn should_show_help(ptr: *const EngineOptions) -> bool {
+pub extern "C" fn EngineOptions_shouldShowHelp(ptr: *const EngineOptions) -> bool {
     let engine_options = unsafe_ref(ptr);
     engine_options.show_help
 }

--- a/rust/src/c/librarydb.rs
+++ b/rust/src/c/librarydb.rs
@@ -121,7 +121,7 @@ pub extern "C" fn LibraryFile_read(
 
 /// Gets the current position in a library database file.
 #[no_mangle]
-pub extern "C" fn LibraryFile_GetPos(file: *mut LibraryFile) -> u64 {
+pub extern "C" fn LibraryFile_getPosition(file: *mut LibraryFile) -> u64 {
     let file = unsafe_mut(file);
     file.current_position()
 }
@@ -145,7 +145,7 @@ mod tests {
 
     fn read_to_end(c_file: *mut LibraryFile) -> Vec<u8> {
         let size = LibraryFile_GetSize(c_file) as usize;
-        let pos = LibraryFile_GetPos(c_file) as usize;
+        let pos = LibraryFile_getPosition(c_file) as usize;
         let mut data = vec![0u8; size - pos];
         assert!(LibraryFile_read(c_file, data.as_mut_ptr(), size - pos));
         data
@@ -155,7 +155,7 @@ mod tests {
         let c_path = c_string_from_str(&path);
         let c_file = LibraryFile_open(c_ldb, c_path.as_ptr()); // must manage the memory
         assert_ne!(c_file, std::ptr::null_mut());
-        assert_eq!(LibraryFile_GetPos(c_file), 0);
+        assert_eq!(LibraryFile_getPosition(c_file), 0);
         let data = read_to_end(c_file);
         LibraryFile_close(c_file); // rust manages the memory
         data
@@ -179,15 +179,15 @@ mod tests {
             assert!(LibraryDB_push(c_ldb, c_data_dir, c_library));
             let c_file = LibraryFile_open(c_ldb, c_foo_txt); // must manage the memory
             assert_ne!(c_file, std::ptr::null_mut());
-            assert_eq!(LibraryFile_GetPos(c_file), 0);
+            assert_eq!(LibraryFile_getPosition(c_file), 0);
             let data = read_to_end(c_file);
             assert_eq!(&data, b"data.slf");
             assert!(LibraryFile_seek(c_file, 0, FILE_SEEK_FROM_START));
-            assert_eq!(LibraryFile_GetPos(c_file), 0);
+            assert_eq!(LibraryFile_getPosition(c_file), 0);
             assert!(LibraryFile_seek(c_file, 0, FILE_SEEK_FROM_END));
-            assert_eq!(LibraryFile_GetPos(c_file), 8);
+            assert_eq!(LibraryFile_getPosition(c_file), 8);
             assert!(LibraryFile_seek(c_file, -4, FILE_SEEK_FROM_CURRENT));
-            assert_eq!(LibraryFile_GetPos(c_file), 4);
+            assert_eq!(LibraryFile_getPosition(c_file), 4);
             let data = read_to_end(c_file);
             assert_eq!(&data, b".slf");
             LibraryFile_close(c_file); // rust manages the memory

--- a/rust/src/c/librarydb.rs
+++ b/rust/src/c/librarydb.rs
@@ -100,7 +100,7 @@ pub extern "C" fn LibraryFile_seek(file: *mut LibraryFile, distance: i64, from: 
 /// Reads from a library database file.
 /// Sets the rust error.
 #[no_mangle]
-pub extern "C" fn LibraryFile_Read(
+pub extern "C" fn LibraryFile_read(
     file: *mut LibraryFile,
     buffer: *mut u8,
     buffer_length: size_t,
@@ -147,7 +147,7 @@ mod tests {
         let size = LibraryFile_GetSize(c_file) as usize;
         let pos = LibraryFile_GetPos(c_file) as usize;
         let mut data = vec![0u8; size - pos];
-        assert!(LibraryFile_Read(c_file, data.as_mut_ptr(), size - pos));
+        assert!(LibraryFile_read(c_file, data.as_mut_ptr(), size - pos));
         data
     }
 

--- a/rust/src/c/librarydb.rs
+++ b/rust/src/c/librarydb.rs
@@ -11,7 +11,7 @@ use crate::librarydb::{LibraryDB, LibraryFile};
 /// Constructor.
 /// The caller is responsible for the memory of the library database.
 #[no_mangle]
-pub extern "C" fn LibraryDB_New() -> *mut LibraryDB {
+pub extern "C" fn LibraryDB_create() -> *mut LibraryDB {
     into_ptr(LibraryDB::new())
 }
 
@@ -175,7 +175,7 @@ mod tests {
             let c_foo_txt = c_string_from_str("foo.txt");
             let c_foo_txt = c_foo_txt.as_ptr();
 
-            let c_ldb = LibraryDB_New(); // must manage the memory
+            let c_ldb = LibraryDB_create(); // must manage the memory
             assert!(LibraryDB_AddLibrary(c_ldb, c_data_dir, c_library));
             let c_file = LibraryFile_Open(c_ldb, c_foo_txt); // must manage the memory
             assert_ne!(c_file, std::ptr::null_mut());
@@ -203,7 +203,7 @@ mod tests {
             let c_foobar_slf = c_string_from_str("foobar.slf");
             let c_foobar_slf = c_foobar_slf.as_ptr();
 
-            let c_ldb = LibraryDB_New(); // must manage the memory
+            let c_ldb = LibraryDB_create(); // must manage the memory
             assert!(LibraryDB_AddLibrary(c_ldb, c_data_dir, c_foo_slf));
             assert!(LibraryDB_AddLibrary(c_ldb, c_data_dir, c_foobar_slf));
             let data = library_file_data(c_ldb, "foo/bar.txt");
@@ -212,7 +212,7 @@ mod tests {
             assert_eq!(&data, b"foo.slf");
             LibraryDB_Delete(c_ldb); // rust manages the memory
 
-            let c_ldb = LibraryDB_New(); // must manage the memory
+            let c_ldb = LibraryDB_create(); // must manage the memory
             assert!(LibraryDB_AddLibrary(c_ldb, c_data_dir, c_foobar_slf));
             assert!(LibraryDB_AddLibrary(c_ldb, c_data_dir, c_foo_slf));
             let data = library_file_data(c_ldb, "foo/BAR.TXT");

--- a/rust/src/c/librarydb.rs
+++ b/rust/src/c/librarydb.rs
@@ -18,7 +18,7 @@ pub extern "C" fn LibraryDB_create() -> *mut LibraryDB {
 /// Destructor.
 /// The caller is no longer responsible for the memory of the library database.
 #[no_mangle]
-pub extern "C" fn LibraryDB_Delete(ldb: *mut LibraryDB) {
+pub extern "C" fn LibraryDB_destroy(ldb: *mut LibraryDB) {
     let _drop_me = from_ptr(ldb);
 }
 
@@ -191,7 +191,7 @@ mod tests {
             let data = read_to_end(c_file);
             assert_eq!(&data, b".slf");
             LibraryFile_Close(c_file); // rust manages the memory
-            LibraryDB_Delete(c_ldb); // rust manages the memory
+            LibraryDB_destroy(c_ldb); // rust manages the memory
         }
 
         // library order matters, file paths are case insensitive, allow both path separators
@@ -210,7 +210,7 @@ mod tests {
             assert_eq!(&data, b"foo.slf");
             let data = library_file_data(c_ldb, "foo/BAR/baz.txt");
             assert_eq!(&data, b"foo.slf");
-            LibraryDB_Delete(c_ldb); // rust manages the memory
+            LibraryDB_destroy(c_ldb); // rust manages the memory
 
             let c_ldb = LibraryDB_create(); // must manage the memory
             assert!(LibraryDB_AddLibrary(c_ldb, c_data_dir, c_foobar_slf));
@@ -219,7 +219,7 @@ mod tests {
             assert_eq!(&data, b"foo.slf");
             let data = library_file_data(c_ldb, "foo\\bar/baz.txt");
             assert_eq!(&data, b"foobar.slf");
-            LibraryDB_Delete(c_ldb); // rust manages the memory
+            LibraryDB_destroy(c_ldb); // rust manages the memory
         }
 
         dir.close().unwrap();

--- a/rust/src/c/librarydb.rs
+++ b/rust/src/c/librarydb.rs
@@ -128,7 +128,7 @@ pub extern "C" fn LibraryFile_getPosition(file: *mut LibraryFile) -> u64 {
 
 /// Gets the size of a library database file.
 #[no_mangle]
-pub extern "C" fn LibraryFile_GetSize(file: *mut LibraryFile) -> u64 {
+pub extern "C" fn LibraryFile_getSize(file: *mut LibraryFile) -> u64 {
     let file = unsafe_mut(file);
     file.file_size()
 }
@@ -144,7 +144,7 @@ mod tests {
     const FILE_SEEK_FROM_CURRENT: c_int = 2;
 
     fn read_to_end(c_file: *mut LibraryFile) -> Vec<u8> {
-        let size = LibraryFile_GetSize(c_file) as usize;
+        let size = LibraryFile_getSize(c_file) as usize;
         let pos = LibraryFile_getPosition(c_file) as usize;
         let mut data = vec![0u8; size - pos];
         assert!(LibraryFile_read(c_file, data.as_mut_ptr(), size - pos));

--- a/rust/src/c/librarydb.rs
+++ b/rust/src/c/librarydb.rs
@@ -69,7 +69,7 @@ pub extern "C" fn LibraryFile_open(ldb: *mut LibraryDB, path: *const c_char) -> 
 /// Closes a library database file.
 /// The caller is no longer responsible for the library file memory.
 #[no_mangle]
-pub extern "C" fn LibraryFile_Close(file: *mut LibraryFile) {
+pub extern "C" fn LibraryFile_close(file: *mut LibraryFile) {
     let _drop_me = from_ptr(file);
 }
 
@@ -157,7 +157,7 @@ mod tests {
         assert_ne!(c_file, std::ptr::null_mut());
         assert_eq!(LibraryFile_GetPos(c_file), 0);
         let data = read_to_end(c_file);
-        LibraryFile_Close(c_file); // rust manages the memory
+        LibraryFile_close(c_file); // rust manages the memory
         data
     }
 
@@ -190,7 +190,7 @@ mod tests {
             assert_eq!(LibraryFile_GetPos(c_file), 4);
             let data = read_to_end(c_file);
             assert_eq!(&data, b".slf");
-            LibraryFile_Close(c_file); // rust manages the memory
+            LibraryFile_close(c_file); // rust manages the memory
             LibraryDB_destroy(c_ldb); // rust manages the memory
         }
 

--- a/rust/src/c/librarydb.rs
+++ b/rust/src/c/librarydb.rs
@@ -77,7 +77,7 @@ pub extern "C" fn LibraryFile_close(file: *mut LibraryFile) {
 /// `from` expects FileSeekMode values (see src/sgp/SGPFile.h)
 /// Sets the rust error.
 #[no_mangle]
-pub extern "C" fn LibraryFile_Seek(file: *mut LibraryFile, distance: i64, from: c_int) -> bool {
+pub extern "C" fn LibraryFile_seek(file: *mut LibraryFile, distance: i64, from: c_int) -> bool {
     let file = unsafe_mut(file);
     let seek_result = match from {
         0 if distance >= 0 => file.seek(SeekFrom::Start(distance as u64)),
@@ -182,11 +182,11 @@ mod tests {
             assert_eq!(LibraryFile_GetPos(c_file), 0);
             let data = read_to_end(c_file);
             assert_eq!(&data, b"data.slf");
-            assert!(LibraryFile_Seek(c_file, 0, FILE_SEEK_FROM_START));
+            assert!(LibraryFile_seek(c_file, 0, FILE_SEEK_FROM_START));
             assert_eq!(LibraryFile_GetPos(c_file), 0);
-            assert!(LibraryFile_Seek(c_file, 0, FILE_SEEK_FROM_END));
+            assert!(LibraryFile_seek(c_file, 0, FILE_SEEK_FROM_END));
             assert_eq!(LibraryFile_GetPos(c_file), 8);
-            assert!(LibraryFile_Seek(c_file, -4, FILE_SEEK_FROM_CURRENT));
+            assert!(LibraryFile_seek(c_file, -4, FILE_SEEK_FROM_CURRENT));
             assert_eq!(LibraryFile_GetPos(c_file), 4);
             let data = read_to_end(c_file);
             assert_eq!(&data, b".slf");

--- a/rust/src/c/librarydb.rs
+++ b/rust/src/c/librarydb.rs
@@ -51,7 +51,7 @@ pub extern "C" fn LibraryDB_push(
 /// The caller is responsible for the library file memory.
 /// Sets the rust error.
 #[no_mangle]
-pub extern "C" fn LibraryFile_Open(ldb: *mut LibraryDB, path: *const c_char) -> *mut LibraryFile {
+pub extern "C" fn LibraryFile_open(ldb: *mut LibraryDB, path: *const c_char) -> *mut LibraryFile {
     let ldb = unsafe_mut(ldb);
     let path = str_from_c_str_or_panic(unsafe_c_str(path));
     match ldb.open_file(&path) {
@@ -153,7 +153,7 @@ mod tests {
 
     fn library_file_data(c_ldb: *mut LibraryDB, path: &str) -> Vec<u8> {
         let c_path = c_string_from_str(&path);
-        let c_file = LibraryFile_Open(c_ldb, c_path.as_ptr()); // must manage the memory
+        let c_file = LibraryFile_open(c_ldb, c_path.as_ptr()); // must manage the memory
         assert_ne!(c_file, std::ptr::null_mut());
         assert_eq!(LibraryFile_GetPos(c_file), 0);
         let data = read_to_end(c_file);
@@ -177,7 +177,7 @@ mod tests {
 
             let c_ldb = LibraryDB_create(); // must manage the memory
             assert!(LibraryDB_push(c_ldb, c_data_dir, c_library));
-            let c_file = LibraryFile_Open(c_ldb, c_foo_txt); // must manage the memory
+            let c_file = LibraryFile_open(c_ldb, c_foo_txt); // must manage the memory
             assert_ne!(c_file, std::ptr::null_mut());
             assert_eq!(LibraryFile_GetPos(c_file), 0);
             let data = read_to_end(c_file);

--- a/rust/src/c/librarydb.rs
+++ b/rust/src/c/librarydb.rs
@@ -26,7 +26,7 @@ pub extern "C" fn LibraryDB_destroy(ldb: *mut LibraryDB) {
 /// Returns true is successful, false otherwise.
 /// Sets the rust error.
 #[no_mangle]
-pub extern "C" fn LibraryDB_AddLibrary(
+pub extern "C" fn LibraryDB_push(
     ldb: *mut LibraryDB,
     data_dir: *const c_char,
     library: *const c_char,
@@ -176,7 +176,7 @@ mod tests {
             let c_foo_txt = c_foo_txt.as_ptr();
 
             let c_ldb = LibraryDB_create(); // must manage the memory
-            assert!(LibraryDB_AddLibrary(c_ldb, c_data_dir, c_library));
+            assert!(LibraryDB_push(c_ldb, c_data_dir, c_library));
             let c_file = LibraryFile_Open(c_ldb, c_foo_txt); // must manage the memory
             assert_ne!(c_file, std::ptr::null_mut());
             assert_eq!(LibraryFile_GetPos(c_file), 0);
@@ -204,8 +204,8 @@ mod tests {
             let c_foobar_slf = c_foobar_slf.as_ptr();
 
             let c_ldb = LibraryDB_create(); // must manage the memory
-            assert!(LibraryDB_AddLibrary(c_ldb, c_data_dir, c_foo_slf));
-            assert!(LibraryDB_AddLibrary(c_ldb, c_data_dir, c_foobar_slf));
+            assert!(LibraryDB_push(c_ldb, c_data_dir, c_foo_slf));
+            assert!(LibraryDB_push(c_ldb, c_data_dir, c_foobar_slf));
             let data = library_file_data(c_ldb, "foo/bar.txt");
             assert_eq!(&data, b"foo.slf");
             let data = library_file_data(c_ldb, "foo/BAR/baz.txt");
@@ -213,8 +213,8 @@ mod tests {
             LibraryDB_destroy(c_ldb); // rust manages the memory
 
             let c_ldb = LibraryDB_create(); // must manage the memory
-            assert!(LibraryDB_AddLibrary(c_ldb, c_data_dir, c_foobar_slf));
-            assert!(LibraryDB_AddLibrary(c_ldb, c_data_dir, c_foo_slf));
+            assert!(LibraryDB_push(c_ldb, c_data_dir, c_foobar_slf));
+            assert!(LibraryDB_push(c_ldb, c_data_dir, c_foo_slf));
             let data = library_file_data(c_ldb, "foo/BAR.TXT");
             assert_eq!(&data, b"foo.slf");
             let data = library_file_data(c_ldb, "foo\\bar/baz.txt");

--- a/rust/src/c/logger.rs
+++ b/rust/src/c/logger.rs
@@ -8,7 +8,7 @@ use crate::logger::Logger;
 
 /// Initializes the logger
 #[no_mangle]
-pub extern "C" fn Logger_Init(log_file: *const c_char) {
+pub extern "C" fn Logger_initialize(log_file: *const c_char) {
     let log_file = path_from_c_str_or_panic(unsafe_c_str(log_file));
     Logger::init(log_file)
 }

--- a/rust/src/c/logger.rs
+++ b/rust/src/c/logger.rs
@@ -21,11 +21,7 @@ pub extern "C" fn Logger_setLevel(level: LogLevel) {
 
 /// Log with custom metadata
 #[no_mangle]
-pub extern "C" fn Logger_log(
-    level: LogLevel,
-    message: *const c_char,
-    target: *const c_char,
-) {
+pub extern "C" fn Logger_log(level: LogLevel, message: *const c_char, target: *const c_char) {
     let message = str_from_c_str_or_panic(unsafe_c_str(message));
     let target = str_from_c_str_or_panic(unsafe_c_str(target));
 

--- a/rust/src/c/logger.rs
+++ b/rust/src/c/logger.rs
@@ -21,7 +21,7 @@ pub extern "C" fn Logger_setLevel(level: LogLevel) {
 
 /// Log with custom metadata
 #[no_mangle]
-pub extern "C" fn Logger_LogWithCustomMetadata(
+pub extern "C" fn Logger_log(
     level: LogLevel,
     message: *const c_char,
     target: *const c_char,

--- a/rust/src/c/logger.rs
+++ b/rust/src/c/logger.rs
@@ -15,7 +15,7 @@ pub extern "C" fn Logger_initialize(log_file: *const c_char) {
 
 /// Set log level
 #[no_mangle]
-pub extern "C" fn Logger_SetLevel(level: LogLevel) {
+pub extern "C" fn Logger_setLevel(level: LogLevel) {
     Logger::set_level(level)
 }
 

--- a/rust/src/c/misc.rs
+++ b/rust/src/c/misc.rs
@@ -184,7 +184,7 @@ pub extern "C" fn VecCString_destroy(vec: *mut VecCString) {
 
 /// Returns the vector length.
 #[no_mangle]
-pub extern "C" fn vec_c_string_len(vec: *mut VecCString) -> size_t {
+pub extern "C" fn VecCString_length(vec: *mut VecCString) -> size_t {
     let vec = unsafe_ref(vec);
     vec.inner.len()
 }

--- a/rust/src/c/misc.rs
+++ b/rust/src/c/misc.rs
@@ -103,7 +103,7 @@ pub extern "C" fn findPathFromStracciatellaHome(
 /// Returns true if it was able to find path relative to base.
 /// Makes caseless searches one component at a time.
 #[no_mangle]
-pub extern "C" fn check_if_relative_path_exists(
+pub extern "C" fn checkIfRelativePathExists(
     base: *const c_char,
     path: *const c_char,
     caseless: bool,
@@ -235,7 +235,7 @@ mod tests {
                 let base = CString::new(temp_dir.path().to_str().unwrap()).unwrap();
                 let path = CString::new($path).unwrap();
                 assert_eq!(
-                    super::check_if_relative_path_exists(base.as_ptr(), path.as_ptr(), $caseless),
+                    super::checkIfRelativePathExists(base.as_ptr(), path.as_ptr(), $caseless),
                     $expected
                 );
             };

--- a/rust/src/c/misc.rs
+++ b/rust/src/c/misc.rs
@@ -33,7 +33,7 @@ pub extern "C" fn findJa2Executable(launcher_path_ptr: *const c_char) -> *mut c_
 /// The caller is no longer responsible for the memory.
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn free_rust_string(s: *mut c_char) {
+pub extern "C" fn CString_destroy(s: *mut c_char) {
     if s.is_null() {
         return;
     }
@@ -203,7 +203,7 @@ mod tests {
     use std::fs;
 
     use crate::c::common::*;
-    use crate::c::misc::free_rust_string;
+    use crate::c::misc::CString_destroy;
 
     #[test]
     fn find_ja2_executable_should_determine_game_path_from_launcher_path() {
@@ -212,7 +212,7 @@ mod tests {
                 let path = c_string_from_str($path);
                 let got = super::findJa2Executable(path.as_ptr());
                 assert_eq!(str_from_c_str_or_panic(unsafe_c_str(got)), $expected);
-                free_rust_string(got);
+                CString_destroy(got);
             };
         }
         t!("/home/test/ja2-launcher", "/home/test/ja2");

--- a/rust/src/c/misc.rs
+++ b/rust/src/c/misc.rs
@@ -15,7 +15,7 @@ use crate::unicode::Nfc;
 /// The executable is assumed to be in the same directory as the launcher.
 /// The caller is responsible for the returned memory.
 #[no_mangle]
-pub extern "C" fn find_ja2_executable(launcher_path_ptr: *const c_char) -> *mut c_char {
+pub extern "C" fn findJa2Executable(launcher_path_ptr: *const c_char) -> *mut c_char {
     let launcher_path = str_from_c_str_or_panic(unsafe_c_str(launcher_path_ptr));
     let is_exe = launcher_path.to_lowercase().ends_with(".exe");
     let end_of_executable_slice = launcher_path.len() - if is_exe { 13 } else { 9 };
@@ -210,7 +210,7 @@ mod tests {
         macro_rules! t {
             ($path:expr, $expected:expr) => {
                 let path = c_string_from_str($path);
-                let got = super::find_ja2_executable(path.as_ptr());
+                let got = super::findJa2Executable(path.as_ptr());
                 assert_eq!(str_from_c_str_or_panic(unsafe_c_str(got)), $expected);
                 free_rust_string(got);
             };

--- a/rust/src/c/misc.rs
+++ b/rust/src/c/misc.rs
@@ -43,7 +43,7 @@ pub extern "C" fn CString_destroy(s: *mut c_char) {
 /// Guesses the resource version from the contents of the game directory.
 /// Returns a VanillaVersion value if it was sucessful, -1 otherwise.
 #[no_mangle]
-pub extern "C" fn guess_resource_version(gamedir: *const c_char) -> c_int {
+pub extern "C" fn guessResourceVersion(gamedir: *const c_char) -> c_int {
     let path = str_from_c_str_or_panic(unsafe_c_str(gamedir));
     let logged = crate::guess::guess_vanilla_version(&path);
     let mut result = -1;

--- a/rust/src/c/misc.rs
+++ b/rust/src/c/misc.rs
@@ -139,7 +139,7 @@ pub extern "C" fn checkIfRelativePathExists(
 /// Returns a list of available mods.
 /// The caller is responsible for the returned memory.
 #[no_mangle]
-pub extern "C" fn get_available_mods() -> *mut VecCString {
+pub extern "C" fn findAvailableMods() -> *mut VecCString {
     let mut path = get_assets_dir();
     path.push("mods");
     if let Ok(entries) = path.read_dir() {

--- a/rust/src/c/misc.rs
+++ b/rust/src/c/misc.rs
@@ -58,7 +58,7 @@ pub extern "C" fn guessResourceVersion(gamedir: *const c_char) -> c_int {
 /// If test_exists is true and the path does not exist, it returns null.
 /// The caller is responsible for the returned memory.
 #[no_mangle]
-pub extern "C" fn find_path_from_assets_dir(path: *const c_char, test_exists: bool) -> *mut c_char {
+pub extern "C" fn findPathFromAssetsDir(path: *const c_char, test_exists: bool) -> *mut c_char {
     let mut path_buf = get_assets_dir();
     if !path.is_null() {
         let path = path_from_c_str_or_panic(unsafe_c_str(path));

--- a/rust/src/c/misc.rs
+++ b/rust/src/c/misc.rs
@@ -178,7 +178,7 @@ impl VecCString {
 
 /// Deletes the vector.
 #[no_mangle]
-pub extern "C" fn vec_c_string_delete(vec: *mut VecCString) {
+pub extern "C" fn VecCString_destroy(vec: *mut VecCString) {
     let _drop_me = from_ptr(vec);
 }
 

--- a/rust/src/c/misc.rs
+++ b/rust/src/c/misc.rs
@@ -77,7 +77,7 @@ pub extern "C" fn findPathFromAssetsDir(path: *const c_char, test_exists: bool) 
 /// If test_exists is true, it makes sure the path exists.
 /// The caller is responsible for the returned memory.
 #[no_mangle]
-pub extern "C" fn find_path_from_stracciatella_home(
+pub extern "C" fn findPathFromStracciatellaHome(
     path: *const c_char,
     test_exists: bool,
 ) -> *mut c_char {

--- a/rust/src/c/misc.rs
+++ b/rust/src/c/misc.rs
@@ -192,7 +192,7 @@ pub extern "C" fn VecCString_length(vec: *mut VecCString) -> size_t {
 /// Returns the string at the target index.
 /// The caller is responsible for the returned memory.
 #[no_mangle]
-pub extern "C" fn vec_c_string_get(vec: *mut VecCString, index: size_t) -> *mut c_char {
+pub extern "C" fn VecCString_get(vec: *mut VecCString, index: size_t) -> *mut c_char {
     let vec = unsafe_ref(vec);
     vec.inner[index].clone().into_raw()
 }

--- a/rust/src/c/mod.rs
+++ b/rust/src/c/mod.rs
@@ -16,7 +16,7 @@ pub mod error {
     /// Returns a copy of the thread local rust error or null.
     /// The caller is responsible for the memory.
     #[no_mangle]
-    pub extern "C" fn get_rust_error() -> *mut c_char {
+    pub extern "C" fn getRustError() -> *mut c_char {
         RUST_ERROR.with(|x| {
             if let Some(ref error) = *x.borrow() {
                 return error.clone().into_raw();
@@ -271,7 +271,7 @@ mod tests {
     #[test]
     fn test_rust_error() {
         fn error() -> Option<CString> {
-            let ptr = get_rust_error(); // get copy
+            let ptr = getRustError(); // get copy
             if ptr.is_null() {
                 None
             } else {

--- a/rust/src/c/mod.rs
+++ b/rust/src/c/mod.rs
@@ -176,7 +176,7 @@ mod tests {
 
     use crate::c::common::*;
     use crate::c::error::*;
-    use crate::c::misc::free_rust_string;
+    use crate::c::misc::CString_destroy;
 
     #[test]
     fn test_pointers() {
@@ -276,7 +276,7 @@ mod tests {
                 None
             } else {
                 let c_string = unsafe_c_str(ptr).to_owned();
-                free_rust_string(ptr); // free copy
+                CString_destroy(ptr); // free copy
                 Some(c_string)
             }
         }

--- a/rust/src/c/mod.rs
+++ b/rust/src/c/mod.rs
@@ -1,4 +1,7 @@
 //! This module and it's submodules contains code for C.
+//!
+//! The C-rust interface should follow the naming style in:
+//! http://geosoft.no/development/cppstyle.html
 
 pub mod config;
 pub mod librarydb;

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -210,7 +210,7 @@ void DefaultContentManager::initGameResouces(const std::string &stracciatellaHom
 void DefaultContentManager::addExtraResources(const std::string &baseDir, const std::string &library)
 {
 	if (!LibraryDB_AddLibrary(m_libraryDB, baseDir.c_str(), library.c_str())) {
-		auto error = get_rust_error();
+		auto error = getRustError();
 		std::string message = FormattedString(
 			"Library '%s' is not found in folder '%s': %s",
 			library.c_str(), baseDir.c_str(), error);

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -485,7 +485,7 @@ bool DefaultContentManager::doesGameResExists(char const* filename) const
 				LibraryFile* libFile = LibraryFile_open(m_libraryDB, filename);
 				if (libFile)
 				{
-					LibraryFile_Close(libFile);
+					LibraryFile_close(libFile);
 					return true;
 				}
 				return false;

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -223,7 +223,7 @@ DefaultContentManager::~DefaultContentManager()
 {
 	if(m_libraryDB)
 	{
-		LibraryDB_Delete(m_libraryDB);
+		LibraryDB_destroy(m_libraryDB);
 		m_libraryDB = nullptr;
 	}
 

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -197,7 +197,7 @@ void DefaultContentManager::initGameResouces(const std::string &stracciatellaHom
 {
 	for (auto it = libraries.begin(); it != libraries.end(); ++it)
 	{
-		if (!LibraryDB_AddLibrary(m_libraryDB, m_dataDir.c_str(), it->c_str()))
+		if (!LibraryDB_push(m_libraryDB, m_dataDir.c_str(), it->c_str()))
 		{
 			std::string message = FormattedString(
 				"Library '%s' is not found in folder '%s'.\n\nPlease make sure that '%s' contains files of the original game.  You can change this path by editing file '%s/ja2.json'.\n",
@@ -209,7 +209,7 @@ void DefaultContentManager::initGameResouces(const std::string &stracciatellaHom
 
 void DefaultContentManager::addExtraResources(const std::string &baseDir, const std::string &library)
 {
-	if (!LibraryDB_AddLibrary(m_libraryDB, baseDir.c_str(), library.c_str())) {
+	if (!LibraryDB_push(m_libraryDB, baseDir.c_str(), library.c_str())) {
 		auto error = getRustError();
 		std::string message = FormattedString(
 			"Library '%s' is not found in folder '%s': %s",

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -426,7 +426,7 @@ SGPFile* DefaultContentManager::openGameResForReading(const char* filename) cons
 				// failed to open in the data dir
 				// let's try libraries
 
-				LibraryFile* libFile = LibraryFile_Open(m_libraryDB, filename);
+				LibraryFile* libFile = LibraryFile_open(m_libraryDB, filename);
 				if (libFile)
 				{
 					SLOGD("Opened file (from library ): %s", filename);
@@ -482,7 +482,7 @@ bool DefaultContentManager::doesGameResExists(char const* filename) const
 			file = fopen(path, "rb");
 			if (!file)
 			{
-				LibraryFile* libFile = LibraryFile_Open(m_libraryDB, filename);
+				LibraryFile* libFile = LibraryFile_open(m_libraryDB, filename);
 				if (libFile)
 				{
 					LibraryFile_Close(libFile);

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -178,7 +178,7 @@ DefaultContentManager::DefaultContentManager(GameVersion gameVersion,
 	}
 #endif
 
-	m_libraryDB = LibraryDB_New();
+	m_libraryDB = LibraryDB_create();
 
 	m_bobbyRayNewInventory = NULL;
 	m_bobbyRayUsedInventory = NULL;

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -214,7 +214,7 @@ void DefaultContentManager::addExtraResources(const std::string &baseDir, const 
 		std::string message = FormattedString(
 			"Library '%s' is not found in folder '%s': %s",
 			library.c_str(), baseDir.c_str(), error);
-		free_rust_string(error);
+		CString_destroy(error);
 		throw LibraryFileNotFoundException(message);
 	}
 }

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -285,7 +285,7 @@ void Launcher::startGame(Fl_Widget* btn, void* userdata) {
 	Launcher* window = static_cast< Launcher* >( userdata );
 
 	window->writeJsonFile();
-	if (!check_if_relative_path_exists(window->gameDirectoryInput->value(), "Data", true)) {
+	if (!checkIfRelativePathExists(window->gameDirectoryInput->value(), "Data", true)) {
 		fl_message_title(window->playButton->label());
 		auto choice = fl_choice("Data dir not found.\nAre you sure you want to continue?", "Stop", "Continue", 0);
 		if (choice != 1) {
@@ -299,12 +299,12 @@ void Launcher::startEditor(Fl_Widget* btn, void* userdata) {
 	Launcher* window = static_cast< Launcher* >( userdata );
 
 	window->writeJsonFile();
-	bool has_editor_slf = check_if_relative_path_exists(window->gameDirectoryInput->value(), "Data/Editor.slf", true);
+	bool has_editor_slf = checkIfRelativePathExists(window->gameDirectoryInput->value(), "Data/Editor.slf", true);
 	if (!has_editor_slf) {
 		auto assets_dir = findPathFromAssetsDir(nullptr, false);
 		if (assets_dir) {
 			// free editor.slf
-			has_editor_slf = check_if_relative_path_exists(assets_dir, "editor.slf", true);
+			has_editor_slf = checkIfRelativePathExists(assets_dir, "editor.slf", true);
 			CString_destroy(assets_dir);
 		}
 	}

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -193,7 +193,7 @@ int Launcher::writeJsonFile() {
 }
 
 void Launcher::populateChoices() {
-	auto mods = get_available_mods();
+	auto mods = findAvailableMods();
 	auto nmods = vec_c_string_len(mods);
 	for (auto i = 0; i < nmods; ++i) {
 		auto mod = vec_c_string_get(mods, i);

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -200,7 +200,7 @@ void Launcher::populateChoices() {
 		addModMenuButton->insert(-1, mod, 0, addMod, this, 0);
 		CString_destroy(mod);
 	}
-	vec_c_string_delete(mods);
+	VecCString_destroy(mods);
 
 	for(GameVersion version : predefinedVersions) {
 		auto resourceVersionString = VanillaVersion_toString(version);

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -164,7 +164,7 @@ int Launcher::writeJsonFile() {
 
 	EngineOptions_setVanillaGameDir(this->engine_options, gameDirectoryInput->value());
 
-	clear_mods(this->engine_options);
+	EngineOptions_clearMods(this->engine_options);
 	auto nitems = modsCheckBrowser->nitems();
 	for (auto item = 1; item <= nitems; ++item) {
 		push_mod(this->engine_options, modsCheckBrowser->text(item));

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -181,7 +181,7 @@ int Launcher::writeJsonFile() {
 	auto currentScalingMode = scalingModes[this->scalingModeChoice->value()];
 	set_scaling_quality(this->engine_options, currentScalingMode);
 
-	bool success = write_engine_options(this->engine_options);
+	bool success = EngineOptions_write(this->engine_options);
 
 	if (success) {
 		update(false, nullptr);

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -162,7 +162,7 @@ int Launcher::writeJsonFile() {
 	set_start_in_fullscreen(this->engine_options, fullscreenCheckbox->value());
 	set_start_without_sound(this->engine_options, !playSoundsCheckbox->value());
 
-	set_vanilla_game_dir(this->engine_options, gameDirectoryInput->value());
+	EngineOptions_setVanillaGameDir(this->engine_options, gameDirectoryInput->value());
 
 	clear_mods(this->engine_options);
 	auto nitems = modsCheckBrowser->nitems();

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -160,7 +160,7 @@ void Launcher::initializeInputsFromDefaults() {
 
 int Launcher::writeJsonFile() {
 	EngineOptions_setStartInFullscreen(this->engine_options, fullscreenCheckbox->value());
-	set_start_without_sound(this->engine_options, !playSoundsCheckbox->value());
+	EngineOptions_setStartWithoutSound(this->engine_options, !playSoundsCheckbox->value());
 
 	EngineOptions_setVanillaGameDir(this->engine_options, gameDirectoryInput->value());
 

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -327,7 +327,7 @@ void Launcher::guessVersion(Fl_Widget* btn, void* userdata) {
 	}
 
 	auto gamedir = window->gameDirectoryInput->value();
-	auto guessedVersion = guess_resource_version(gamedir);
+	auto guessedVersion = guessResourceVersion(gamedir);
 	if (guessedVersion != -1) {
 		auto resourceVersionIndex = 0;
 		for (auto version : predefinedVersions) {

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -159,7 +159,7 @@ void Launcher::initializeInputsFromDefaults() {
 }
 
 int Launcher::writeJsonFile() {
-	set_start_in_fullscreen(this->engine_options, fullscreenCheckbox->value());
+	EngineOptions_setStartInFullscreen(this->engine_options, fullscreenCheckbox->value());
 	set_start_without_sound(this->engine_options, !playSoundsCheckbox->value());
 
 	EngineOptions_setVanillaGameDir(this->engine_options, gameDirectoryInput->value());

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -167,7 +167,7 @@ int Launcher::writeJsonFile() {
 	EngineOptions_clearMods(this->engine_options);
 	auto nitems = modsCheckBrowser->nitems();
 	for (auto item = 1; item <= nitems; ++item) {
-		push_mod(this->engine_options, modsCheckBrowser->text(item));
+		EngineOptions_pushMod(this->engine_options, modsCheckBrowser->text(item));
 	}
 
 	int x = (int)resolutionXInput->value();

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -124,7 +124,7 @@ void Launcher::initializeInputsFromDefaults() {
 	auto n = EngineOptions_getModsLength(this->engine_options);
 	modsCheckBrowser->clear();
 	for (auto i = 0; i < n; ++i) {
-		modsCheckBrowser->add(get_mod(this->engine_options, i));
+		modsCheckBrowser->add(EngineOptions_getMod(this->engine_options, i));
 	}
 
 	auto rustResVersion = get_resource_version(this->engine_options);

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -127,7 +127,7 @@ void Launcher::initializeInputsFromDefaults() {
 		modsCheckBrowser->add(EngineOptions_getMod(this->engine_options, i));
 	}
 
-	auto rustResVersion = get_resource_version(this->engine_options);
+	auto rustResVersion = EngineOptions_getResourceVersion(this->engine_options);
 	auto resourceVersionIndex = 0;
 	for (auto version : predefinedVersions) {
 		if (version == rustResVersion) {

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -143,7 +143,7 @@ void Launcher::initializeInputsFromDefaults() {
 	resolutionXInput->value(x);
 	resolutionYInput->value(y);
 
-	VideoScaleQuality quality = get_scaling_quality(this->engine_options);
+	VideoScaleQuality quality = EngineOptions_getScalingQuality(this->engine_options);
 	auto scalingModeIndex = 0;
 	for (auto scalingMode : scalingModes) {
 		if (scalingMode == quality) {

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -214,7 +214,7 @@ void Launcher::populateChoices() {
 	}
 
 	for (auto scalingMode : scalingModes) {
-		auto scalingModeString = get_scaling_quality_string(scalingMode);
+		auto scalingModeString = ScalingQuality_toString(scalingMode);
 		this->scalingModeChoice->add(scalingModeString);
 		free_rust_string(scalingModeString);
 	}

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -51,7 +51,7 @@ Launcher::Launcher(int argc, char* argv[]) : StracciatellaLauncher() {
 
 Launcher::~Launcher() {
 	if (this->engine_options) {
-		free_engine_options(this->engine_options);
+		EngineOptions_destroy(this->engine_options);
 		this->engine_options = nullptr;
 	}
 }
@@ -62,7 +62,7 @@ void Launcher::loadJa2Json() {
 	free_rust_string(rustExePath);
 
 	if (this->engine_options) {
-		free_engine_options(this->engine_options);
+		EngineOptions_destroy(this->engine_options);
 		this->engine_options = nullptr;
 	}
 	this->engine_options = EngineOptions_create(argv, argc);

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -194,7 +194,7 @@ int Launcher::writeJsonFile() {
 
 void Launcher::populateChoices() {
 	auto mods = findAvailableMods();
-	auto nmods = vec_c_string_len(mods);
+	auto nmods = VecCString_length(mods);
 	for (auto i = 0; i < nmods; ++i) {
 		auto mod = vec_c_string_get(mods, i);
 		addModMenuButton->insert(-1, mod, 0, addMod, this, 0);

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -203,7 +203,7 @@ void Launcher::populateChoices() {
 	vec_c_string_delete(mods);
 
 	for(GameVersion version : predefinedVersions) {
-		auto resourceVersionString = get_resource_version_string(version);
+		auto resourceVersionString = VanillaVersion_toString(version);
 		gameVersionInput->add(resourceVersionString);
 		free_rust_string(resourceVersionString);
     }

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -85,7 +85,7 @@ void Launcher::show() {
 	scalingModeChoice->callback( (Fl_Callback*)widgetChanged, (void*)(this) );
 	resolutionXInput->callback( (Fl_Callback*)widgetChanged, (void*)(this) );
 	resolutionYInput->callback( (Fl_Callback*)widgetChanged, (void*)(this) );
-	auto game_json_path = find_path_from_assets_dir("externalized/game.json", true);
+	auto game_json_path = findPathFromAssetsDir("externalized/game.json", true);
 	if (game_json_path) {
 		gameSettingsOutput->value(game_json_path);
 		CString_destroy(game_json_path);
@@ -301,7 +301,7 @@ void Launcher::startEditor(Fl_Widget* btn, void* userdata) {
 	window->writeJsonFile();
 	bool has_editor_slf = check_if_relative_path_exists(window->gameDirectoryInput->value(), "Data/Editor.slf", true);
 	if (!has_editor_slf) {
-		auto assets_dir = find_path_from_assets_dir(nullptr, false);
+		auto assets_dir = findPathFromAssetsDir(nullptr, false);
 		if (assets_dir) {
 			// free editor.slf
 			has_editor_slf = check_if_relative_path_exists(assets_dir, "editor.slf", true);

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -196,7 +196,7 @@ void Launcher::populateChoices() {
 	auto mods = findAvailableMods();
 	auto nmods = VecCString_length(mods);
 	for (auto i = 0; i < nmods; ++i) {
-		auto mod = vec_c_string_get(mods, i);
+		auto mod = VecCString_get(mods, i);
 		addModMenuButton->insert(-1, mod, 0, addMod, this, 0);
 		CString_destroy(mod);
 	}

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -176,7 +176,7 @@ int Launcher::writeJsonFile() {
 
 	auto currentResourceVersionIndex = gameVersionInput->value();
 	auto currentResourceVersion = predefinedVersions.at(currentResourceVersionIndex);
-	set_resource_version(this->engine_options, currentResourceVersion);
+	EngineOptions_setResourceVersion(this->engine_options, currentResourceVersion);
 
 	auto currentScalingMode = scalingModes[this->scalingModeChoice->value()];
 	set_scaling_quality(this->engine_options, currentScalingMode);

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -94,7 +94,7 @@ void Launcher::show() {
 	}
 	fullscreenCheckbox->callback( (Fl_Callback*)widgetChanged, (void*)(this) );
 	playSoundsCheckbox->callback( (Fl_Callback*)widgetChanged, (void*)(this) );
-	auto ja2_json_path = find_path_from_stracciatella_home("ja2.json", false);
+	auto ja2_json_path = findPathFromStracciatellaHome("ja2.json", false);
 	if (ja2_json_path) {
 		ja2JsonPathOutput->value(ja2_json_path);
 		CString_destroy(ja2_json_path);

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -137,7 +137,7 @@ void Launcher::initializeInputsFromDefaults() {
 	}
 	gameVersionInput->value(resourceVersionIndex);
 
-	int x = get_resolution_x(this->engine_options);
+	int x = EngineOptions_getResolutionX(this->engine_options);
 	int y = get_resolution_y(this->engine_options);
 
 	resolutionXInput->value(x);

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -121,7 +121,7 @@ void Launcher::initializeInputsFromDefaults() {
 	gameDirectoryInput->value(rustResRootPath);
 	free_rust_string(rustResRootPath);
 
-	auto n = get_number_of_mods(this->engine_options);
+	auto n = EngineOptions_getModsLength(this->engine_options);
 	modsCheckBrowser->clear();
 	for (auto i = 0; i < n; ++i) {
 		modsCheckBrowser->add(get_mod(this->engine_options, i));

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -57,7 +57,7 @@ Launcher::~Launcher() {
 }
 
 void Launcher::loadJa2Json() {
-	char* rustExePath = find_ja2_executable(argv[0]);
+	char* rustExePath = findJa2Executable(argv[0]);
 	this->exePath = std::string(rustExePath);
 	free_rust_string(rustExePath);
 

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -138,7 +138,7 @@ void Launcher::initializeInputsFromDefaults() {
 	gameVersionInput->value(resourceVersionIndex);
 
 	int x = EngineOptions_getResolutionX(this->engine_options);
-	int y = get_resolution_y(this->engine_options);
+	int y = EngineOptions_getResolutionY(this->engine_options);
 
 	resolutionXInput->value(x);
 	resolutionYInput->value(y);

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -117,7 +117,7 @@ void Launcher::show() {
 }
 
 void Launcher::initializeInputsFromDefaults() {
-	char* rustResRootPath = get_vanilla_game_dir(this->engine_options);
+	char* rustResRootPath = EngineOptions_getVanillaGameDir(this->engine_options);
 	gameDirectoryInput->value(rustResRootPath);
 	free_rust_string(rustResRootPath);
 

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -153,7 +153,7 @@ void Launcher::initializeInputsFromDefaults() {
 	}
 	this->scalingModeChoice->value(scalingModeIndex);
 
-	fullscreenCheckbox->value(should_start_in_fullscreen(this->engine_options) ? 1 : 0);
+	fullscreenCheckbox->value(EngineOptions_shouldStartInFullscreen(this->engine_options) ? 1 : 0);
 	playSoundsCheckbox->value(should_start_without_sound(this->engine_options) ? 0 : 1);
 	update(false, nullptr);
 }

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -179,7 +179,7 @@ int Launcher::writeJsonFile() {
 	EngineOptions_setResourceVersion(this->engine_options, currentResourceVersion);
 
 	auto currentScalingMode = scalingModes[this->scalingModeChoice->value()];
-	set_scaling_quality(this->engine_options, currentScalingMode);
+	EngineOptions_setScalingQuality(this->engine_options, currentScalingMode);
 
 	bool success = EngineOptions_write(this->engine_options);
 

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -172,7 +172,7 @@ int Launcher::writeJsonFile() {
 
 	int x = (int)resolutionXInput->value();
 	int y = (int)resolutionYInput->value();
-	set_resolution(this->engine_options, x, y);
+	EngineOptions_setResolution(this->engine_options, x, y);
 
 	auto currentResourceVersionIndex = gameVersionInput->value();
 	auto currentResourceVersion = predefinedVersions.at(currentResourceVersionIndex);

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -65,7 +65,7 @@ void Launcher::loadJa2Json() {
 		free_engine_options(this->engine_options);
 		this->engine_options = nullptr;
 	}
-	this->engine_options = create_engine_options(argv, argc);
+	this->engine_options = EngineOptions_create(argv, argc);
 
 	if (this->engine_options == NULL) {
 		exit(EXIT_FAILURE);

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -70,7 +70,7 @@ void Launcher::loadJa2Json() {
 	if (this->engine_options == NULL) {
 		exit(EXIT_FAILURE);
 	}
-	if (should_show_help(this->engine_options)) {
+	if (EngineOptions_shouldShowHelp(this->engine_options)) {
 		exit(EXIT_SUCCESS);
 	}
 }

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -59,7 +59,7 @@ Launcher::~Launcher() {
 void Launcher::loadJa2Json() {
 	char* rustExePath = findJa2Executable(argv[0]);
 	this->exePath = std::string(rustExePath);
-	free_rust_string(rustExePath);
+	CString_destroy(rustExePath);
 
 	if (this->engine_options) {
 		EngineOptions_destroy(this->engine_options);
@@ -88,7 +88,7 @@ void Launcher::show() {
 	auto game_json_path = find_path_from_assets_dir("externalized/game.json", true);
 	if (game_json_path) {
 		gameSettingsOutput->value(game_json_path);
-		free_rust_string(game_json_path);
+		CString_destroy(game_json_path);
 	} else {
 		gameSettingsOutput->value("failed to find path to game.json");
 	}
@@ -97,7 +97,7 @@ void Launcher::show() {
 	auto ja2_json_path = find_path_from_stracciatella_home("ja2.json", false);
 	if (ja2_json_path) {
 		ja2JsonPathOutput->value(ja2_json_path);
-		free_rust_string(ja2_json_path);
+		CString_destroy(ja2_json_path);
 	} else {
 		ja2JsonPathOutput->value("failed to find path to ja2.json");
 	}
@@ -119,7 +119,7 @@ void Launcher::show() {
 void Launcher::initializeInputsFromDefaults() {
 	char* rustResRootPath = EngineOptions_getVanillaGameDir(this->engine_options);
 	gameDirectoryInput->value(rustResRootPath);
-	free_rust_string(rustResRootPath);
+	CString_destroy(rustResRootPath);
 
 	auto n = EngineOptions_getModsLength(this->engine_options);
 	modsCheckBrowser->clear();
@@ -198,14 +198,14 @@ void Launcher::populateChoices() {
 	for (auto i = 0; i < nmods; ++i) {
 		auto mod = vec_c_string_get(mods, i);
 		addModMenuButton->insert(-1, mod, 0, addMod, this, 0);
-		free_rust_string(mod);
+		CString_destroy(mod);
 	}
 	vec_c_string_delete(mods);
 
 	for(GameVersion version : predefinedVersions) {
 		auto resourceVersionString = VanillaVersion_toString(version);
 		gameVersionInput->add(resourceVersionString);
-		free_rust_string(resourceVersionString);
+		CString_destroy(resourceVersionString);
     }
 	for (auto res : predefinedResolutions) {
 		char resolutionString[255];
@@ -216,7 +216,7 @@ void Launcher::populateChoices() {
 	for (auto scalingMode : scalingModes) {
 		auto scalingModeString = ScalingQuality_toString(scalingMode);
 		this->scalingModeChoice->add(scalingModeString);
-		free_rust_string(scalingModeString);
+		CString_destroy(scalingModeString);
 	}
 }
 
@@ -305,7 +305,7 @@ void Launcher::startEditor(Fl_Widget* btn, void* userdata) {
 		if (assets_dir) {
 			// free editor.slf
 			has_editor_slf = check_if_relative_path_exists(assets_dir, "editor.slf", true);
-			free_rust_string(assets_dir);
+			CString_destroy(assets_dir);
 		}
 	}
 	if (!has_editor_slf) {

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -154,7 +154,7 @@ void Launcher::initializeInputsFromDefaults() {
 	this->scalingModeChoice->value(scalingModeIndex);
 
 	fullscreenCheckbox->value(EngineOptions_shouldStartInFullscreen(this->engine_options) ? 1 : 0);
-	playSoundsCheckbox->value(should_start_without_sound(this->engine_options) ? 0 : 1);
+	playSoundsCheckbox->value(EngineOptions_shouldStartWithoutSound(this->engine_options) ? 0 : 1);
 	update(false, nullptr);
 }
 

--- a/src/launcher/main.cc
+++ b/src/launcher/main.cc
@@ -5,7 +5,7 @@
 #include "RustInterface.h"
 
 int main(int argc, char* argv[]) {
-	Logger_Init("ja2-launcher.log");
+	Logger_initialize("ja2-launcher.log");
 
 	Launcher launcher(argc, argv);
 	launcher.loadJa2Json();

--- a/src/sgp/FileMan.cc
+++ b/src/sgp/FileMan.cc
@@ -215,7 +215,7 @@ void FileRead(SGPFile* const f, void* const pDest, size_t const uiBytesToRead)
 	}
 	else
 	{
-		ret = LibraryFile_Read(f->u.lib, static_cast<uint8_t *>(pDest), uiBytesToRead);
+		ret = LibraryFile_read(f->u.lib, static_cast<uint8_t *>(pDest), uiBytesToRead);
 	}
 
 	if (!ret) throw std::runtime_error("Reading from file failed");

--- a/src/sgp/FileMan.cc
+++ b/src/sgp/FileMan.cc
@@ -345,7 +345,7 @@ UINT32 FileGetSize(const SGPFile* f)
 	}
 	else
 	{
-		return (UINT32)LibraryFile_GetSize(f->u.lib);
+		return (UINT32)LibraryFile_getSize(f->u.lib);
 	}
 }
 

--- a/src/sgp/FileMan.cc
+++ b/src/sgp/FileMan.cc
@@ -201,7 +201,7 @@ void FileClose(SGPFile* f)
 	}
 	else
 	{
-		LibraryFile_Close(f->u.lib);
+		LibraryFile_close(f->u.lib);
 	}
 	MemFree(f);
 }

--- a/src/sgp/FileMan.cc
+++ b/src/sgp/FileMan.cc
@@ -320,7 +320,7 @@ void FileSeek(SGPFile* const f, INT32 distance, FileSeekMode const how)
 	}
 	else
 	{
-		success = LibraryFile_Seek(f->u.lib, distance, how);
+		success = LibraryFile_seek(f->u.lib, distance, how);
 	}
 	if (!success) throw std::runtime_error("Seek in file failed");
 }

--- a/src/sgp/FileMan.cc
+++ b/src/sgp/FileMan.cc
@@ -328,7 +328,7 @@ void FileSeek(SGPFile* const f, INT32 distance, FileSeekMode const how)
 
 INT32 FileGetPos(const SGPFile* f)
 {
-	return f->flags & SGPFILE_REAL ? (INT32)ftell(f->u.file) : (INT32)LibraryFile_GetPos(f->u.lib);
+	return f->flags & SGPFILE_REAL ? (INT32)ftell(f->u.file) : (INT32)LibraryFile_getPosition(f->u.lib);
 }
 
 

--- a/src/sgp/Logger.cc
+++ b/src/sgp/Logger.cc
@@ -19,7 +19,7 @@ void LogMessage(bool isAssert, LogLevel level, const char *file, const char *for
   vsnprintf(message, 256, format, args);
   va_end(args);
 
-  Logger_LogWithCustomMetadata(level, message, file);
+  Logger_log(level, message, file);
 
   #ifdef ENABLE_ASSERTS
     if (isAssert)

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -330,7 +330,7 @@ int main(int argc, char* argv[])
 #endif
 	}
 
-	GameVersion version = get_resource_version(params);
+	GameVersion version = EngineOptions_getResourceVersion(params);
 	setGameVersion(version);
 
 	VideoScaleQuality scalingQuality = get_scaling_quality(params);

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -291,7 +291,7 @@ int main(int argc, char* argv[])
 		VideoSetFullScreen(FALSE);
 	}
 
-	if (should_start_without_sound(params)) {
+	if (EngineOptions_shouldStartWithoutSound(params)) {
 		SoundEnableSound(FALSE);
 	}
 

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -281,7 +281,7 @@ int main(int argc, char* argv[])
 		return EXIT_FAILURE;
 	}
 
-	if (should_show_help(params)) {
+	if (EngineOptions_shouldShowHelp(params)) {
 		return EXIT_SUCCESS;
 	}
 

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -358,7 +358,7 @@ int main(int argc, char* argv[])
 
 	SLOGD("Initializing Game Resources");
 	char* rustConfigFolderPath = EngineOptions_getStracciatellaHome(params);
-	char* rustResRootPath = get_vanilla_game_dir(params);
+	char* rustResRootPath = EngineOptions_getVanillaGameDir(params);
 	std::string configFolderPath = std::string(rustConfigFolderPath);
 	std::string gameResRootPath = std::string(rustResRootPath);
 	free_rust_string(rustConfigFolderPath);

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -310,7 +310,7 @@ int main(int argc, char* argv[])
 		GameState::getInstance()->setDebugging(true);
 	}
 
-	if (should_run_editor(params)) {
+	if (EngineOptions_shouldRunEditor(params)) {
 		GameState::getInstance()->setEditorMode(false);
 	}
 
@@ -428,7 +428,7 @@ int main(int argc, char* argv[])
 	cm->initGameResouces(configFolderPath, libraries);
 
 	// free editor.slf has the lowest priority (last library) and is optional
-	if(should_run_editor(params))
+	if(EngineOptions_shouldRunEditor(params))
 	{
 		try
 		{

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -357,7 +357,7 @@ int main(int argc, char* argv[])
 	InitializeMemoryManager();
 
 	SLOGD("Initializing Game Resources");
-	char* rustConfigFolderPath = get_stracciatella_home(params);
+	char* rustConfigFolderPath = EngineOptions_getStracciatellaHome(params);
 	char* rustResRootPath = get_vanilla_game_dir(params);
 	std::string configFolderPath = std::string(rustConfigFolderPath);
 	std::string gameResRootPath = std::string(rustResRootPath);

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -441,7 +441,7 @@ int main(int argc, char* argv[])
 		}
 	}
 
-	free_engine_options(params);
+	EngineOptions_destroy(params);
 	params = nullptr;
 
 	if(!cm->loadGameData())

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -361,8 +361,8 @@ int main(int argc, char* argv[])
 	char* rustResRootPath = EngineOptions_getVanillaGameDir(params);
 	std::string configFolderPath = std::string(rustConfigFolderPath);
 	std::string gameResRootPath = std::string(rustResRootPath);
-	free_rust_string(rustConfigFolderPath);
-	free_rust_string(rustResRootPath);
+	CString_destroy(rustConfigFolderPath);
+	CString_destroy(rustResRootPath);
 
 	std::string extraDataDir = EXTRA_DATA_DIR;
 	if(extraDataDir.empty())
@@ -386,7 +386,7 @@ int main(int argc, char* argv[])
 		{
 			char* rustModName = EngineOptions_getMod(params, i);
 			std::string modName(rustModName);
-			free_rust_string(rustModName);
+			CString_destroy(rustModName);
 			std::string modResFolder = FileMan::joinPaths(FileMan::joinPaths(FileMan::joinPaths(extraDataDir, "mods"), modName), "data");
 			modNames.emplace_back(modName);
 			modResFolders.emplace_back(modResFolder);

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -306,7 +306,7 @@ int main(int argc, char* argv[])
 	}
 
 	if (EngineOptions_shouldStartInDebugMode(params)) {
-		Logger_SetLevel(LogLevel::Debug);
+		Logger_setLevel(LogLevel::Debug);
 		GameState::getInstance()->setDebugging(true);
 	}
 

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -377,7 +377,7 @@ int main(int argc, char* argv[])
 
 	DefaultContentManager *cm;
 
-	auto n = get_number_of_mods(params);
+	auto n = EngineOptions_getModsLength(params);
 	if(n > 0)
 	{
 		std::vector<std::string> modNames;

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -287,7 +287,7 @@ int main(int argc, char* argv[])
 
 	if (EngineOptions_shouldStartInFullscreen(params)) {
 		VideoSetFullScreen(TRUE);
-	} else if (should_start_in_window(params)) {
+	} else if (EngineOptions_shouldStartInWindow(params)) {
 		VideoSetFullScreen(FALSE);
 	}
 

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -384,7 +384,7 @@ int main(int argc, char* argv[])
 		std::vector<std::string> modResFolders;
 		for (auto i = 0; i < n; ++i)
 		{
-			char* rustModName = get_mod(params, i);
+			char* rustModName = EngineOptions_getMod(params, i);
 			std::string modName(rustModName);
 			free_rust_string(rustModName);
 			std::string modResFolder = FileMan::joinPaths(FileMan::joinPaths(FileMan::joinPaths(extraDataDir, "mods"), modName), "data");

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -314,10 +314,10 @@ int main(int argc, char* argv[])
 		GameState::getInstance()->setEditorMode(false);
 	}
 
-	bool result = g_ui.setScreenSize(EngineOptions_getResolutionX(params), get_resolution_y(params));
+	bool result = g_ui.setScreenSize(EngineOptions_getResolutionX(params), EngineOptions_getResolutionY(params));
 	if(!result)
 	{
-		SLOGE("Failed to set screen resolution %d x %d", EngineOptions_getResolutionX(params), get_resolution_y(params));
+		SLOGE("Failed to set screen resolution %d x %d", EngineOptions_getResolutionX(params), EngineOptions_getResolutionY(params));
 		return EXIT_FAILURE;
 	}
 

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -333,7 +333,7 @@ int main(int argc, char* argv[])
 	GameVersion version = EngineOptions_getResourceVersion(params);
 	setGameVersion(version);
 
-	VideoScaleQuality scalingQuality = get_scaling_quality(params);
+	VideoScaleQuality scalingQuality = EngineOptions_getScalingQuality(params);
 
 	FLOAT brightness = EngineOptions_getBrightness(params);
 

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -305,7 +305,7 @@ int main(int argc, char* argv[])
 		SoundEnableSound(FALSE);
 	}
 
-	if (should_start_in_debug_mode(params)) {
+	if (EngineOptions_shouldStartInDebugMode(params)) {
 		Logger_SetLevel(LogLevel::Debug);
 		GameState::getInstance()->setDebugging(true);
 	}

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -274,7 +274,7 @@ int main(int argc, char* argv[])
 #endif
 
 	// init logging
-	Logger_Init("ja2.log");
+	Logger_initialize("ja2.log");
 
 	EngineOptions* params = EngineOptions_create(argv, argc);
 	if (params == NULL) {

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -285,7 +285,7 @@ int main(int argc, char* argv[])
 		return EXIT_SUCCESS;
 	}
 
-	if (should_start_in_fullscreen(params)) {
+	if (EngineOptions_shouldStartInFullscreen(params)) {
 		VideoSetFullScreen(TRUE);
 	} else if (should_start_in_window(params)) {
 		VideoSetFullScreen(FALSE);

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -314,10 +314,10 @@ int main(int argc, char* argv[])
 		GameState::getInstance()->setEditorMode(false);
 	}
 
-	bool result = g_ui.setScreenSize(get_resolution_x(params), get_resolution_y(params));
+	bool result = g_ui.setScreenSize(EngineOptions_getResolutionX(params), get_resolution_y(params));
 	if(!result)
 	{
-		SLOGE("Failed to set screen resolution %d x %d", get_resolution_x(params), get_resolution_y(params));
+		SLOGE("Failed to set screen resolution %d x %d", EngineOptions_getResolutionX(params), get_resolution_y(params));
 		return EXIT_FAILURE;
 	}
 

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -335,7 +335,7 @@ int main(int argc, char* argv[])
 
 	VideoScaleQuality scalingQuality = get_scaling_quality(params);
 
-	FLOAT brightness = get_brightness(params);
+	FLOAT brightness = EngineOptions_getBrightness(params);
 
 	////////////////////////////////////////////////////////////
 

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -276,7 +276,7 @@ int main(int argc, char* argv[])
 	// init logging
 	Logger_Init("ja2.log");
 
-	EngineOptions* params = create_engine_options(argv, argc);
+	EngineOptions* params = EngineOptions_create(argv, argc);
 	if (params == NULL) {
 		return EXIT_FAILURE;
 	}

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -321,7 +321,7 @@ int main(int argc, char* argv[])
 		return EXIT_FAILURE;
 	}
 
-	if (should_run_unittests(params)) {
+	if (EngineOptions_shouldRunUnittests(params)) {
 #ifdef WITH_UNITTESTS
 		testing::InitGoogleTest(&argc, argv);
 		return RUN_ALL_TESTS();


### PR DESCRIPTION
Rename C-rust interface functions according to http://geosoft.no/development/cppstyle.html

The C-rust interface is an interface to rust code that is only used in C/C++.
Therefore it should try to use the recommended naming style of C++, which we have not defined.
#863 is an attempt to define a "last resort" recommended naming style (when there is no old code to reference).

Feel free to voice complaints about the names.
I just want a consistent naming style and can redo the PR.

Split from: #855