### PR TITLE
Set locale at the start

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ option(WITH_FIXMES "Build with fixme messages" OFF)
 option(WITH_MAEMO "Build with right click mapped to F4 (menu button)" OFF)
 option(BUILD_LAUNCHER "Build the ja2 launcher application" ON)
 option(WITH_EDITOR_SLF "Include the latest free editor.slf" OFF)
+set(WITH_CUSTOM_LOCALE "" CACHE STRING "Set a custom locale at the start, leave empty to disable")
 
 set(EXTERNAL_PROJECT_CMAKE_ARGS
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
@@ -61,12 +62,16 @@ set(EXTERNAL_PROJECT_CMAKE_ARGS
     -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=${CMAKE_FIND_ROOT_PATH_MODE_INCLUDE}
 )
 
+## Build
+
 if(MSVC)
 	# set the source and execution charset
 	add_compile_options("/utf-8")
 endif()
 
-## Build
+if(NOT "${WITH_CUSTOM_LOCALE}" STREQUAL "")
+    add_definitions("-DWITH_CUSTOM_LOCALE=\"${WITH_CUSTOM_LOCALE}\"")
+endif()
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "")
 


### PR DESCRIPTION
This is an attempt to fix #485 and fix #487.

According to  https://stackoverflow.com/a/15440423, the wchar_t representation  is  platform-dependent  and  locale-dependent.

In particular, the LC_CTYPE category of the locale at compile time and at run time should be the same.

~This PR will attempt to make them match.~

This PR sets a unicode locale at the start, which hopefully means it can handle the characters of all game languages. (our linux and mac builders have a utf-8 locales)