### PR TITLE
Add RustPointer

### DIFF
--- a/rust/stracciatella_c_api/cbindgen.toml
+++ b/rust/stracciatella_c_api/cbindgen.toml
@@ -1,7 +1,10 @@
 autogen_warning = "/* DO NOT MODIFY MANUALLY! Changes will be discarded during build. */"
-include_guard = "stracciatella_h"
 include_version = true
 language = "C++"
+
+# Top of stracciatella.h
+header = '''
+#pragma once'''
 
 [parse]
 parse_deps = true

--- a/rust/stracciatella_c_api/cbindgen.toml
+++ b/rust/stracciatella_c_api/cbindgen.toml
@@ -1,14 +1,38 @@
 autogen_warning = "/* DO NOT MODIFY MANUALLY! Changes will be discarded during build. */"
 include_version = true
 language = "C++"
+sys_includes = [
+    # std::unique_ptr
+    "memory",
+]
 
 # Top of stracciatella.h
 header = '''
 #pragma once'''
 
+# Bottom of stracciatella.h
+trailer = '''
+/// Callable that deletes rust memory.
+struct RustDelete
+{
+	void operator()(char* ptr) const { CString_destroy(ptr); }
+	void operator()(EngineOptions* ptr) const { EngineOptions_destroy(ptr); }
+	void operator()(LibraryDB* ptr) const { LibraryDB_destroy(ptr); }
+	void operator()(LibraryFile* ptr) const { LibraryFile_close(ptr); }
+	void operator()(VecCString* ptr) const { VecCString_destroy(ptr); }
+};
+
+/// Alias to a std::unique_ptr that deletes with RustDelete.
+///
+/// By using this alias you are delegating memory management to the C++ compiler.
+template<typename T>
+using RustPointer = std::unique_ptr<T, RustDelete>;'''
+
+
 [parse]
 parse_deps = true
 include = ["stracciatella"]
+
 
 [export]
 exclude = [

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -179,7 +179,7 @@ protected:
 	const IMPPolicy *m_impPolicy;
 	const GamePolicy *m_gamePolicy;
 
-	LibraryDB *m_libraryDB;
+	RustPointer<LibraryDB> m_libraryDB;
 
 	bool loadWeapons();
 	bool loadMagazines();

--- a/src/launcher/Launcher.h
+++ b/src/launcher/Launcher.h
@@ -17,7 +17,7 @@ private:
 	int argc;
 	char** argv;
 	std::string exePath;
-	EngineOptions* engine_options;
+	RustPointer<EngineOptions> engine_options;
 
 	void populateChoices();
 	void startExecutable(bool asEditor);


### PR DESCRIPTION
Manually freeing rust memory is an easy recipe for resource/memory leaks, specially when exceptions are involved.

This PR introduces the use of `std::unique_ptr` with a custom deleter, aliased as `RustPointer`.
`SGPFile` is excluded because it feels unsafe to put `RustPointer` there.