### PR TITLE
Trigger daily coverity builds as well

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,28 +1,28 @@
-name: Nightly trigger
+name: Coverity trigger
 
 on:
   schedule:
-    - cron:  '0 2 * * *'
+    - cron:  '0 3 * * *'
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     steps:
-    - name: Checkout nightly
+    - name: Checkout coverity
       uses: actions/checkout@v1
       with:
-        ref: nightly
-    - name: Update nightly
+        ref: coverity
+    - name: Update coverity
       run: |
         # user and email are required for pushing
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         # fast forward to current master
         git merge origin/master --ff-only
-    - name: Push nightly
+    - name: Push coverity
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: nightly
+        branch: coverity

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ branches:
   only:
     - master
     - nightly
+    - coverity
 
 before_install:
   - export PUBLISH_BINARY="false"
@@ -128,7 +129,7 @@ addons:
     notification_email: github@stefanlau.com
     build_command_prepend: "mkdir coverage-build && cd coverage-build && cmake .."
     build_command:   "make"
-    branch_pattern: coverity-via-travis
+    branch_pattern: coverity
 
 env:
   global:


### PR DESCRIPTION
According to https://scan.coverity.com/faq#frequency we have minimum 1 build a day, so we can trigger a coverity build similarily to nightlies every day. Now we can think about how to make the results of the scan more visible to developers (us).

~Ref: https://scan.coverity.com/projects/ja2-stracciatella~
Ref: https://scan.coverity.com/projects/ja2-stracciatella-ja2-stracciatella