### PR TITLE
Remove SOURCE_PATH_SIZE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,6 @@ add_definitions(-DEXTRA_DATA_DIR="${EXTRA_DATA_DIR}")
 message(STATUS "Setting directory for libraries to" "${INSTALL_LIB_DIR}")
 add_definitions(-DINSTALL_LIB_DIR="${INSTALL_LIB_DIR}")
 
-string(LENGTH "${CMAKE_SOURCE_DIR}/src/" SOURCE_PATH_SIZE)
-add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
-
 if (WITH_FIXMES)
     message(STATUS "Building with fixme messages" )
     add_definitions(-DWITH_FIXMES)

--- a/rust/stracciatella_c_api/src/c/logger.rs
+++ b/rust/stracciatella_c_api/src/c/logger.rs
@@ -26,5 +26,9 @@ pub extern "C" fn Logger_log(level: LogLevel, message: *const c_char, target: *c
     let message = str_from_c_str_or_panic(unsafe_c_str(message));
     let target = str_from_c_str_or_panic(unsafe_c_str(target));
 
-    Logger::log_with_custom_metadata(level, message, target);
+    let mut target = target.replace("\\", "/");
+    if let Some(subpath) = target.rsplit("/src/").next() {
+        target = subpath.to_owned();
+    }
+    Logger::log_with_custom_metadata(level, message, &target);
 }

--- a/src/sgp/Logger.h
+++ b/src/sgp/Logger.h
@@ -2,21 +2,19 @@
 
 #include "RustInterface.h"
 
-#define __FILENAME__ (__FILE__ + SOURCE_PATH_SIZE)
-
 void LogMessage(bool isAssert, LogLevel level, const char *file, const char *format, ...);
 
 /** Print debug message macro. */
-#define SLOGD(FORMAT, ...) LogMessage(false, LogLevel::Debug, __FILENAME__, FORMAT, ##__VA_ARGS__)
+#define SLOGD(FORMAT, ...) LogMessage(false, LogLevel::Debug, __FILE__, FORMAT, ##__VA_ARGS__)
 
 /** Print info message macro. */
-#define SLOGI(FORMAT, ...) LogMessage(false, LogLevel::Info,  __FILENAME__, FORMAT, ##__VA_ARGS__)
+#define SLOGI(FORMAT, ...) LogMessage(false, LogLevel::Info,  __FILE__, FORMAT, ##__VA_ARGS__)
 
 /** Print warning message macro. */
-#define SLOGW(FORMAT, ...) LogMessage(false, LogLevel::Warn, __FILENAME__, FORMAT, ##__VA_ARGS__)
+#define SLOGW(FORMAT, ...) LogMessage(false, LogLevel::Warn, __FILE__, FORMAT, ##__VA_ARGS__)
 
 /** Print error message macro. */
-#define SLOGE(FORMAT, ...) LogMessage(false, LogLevel::Error, __FILENAME__, FORMAT, ##__VA_ARGS__)
+#define SLOGE(FORMAT, ...) LogMessage(false, LogLevel::Error, __FILE__, FORMAT, ##__VA_ARGS__)
 
 /** Print error message macro. */
-#define SLOGA(FORMAT, ...) LogMessage(true, LogLevel::Error, __FILENAME__, FORMAT, ##__VA_ARGS__)
+#define SLOGA(FORMAT, ...) LogMessage(true, LogLevel::Error, __FILE__, FORMAT, ##__VA_ARGS__)


### PR DESCRIPTION
An absolute path is assumed but it might be relative.

Coverity was marking it as "Illegal address computation (OVERRUN)" because it was relative there.

Introduced in: #844