### PR TITLE
Convert canonicalized UNC paths to normal paths when possible

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -250,6 +250,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "either"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +666,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dunce 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "json_comments 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -857,6 +863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+"checksum dunce 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0ad6bf6a88548d1126045c413548df1453d9be094a8ab9fd59bf1fdd338da4f"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"

--- a/rust/stracciatella/Cargo.toml
+++ b/rust/stracciatella/Cargo.toml
@@ -32,6 +32,7 @@ caseless = "0.2"
 log = "0.4"
 simplelog = "0.6"
 rayon = "1.1.0"
+dunce = "1"
 
 [dependencies.clap]
 optional = true

--- a/rust/stracciatella/src/config/cli.rs
+++ b/rust/stracciatella/src/config/cli.rs
@@ -1,6 +1,5 @@
 //! This module contains code to read command line arguments for the ja2 executable
 
-use std::fs;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -8,6 +7,7 @@ use getopts::Options;
 use log::warn;
 
 use crate::config::{EngineOptions, Resolution, VanillaVersion};
+use crate::fs::canonicalize;
 
 #[cfg(not(windows))]
 static GAME_DIR_OPTION_EXAMPLE: &str = "/opt/ja2";
@@ -105,7 +105,7 @@ impl Cli {
                 }
 
                 if let Some(s) = m.opts_str(&["gamedir".to_owned(), "datadir".to_owned()]) {
-                    match fs::canonicalize(PathBuf::from(s)) {
+                    match canonicalize(PathBuf::from(s)) {
                         Ok(s) => {
                             let mut temp = String::from(s.to_str().expect("Should not happen"));
                             // remove UNC path prefix (Windows)

--- a/rust/stracciatella/src/fs.rs
+++ b/rust/stracciatella/src/fs.rs
@@ -1,0 +1,9 @@
+//! This module contains code to interact with the filesystem.
+
+use dunce;
+
+/// Returns the canonical, absolute form of a path with all intermediate
+/// components normalized and symbolic links resolved.
+///
+/// On windows, UNC paths are converted to normal paths when possible.
+pub use dunce::canonicalize;

--- a/rust/stracciatella/src/stracciatella.rs
+++ b/rust/stracciatella/src/stracciatella.rs
@@ -6,6 +6,7 @@
 
 pub mod config;
 pub mod file_formats;
+pub mod fs;
 pub mod guess;
 pub mod json;
 pub mod librarydb;
@@ -19,6 +20,7 @@ use std::path::PathBuf;
 use log::warn;
 
 use crate::config::{Cli, EngineOptions, Ja2Json};
+use crate::fs::canonicalize;
 
 fn parse_args(engine_options: &mut EngineOptions, args: &[String]) -> Option<String> {
     let cli = Cli::from_args(args);
@@ -48,7 +50,7 @@ pub fn get_assets_dir() -> PathBuf {
             return extra_data_dir.into();
         }
     }
-    match std::env::current_exe().and_then(|x| x.canonicalize()) {
+    match std::env::current_exe().and_then(canonicalize) {
         Ok(exe) => {
             // use directory of the executable
             if let Some(dir) = exe.parent() {
@@ -210,7 +212,7 @@ mod tests {
         assert_eq!(parse_args(&mut engine_options, &input), None);
         let comp = engine_options.vanilla_game_dir;
         let base =
-            fs::canonicalize(temp_dir.path()).expect("Problem during building of reference value.");
+            canonicalize(temp_dir.path()).expect("Problem during building of reference value.");
 
         assert_eq!(comp, base);
     }

--- a/rust/stracciatella_c_api/src/c/misc.rs
+++ b/rust/stracciatella_c_api/src/c/misc.rs
@@ -7,6 +7,7 @@ use std::path::{Component, PathBuf};
 use std::ptr;
 
 use stracciatella::config::find_stracciatella_home;
+use stracciatella::fs::canonicalize;
 use stracciatella::get_assets_dir;
 use stracciatella::guess::guess_vanilla_version;
 use stracciatella::unicode::Nfc;
@@ -91,7 +92,7 @@ pub extern "C" fn findPathFromStracciatellaHome(
         if test_exists && !path_buf.exists() {
             ptr::null_mut() // path not found
         } else {
-            if let Ok(p) = path_buf.canonicalize() {
+            if let Ok(p) = canonicalize(&path_buf) {
                 path_buf = p;
             }
             let s: String = path_buf.to_string_lossy().into();

--- a/rust/stracciatella_c_api/src/c/misc.rs
+++ b/rust/stracciatella_c_api/src/c/misc.rs
@@ -65,7 +65,7 @@ pub extern "C" fn findPathFromAssetsDir(path: *const c_char, test_exists: bool) 
     let mut path_buf = get_assets_dir();
     if !path.is_null() {
         let path = path_from_c_str_or_panic(unsafe_c_str(path));
-        path_buf.push(&path);
+        path.components().for_each(|x| path_buf.push(x));
     }
     if test_exists && !path_buf.exists() {
         ptr::null_mut()
@@ -86,8 +86,8 @@ pub extern "C" fn findPathFromStracciatellaHome(
 ) -> *mut c_char {
     if let Ok(mut path_buf) = find_stracciatella_home() {
         if !path.is_null() {
-            let s = str_from_c_str_or_panic(unsafe_c_str(path));
-            path_buf.push(&s);
+            let path = path_from_c_str_or_panic(unsafe_c_str(path));
+            path.components().for_each(|x| path_buf.push(x));
         }
         if test_exists && !path_buf.exists() {
             ptr::null_mut() // path not found
@@ -115,7 +115,7 @@ pub extern "C" fn checkIfRelativePathExists(
     let path: PathBuf = path_from_c_str_or_panic(unsafe_c_str(path)).to_owned();
     let mut buf = base;
     if !caseless {
-        buf.push(path);
+        path.components().for_each(|x| buf.push(x));
         return buf.exists();
     }
     'outer: for component in path.components() {


### PR DESCRIPTION
On windows the launcher couldn't find the path to `game.json` because the canonicalized base path was in UNC form and the relative part had a `/` path separator.

With a normal base path it works as expected, so crate [dunce](https://crates.io/crates/dunce) is being used to turn UNC paths into normal paths when possible.

Referencce: https://github.com/rust-lang/rust/issues/65397
