### PR TITLE
Make GetAPsToAutoReload agree with AutoReload

### DIFF
--- a/src/game/Tactical/Points.cc
+++ b/src/game/Tactical/Points.cc
@@ -1447,12 +1447,16 @@ INT8 GetAPsToAutoReload( SOLDIERTYPE * pSoldier )
 	if (GCM->getItem(pObj->usItem)->getItemClass() == IC_GUN || GCM->getItem(pObj->usItem)->getItemClass() == IC_LAUNCHER)
 	{
 		bSlot = FindAmmoToReload( pSoldier, HANDPOS, NO_SLOT );
-		if (bSlot != NO_SLOT)
+		if (bSlot == NO_SLOT)
 		{
-			// we would reload using this ammo!
-			bAPCost += GetAPsToReloadGunWithAmmo( pObj, &(pSoldier->inv[bSlot] ) );
+			// we would not reload
+			return( 0 );
 		}
 
+		// we would reload using this ammo!
+		bAPCost += GetAPsToReloadGunWithAmmo( pObj, &(pSoldier->inv[bSlot] ) );
+		// if we are valid for two-pistol shooting (reloading) and we have enough APs still
+		// then we would do a reload of both guns!
 		if ( IsValidSecondHandShotForReloadingPurposes( pSoldier ) )
 		{
 			pObj = &(pSoldier->inv[SECONDHANDPOS]);


### PR DESCRIPTION
Coverity detected "Negative array index read (NEGATIVE_RETURNS)" in `GetAPsToAutoReload` when we can't find ammo for the first gun and check if that ammo is compatible with the second gun:

https://github.com/ja2-stracciatella/ja2-stracciatella/blob/36148be0d0d9196050c12799c884af9eda7cb256/src/game/Tactical/Points.cc#L1463

`AutoReload` only reloads the second gun if the first one reloads so here we enforce the same behavior, avoiding the check.