### PR TITLE
Fix memory leak in NewDirective

### DIFF
--- a/src/game/Strategic/Creature_Spreading.cc
+++ b/src/game/Strategic/Creature_Spreading.cc
@@ -134,11 +134,11 @@ static CREATURE_DIRECTIVE* NewDirective(UINT8 ubSectorID, UINT8 ubSectorZ, UINT8
 	{
 		SLOGA("Could not find underground sector node (%c%db_%d) that should exist.",
 			ubSectorY + 'A' - 1, ubSectorX, ubSectorZ);
+		MemFree(curr);
 		return 0;
 	}
 
 	curr->pLevel->ubCreatureHabitat = ubCreatureHabitat;
-	Assert( curr->pLevel );
 	curr->next = NULL;
 	return curr;
 }


### PR DESCRIPTION
Coverity detected "Resource leak (RESOURCE_LEAK)" in `NewDirective`.
The memory of variable `curr` was being leaked when we can't find the underground sector node.