### PR TITLE
Remove constant expression in HandleTalkingSpeck

### DIFF
--- a/src/game/Laptop/Mercs.cc
+++ b/src/game/Laptop/Mercs.cc
@@ -886,10 +886,11 @@ static void HandleTalkingSpeck(void)
 				gsSpeckDialogueTextPopUp[0] = '\0';
 
 				//Start speck talking
-				if( gusMercVideoSpeckSpeech != MERC_VIDEO_SPECK_SPEECH_NOT_TALKING || 	gusMercVideoSpeckSpeech != MERC_VIDEO_SPECK_HAS_TO_TALK_BUT_QUOTE_NOT_CHOSEN_YET )
-					StartSpeckTalking( gusMercVideoSpeckSpeech );
+				if( !StartSpeckTalking( gusMercVideoSpeckSpeech ) )
+				{
+					gusMercVideoSpeckSpeech = MERC_VIDEO_SPECK_SPEECH_NOT_TALKING;
+				}
 
-				gusMercVideoSpeckSpeech = MERC_VIDEO_SPECK_SPEECH_NOT_TALKING;
 				gubCurrentMercVideoMode = MERC_VIDEO_VIDEO_MODE;
 			}
 			break;


### PR DESCRIPTION
This is equivalent code.

Coverity complained that the `if` test was always true.
`StartSpeckTalking` already checks for the tested values and sets `gusMercVideoSpeckSpeech` to the value we want if they pass.
To make it equivalent we just set `gusMercVideoSpeckSpeech` on failure.