### PR TITLE
Fix copy-paste error in DrawMap with zoom enabled.

### DIFF
--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -617,7 +617,7 @@ void DrawMap(void)
 			UINT16 const src_w = guiBIGMAP->Width();
 			UINT16 const src_h = guiBIGMAP->Height();
 			if (w > src_w - x) w = src_w - x;
-			if (h > src_h - x) h = src_h - y;
+			if (h > src_h - y) h = src_h - y;
 			SGPBox const clip = { x, y, w, h };
 			BltVideoSurface(guiSAVEBUFFER, guiBIGMAP, MAP_VIEW_START_X + MAP_GRID_X, MAP_VIEW_START_Y + MAP_GRID_Y - 2, &clip);
 		}


### PR DESCRIPTION
Coverity complained it was a copy-paste error and I agree.

The code that enables zoom is commented out since the original version.
Maybe they were hunting down this hard to spot bug?