### PR TITLE
Add function to resolve caseless path to caseful variant

### DIFF
--- a/rust/stracciatella/src/config/ja2_json.rs
+++ b/rust/stracciatella/src/config/ja2_json.rs
@@ -6,8 +6,10 @@ use std::path::PathBuf;
 
 use log::warn;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 use crate::config::{EngineOptions, Resolution, ScalingQuality, VanillaVersion};
+use crate::fs::resolve_existing_components;
 use crate::json;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -31,9 +33,7 @@ pub struct Ja2Json {
 }
 
 fn build_json_config_location(stracciatella_home: &PathBuf) -> PathBuf {
-    let mut path = PathBuf::from(stracciatella_home);
-    path.push("ja2.json");
-    path
+    resolve_existing_components(&Path::new("ja2.json"), Some(&stracciatella_home), true)
 }
 
 impl Ja2Json {
@@ -70,6 +70,8 @@ impl Ja2Json {
         }
 
         copy_to!(content.game_dir, engine_options.vanilla_game_dir);
+        engine_options.vanilla_game_dir =
+            resolve_existing_components(&engine_options.vanilla_game_dir, None, true);
         copy_to!(content.mods, engine_options.mods);
         copy_to!(content.res, engine_options.resolution);
         copy_to!(content.brightness, engine_options.brightness);

--- a/rust/stracciatella/src/config/stracciatella_home.rs
+++ b/rust/stracciatella/src/config/stracciatella_home.rs
@@ -1,6 +1,6 @@
-use std::path::PathBuf;
-
+use crate::fs::resolve_existing_components;
 use dirs;
+use std::path::PathBuf;
 
 /// Find ja2 stracciatella configuration directory inside the user's home directory
 pub fn find_stracciatella_home() -> Result<PathBuf, String> {
@@ -16,7 +16,7 @@ pub fn find_stracciatella_home() -> Result<PathBuf, String> {
     match base {
         Some(mut path) => {
             path.push(dir);
-            Ok(path)
+            Ok(resolve_existing_components(&path, None, true))
         }
         None => Err(String::from("Could not find home directory")),
     }

--- a/rust/stracciatella/src/fs.rs
+++ b/rust/stracciatella/src/fs.rs
@@ -1,9 +1,55 @@
 //! This module contains code to interact with the filesystem.
 
+use crate::unicode::Nfc;
 use dunce;
+use std::path::{Component, Path, PathBuf};
 
 /// Returns the canonical, absolute form of a path with all intermediate
 /// components normalized and symbolic links resolved.
 ///
 /// On windows, UNC paths are converted to normal paths when possible.
 pub use dunce::canonicalize;
+
+/// Resolves all components of a path to their existing variant using unicode normalization.
+/// Can be run in caseless mode.
+/// The return value of the function has all components of the path that exist
+/// in the file system replaced by their (correctly cased) variant.
+pub fn resolve_existing_components(path: &Path, base: Option<&Path>, caseless: bool) -> PathBuf {
+    let to_nfc = |x: &str| {
+        if caseless {
+            Nfc::caseless(x)
+        } else {
+            Nfc::from(x)
+        }
+    };
+    let path = if let Some(b) = base {
+        b.join(path)
+    } else {
+        path.to_owned()
+    };
+    path.components()
+        .fold(PathBuf::new(), |mut current, component| {
+            let next = match component {
+                Component::CurDir => Component::CurDir.as_os_str().to_owned(),
+                Component::ParentDir => Component::ParentDir.as_os_str().to_owned(),
+                Component::Normal(os_str) => {
+                    let existing = os_str.to_str().map(to_nfc).and_then(|want_caseless| {
+                        current.read_dir().ok().and_then(|entries| {
+                            entries
+                                .filter_map(|x| x.ok())
+                                .map(|entry| entry.file_name())
+                                .find(|file_name| {
+                                    file_name.to_str().map(to_nfc).map(|f| f == want_caseless)
+                                        == Some(true)
+                                })
+                        })
+                    });
+                    existing.unwrap_or_else(|| os_str.to_owned())
+                }
+                Component::Prefix(e) => Component::Prefix(e).as_os_str().to_owned(),
+                Component::RootDir => Component::RootDir.as_os_str().to_owned(),
+            };
+            current.push(next.as_os_str());
+            current
+        })
+}

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -75,7 +75,7 @@ void Launcher::show() {
 	scalingModeChoice->callback( (Fl_Callback*)widgetChanged, (void*)(this) );
 	resolutionXInput->callback( (Fl_Callback*)widgetChanged, (void*)(this) );
 	resolutionYInput->callback( (Fl_Callback*)widgetChanged, (void*)(this) );
-	RustPointer<char> game_json_path(findPathFromAssetsDir("externalized/game.json", true));
+	RustPointer<char> game_json_path(findPathFromAssetsDir("externalized/game.json", true, true));
 	if (game_json_path) {
 		gameSettingsOutput->value(game_json_path.get());
 	} else {
@@ -83,7 +83,7 @@ void Launcher::show() {
 	}
 	fullscreenCheckbox->callback( (Fl_Callback*)widgetChanged, (void*)(this) );
 	playSoundsCheckbox->callback( (Fl_Callback*)widgetChanged, (void*)(this) );
-	RustPointer<char> ja2_json_path(findPathFromStracciatellaHome("ja2.json", false));
+	RustPointer<char> ja2_json_path(findPathFromStracciatellaHome("ja2.json", false, true));
 	if (ja2_json_path) {
 		ja2JsonPathOutput->value(ja2_json_path.get());
 	} else {
@@ -284,7 +284,7 @@ void Launcher::startEditor(Fl_Widget* btn, void* userdata) {
 	window->writeJsonFile();
 	bool has_editor_slf = checkIfRelativePathExists(window->gameDirectoryInput->value(), "Data/Editor.slf", true);
 	if (!has_editor_slf) {
-		RustPointer<char> assets_dir(findPathFromAssetsDir(nullptr, false));
+		RustPointer<char> assets_dir(findPathFromAssetsDir(nullptr, false, false));
 		if (assets_dir) {
 			// free editor.slf
 			has_editor_slf = checkIfRelativePathExists(assets_dir.get(), "editor.slf", true);


### PR DESCRIPTION
This should extract a common functionality used to find a directory case insensitively. Basically now all user editable paths should be canonicalized and made case insensitive with this commit. It also seems to fix one of the issues in #886 where the launcher mishandles spaces.