### PR TITLE
Fix copy-paste error in WriteSTIFile

### DIFF
--- a/src/game/Utils/STIConvert.cc
+++ b/src/game/Utils/STIConvert.cc
@@ -156,7 +156,7 @@ void WriteSTIFile(UINT8* const pData, SGPPaletteEntry* const pPalette, const INT
 	}
 	if( pSubImageBuffer != NULL )
 	{
-		MemFree( pOutputBuffer );
+		MemFree( pSubImageBuffer );
 	}
 }
 


### PR DESCRIPTION
Coverity detect the copy-paste mistake I made in #881.

I'm glad coverity is working again. :)