### PR TITLE
Fix missing break in HandleKeyboardShortcuts

### DIFF
--- a/src/game/Editor/EditScreen.cc
+++ b/src/game/Editor/EditScreen.cc
@@ -1762,6 +1762,7 @@ static void HandleKeyboardShortcuts(void)
 					if( gusPreserveSelectionWidth > 8 )
 						gusPreserveSelectionWidth = 1;
 					gfRenderTaskbar = TRUE;
+					break;
 				default:
 					iCurrentAction = ACTION_NULL;
 					break;


### PR DESCRIPTION
Coverity detected a missing break in switch.

Looking at the previous switch case, it should not fall through.