### PR TITLE
Fix out of bounds access from BtnHistoryMenuButtonCallback

### DIFF
--- a/src/game/Laptop/AIMHistory.cc
+++ b/src/game/Laptop/AIMHistory.cc
@@ -382,7 +382,7 @@ static void BtnHistoryMenuButtonCallback(GUI_BUTTON *btn, INT32 reason)
 				break;
 
 			case 4: //Next Page
-				if (gubCurPageNum < NUM_AIM_HISTORY_PAGES)
+				if (gubCurPageNum + 1 < NUM_AIM_HISTORY_PAGES)
 				{
 					gubCurPageNum++;
 					ChangingAimHistorySubPage(gubCurPageNum);


### PR DESCRIPTION
Coverity detect an out of bounds access caused by this test.

The page number could be set to NUM_AIM_HISTORY_PAGES, which is invalid.