### PR TITLE
Fix checks for validity of the grid number.

### DIFF
--- a/src/game/Editor/NewSmooth.cc
+++ b/src/game/Editor/NewSmooth.cc
@@ -233,7 +233,7 @@ void AddCave( INT32 iMapIndex, UINT16 usIndex )
 {
 	LEVELNODE *pStruct;
 
-	if( iMapIndex < 0 || iMapIndex >= NOWHERE )
+	if( iMapIndex < 0 || iMapIndex >= GRIDSIZE )
 		return;
 	//First toast any existing wall (caves)
 	RemoveAllStructsOfTypeRange( iMapIndex, FIRSTWALL, LASTWALL );
@@ -794,7 +794,7 @@ void AddCaveSectionToWorld( SGPRect *pSelectRegion )
 	for( y = top; y <= bottom; y++ ) for( x = left; x <= right; x++ )
 	{
 		uiMapIndex = y * WORLD_COLS + x;
-		if( uiMapIndex < NOWHERE )
+		if( uiMapIndex < GRIDSIZE )
 		{
 			usIndex = GetCaveTileIndexFromPerimeterValue( 0xff );
 			AddToUndoList( uiMapIndex );
@@ -805,7 +805,7 @@ void AddCaveSectionToWorld( SGPRect *pSelectRegion )
 	for( y = top - 1; y <= bottom + 1; y++ ) for( x = left - 1; x <= right + 1; x++ )
 	{
 		uiMapIndex = y * WORLD_COLS + x;
-		if( uiMapIndex < NOWHERE )
+		if( uiMapIndex < GRIDSIZE )
 		{
 			if( CaveAtGridNo( uiMapIndex ) )
 			{

--- a/src/game/TacticalAI/Movement.cc
+++ b/src/game/TacticalAI/Movement.cc
@@ -592,7 +592,7 @@ void SoldierTriesToContinueAlongPath(SOLDIERTYPE *pSoldier)
 		return;
 	}
 
-	if (pSoldier->usActionData >= NOWHERE)
+	if (pSoldier->usActionData >= GRIDSIZE)
 	{
 		CancelAIAction(pSoldier);
 		return;

--- a/src/game/TileEngine/Lighting.cc
+++ b/src/game/TileEngine/Lighting.cc
@@ -360,12 +360,12 @@ static BOOLEAN LightTileBlocked(INT16 iSrcX, INT16 iSrcY, INT16 iX, INT16 iY)
 	usTileNo=MAPROWCOLTOPOS(iY, iX);
 	usSrcTileNo=MAPROWCOLTOPOS(iSrcY, iSrcX);
 
-	if ( usTileNo >= NOWHERE )
+	if ( usTileNo >= GRIDSIZE )
 	{
 		return( FALSE );
 	}
 
-	if ( usSrcTileNo >= NOWHERE )
+	if ( usSrcTileNo >= GRIDSIZE )
 	{
 		return( FALSE );
 	}
@@ -418,12 +418,12 @@ static BOOLEAN LightTileHasWall(INT16 iSrcX, INT16 iSrcY, INT16 iX, INT16 iY)
 	//	int i = 0;
 	//}
 
-	if ( usTileNo >= NOWHERE )
+	if ( usTileNo >= GRIDSIZE )
 	{
 		return( FALSE );
 	}
 
-	if ( usSrcTileNo >= NOWHERE )
+	if ( usSrcTileNo >= GRIDSIZE )
 	{
 		return( FALSE );
 	}
@@ -661,7 +661,7 @@ static BOOLEAN LightAddTile(const INT16 iSrcX, const INT16 iSrcY, const INT16 iX
 
 	uiTile= MAPROWCOLTOPOS( iY, iX );
 
-	if ( uiTile >= NOWHERE )
+	if ( uiTile >= GRIDSIZE )
 	{
 		return( FALSE );
 	}
@@ -796,7 +796,7 @@ static BOOLEAN LightSubtractTile(const INT16 iSrcX, const INT16 iSrcY, const INT
 
 	uiTile= MAPROWCOLTOPOS( iY, iX );
 
-	if ( uiTile >= NOWHERE )
+	if ( uiTile >= GRIDSIZE )
 	{
 		return( FALSE );
 	}

--- a/src/game/TileEngine/Render_Fun.cc
+++ b/src/game/TileEngine/Render_Fun.cc
@@ -78,12 +78,12 @@ void SetGridNoRevealedFlag(UINT16 const grid_no)
 		SetStructAframeFlags(grid_no, LEVELNODE_HIDDEN);
 
 		// Find gridno one east as well
-		if (grid_no + WORLD_COLS < NOWHERE)
+		if (grid_no + WORLD_COLS < GRIDSIZE)
 		{
 			SetStructAframeFlags(grid_no + WORLD_COLS, LEVELNODE_HIDDEN);
 		}
 
-		if (grid_no + 1 < NOWHERE)
+		if (grid_no + 1 < GRIDSIZE)
 		{
 			SetStructAframeFlags(grid_no + 1, LEVELNODE_HIDDEN);
 		}


### PR DESCRIPTION
Coverity detected an access out of bounds in at least one of these.

NOWHERE must not change to keep compatibility with old saves, so instead all checks with >= NOWHERE and < NOWHERE are changed.

https://github.com/ja2-stracciatella/ja2-stracciatella/blob/b430600fac6648445be19d524551a43d5472b9be/src/game/TileEngine/Isometric_Utils.h#L13