### PR TITLE
Silence coverity issue in AddLifeInsurancePayout

### DIFF
--- a/src/game/Laptop/Insurance_Contract.cc
+++ b/src/game/Laptop/Insurance_Contract.cc
@@ -852,7 +852,7 @@ void AddLifeInsurancePayout(SOLDIERTYPE* const pSoldier)
 		memset( &LaptopSaveInfo.pLifeInsurancePayouts[ LaptopSaveInfo.ubNumberLifeInsurancePayouts - 1 ], 0, sizeof( LIFE_INSURANCE_PAYOUT ) );
 	}
 
-	for( ubPayoutID = 0; ubPayoutID < LaptopSaveInfo.ubNumberLifeInsurancePayouts; ubPayoutID++ )
+	for( ubPayoutID = 0; ubPayoutID < LaptopSaveInfo.ubNumberLifeInsurancePayoutUsed; ubPayoutID++ )
 	{
 		//get an empty element in the array
 		if( !LaptopSaveInfo.pLifeInsurancePayouts[ ubPayoutID ].fActive )


### PR DESCRIPTION
Coverity complained about an out-of-bounds read when `ubPayoutID` equals `ubNumberLifeInsurancePayout`.

New space is reserved based on `ubNumberLifeInsurancePayoutUsed`.
There was no real bug if `ubNumberLifeInsurancePayoutUsed` was maintained properly.