### PR TITLE
Fix use of uninitialized value in CreateAnimationTile

### DIFF
--- a/src/game/Tactical/Keys.cc
+++ b/src/game/Tactical/Keys.cc
@@ -628,6 +628,7 @@ BOOLEAN AttemptToBlowUpLock( SOLDIERTYPE * pSoldier, DOOR * pDoor )
 			// Get Z position, based on orientation....
 			sZ = 20;
 
+			memset(&AniParams, 0, sizeof(AniParams));
 			AniParams.sGridNo = sGridNo;
 			AniParams.ubLevelID = ANI_TOPMOST_LEVEL;
 			AniParams.sDelay = (INT16)( 100 );

--- a/src/game/TileEngine/Physics.cc
+++ b/src/game/TileEngine/Physics.cc
@@ -1113,7 +1113,7 @@ static BOOLEAN PhysicsMoveObject(REAL_OBJECT* pObject)
 				if ( sNewGridNo != pObject->sGridNo )
 				{
 					ANITILE_PARAMS	AniParams;
-
+					memset(&AniParams, 0, sizeof(AniParams));
 					AniParams.sGridNo = (INT16)sNewGridNo;
 					AniParams.ubLevelID = ANI_STRUCT_LEVEL;
 					AniParams.sDelay = (INT16)( 100 + PreRandom( 100 ) );


### PR DESCRIPTION
Coverity detected the use of an uninitialized value of `usTileIndex`.

On the other calls the data is initialized with memset, so do the same here.