### PR TITLE
Fix some coverity issues with format strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,7 +218,7 @@ endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CFLAGS}")
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-missing-braces -Wno-unused-function -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-missing-braces -Wno-unused-function -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers -Werror=format=2 -Werror=format-signedness")
 endif()
 
 add_executable(${JA2_BINARY} ${JA2_SOURCES})

--- a/src/game/Editor/LoadScreen.cc
+++ b/src/game/Editor/LoadScreen.cc
@@ -856,7 +856,7 @@ static ScreenID ProcessFileIO(void)
 			gbCurrentFileIOStatus = SAVING_MAP;
 			return LOADSAVE_SCREEN;
 		case SAVING_MAP: //save map
-			sprintf( ubNewFilename, "%ls", gzFilename );
+			sprintf( ubNewFilename, "%.49ls", gzFilename );
 			RaiseWorldLand();
 			if( gfShowPits )
 				RemoveAllPits();
@@ -901,7 +901,7 @@ static ScreenID ProcessFileIO(void)
 			return LOADSAVE_SCREEN;
 		case LOADING_MAP: //load map
 			DisableUndo();
-			sprintf( ubNewFilename, "%ls", gzFilename );
+			sprintf( ubNewFilename, "%.49ls", gzFilename );
 
 			RemoveMercsInSector( );
 

--- a/src/game/Laptop/Florist_Order_Form.cc
+++ b/src/game/Laptop/Florist_Order_Form.cc
@@ -283,7 +283,7 @@ void EnterFloristOrderForm()
 
 	// load the currently selected flower bouquet
 	char sTemp[40];
-	sprintf(sTemp, LAPTOPDIR "/flower_%d.sti", guiCurrentlySelectedFlower);
+	sprintf(sTemp, LAPTOPDIR "/flower_%u.sti", guiCurrentlySelectedFlower);
 	guiCurrentlySelectedFlowerImage = AddVideoObjectFromFile(sTemp);
 
 	guiDropDownBorder = AddVideoObjectFromFile(INTERFACEDIR "/tactpopup.sti");

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -1556,7 +1556,7 @@ void CreateSavedGameFileNameFromNumber(const UINT8 ubSaveGameID, char* const pzN
 		}
 
 		case SAVE__END_TURN_NUM:
-			sprintf(pzNewFileName, "%s/Auto%02d.%s", dir.c_str(), guiLastSaveGameNum, ext);
+			sprintf(pzNewFileName, "%s/Auto%02u.%s", dir.c_str(), guiLastSaveGameNum, ext);
 			guiLastSaveGameNum = (guiLastSaveGameNum + 1) % 2;
 			break;
 

--- a/src/game/Tactical/Faces.cc
+++ b/src/game/Tactical/Faces.cc
@@ -150,31 +150,28 @@ FACETYPE& InitFace(const ProfileID id, SOLDIERTYPE* const s, const UINT32 uiInit
 
 	FACETYPE& f = GetFreeFace();
 
-	const char* face_file;
+	std::string prefix = "";
+	std::string suffix = "";
 	// Check if we are a big-face....
 	if (uiInitFlags & FACE_BIGFACE)
 	{
-		face_file = FACESDIR "/b%02d.sti";
-		// ATE: Check for profile - if elliot, use special face :)
+		prefix = "b";
+		// Check for profile - if elliot, use special face :)
 		if (id == ELLIOT && p.bNPCData > 3)
 		{
-			if      (p.bNPCData <   7) face_file = FACESDIR "/b%02da.sti";
-			else if (p.bNPCData <  10) face_file = FACESDIR "/b%02db.sti";
-			else if (p.bNPCData <  13) face_file = FACESDIR "/b%02dc.sti";
-			else if (p.bNPCData <  16) face_file = FACESDIR "/b%02dd.sti";
-			else if (p.bNPCData == 17) face_file = FACESDIR "/b%02de.sti";
+			if      (p.bNPCData <   7) suffix = "a";
+			else if (p.bNPCData <  10) suffix = "b";
+			else if (p.bNPCData <  13) suffix = "c";
+			else if (p.bNPCData <  16) suffix = "d";
+			else if (p.bNPCData == 17) suffix = "e";
 		}
-	}
-	else
-	{
-		face_file = FACESDIR "/%02d.sti";
 	}
 
 	// HERVE, PETER, ALBERTO and CARLO all use HERVE's portrait
 	INT32 const face_id = HERVE <= id && id <= CARLO ? HERVE : p.ubFaceIndex;
 
 	SGPFILENAME ImageFile;
-	sprintf(ImageFile, face_file, face_id);
+	sprintf(ImageFile, "%s/%s%02d%s.sti", FACESDIR, prefix.c_str(), face_id, suffix.c_str());
 	SGPVObject* const vo = AddVideoObjectFromFile(ImageFile);
 
 	memset(&f, 0, sizeof(f));

--- a/src/game/Tactical/Soldier_Init_List.cc
+++ b/src/game/Tactical/Soldier_Init_List.cc
@@ -239,7 +239,7 @@ void LoadSoldiersFromMap(HWFILE const f, bool stracLinuxFormat)
 	if (cow_in_sector)
 	{
 		char str[40];
-		sprintf(str, SOUNDSDIR "/cowmoo%d.wav", Random(3) + 1);
+		sprintf(str, SOUNDSDIR "/cowmoo%u.wav", Random(3) + 1);
 		PlayJA2SampleFromFile(str, MIDVOLUME, 1, MIDDLEPAN);
 	}
 }

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -535,7 +535,7 @@ static FILE* CreateScreenshotFile(void)
 	do
 	{
 		char filename[2048];
-		sprintf(filename, "%s/SCREEN%03d.TGA", exec_dir.c_str(), guiPrintFrameBufferIndex++);
+		sprintf(filename, "%s/SCREEN%03u.TGA", exec_dir.c_str(), guiPrintFrameBufferIndex++);
 #ifndef _WIN32
 #	define O_BINARY 0
 #endif
@@ -806,7 +806,7 @@ static void RefreshMovieCache(void)
 	for (INT32 cnt = 0; cnt < giNumFrames; cnt++)
 	{
 		CHAR8 cFilename[2048];
-		sprintf(cFilename, "%s/JA%5.5d.TGA", exec_dir.c_str(), uiPicNum++);
+		sprintf(cFilename, "%s/JA%5.5u.TGA", exec_dir.c_str(), uiPicNum++);
 
 		FILE* disk = fopen(cFilename, "wb");
 		if (disk == NULL) return;


### PR DESCRIPTION
Unfortunately gcc does not seem to pick up `SLOG` as format strings. Will have to check how to make it work.