### PR TITLE
Fix out of bounds read in ResetIMPCharactersEyesAndMouthOf

### DIFF
--- a/src/game/Laptop/IMP_Confirm.cc
+++ b/src/game/Laptop/IMP_Confirm.cc
@@ -439,7 +439,7 @@ void ResetIMPCharactersEyesAndMouthOffsets(const UINT8 ubMercProfileID)
 {
 	// ATE: Check boundary conditions!
 	MERCPROFILESTRUCT& p = GetProfile(ubMercProfileID);
-	if (p.ubFaceIndex - 200 > 16 || ubMercProfileID >= PROF_HUMMER) return;
+	if (p.ubFaceIndex < 200 || p.ubFaceIndex >= 200 + lengthof(g_face_info) || ubMercProfileID >= PROF_HUMMER) return;
 
 	const FacePosInfo* const fi = &g_face_info[p.ubFaceIndex - 200];
 	p.usEyesX  = fi->eye_x;


### PR DESCRIPTION
Coverity detect an out of bounds read in ResetIMPCharactersEyesAndMouthOf when ubFaceIndex is 216.
The g_face_info array has 16 elements, so only indexes 0 to 15 are valid.

A crafted save file can trigger this bug.
The eyes and mouth would be placed at undefined locations.