### PR TITLE
Update shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status Travis](https://img.shields.io/travis/ja2-stracciatella/ja2-stracciatella/master.svg?style=flat-square)](https://travis-ci.org/ja2-stracciatella/ja2-stracciatella)
 [![Build Status Appveyor](https://img.shields.io/appveyor/ci/ja2-stracciatella/ja2-stracciatella/master.svg?style=flat-square)](https://ci.appveyor.com/project/ja2-stracciatella/ja2-stracciatella)
+[![Build Status Coverity Scan](https://img.shields.io/coverity/scan/8431.svg?style=flat-square)](https://scan.coverity.com/projects/ja2-stracciatella-ja2-stracciatella)
 
 This is continuation of venerable JA2-Stracciatella project.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JA2-Stracciatella Continued
 
-[![Travis CI](https://img.shields.io/travis/ja2-stracciatella/ja2-stracciatella/master.svg?style=flat-square&logo=travis&label=Travis%20CI)](https://travis-ci.org/ja2-stracciatella/ja2-stracciatella)
-[![AppVeyor](https://img.shields.io/appveyor/ci/ja2-stracciatella/ja2-stracciatella/master.svg?style=flat-square&logo=appveyor&label=AppVeyor)](https://ci.appveyor.com/project/ja2-stracciatella/ja2-stracciatella)
+[![Travis CI](https://img.shields.io/travis/ja2-stracciatella/ja2-stracciatella/nightly.svg?style=flat-square&logo=travis&label=Travis%20CI)](https://travis-ci.org/ja2-stracciatella/ja2-stracciatella)
+[![AppVeyor](https://img.shields.io/appveyor/ci/ja2-stracciatella/ja2-stracciatella/nightly.svg?style=flat-square&logo=appveyor&label=AppVeyor)](https://ci.appveyor.com/project/ja2-stracciatella/ja2-stracciatella)
 [![Coverity Scan](https://img.shields.io/coverity/scan/8431.svg?style=flat-square&label=Coverity%20Scan)](https://scan.coverity.com/projects/ja2-stracciatella-ja2-stracciatella)
 
 This is continuation of venerable JA2-Stracciatella project.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # JA2-Stracciatella Continued
 
-[![Build Status Travis](https://img.shields.io/travis/ja2-stracciatella/ja2-stracciatella/master.svg?style=flat-square)](https://travis-ci.org/ja2-stracciatella/ja2-stracciatella)
-[![Build Status Appveyor](https://img.shields.io/appveyor/ci/ja2-stracciatella/ja2-stracciatella/master.svg?style=flat-square)](https://ci.appveyor.com/project/ja2-stracciatella/ja2-stracciatella)
-[![Build Status Coverity Scan](https://img.shields.io/coverity/scan/8431.svg?style=flat-square)](https://scan.coverity.com/projects/ja2-stracciatella-ja2-stracciatella)
+[![Travis CI](https://img.shields.io/travis/ja2-stracciatella/ja2-stracciatella/master.svg?style=flat-square&logo=travis&label=Travis%20CI)](https://travis-ci.org/ja2-stracciatella/ja2-stracciatella)
+[![AppVeyor](https://img.shields.io/appveyor/ci/ja2-stracciatella/ja2-stracciatella/master.svg?style=flat-square&logo=appveyor&label=AppVeyor)](https://ci.appveyor.com/project/ja2-stracciatella/ja2-stracciatella)
+[![Coverity Scan](https://img.shields.io/coverity/scan/8431.svg?style=flat-square&label=Coverity%20Scan)](https://scan.coverity.com/projects/ja2-stracciatella-ja2-stracciatella)
 
 This is continuation of venerable JA2-Stracciatella project.
 


### PR DESCRIPTION
Add coverity shield.
Add labels to the shields. 
Use the nightly branch in the travis and appveyor shields.

---

I saw that the other shields are for the master branch while coverity is for nightly.

@selaux @lynxlynxlynx Changing the other shields to nightly seems good to me, any objections?