### PR TITLE
Fix Speck's reaction to Bubba's death

### DIFF
--- a/src/game/Laptop/Mercs.cc
+++ b/src/game/Laptop/Mercs.cc
@@ -1223,7 +1223,7 @@ static BOOLEAN GetSpeckConditionalOpening(BOOLEAN fJustEnteredScreen)
 		}
 
 		//loop through all the mercs and see if any are dead and the quote is not said
-		for(ubCnt=MERC_FIRST_MERC ; ubCnt<MERC_LAST_MERC; ubCnt++ )
+		for(ubCnt=MERC_FIRST_MERC ; ubCnt<=MERC_LAST_MERC; ubCnt++ )
 		{
 			MERCPROFILESTRUCT& p = GetProfile(ubCnt);
 			if (!IsMercDead(p)) continue;


### PR DESCRIPTION
Coverity detected logically dead code when ubCnt is BUBBA.

The BUBBA switch branch was never executed because MERC_LAST_MERC is equal to BUBBA.