### PR TITLE
Fix null pointer dereference in IncrementStat and DecrementStat.

### DIFF
--- a/src/game/Laptop/IMP_Attribute_Selection.cc
+++ b/src/game/Laptop/IMP_Attribute_Selection.cc
@@ -323,6 +323,7 @@ static void IncrementStat(INT32 iStatToIncrement)
 		case MEDICAL_SKILL:        val = &iCurrentMedical;     break;
 		case MECHANICAL_SKILL:     val = &iCurrentMechanical;  break;
 		case EXPLOSIVE_SKILL:      val = &iCurrentExplosives;  break;
+		default:                   SLOGA("unexpected stat %d", iStatToIncrement); return;
 	}
 
 	if (*val == 0)
@@ -364,6 +365,7 @@ static void DecrementStat(INT32 iStatToDecrement)
 		case MEDICAL_SKILL:        val = &iCurrentMedical;     may_be_zero = TRUE; break;
 		case MECHANICAL_SKILL:     val = &iCurrentMechanical;  may_be_zero = TRUE; break;
 		case EXPLOSIVE_SKILL:      val = &iCurrentExplosives;  may_be_zero = TRUE; break;
+		default:                   SLOGA("unexpected stat %d", iStatToDecrement); return;
 	}
 
 	if (*val > MIN_ATTRIBUTE_POINTS)


### PR DESCRIPTION
Coverity detected a null pointer dereference when val is not set in the switch.