### PR TITLE
Fix negative array read in SkillCheck

### DIFF
--- a/src/game/Tactical/SkillCheck.cc
+++ b/src/game/Tactical/SkillCheck.cc
@@ -213,7 +213,10 @@ INT32 SkillCheck( SOLDIERTYPE * pSoldier, INT8 bReason, INT8 bChanceMod )
 				// this should never happen, but might as well check...
 				iSkill = 0;
 			}
-			iSkill = iSkill * pSoldier->inv[bSlot].bStatus[0] / 100;
+			else
+			{
+				iSkill = iSkill * pSoldier->inv[bSlot].bStatus[0] / 100;
+			}
 			break;
 		case ATTACHING_DETONATOR_CHECK:
 		case ATTACHING_REMOTE_DETONATOR_CHECK:


### PR DESCRIPTION
Coverity detect a negative array read when bSlot is NO_SLOT.