### PR TITLE
Fix out of bounds reads/writes

### DIFF
--- a/src/game/Tactical/OppList.cc
+++ b/src/game/Tactical/OppList.cc
@@ -1345,12 +1345,12 @@ static INT16 ManLooksForMan(SOLDIERTYPE* pSoldier, SOLDIERTYPE* pOpponent, UINT8
 
 
 	/*
-	if (ptr->guynum >= NOBODY)
+	if (ptr->guynum >= MAX_NUM_SOLDIERS)
 	{
 		return(success);
 	}
 
-	if (oppPtr->guynum >= NOBODY)
+	if (oppPtr->guynum >= MAX_NUM_SOLDIERS)
 	{
 		return(success);
 	}*/
@@ -1518,8 +1518,8 @@ static void UpdatePersonal(SOLDIERTYPE* pSoldier, UINT8 ubID, INT8 bNewOpplist, 
 
 static void ManSeesMan(SOLDIERTYPE& s, SOLDIERTYPE& opponent, UINT8 const caller2)
 {
-	if (s.ubID        >= NOBODY) return;
-	if (opponent.ubID >= NOBODY) return;
+	if (s.ubID        >= MAX_NUM_SOLDIERS) return;
+	if (opponent.ubID >= MAX_NUM_SOLDIERS) return;
 
 	// if we're somehow looking while inactive, at base, dying or already dead
 	if (!s.bActive)       return;

--- a/src/game/Tactical/Overhead.cc
+++ b/src/game/Tactical/Overhead.cc
@@ -4206,7 +4206,7 @@ static BOOLEAN WeSawSomeoneThisTurn(void)
 		const SOLDIERTYPE* const s = *i;
 		if (s->bTeam != OUR_TEAM) continue;
 
-		for (UINT32 uiLoop2 = gTacticalStatus.Team[ENEMY_TEAM].bFirstID; uiLoop2 < TOTAL_SOLDIERS; ++uiLoop2)
+		for (UINT32 uiLoop2 = gTacticalStatus.Team[ENEMY_TEAM].bFirstID; uiLoop2 < MAX_NUM_SOLDIERS; ++uiLoop2)
 		{
 			if (s->bOppList[uiLoop2] == SEEN_THIS_TURN) return TRUE;
 		}

--- a/src/game/Tactical/Overhead_Types.h
+++ b/src/game/Tactical/Overhead_Types.h
@@ -223,7 +223,7 @@ enum WorldDirections
 
 // ENUMERATION OF SOLDIER POSIITONS IN GLOBAL SOLDIER LIST
 #define MAX_NUM_SOLDIERS				148
-#define NUM_PLANNING_MERCS				8
+#define NUM_PLANNING_MERCS				8 // XXX this is a remnant of the planning mode, see issue #902
 #define TOTAL_SOLDIERS					( NUM_PLANNING_MERCS + MAX_NUM_SOLDIERS )
 
 // DEFINE TEAMS

--- a/src/game/Tactical/TeamTurns.cc
+++ b/src/game/Tactical/TeamTurns.cc
@@ -1646,7 +1646,7 @@ void ResolveInterruptsVs( SOLDIERTYPE * pSoldier, UINT8 ubInterruptType)
 					}
 				}
 
-				if (ubSmallestSlot < NOBODY)
+				if (ubSmallestSlot < MAX_NUM_SOLDIERS)
 				{
 					// add this guy to everyone's interrupt queue
 					AddToIntList(IntList[ubSmallestSlot], TRUE, TRUE);


### PR DESCRIPTION
Coverity detected at least one out of bounds read in ManSeesMan when the opponent id is 155.

SOLDIERTYPE::bOppList has length 148 and is part of the AI system.
Ids 148 to 155 belonged to the PLAYER_PLAN team, used in the planning mode.
The planning mode was removed by tron because it was unused (not bound to a hotkey).
These soldiers were temporary and only existed during the player turn, they were not meant to have AI interaction.

This commit fixes the range checks that are related to arrays with length 148, there might be more.

Closes #902