### PR TITLE
Fix unintended integer division in SmackDoFrame.

### DIFF
--- a/src/sgp/Smack_Stub.cc
+++ b/src/sgp/Smack_Stub.cc
@@ -183,7 +183,7 @@ UINT32 SmackDoFrame(Smack* Smk)
 	UINT16 millisecondspassed = SDL_GetTicks() - Smk->LastTick;
 	UINT16 skiptime;
 	UINT16 delay, skipframes = 0;
-	DOUBLE framerate = Smk->FramesPerSecond/1000;
+	DOUBLE framerate = Smk->FramesPerSecond/1000.0;
 
 	if(framerate > millisecondspassed)
 	{


### PR DESCRIPTION
Coverity detected an unintended integer division in SmackDoFrame.

"FramesPerSecond" is actually the number of microseconds per frame.
Therefore "framerate" is the number of milliseconds per frame.

"framerate" is double, so it should not be truncated to integer values.