### PR TITLE
Fix unintended sign extension in BlitPcxToBuffer.

### DIFF
--- a/src/sgp/PCX.cc
+++ b/src/sgp/PCX.cc
@@ -86,11 +86,11 @@ SGPImage* LoadPCXFileToImage(char const* const filename, UINT16 const contents)
 
 static void BlitPcxToBuffer(UINT8 const* src, UINT8* dst, UINT16 const w, UINT16 const h)
 {
-	for (size_t n = w * h; n != 0;)
+	for (UINT32 n = static_cast<UINT32>(w) * h; n != 0;)
 	{
 		if (*src >= 0xC0)
 		{
-			size_t      n_px   = *src++ & 0x3F;
+			UINT32      n_px   = *src++ & 0x3F;
 			UINT8 const colour = *src++;
 			if (n_px > n) n_px = n;
 			n -= n_px;


### PR DESCRIPTION
Coverity detected an unintended sign extension in BlitPcxToBuffer.

In the w * h operation, w and h are first promoted to int, then multiplied, then sign-extended to size_t.
When w * h is greater than 0x7FFFFFFF, the int will be negative.
When size_t is 64 bits and the int is negative, the upper bits will be 1. (bigger than UINT32_MAX)

UINT16_MAX * UINT16_MAX = 0xFFFE0001, so a bigger value is a wrong result.