### PR TITLE
Fix uninitialized scalar variable in DisplayItemInfo

### DIFF
--- a/src/game/Laptop/BobbyRGuns.cc
+++ b/src/game/Laptop/BobbyRGuns.cc
@@ -487,6 +487,7 @@ void DisplayItemInfo(UINT32 uiItemClass)
 	}
 
 	const ItemModel* items[BOBBYR_NUM_WEAPONS_ON_PAGE];
+	memset(items, 0, sizeof(items));
 	for(i=gusCurWeaponIndex; ((i<=gusLastItemIndex) && (ubCount < 4)); i++)
 	{
 		if( uiItemClass == BOBBYR_USED_ITEMS )


### PR DESCRIPTION
Coverity detected an uninitialized scalar variable in DisplayItemInfo.

I'm not sure about this one, it seems to be about sending the uninitialized array items to CreateMouseRegionForBigImage when ubCount is 0.

~If the interpretation is correct, then not calling the function when ubCount is 0 is enough to fix it.~
Fixed by initializing the items array to 0.