### PR TITLE
Fix possible out of bounds access in CreatureCall

### DIFF
--- a/src/game/TacticalAI/CreatureDecideAction.cc
+++ b/src/game/TacticalAI/CreatureDecideAction.cc
@@ -88,7 +88,12 @@ void CreatureCall( SOLDIERTYPE * pCaller )
 			ubCallerType = CALLER_FEMALE;
 			break;
 	}
-	if (pCaller->bHunting) // which should only be set for females outside of the hive
+	if (pCaller->usActionData >= NUM_CREATURE_CALLS)
+	{
+		SLOGW("unexpected action data %u, defaulting call priority to 0", pCaller->usActionData);
+		bFullPriority = 0;
+	}
+	else if (pCaller->bHunting) // which should only be set for females outside of the hive
 	{
 		bFullPriority = gbHuntCallPriority[pCaller->usActionData];
 	}


### PR DESCRIPTION
Coverity detected a possible out of bounds access in CreatureCall.
It is not clear if it actually happens in the current code.

SoldierTriesToContinueAlongPath limits the value of usActionData to 0-25599.
CreatureCall assumes usActionData is 0-4.