### PR TITLE
Fix out of bounds access in PasteRoomNumber

### DIFF
--- a/src/game/Editor/Edit_Sys.cc
+++ b/src/game/Editor/Edit_Sys.cc
@@ -257,7 +257,7 @@ void PasteSingleRoof( UINT32 iMapIndex )
 
 void PasteRoomNumber( UINT32 iMapIndex, UINT8 ubRoomNumber )
 {
-	if( gubWorldRoomInfo[ iMapIndex ] != ubRoomNumber )
+	if( iMapIndex < lengthof(gubWorldRoomInfo) && gubWorldRoomInfo[ iMapIndex ] != ubRoomNumber )
 	{
 		AddToUndoList( iMapIndex );
 		gubWorldRoomInfo[ iMapIndex ] = ubRoomNumber;


### PR DESCRIPTION
Coverity detected an out of bounds access in PasteRoomNumber when iMapIndex too big.