### PR TITLE
Fix dereference after null check in WeaponModel::deserialize

### DIFF
--- a/src/externalized/WeaponModels.cc
+++ b/src/externalized/WeaponModels.cc
@@ -575,6 +575,7 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 	if(!wep)
 	{
 		SLOGE("Weapon type '%s' is not found", internalType);
+		return wep;
 	}
 
 	wep->ubGraphicType    = obj.GetInt("ubGraphicType");


### PR DESCRIPTION
Coverity detected a dereference after null check in WeaponModel::deserialize.

An error message is logged when wep is null, but a return was missing.