### PR TITLE
Fix crash from NPCConsiderQuote

### DIFF
--- a/src/game/TacticalAI/NPC.cc
+++ b/src/game/TacticalAI/NPC.cc
@@ -1161,14 +1161,6 @@ static UINT8 NPCConsiderQuote(UINT8 const ubNPC, UINT8 const ubMerc, Approach co
 	// if the quote is quest-specific, is the player on that quest?
 	if (pNPCQuoteInfo->ubQuest != NO_QUEST)
 	{
-		if (ubApproach != NPC_INITIATING_CONV)
-		{
-			SLOGD("Quest(%d:'%ls') Must be in Progress, status is %d. %s",
-						pNPCQuoteInfo->ubQuest, QuestDescText[ pNPCQuoteInfo->ubQuest ],
-						gubQuest[pNPCQuoteInfo->ubQuest],
-						(gubQuest[pNPCQuoteInfo->ubQuest] != QUESTINPROGRESS) ? "False, return" : "True" );
-		}
-
 		if (pNPCQuoteInfo->ubQuest > QUEST_DONE_NUM)
 		{
 			if (gubQuest[pNPCQuoteInfo->ubQuest - QUEST_DONE_NUM] != QUESTDONE)


### PR DESCRIPTION
The purpose of this log message in uncertain, so just remove it.

It was reading out of bounds when pNPCQuoteInfo->ubQuest includes QUEST_DONE_NUM or QUEST_NOT_STARTED_NUM.
The log only accepts valid utf8, so it would crash with the garbade data.

Fixes #927