### PR TITLE
Fix unintended sign extension in LoadPCXFileToImage

### DIFF
--- a/src/sgp/PCX.cc
+++ b/src/sgp/PCX.cc
@@ -63,7 +63,7 @@ SGPImage* LoadPCXFileToImage(char const* const filename, UINT16 const contents)
 	// Read and allocate bitmap block if requested
 	if (contents & IMAGE_BITMAPDATA)
 	{
-		UINT8* const img_data = img->pImageData.Allocate(w * h);
+		UINT8* const img_data = img->pImageData.Allocate(static_cast<UINT32>(w) * h);
 		BlitPcxToBuffer(pcx_buffer, img_data, w, h);
 	}
 


### PR DESCRIPTION
Coverity detected an unintended sign extension in LoadPCXFileToImage.

It would try to allocate more memory than necessary.