### PR TITLE
Allow known map versions

### DIFF
--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -1460,6 +1460,13 @@ try
 		FileWrite(f, &ubCombine, sizeof(ubCombine));
 	}
 
+	if(getMajorMapVersion() == 6.00 && gubMinorMapVersion == 26)
+	{
+		// the data appears to be 37 INT32/UINT32 numbers and is present in russian ja2 maps
+		UINT8 data[148] = {0};
+		FileWrite(f, &data, sizeof(data));
+	}
+
 	UINT8 const test[] = { 1, 1 };
 	FOR_EACH_WORLD_TILE(e)
 	{ // Write land layers


### PR DESCRIPTION
Non-russian maps can be loaded when playing the russian version of the game.
Russian maps are loaded correctly when playing a non-russian version of the game.
Newer (unknown) versions are not loaded.

The map version is checked against the minor version.
A missmatch implies a bad load.

Warn when an unexpected version is loaded.

Include the description of the exception when setting the error.

Superseeds #706 