### PR TITLE
Fix warning C4805

### DIFF
--- a/src/game/Utils/Text_Input.cc
+++ b/src/game/Utils/Text_Input.cc
@@ -107,7 +107,7 @@ static void PopTextInputLevel(void)
 
 
 //flags for determining various editing modes.
-static BOOLEAN gfEditingText = FALSE;
+static bool gfEditingText = false;
 static BOOLEAN gfTextInputMode = FALSE;
 
 void SetEditingStatus(bool bIsEditing)


### PR DESCRIPTION
Was complaining about comparing bool with BOOLEAN in SetEditingStatus.
Now it's comparing bool with bool.

Reference #857