### PR TITLE
Fix warning C4838

### DIFF
--- a/src/game/MessageBoxScreen.cc
+++ b/src/game/MessageBoxScreen.cc
@@ -27,6 +27,8 @@
 #include "Video.h"
 #include "UILayout.h"
 
+#include <string_theory/format>
+
 
 #define MSGBOX_DEFAULT_WIDTH      300
 
@@ -210,8 +212,8 @@ void DoMessageBox(MessageBoxStyleID const ubStyle, wchar_t const* const zString,
 
 			for (UINT8 i = 0; i < 4; ++i)
 			{
-				wchar_t text[] = { '1' + i, '\0' };
-				GUIButtonRef const btn = MakeButton(text, font_colour, shadow_colour, x + dx * i, y, NumberedMsgBoxCallback, cursor);
+				ST::wchar_buffer text = ST::format("{}", i + 1).to_wchar();
+				GUIButtonRef const btn = MakeButton(text.c_str(), font_colour, shadow_colour, x + dx * i, y, NumberedMsgBoxCallback, cursor);
 				gMsgBox.uiButton[i] = btn;
 				btn->SetUserData(i + 1);
 			}


### PR DESCRIPTION
It was complaining about converting int to wchar_t.
`'1' + i` promotes to int and wchar_t is compiler dependent.

Reference #857