### PR TITLE
Fix unintended fallthrough with ACTION_QUIT_GAME

### DIFF
--- a/src/game/Editor/EditScreen.cc
+++ b/src/game/Editor/EditScreen.cc
@@ -1818,6 +1818,7 @@ static ScreenID PerformSelectedAction(void)
 
 		case ACTION_QUIT_GAME:
 			requestGameExit();
+			break;
 		case ACTION_EXIT_EDITOR:
 			if( EditModeShutdown( ) )
 			{


### PR DESCRIPTION
`requestGameExit` queues a `SDL_QUIT` event, which later calls `deinitGameAndExit`.
`EditModeShutdown` asks if we want to quit the editor, but the `SDL_QUIT` event won't be stopped.
It is clear that a fallthrough was not intended.

Reference #857