### PR TITLE
Silence fallthrough warning in WaitForSelectionWindowResponse

### DIFF
--- a/src/game/Editor/EditScreen.cc
+++ b/src/game/Editor/EditScreen.cc
@@ -2405,6 +2405,7 @@ static ScreenID WaitForSelectionWindowResponse(void)
 
 				case SDLK_ESCAPE:
 					RestoreSelectionList();
+					// fallthrough
 				case SDLK_RETURN:
 					fAllDone = TRUE;
 					break;


### PR DESCRIPTION
Using enter/escape to accept/reject a dialog window is common practice.
The fallthrough is probably intended.

Reference #857