### PR TITLE
Silence fallthrough warning in SetAssignmentForList

### DIFF
--- a/src/game/Strategic/Assignments.cc
+++ b/src/game/Strategic/Assignments.cc
@@ -6918,7 +6918,8 @@ void SetAssignmentForList(INT8 const bAssignment, INT8 const bParam)
 
 						// able to add, do it
 						AddCharacterToSquad(&s, bAssignment);
-						/* FALLTHROUGH */
+						fItWorked = TRUE;
+						break;
 					}
 
 					// if already in it, don't report that as an error


### PR DESCRIPTION
Instead of moving the comment, the fallthrough code was copied.

Reference #857