### PR TITLE
Fix unintended fallthrough in HandleSummaryInput

### DIFF
--- a/src/game/Editor/Sector_Summary.cc
+++ b/src/game/Editor/Sector_Summary.cc
@@ -1654,6 +1654,7 @@ BOOLEAN HandleSummaryInput( InputAtom *pEvent )
 					gfOverheadMapDirty = TRUE;
 					return FALSE;
 				}
+				break;
 			case SDLK_RETURN:
 				if( GetActiveFieldID() == 1 )
 					SelectNextField();


### PR DESCRIPTION
After testing, it's probably an unintended fallthrough.

When you start the editor it mentions quitting with ESC or ALT+x.
Before loading a map, ESC quits the game (expected).
After loading a map, ESC had the same effect as ENTER or clicking the Okay button.
Now it ignores ESC after a map is loaded.

Reference #857