### PR TITLE
Remove extra warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CFLAGS}")
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-missing-braces -Wno-unused-function -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-missing-braces -Wno-unused-function")
 endif()
 
 add_executable(${JA2_BINARY} ${JA2_SOURCES})


### PR DESCRIPTION
I tried to fix "enumeral and non-enumeral type in conditional expression", but I coun't find of think of a rationale for the warning.
Are they trying to say "stop using C-style enums"?
That's unlikely to happen until there is an auto-numering alternative.

There are three ways to handle the warning:
1) cast enum value to an integer type
2) convert enum to constants
3) remove option -Wextra

The -Wextra warnings seem to be subjective or a matter of taste.
It's a waste of time to worry about them when we don't even have a preferred style.
Anything that actually matters should be covered by coverity, so I'm removing the options related to -Wextra.

Reference #857