### PR TITLE
Fix variable set but not used in ForecastDayEvents

### DIFF
--- a/src/game/TileEngine/Environment.cc
+++ b/src/game/TileEngine/Environment.cc
@@ -330,9 +330,8 @@ void BuildDayAmbientSounds( )
 void ForecastDayEvents( )
 {
 	UINT32 uiOldDay;
-	UINT32 uiStartTime, uiEndTime;
-	UINT8  ubStormIntensity;
-//	UINT32 cnt;
+	//UINT32 uiStartTime, uiEndTime;
+	//UINT8  ubStormIntensity;
 
 	// Get current day and see if different
 	if ( ( uiOldDay = GetWorldDay() ) != guiEnvDay )
@@ -349,32 +348,32 @@ void ForecastDayEvents( )
 		// Build weather....
 
 		// ATE: Don't forecast if start of game...
-		if ( guiEnvDay > 1 )
-		{
+		//if ( guiEnvDay > 1 )
+		//{
 			// Should it rain...?
-			if ( Random( 100 ) < 20 )
-			{
+			//if ( Random( 100 ) < 20 )
+			//{
 				// Add rain!
 				// Between 6:00 and 10:00
-				uiStartTime = (UINT32)( 360 + Random( 1080 ) );
+				//uiStartTime = (UINT32)( 360 + Random( 1080 ) );
 				// Between 5 - 15 miniutes
-				uiEndTime		= uiStartTime + ( 5 + Random( 10 ) );
+				//uiEndTime		= uiStartTime + ( 5 + Random( 10 ) );
 
-				ubStormIntensity = 0;
+				//ubStormIntensity = 0;
 
 				// Randomze for a storm!
-				if ( Random( 10 ) < 5 )
-				{
-					ubStormIntensity = 1;
-				}
+				//if ( Random( 10 ) < 5 )
+				//{
+					//ubStormIntensity = 1;
+				//}
 
 				// ATE: Disable RAIN!
 				//AddSameDayRangedStrategicEvent( EVENT_RAINSTORM, uiStartTime, uiEndTime - uiStartTime, ubStormIntensity );
 
 				//AddSameDayStrategicEvent( EVENT_BEGINRAINSTORM, uiStartTime, ubStormIntensity );
 				//AddSameDayStrategicEvent( EVENT_ENDRAINSTORM, uiEndTime, 0 );
-			}
-		}
+			//}
+		//}
 	}
 
 }


### PR DESCRIPTION
While playing vanilla I recall the laptop behaved differently during a rainstorm.
Is this related? Just in case, I'm commenting instead of deleting.

Reference #857