### PR TITLE
Avoid the use of auto

### DIFF
--- a/src/game/Tactical/DisplayCover.cc
+++ b/src/game/Tactical/DisplayCover.cc
@@ -499,7 +499,7 @@ static void CalculateVisibleToSoldierAroundGridno(INT16 sTargetGridNo, INT8 bSea
 	BOOLEAN fRoof=FALSE;
 
 	//clear out the struct
-	for (auto i = 0; i < DC__SOLDIER_VISIBLE_RANGE; ++i)
+	for (int i = 0; i < DC__SOLDIER_VISIBLE_RANGE; ++i)
 	{
 		std::fill_n(gVisibleToSoldierStruct[i], DC__SOLDIER_VISIBLE_RANGE, VISIBLE_TO_SOLDIER_STRUCT{});
 	}

--- a/src/game/Tactical/Squads.cc
+++ b/src/game/Tactical/Squads.cc
@@ -54,7 +54,7 @@ void InitSquads( void )
 		SquadMovementGroups[iCounter] = g->ubGroupID;
 	}
 
-	for (auto i = 0; i < NUMBER_OF_SQUADS; ++i)
+	for (int i = 0; i < NUMBER_OF_SQUADS; ++i)
 	{
 		std::fill_n(sDeadMercs[i], NUMBER_OF_SOLDIERS_PER_SQUAD, -1);
 	}

--- a/src/game/Utils/Cinematics.cc
+++ b/src/game/Utils/Cinematics.cc
@@ -139,7 +139,7 @@ SMKFLIC* SmkPlayFlic(const char* const filename, const UINT32 left, const UINT32
 				SLOGW("smacker failed to decode audio data");
 				break;
 			}
-			for (auto i = 0; i < 7; i++)
+			for (uint8_t i = 0; i < 7; i++)
 			{
 				if (!(audio_tracks & (1 << i))) continue;
 				unsigned long audio_size = smk_get_audio_size(sf->smacker, i);
@@ -166,7 +166,7 @@ SMKFLIC* SmkPlayFlic(const char* const filename, const UINT32 left, const UINT32
 	sf->status = smk_first(sf->smacker);
 	sf->start_tick = SDL_GetTicks();
 	sf->frame_no = 0;
-	for (auto i = 0; i < 7; i++)
+	for (uint8_t i = 0; i < 7; i++)
 	{
 		if (audio[i].empty())
 		{
@@ -289,7 +289,7 @@ static void SmkBlitVideoFrame(SMKFLIC* const sf, SGPVSurface* surface)
 
 	// convert palette
 	UINT16 palette[256];
-	for (auto i = 0; i < 256; i++)
+	for (int i = 0; i < 256; i++)
 	{
 		unsigned char* rgb = src_palette + i * 3;
 		palette[i] = Get16BPPColor(FROMRGB(rgb[0], rgb[1], rgb[2]));

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -340,8 +340,8 @@ int main(int argc, char* argv[])
 		GameState::getInstance()->setEditorMode(false);
 	}
 
-	auto width = EngineOptions_getResolutionX(params.get());
-	auto height = EngineOptions_getResolutionY(params.get());
+	uint16_t width = EngineOptions_getResolutionX(params.get());
+	uint16_t height = EngineOptions_getResolutionY(params.get());
 	bool result = g_ui.setScreenSize(width, height);
 	if(!result)
 	{
@@ -401,12 +401,12 @@ int main(int argc, char* argv[])
 
 	DefaultContentManager *cm;
 
-	auto n = EngineOptions_getModsLength(params.get());
+	uint32_t n = EngineOptions_getModsLength(params.get());
 	if(n > 0)
 	{
 		std::vector<std::string> modNames;
 		std::vector<std::string> modResFolders;
-		for (auto i = 0; i < n; ++i)
+		for (uint32_t i = 0; i < n; ++i)
 		{
 			RustPointer<char> modName(EngineOptions_getMod(params.get(), i));
 			std::string modResFolder = FileMan::joinPaths(FileMan::joinPaths(FileMan::joinPaths(extraDataDir, "mods"), modName.get()), "data");
@@ -424,7 +424,7 @@ int main(int argc, char* argv[])
 		SLOGI("Tilecache directory:           '%s'", cm->getTileDir().c_str());
 		SLOGI("Saved games directory:         '%s'", cm->getSavedGamesFolder().c_str());
 		SLOGI("------------------------------------------------------------------------------");
-		for (auto i = 0; i < n; ++i)
+		for (uint32_t i = 0; i < n; ++i)
 		{
 			SLOGI("MOD name:                      '%s'", modNames[i].c_str());
 			SLOGI("MOD resource directory:        '%s'", modResFolders[i].c_str());


### PR DESCRIPTION
`auto i = 0` always picks `int`, even though it should be another type.
auto resolution is dumb... it only considers the first statement, not the uses of the variable.

To discourage further uses of auto, I'm changing everything except iterators to explicit types.

Fixes some sign-compare warnings

Reference #857