### PR TITLE
Fix delay when msPerGameCycle is negative

### DIFF
--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -227,7 +227,7 @@ static void MainLoop(int msPerGameCycle)
 				GameLoop();
 				gameCycleMS = GetClock() - gameCycleMS;
 
-				if(gameCycleMS < msPerGameCycle)
+				if(static_cast<int>(gameCycleMS) < msPerGameCycle)
 				{
 					SDL_Delay(msPerGameCycle - gameCycleMS);
 				}


### PR DESCRIPTION
In the comparison msPerGameCycle became unsigned, so a negative number would be bigger than INT32_MAX.

Fixes a sign-compare warning.

Reference #857