### PR TITLE
Unbreak strategic pathing

### DIFF
--- a/src/game/Strategic/Strategic_Pathing.cc
+++ b/src/game/Strategic/Strategic_Pathing.cc
@@ -54,6 +54,7 @@ struct trail_t
 //#define NOPASS (TRAVELCOST_OBSTACLE)
 //#define VEINCOST TRAVELCOST_FLAT     //actual cost for bridges and doors and such
 #define TRAILCELLTYPE UINT32
+#define TRAILCELLMAX 0xFFFFFFFF
 
 static path_t        pathQB[MAXpathQ];
 static TRAILCELLTYPE trailCostB[MAP_LENGTH];
@@ -214,7 +215,7 @@ INT32 FindStratPath(INT16 const sStart, INT16 const sDestination, GROUP const& g
 
 	//initialize the ai data structures
 	std::fill(std::begin(trailStratTreeB), std::end(trailStratTreeB), trail_t{});
-	std::fill(std::begin(trailCostB), std::end(trailCostB), 255);
+	std::fill(std::begin(trailCostB), std::end(trailCostB), TRAILCELLMAX);
 
 	std::fill(std::begin(pathQB), std::end(pathQB), path_t{});
 


### PR DESCRIPTION
Strategic pathing (easily visible when trying to use the helicopter; the behavior isn't perfectly consistent, but generally it won't take any paths longer than two sectors) has apparently been broken since 0e013cb67be05e598a3de1fbb245b6e5cff7b49a, which switched from byte assignment with memset to item assignment with std::fill, but keeping the same value (so each element is 0x000000FF instead of 0xFFFFFFFF). This should restore the correct behavior.