### PR TITLE
Remove uiTraverseTime -1

### DIFF
--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -3173,9 +3173,6 @@ void DisplayPositionOfHelicopter( void )
 		{
 			const GROUP* const pGroup = GetGroup(v.ubMovementGroup);
 
-			// this came up in one bug report!
-			Assert( pGroup->uiTraverseTime != -1 );
-
 			if (pGroup->uiTraverseTime > 0 && pGroup->uiTraverseTime != TRAVERSE_TIME_IMPOSSIBLE)
 			{
 				flRatio = ( ( pGroup->uiTraverseTime + GetWorldTotalMin() ) - pGroup->uiArrivalTime ) / ( float ) pGroup->uiTraverseTime;
@@ -3338,9 +3335,6 @@ BOOLEAN CheckForClickOverHelicopterIcon( INT16 sClickedSectorX, INT16 sClickedSe
 
 	if ( pGroup->fBetweenSectors )
 	{
-		// this came up in one bug report!
-		Assert( pGroup->uiTraverseTime != -1 );
-
 		if (pGroup->uiTraverseTime > 0 && pGroup->uiTraverseTime != TRAVERSE_TIME_IMPOSSIBLE)
 		{
 			flRatio = ( pGroup->uiTraverseTime - pGroup->uiArrivalTime + GetWorldTotalMin() ) / ( float ) pGroup->uiTraverseTime;

--- a/src/game/Tactical/Vehicles.cc
+++ b/src/game/Tactical/Vehicles.cc
@@ -908,7 +908,6 @@ static void TeleportVehicleToItsClosestSector(const UINT8 ubGroupID)
 	pGroup = GetGroup( ubGroupID );
 	Assert( pGroup );
 
-	Assert( pGroup->uiTraverseTime != -1 );
 	Assert(pGroup->uiTraverseTime > 0 && pGroup->uiTraverseTime != TRAVERSE_TIME_IMPOSSIBLE);
 
 	Assert( pGroup->uiArrivalTime >= GetWorldTotalMin() );


### PR DESCRIPTION
It is equivalent to TRAVERSE_TIME_IMPOSSIBLE, so it's already handled.

Fixes sign-compare warnings.

Reference #857