### PR TITLE
Fix sign-compare warnings in Vehicles.cc

### DIFF
--- a/src/game/Tactical/Vehicles.h
+++ b/src/game/Tactical/Vehicles.h
@@ -50,7 +50,7 @@ extern VEHICLETYPE *pVehicleList;
 // number of vehicles on the list
 extern UINT8 ubNumberOfVehicles;
 
-#define VEHICLE2ID(v) (UINT32)((&(v) - pVehicleList))
+#define VEHICLE2ID(v) (INT32)((&(v) - pVehicleList))
 
 #define BASE_FOR_EACH_VEHICLE(type, iter)                           \
 	for (type* iter = pVehicleList,                      \


### PR DESCRIPTION
All the related variables seem to be INT32, so match that.

Reference #857