### PR TITLE
Fix sign-compare warning in DefaultContentManager::getNewString

### DIFF
--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -107,7 +107,7 @@ public:
 	virtual const GamePolicy* getGamePolicy() const = 0;
 	virtual const IMPPolicy* getIMPPolicy() const = 0;
 
-	virtual const ST::string* getNewString(int stringId) const = 0;
+	virtual const ST::string* getNewString(size_t stringId) const = 0;
 
 	/** Open temporary file for writing. */
 	virtual SGPFile* openTempFileForWriting(const char* filename, bool truncate) const = 0;

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -1010,7 +1010,7 @@ const GamePolicy* DefaultContentManager::getGamePolicy() const
 	return m_gamePolicy;
 }
 
-const ST::string* DefaultContentManager::getNewString(int stringId) const
+const ST::string* DefaultContentManager::getNewString(size_t stringId) const
 {
 	if(stringId >= m_newStrings.size())
 	{

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -140,7 +140,7 @@ public:
 	virtual const GamePolicy* getGamePolicy() const;
 	virtual const IMPPolicy* getIMPPolicy() const;
 
-	virtual const ST::string* getNewString(int stringId) const;
+	virtual const ST::string* getNewString(size_t stringId) const;
 
 protected:
 	std::string m_dataDir;


### PR DESCRIPTION
Reference #857