### PR TITLE
Rustify paths

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -690,6 +690,7 @@ name = "stracciatella_c_api"
 version = "0.1.0"
 dependencies = [
  "cbindgen 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "stracciatella 0.1.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.4"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -13,72 +13,52 @@ name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "argon2rs"
-version = "0.2.5"
+name = "arrayref"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "arrayvec"
-version = "0.4.11"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "atty"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "autocfg"
-version = "0.1.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "backtrace"
-version = "0.3.33"
+name = "base64"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "bitflags"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "blake2-rfc"
-version = "0.2.18"
+name = "blake2b_simd"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -86,15 +66,15 @@ name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "block-padding"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -107,61 +87,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.3.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "c2-chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "caseless"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cbindgen"
-version = "0.9.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "cfg-if"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chrono"
-version = "0.4.7"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -171,64 +136,60 @@ version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "constant_time_eq"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.6.3"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.7.2"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.6.6"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -244,9 +205,9 @@ name = "dirs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -256,32 +217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "either"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "failure"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -289,24 +225,33 @@ name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "getopts"
-version = "0.2.19"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.1.6"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -316,12 +261,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "indexmap"
-version = "1.0.2"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "itoa"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -331,24 +279,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "libc"
-version = "0.2.60"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "md-5"
@@ -357,119 +307,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.2.1"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memoffset"
-version = "0.5.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "num-integer"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.10.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quote"
-version = "0.6.13"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.7.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rand_core"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -477,50 +409,29 @@ name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon-core 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -530,111 +441,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "redox_users"
-version = "0.3.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "1.2.0"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.10"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ucd-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "remove_dir_all"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
+name = "rust-argon2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "scoped_threadpool"
-version = "0.1.9"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "scopeguard"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.97"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.97"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.40"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -642,56 +528,51 @@ name = "simplelog"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "smallvec"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "spin"
-version = "0.5.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stracciatella"
 version = "0.1.0"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "caseless 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "dunce 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "json_comments 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "md-5 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "stracciatella_c_api"
 version = "0.1.0"
 dependencies = [
- "cbindgen 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cbindgen 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "stracciatella 0.1.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -703,23 +584,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.39"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -727,12 +597,12 @@ name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -740,9 +610,9 @@ name = "term"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -750,15 +620,15 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thread_local"
-version = "0.3.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -766,50 +636,40 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "toml"
-version = "0.5.1"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "ucd-util"
-version = "0.1.5"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.8"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "utf8-ranges"
-version = "1.0.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -818,8 +678,13 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "winapi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -837,105 +702,88 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "36b7aa1ccb7d7ea3f437cf025a2ab1c47cc6c1bc9fc84918ff449def12f5e282"
+"checksum aho-corasick 0.7.10 (registry+https://github.com/rust-lang/crates.io-index)" = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
-"checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
-"checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
-"checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
-"checksum backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "88fb679bc9af8fa639198790a77f52d345fe13656c08b43afa9424c206b731c6"
-"checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
-"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
-"checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
+"checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+"checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+"checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+"checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+"checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-"checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
+"checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
-"checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
+"checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum caseless 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "808dab3318747be122cb31d36de18d4d1c81277a76f8332a02b81a3d73463d7f"
-"checksum cbindgen 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7e19db9a3892c88c74cbbdcd218196068a928f1b60e736c448b13a1e81f277"
-"checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
-"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
-"checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
+"checksum cbindgen 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2db2df1ebc842c41fd2c4ae5b5a577faf63bd5151b953db752fc686812bee318"
+"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+"checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
-"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
-"checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
-"checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
-"checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
-"checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
+"checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+"checksum crossbeam-deque 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+"checksum crossbeam-epoch 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+"checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
+"checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dunce 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0ad6bf6a88548d1126045c413548df1453d9be094a8ab9fd59bf1fdd338da4f"
-"checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
-"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
-"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
-"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+"checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-"checksum getopts 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "72327b15c228bfe31f1390f93dd5e9279587f0463836393c9df719ce62a3e450"
-"checksum getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e65cce4e5084b14874c4e7097f38cab54f47ee554f9194673456ea379dcc4c55"
+"checksum getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+"checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+"checksum hermit-abi 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
-"checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
-"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum json_comments 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab25c689752fbb49903458495d3e71853229e262a2e6136325359e0705606483"
-"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
-"checksum libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d44e80633f007889c7eff624b709ab43c92d708caad982295768a7b13ca3b5eb"
-"checksum log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c275b6ad54070ac2d665eef9197db647b32239c9d244bfb6f041a766d00da5b3"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+"checksum libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)" = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
+"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum md-5 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a18af3dcaf2b0219366cdb4e2af65a6101457b415c3d1a5c71dd9c2b7c77b9c8"
-"checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
-"checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
-"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
-"checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
-"checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
-"checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
-"checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
-"checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
-"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-"checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
-"checksum rand_chacha 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e193067942ef6f485a349a113329140d0ab9e2168ce92274499bb0e9a4190d9d"
-"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
-"checksum rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "615e683324e75af5d43d8f7a39ffe3ee4a9dc42c5c701167a71dc59c3a493aca"
+"checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+"checksum memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
+"checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+"checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+"checksum num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46203554f085ff89c235cd12f7075f3233af9b11ed7c9e16dfe2560d03313ce6"
+"checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+"checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+"checksum proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+"checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+"checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+"checksum rand_chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-"checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-"checksum rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a4b0186e22767d5b9738a05eab7c6ac90b15db17e5b5f9bd87976dd7d89a10a4"
-"checksum rayon-core 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbe0df8435ac0c397d467b6cad6d25543d06e8a019ef3f6af3c384597515bd2"
-"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+"checksum rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
+"checksum rayon-core 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
-"checksum regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6b23da8dfd98a84bd7e08700190a5d9f7d2d38abd4369dd1dae651bc40bfd2cc"
-"checksum regex-syntax 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5485bf1523a9ed51c4964273f22f63f24e31632adb5dad134f488f86a3875c"
+"checksum redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
+"checksum regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
+"checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
-"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
-"checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
-"checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
-"checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "d46b3dfedb19360a74316866cef04687cd4d6a70df8e6a506c63512790769b72"
-"checksum serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "c22a0820adfe2f257b098714323563dd06426502abbbce4f51b72ef544c5027f"
-"checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
+"checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
+"checksum ryu 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
+"checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+"checksum serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)" = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
+"checksum serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)" = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
+"checksum serde_json 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "78a7a12c167809363ec3bd7329fc0a3369056996de43c4b37ef3cd54a6ce4867"
 "checksum simplelog 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aa9c948a5a26cd38340ddbeaa557a8c8a5ce4442408eb60453bee2bb3c84a3fb"
-"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
-"checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
+"checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d960b829a55e56db167e861ddb43602c003c7be0bee1d345021703fac2fb7c"
-"checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
+"checksum syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
-"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
-"checksum ucd-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa9b3b49edd3468c0e6565d85783f51af95212b6fa3986a5500954f00b460874"
-"checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
-"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
-"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
+"checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
+"checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+"checksum unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
+"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
+"checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/rust/stracciatella/src/fs.rs
+++ b/rust/stracciatella/src/fs.rs
@@ -23,6 +23,8 @@ pub use std::fs::read_dir;
 pub use std::fs::rename;
 pub use std::fs::set_permissions;
 pub use std::fs::write;
+pub use std::fs::File;
+pub use std::fs::OpenOptions;
 
 pub use tempfile::TempDir;
 

--- a/rust/stracciatella/src/fs.rs
+++ b/rust/stracciatella/src/fs.rs
@@ -18,9 +18,11 @@ use crate::unicode::Nfc;
 
 pub use std::fs::create_dir;
 pub use std::fs::metadata;
+pub use std::fs::read;
 pub use std::fs::read_dir;
 pub use std::fs::rename;
 pub use std::fs::set_permissions;
+pub use std::fs::write;
 
 pub use tempfile::TempDir;
 

--- a/rust/stracciatella_c_api/Cargo.toml
+++ b/rust/stracciatella_c_api/Cargo.toml
@@ -17,4 +17,4 @@ stracciatella = { path = "../stracciatella" }
 tempfile = "3.0"
 
 [build-dependencies]
-cbindgen = "0.9"
+cbindgen = "0.13, ~0.13.2"

--- a/rust/stracciatella_c_api/Cargo.toml
+++ b/rust/stracciatella_c_api/Cargo.toml
@@ -9,6 +9,7 @@ workspace = ".."
 crate-type = ["staticlib"]
 
 [dependencies]
+hex = "0.3.2"
 libc = "0.2"
 stracciatella = { path = "../stracciatella" }
 

--- a/rust/stracciatella_c_api/cbindgen.toml
+++ b/rust/stracciatella_c_api/cbindgen.toml
@@ -17,10 +17,12 @@ struct RustDelete
 {
 	void operator()(char* ptr) const { CString_destroy(ptr); }
 	void operator()(EngineOptions* ptr) const { EngineOptions_destroy(ptr); }
+	void operator()(File* ptr) const { File_close(ptr); }
 	void operator()(LibraryDB* ptr) const { LibraryDB_destroy(ptr); }
 	void operator()(LibraryFile* ptr) const { LibraryFile_close(ptr); }
 	void operator()(TempDir* ptr) const { TempDir_destroy(ptr); }
 	void operator()(VecCString* ptr) const { VecCString_destroy(ptr); }
+	void operator()(VecU8* ptr) const { VecU8_destroy(ptr); }
 };
 
 /// Alias to a std::unique_ptr that deletes with RustDelete.

--- a/rust/stracciatella_c_api/src/any_path.rs
+++ b/rust/stracciatella_c_api/src/any_path.rs
@@ -1,0 +1,535 @@
+//! This module contains a class that encodes known path types with [percent-encoding].
+//!
+//! Paths that are unicode without '\0' or '%' will remain unchanged.
+//! Compatibility with `String` and `CString` is always maintained.
+//!
+//! Unix and mac paths are `[u8]`.
+//! Windows paths are `[u16]`.
+//! Fltk paths are utf8.
+//!
+//! # Format:
+//!  * as much data as possible is kept as unencoded utf8
+//!  * '\0' and '%' are always encoded
+//!  * `u8` data and ASCII `u16` data is encoded as "%XX"
+//!  * `u16` data is encoded as "%uXXXX"
+//!
+//! [percent-encoding]: https://en.wikipedia.org/wiki/Percent-encoding
+
+use std::char;
+use std::convert::TryFrom;
+use std::ffi::{CStr, CString, OsStr};
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::str;
+
+use hex;
+
+/// Unicode string that is compatible with `CString`.
+/// It can encode `Path`, `[u8]` and `[u16]`.
+#[derive(Clone, Default, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct AnyPath {
+    inner: String,
+}
+
+impl AnyPath {
+    /// Creates a `AnyPath` that is empty.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Encodes a `[u8]` path.
+    pub fn encode_slice_u8(path: &[u8]) -> Self {
+        let mut any_path = Self::default();
+        any_path.push_slice_u8(path);
+        any_path
+    }
+
+    /// Encodes a `[u16]` path.
+    pub fn encode_slice_u16(path: &[u16]) -> Self {
+        let mut any_path = Self::default();
+        any_path.push_slice_u16(path);
+        any_path
+    }
+
+    /// Encodes a `Path`.
+    pub fn encode_path(path: &Path) -> Self {
+        let mut any_path = Self::default();
+        any_path.push_os_str(path.as_os_str());
+        any_path
+    }
+
+    /// Decodes a `Vec<u8>` if possible.
+    pub fn decode_vec_u8(&self) -> Result<Vec<u8>, String> {
+        let mut vec = Vec::new();
+        for split in percent_split(self.inner.as_str())? {
+            match split {
+                PercentSplit::U16(_) => {
+                    return Err("u16 data is not supported".into());
+                }
+                PercentSplit::U8(b) => vec.push(b),
+                PercentSplit::Str(s) => s.as_bytes().iter().for_each(|&b| vec.push(b)),
+            }
+        }
+        Ok(vec)
+    }
+
+    /// Decodes a `Vec<u16>` if possible.
+    pub fn decode_vec_u16(&self) -> Result<Vec<u16>, String> {
+        let mut vec = Vec::new();
+        for split in percent_split(self.inner.as_str())? {
+            match split {
+                PercentSplit::U16(w) => vec.push(w),
+                PercentSplit::U8(b) => {
+                    if b < 0x80 {
+                        vec.push(u16::from(b));
+                    } else {
+                        return Err("u8 data must be ASCII".into());
+                    }
+                }
+                PercentSplit::Str(s) => s.encode_utf16().for_each(|w| vec.push(w)),
+            }
+        }
+        Ok(vec)
+    }
+
+    /// Decodes a `PathBuf` if possible.
+    pub fn decode_path_buf(&self) -> Result<PathBuf, String> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStrExt;
+
+            let vec = self.decode_vec_u8()?;
+            Ok(OsStr::from_bytes(vec.as_ref()).to_owned().into())
+        }
+        #[cfg(windows)]
+        {
+            use std::ffi::OsString;
+            use std::os::windows::ffi::OsStringExt;
+
+            let vec = self.decode_vec_u16()?;
+            Ok(OsString::from_wide(vec.as_ref()).into())
+        }
+    }
+
+    /// Encodes and adds a u8 value.
+    pub fn push_byte(&mut self, b: u8) {
+        self.inner.push_str(&format!("%{:02X}", b));
+    }
+
+    /// Encodes and adds a wide value.
+    pub fn push_wide(&mut self, w: u16) {
+        if w < 0x80 {
+            self.push_byte(w as u8);
+        } else {
+            self.inner.push_str(&format!("%u{:04X}", w));
+        }
+    }
+
+    /// Encodes and adds a character.
+    pub fn push_char(&mut self, c: char) {
+        if c == '\0' || c == '%' {
+            debug_assert!(c.len_utf8() == 1);
+            self.push_byte(c as u8);
+        } else {
+            self.inner.push(c);
+        }
+    }
+
+    /// Encodes and adds a `[u8]`.
+    pub fn push_slice_u8(&mut self, mut data: &[u8]) {
+        while !data.is_empty() {
+            let s = match str::from_utf8(&data) {
+                Ok(s) => s,
+                Err(err) => {
+                    let len = err.valid_up_to();
+                    if len == 0 {
+                        let len = err.error_len().unwrap_or_else(|| data.len());
+                        let (invalid, next) = data.split_at(len);
+                        data = next;
+                        invalid.iter().for_each(|&b| self.push_byte(b));
+                        continue;
+                    }
+                    unsafe { str::from_utf8_unchecked(&data[..len]) }
+                }
+            };
+            data = &data[s.len()..];
+            self.push_str(s);
+        }
+    }
+
+    /// Encodes and adds a `[u8]`.
+    pub fn push_slice_u16(&mut self, data: &[u16]) {
+        for char_result in char::decode_utf16(data.iter().copied()) {
+            match char_result {
+                Ok(c) => self.push_char(c),
+                Err(err) => {
+                    self.push_wide(err.unpaired_surrogate());
+                }
+            }
+        }
+    }
+
+    /// Encodes and adds a `str`.
+    pub fn push_str(&mut self, s: &str) {
+        s.chars().for_each(|c| self.push_char(c));
+    }
+
+    /// Encodes and adds an `OsStr`.
+    pub fn push_os_str(&mut self, os_s: &OsStr) {
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStrExt;
+
+            self.push_slice_u8(os_s.as_bytes());
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::ffi::OsStrExt;
+
+            let vec: Vec<_> = os_s.encode_wide().collect();
+            self.push_slice_u16(&vec);
+        }
+    }
+
+    /// Returns true if it can be decoded to a `Vec<u8>`.
+    pub fn is_vec_u8(&self) -> bool {
+        percent_split(self.inner.as_str())
+            .expect("percent_split")
+            .iter()
+            .all(|x| match x {
+                PercentSplit::U16(_) => false,
+                _ => true,
+            })
+    }
+
+    /// Returns true if it can be decoded to a `Vec<u16>`.
+    pub fn is_vec_u16(&self) -> bool {
+        percent_split(self.inner.as_str())
+            .expect("percent_split")
+            .iter()
+            .all(|x| match x {
+                PercentSplit::U8(b) => *b < 0x80,
+                _ => true,
+            })
+    }
+
+    /// Returns true if it can be decoded to a `PathBuf`.
+    pub fn is_path_buf(&self) -> bool {
+        #[cfg(unix)]
+        {
+            self.is_unix()
+        }
+        #[cfg(windows)]
+        {
+            self.is_windows()
+        }
+    }
+
+    /// Returns true if it can be decoded to a unix `PathBuf`.
+    pub fn is_unix(&self) -> bool {
+        self.is_vec_u8()
+    }
+
+    /// Returns true if it can be decoded to windows `PathBuf`.
+    pub fn is_windows(&self) -> bool {
+        self.is_vec_u16()
+    }
+}
+
+/// `AnyPath` is always a valid `CString`
+impl From<AnyPath> for CString {
+    fn from(path: AnyPath) -> Self {
+        CString::new(path.inner.into_bytes()).expect("AnyPath does not have nul bytes")
+    }
+}
+
+/// `AnyPath` is always a valid `String`
+impl From<AnyPath> for String {
+    fn from(path: AnyPath) -> Self {
+        path.inner
+    }
+}
+
+/// `CString` can be a valid `AnyPath`.
+impl TryFrom<CString> for AnyPath {
+    type Error = String;
+
+    fn try_from(path: CString) -> Result<Self, String> {
+        let inner = path.into_string().map_err(|err| format!("{}", err))?;
+        percent_split(&inner)?;
+        Ok(Self { inner })
+    }
+}
+
+/// `&CStr` can be a valid `AnyPath`.
+impl TryFrom<&CStr> for AnyPath {
+    type Error = String;
+
+    fn try_from(path: &CStr) -> Result<Self, String> {
+        Self::try_from(path.to_owned())
+    }
+}
+
+/// `String` can be a valid `AnyPath`.
+impl TryFrom<String> for AnyPath {
+    type Error = String;
+
+    fn try_from(path: String) -> Result<Self, String> {
+        percent_split(&path)?;
+        Ok(Self { inner: path })
+    }
+}
+
+/// `&str` can be a valid `AnyPath`.
+impl TryFrom<&str> for AnyPath {
+    type Error = String;
+
+    fn try_from(path: &str) -> Result<Self, String> {
+        percent_split(&path)?;
+        let inner = path.to_owned();
+        Ok(Self { inner })
+    }
+}
+
+/// Inherits all the methods of `str`.
+impl AsRef<str> for AnyPath {
+    fn as_ref(&self) -> &str {
+        self.inner.as_str()
+    }
+}
+
+/// Matches the inner string.
+impl fmt::Display for AnyPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let display: &dyn fmt::Display = &self.inner;
+        display.fmt(f)
+    }
+}
+
+/// Matches the inner string.
+impl fmt::Debug for AnyPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let debug: &dyn fmt::Debug = &self.inner;
+        debug.fmt(f)
+    }
+}
+
+enum PercentSplit<'a> {
+    U16(u16),
+    U8(u8),
+    Str(&'a str),
+}
+
+fn percent_split<'a>(mut s: &'a str) -> Result<Vec<PercentSplit<'a>>, String> {
+    if s.bytes().any(|b| b == 0) {
+        return Err("unexpected embedded nul".into());
+    }
+    let mut splits = Vec::new();
+    fn n_chars_len(n: usize, s: &str) -> Option<usize> {
+        let mut len = 0;
+        let mut chars = s.chars();
+        for _ in 0..n {
+            if let Some(c) = chars.next() {
+                len += c.len_utf8();
+            } else {
+                return None;
+            }
+        }
+        Some(len)
+    }
+    while !s.is_empty() {
+        if s.starts_with("%u") {
+            if let Some(len) = n_chars_len(6, &s) {
+                let (encoded, next) = s.split_at(len);
+                if let Ok(hex_bytes) = hex::decode(&encoded[2..]) {
+                    assert!(hex_bytes.len() == 2);
+                    let w = (u16::from(hex_bytes[0]) << 8) + u16::from(hex_bytes[1]);
+                    splits.push(PercentSplit::U16(w));
+                    s = next;
+                    continue;
+                }
+            }
+            return Err(format!("expected '%uXXXX', got {:?}", s));
+        } else if s.starts_with('%') {
+            if let Some(len) = n_chars_len(3, &s) {
+                let (encoded, next) = s.split_at(len);
+                if let Ok(hex_bytes) = hex::decode(&encoded[1..]) {
+                    assert!(hex_bytes.len() == 1);
+                    let b = hex_bytes[0];
+                    splits.push(PercentSplit::U8(b));
+                    s = next;
+                    continue;
+                }
+            }
+            return Err(format!("expected '%XX', got {:?}", s));
+        } else {
+            let index = s.find('%').unwrap_or_else(|| s.len());
+            let (raw, next) = s.split_at(index);
+            s = next;
+            splits.push(PercentSplit::Str(raw));
+        }
+    }
+    Ok(splits)
+}
+
+#[cfg(test)]
+mod test {
+    use std::convert::TryFrom;
+    use std::ffi::CString;
+    use std::path::PathBuf;
+
+    use crate::any_path::AnyPath;
+
+    #[test]
+    fn try_from_str_ok() {
+        fn t(s: &str) {
+            assert!(AnyPath::try_from(s).is_ok());
+        }
+        t("%00"); // nul
+        t("%25"); // percent
+        t("x"); // 1-byte utf8
+        t("\u{00A2}"); // 2-byte utf8
+        t("\u{20AC}"); // 3-byte utf8
+        t("\u{24B62}"); // 4-byte utf8
+        t("%80%C0%FF"); // unix OsString
+        t("%uDF62%uD852"); // windows OsString
+    }
+
+    #[test]
+    fn try_from_str_err() {
+        fn t(s: &str) {
+            assert!(AnyPath::try_from(s).is_err());
+        }
+        t("\0");
+        t("%");
+        t("%F");
+        t("%FG");
+        t("%u0");
+        t("%u00");
+        t("%u00F");
+        t("%u00FG");
+    }
+
+    #[test]
+    fn roundtrip_u8_path() {
+        fn t(s: &str) {
+            let bytes = s.as_bytes();
+            assert_eq!(
+                AnyPath::encode_slice_u8(bytes).decode_vec_u8(),
+                Ok(bytes.to_owned())
+            );
+        }
+        t("\0");
+        t("%");
+        t("x"); // 1-byte utf8
+        t("\u{00A2}"); // 2-byte utf8
+        t("\u{20AC}"); // 3-byte utf8
+        t("\u{24B62}"); // 4-byte utf8
+    }
+
+    #[test]
+    fn roundtrip_c_string() {
+        fn t(s: &str) {
+            let c_path = AnyPath::try_from(s).unwrap();
+            let c_string = CString::from(c_path.clone());
+            assert_eq!(AnyPath::try_from(c_string.clone()), Ok(c_path.clone())); // CString to AnyPath
+            assert_eq!(AnyPath::try_from(c_string.as_ref()), Ok(c_path.clone())); // CStr to AnyPath
+            assert_eq!(CString::from(c_path), c_string); // AnyPath to CString
+        }
+        t("%00"); // null
+        t("%25"); // percent
+        t("x"); // 1-byte utf8
+        t("\u{00A2}"); // 2-byte utf8
+        t("\u{20AC}"); // 3-byte utf8
+        t("\u{24B62}"); // 4-byte utf8
+        t("%80%C0%FF"); // invalid utf8 (unix)
+        t("x%uD852x"); // lead surrogate (windows)
+        t("x%uDF62x"); // tail surrogate (windows)
+        t("x%uDF62%uD852x"); // tail surrogate + lead surrogate (windows)
+        t("x%uD852%uD852x"); // lead surrogate + lead surrogate (windows)
+    }
+
+    #[test]
+    fn roundtrip_path() {
+        #[cfg(unix)]
+        {
+            use std::ffi::OsStr;
+            use std::os::unix::ffi::OsStrExt;
+
+            fn t(bytes: &[u8], s: &str) {
+                let c_path = AnyPath::try_from(s).unwrap();
+                let path_buf = PathBuf::from(OsStr::from_bytes(bytes).to_owned());
+                assert_eq!(AnyPath::encode_path(&path_buf), c_path); // Path to AnyPath
+                assert_eq!(c_path.decode_path_buf(), Ok(path_buf)); // AnyPath to PathBuf
+            }
+            t(&[0x00], "%00"); // nul
+            t(&[b'%'], "%25"); // percent
+            t(&[b'x'], "x"); // 1-byte utf8
+            t(&[0xC2, 0xA2], "\u{00A2}"); // 2-byte utf8
+            t(&[0xE2, 0x82, 0xAC], "\u{20AC}"); // 3-byte utf8
+            t(&[0xF0, 0xA4, 0xAD, 0xA2], "\u{24B62}"); // 4-byte utf8
+
+            // unexpected continuation utf8 = 0x80 to 0xBF
+            // lonely start utf8 = 0xC0 to 0xFD
+            // impossible utf8 = 0xFE to 0xFF
+            for b in 0x80..=0xFF {
+                t(&[b], &format!("%{:02X}", b));
+            }
+        }
+        #[cfg(windows)]
+        {
+            use std::ffi::OsString;
+            use std::os::windows::ffi::OsStringExt;
+
+            fn t(wide: &[u16], s: &str) {
+                let c_path = AnyPath::try_from(s).unwrap();
+                let path_buf = PathBuf::from(OsString::from_wide(wide));
+                assert_eq!(AnyPath::encode_path(&path_buf), c_path); // Path to AnyPath
+                assert_eq!(c_path.decode_path_buf(), Ok(path_buf)); // AnyPath to PathBuf
+            }
+            t(&[0x0000], "%00"); // nul
+            t(&[u16::from(b'%')], "%25"); // percent
+            t(&[u16::from(b'x')], "x");
+            t(&[0xD852], "%uD852"); // lead surrogate
+            t(&[0xDF62], "%uDF62"); // tail surrogate
+            t(&[0xDF62, 0xD852], "%uDF62%uD852"); // tail surrogate + lead surrogate
+            t(&[0xD852, 0xD852], "%uD852%uD852"); // lead surrogate + lead surrogate
+            t(&[0xD852, 0xDF62], "\u{24B62}"); // lead surrogate + tail surrogate
+        }
+    }
+
+    #[test]
+    fn decode_path_err() {
+        fn t(s: &str) {
+            let c_path = AnyPath::try_from(s).unwrap();
+            assert!(c_path.decode_path_buf().is_err());
+        }
+        t("%uDF62%uD852%80%C0%FF"); // must be either unix or windows
+        #[cfg(unix)]
+        {
+            t("%uDF62%uD852"); // wide data is not supported in unix
+        }
+        #[cfg(windows)]
+        {
+            t("%80%C0%FF"); // byte data must be ASCII in windows
+        }
+    }
+
+    #[test]
+    fn is_unix_is_windows() {
+        fn t(s: &str, unix: bool, windows: bool) {
+            let c_path = AnyPath::try_from(s).unwrap();
+            assert_eq!(c_path.is_unix(), unix);
+            assert_eq!(c_path.is_windows(), windows);
+        }
+        t("x%00x", true, true); // nul
+        t("x%25x", true, true); // percent
+        t("x", true, true); // 1-byte utf8
+        t("\u{00A2}", true, true); // 2-byte utf8
+        t("\u{20AC}", true, true); // 3-byte utf8
+        t("\u{24B62}", true, true); // 4-byte utf8
+        t("%80%C0%FF", true, false); // unix Path
+        t("%uDF62%uD852", false, true); // windows Path
+        t("%80%C0%FF%uDF62%uD852", false, false); // mixed
+    }
+}

--- a/rust/stracciatella_c_api/src/c/config.rs
+++ b/rust/stracciatella_c_api/src/c/config.rs
@@ -78,7 +78,7 @@ pub extern "C" fn EngineOptions_setVanillaGameDir(
     game_dir_ptr: *const c_char,
 ) {
     let engine_options = unsafe_mut(ptr);
-    let vanilla_game_dir = path_from_c_str_or_panic(unsafe_c_str(game_dir_ptr));
+    let vanilla_game_dir = path_buf_from_c_str_or_panic(unsafe_c_str(game_dir_ptr));
     engine_options.vanilla_game_dir = vanilla_game_dir.to_owned();
 }
 

--- a/rust/stracciatella_c_api/src/c/fs.rs
+++ b/rust/stracciatella_c_api/src/c/fs.rs
@@ -44,7 +44,7 @@ pub extern "C" fn TempDir_path(tempdir: *mut TempDir) -> *mut c_char {
 #[no_mangle]
 pub extern "C" fn Fs_createDir(path: *const c_char) -> bool {
     forget_rust_error();
-    let path = path_from_c_str_or_panic(unsafe_c_str(path));
+    let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
     if let Err(err) = fs::create_dir(&path) {
         remember_rust_error(format!("Fs_createDir {:?}: {}", path, err));
     }
@@ -70,7 +70,7 @@ pub extern "C" fn Fs_createTempDir() -> *mut TempDir {
 /// Checks if the path exists.
 #[no_mangle]
 pub extern "C" fn Fs_exists(path: *const c_char) -> bool {
-    let path = path_from_c_str_or_panic(unsafe_c_str(path));
+    let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
     fs::metadata(&path).is_ok()
 }
 
@@ -80,7 +80,7 @@ pub extern "C" fn Fs_exists(path: *const c_char) -> bool {
 #[no_mangle]
 pub extern "C" fn Fs_freeSpace(path: *const c_char, bytes: *mut u64) -> bool {
     forget_rust_error();
-    let path = path_from_c_str_or_panic(unsafe_c_str(path));
+    let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
     let bytes = unsafe_mut(bytes);
     let free_space = match fs::free_space(&path) {
         Err(err) => {
@@ -96,14 +96,14 @@ pub extern "C" fn Fs_freeSpace(path: *const c_char, bytes: *mut u64) -> bool {
 /// Checks if the path points to a directory.
 #[no_mangle]
 pub extern "C" fn Fs_isDir(path: *const c_char) -> bool {
-    let path = path_from_c_str_or_panic(unsafe_c_str(path));
+    let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
     fs::metadata(&path).map(|x| x.is_dir()).unwrap_or(false)
 }
 
 /// Checks if the path points to a file.
 #[no_mangle]
 pub extern "C" fn Fs_isFile(path: *const c_char) -> bool {
-    let path = path_from_c_str_or_panic(unsafe_c_str(path));
+    let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
     fs::metadata(&path).map(|x| x.is_file()).unwrap_or(false)
 }
 
@@ -116,7 +116,7 @@ pub extern "C" fn Fs_readDirPaths(
     ignore_entry_errors: bool,
 ) -> *mut VecCString {
     forget_rust_error();
-    let dir = path_from_c_str_or_panic(unsafe_c_str(dir));
+    let dir = path_buf_from_c_str_or_panic(unsafe_c_str(dir));
     match fs::read_dir_paths(&dir, ignore_entry_errors) {
         Err(err) => {
             remember_rust_error(format!("Fs_readDirPaths {:?}: {}", dir, err));
@@ -139,7 +139,7 @@ pub extern "C" fn Fs_readDirPaths(
 #[no_mangle]
 pub extern "C" fn Fs_modifiedSecs(path: *const c_char, modified_secs: *mut f64) -> bool {
     forget_rust_error();
-    let path = path_from_c_str_or_panic(unsafe_c_str(path));
+    let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
     let modified_secs = unsafe_mut(modified_secs);
     // FIXME use Duration.as_secs_f64 with rust 1.38.0+
     let as_secs_f64 = |duration: time::Duration| {
@@ -170,7 +170,7 @@ pub extern "C" fn Fs_modifiedSecs(path: *const c_char, modified_secs: *mut f64) 
 #[no_mangle]
 pub extern "C" fn Fs_removeDirAll(dir: *const c_char) -> bool {
     forget_rust_error();
-    let dir = path_from_c_str_or_panic(unsafe_c_str(dir));
+    let dir = path_buf_from_c_str_or_panic(unsafe_c_str(dir));
     if let Err(err) = fs::remove_dir_all(&dir) {
         remember_rust_error(format!("Fs_removeDirAll {:?}: {}", dir, err));
     }
@@ -183,8 +183,8 @@ pub extern "C" fn Fs_removeDirAll(dir: *const c_char) -> bool {
 #[no_mangle]
 pub extern "C" fn Fs_rename(from: *const c_char, to: *const c_char) -> bool {
     forget_rust_error();
-    let from = path_from_c_str_or_panic(unsafe_c_str(from));
-    let to = path_from_c_str_or_panic(unsafe_c_str(to));
+    let from = path_buf_from_c_str_or_panic(unsafe_c_str(from));
+    let to = path_buf_from_c_str_or_panic(unsafe_c_str(to));
     if let Err(err) = fs::rename(&from, &to) {
         remember_rust_error(format!("Fs_rename {:?} {:?}: {}", from, to, err));
     }
@@ -196,7 +196,7 @@ pub extern "C" fn Fs_rename(from: *const c_char, to: *const c_char) -> bool {
 #[no_mangle]
 pub extern "C" fn Fs_setReadOnly(path: *const c_char, readonly: bool) -> bool {
     forget_rust_error();
-    let path = path_from_c_str_or_panic(unsafe_c_str(path));
+    let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
     let result = fs::metadata(&path).and_then(|x| {
         let mut permissions = x.permissions();
         permissions.set_readonly(readonly);

--- a/rust/stracciatella_c_api/src/c/fs.rs
+++ b/rust/stracciatella_c_api/src/c/fs.rs
@@ -355,10 +355,10 @@ pub extern "C" fn File_readExact(file: *mut File, buf: *mut u8, buf_len: usize) 
     let file = unsafe_mut(file);
     let buf = unsafe_slice_mut(buf, buf_len);
     while let Err(err) = file.inner.read_exact(buf) {
-        if err.kind() == io::ErrorKind::Interrupted {
-            continue;
+        if err.kind() != io::ErrorKind::Interrupted {
+            remember_rust_error(format!("File_readExact {}: {}", buf_len, err));
+            break;
         }
-        remember_rust_error(format!("File_readExact {}: {}", buf_len, err));
     }
     no_rust_error()
 }
@@ -447,7 +447,7 @@ pub extern "C" fn File_seekFromEnd(file: *mut File, offset: i64) -> u64 {
 pub extern "C" fn File_seekFromCurrent(file: *mut File, offset: i64) -> u64 {
     forget_rust_error();
     let file = unsafe_mut(file);
-    match file.inner.seek(io::SeekFrom::End(offset)) {
+    match file.inner.seek(io::SeekFrom::Current(offset)) {
         Err(err) => {
             remember_rust_error(format!("File_seekFromCurrent {}: {}", offset, err));
             u64::MAX

--- a/rust/stracciatella_c_api/src/c/fs.rs
+++ b/rust/stracciatella_c_api/src/c/fs.rs
@@ -3,8 +3,12 @@
 //! [`stracciatella::fs`]: ../../stracciatella/fs/index.html
 
 use std::f64;
+use std::io;
+use std::io::{Read, Seek, Write};
 use std::ptr;
 use std::time;
+use std::u64;
+use std::usize;
 
 use stracciatella::fs;
 
@@ -238,4 +242,216 @@ pub extern "C" fn Fs_write(path: *const c_char, buf: *const u8, buf_len: usize) 
         remember_rust_error(format!("Fs_write {:?} {}: {}", path, buf_len, err));
     }
     no_rust_error()
+}
+
+/// Opens the file for reading.
+/// @see https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.read
+pub const FILE_OPEN_READ: u8 = 0x01;
+
+/// Opens the file for writing.
+/// @see https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.write
+pub const FILE_OPEN_WRITE: u8 = 0x02;
+
+/// Opens the file for appending.
+/// Setting WRITE and APPEND has the same effect as setting only APPEND.
+/// @see https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.append
+pub const FILE_OPEN_APPEND: u8 = 0x04;
+
+/// Truncates the file to 0 length.
+/// @see https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.truncate
+pub const FILE_OPEN_TRUNCATE: u8 = 0x08;
+
+/// Creates the file if it does not exist.
+/// Needs WRITE or APPEND.
+/// @see https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.create
+pub const FILE_OPEN_CREATE: u8 = 0x10;
+
+/// Creates a new file or fails if it already exists.
+/// CREATE and TRUNCATE will be ignored.
+/// Needs WRITE or APPEND.
+/// @see https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.create_new
+pub const FILE_OPEN_CREATE_NEW: u8 = 0x20;
+
+/// A wrapper around [`File`] for C.
+/// @see https://doc.rust-lang.org/std/fs/struct.File.html
+pub struct File {
+    inner: fs::File,
+}
+
+/// Opens a file according to the options.
+/// Sets the rust error.
+/// @see FILE_OPEN_*
+#[no_mangle]
+pub extern "C" fn File_open(path: *const c_char, options: u8) -> *mut File {
+    forget_rust_error();
+    let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
+    let file_result = fs::OpenOptions::new()
+        .read((options & FILE_OPEN_READ) != 0)
+        .write((options & FILE_OPEN_WRITE) != 0)
+        .append((options & FILE_OPEN_APPEND) != 0)
+        .truncate((options & FILE_OPEN_TRUNCATE) != 0)
+        .create((options & FILE_OPEN_CREATE) != 0)
+        .create_new((options & FILE_OPEN_CREATE_NEW) != 0)
+        .open(&path);
+    match file_result {
+        Err(err) => {
+            remember_rust_error(format!("File_open {:?} {:#02x}: {}", path, options, err));
+            ptr::null_mut()
+        }
+        Ok(file) => into_ptr(File { inner: file }),
+    }
+}
+
+/// Closes the file.
+#[no_mangle]
+pub extern "C" fn File_close(file: *mut File) {
+    let _drop_me = from_ptr(file);
+}
+
+/// Returns the size of the file in bytes, or ´u64::MAX´ if there is an error.
+/// Sets the rust error.
+/// @see https://doc.rust-lang.org/std/fs/struct.Metadata.html#method.len
+#[no_mangle]
+pub extern "C" fn File_len(file: *mut File) -> u64 {
+    forget_rust_error();
+    let file = unsafe_ref(file);
+    match file.inner.metadata() {
+        Err(err) => {
+            remember_rust_error(format!("File_len: {}", err));
+            u64::MAX
+        }
+        Ok(metadata) => metadata.len(),
+    }
+}
+
+/// Reads data from the file to the buffer.
+/// Returns the number of bytes read or ´usize::MAX´ if there is an error.
+/// Sets the rust error.
+/// @see https://doc.rust-lang.org/std/io/trait.Read.html#tymethod.read
+#[no_mangle]
+pub extern "C" fn File_read(file: *mut File, buf: *mut u8, buf_len: usize) -> usize {
+    forget_rust_error();
+    let file = unsafe_mut(file);
+    let buf = unsafe_slice_mut(buf, buf_len);
+    loop {
+        match file.inner.read(buf) {
+            Err(err) => {
+                if err.kind() != io::ErrorKind::Interrupted {
+                    remember_rust_error(format!("File_read {}: {}", buf_len, err));
+                    return usize::MAX;
+                }
+            }
+            Ok(n) => return n,
+        }
+    }
+}
+
+/// Reads data from the file to the buffer until it is full.
+/// Sets the rust error.
+/// @see https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+#[no_mangle]
+pub extern "C" fn File_readExact(file: *mut File, buf: *mut u8, buf_len: usize) -> bool {
+    forget_rust_error();
+    let file = unsafe_mut(file);
+    let buf = unsafe_slice_mut(buf, buf_len);
+    while let Err(err) = file.inner.read_exact(buf) {
+        if err.kind() == io::ErrorKind::Interrupted {
+            continue;
+        }
+        remember_rust_error(format!("File_readExact {}: {}", buf_len, err));
+    }
+    no_rust_error()
+}
+
+/// Writes data from the buffer to the file.
+/// Returns the number of bytes written or ´usize::MAX´ if there is an error.
+/// Sets the rust error.
+/// @see https://doc.rust-lang.org/std/io/trait.Write.html#tymethod.write
+#[no_mangle]
+pub extern "C" fn File_write(file: *mut File, buf: *const u8, buf_len: usize) -> usize {
+    forget_rust_error();
+    let file = unsafe_mut(file);
+    let buf = unsafe_slice(buf, buf_len);
+    loop {
+        match file.inner.write(buf) {
+            Err(err) => {
+                if err.kind() != io::ErrorKind::Interrupted {
+                    remember_rust_error(format!("File_write {}: {}", buf_len, err));
+                    return usize::MAX;
+                }
+            }
+            Ok(n) => return n,
+        }
+    }
+}
+
+/// Writes all the data from the buffer to the file.
+/// Sets the rust error.
+/// @see https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all
+#[no_mangle]
+pub extern "C" fn File_writeAll(file: *mut File, buf: *const u8, buf_len: usize) -> bool {
+    forget_rust_error();
+    let file = unsafe_mut(file);
+    let buf = unsafe_slice(buf, buf_len);
+    while let Err(err) = file.inner.write_all(buf) {
+        if err.kind() == io::ErrorKind::Interrupted {
+            continue;
+        }
+        remember_rust_error(format!("File_writeAll {}: {}", buf_len, err));
+    }
+    no_rust_error()
+}
+
+/// Seeks to an offset relative to the start of the file.
+/// Returns the resulting position or u64::MAX if there is an error.
+/// Sets the rust error.
+/// @see https://doc.rust-lang.org/std/io/trait.Seek.html#tymethod.seek
+/// @see https://doc.rust-lang.org/std/io/enum.SeekFrom.html#variant.Start
+#[no_mangle]
+pub extern "C" fn File_seekFromStart(file: *mut File, offset: u64) -> u64 {
+    forget_rust_error();
+    let file = unsafe_mut(file);
+    match file.inner.seek(io::SeekFrom::Start(offset)) {
+        Err(err) => {
+            remember_rust_error(format!("File_seekFromStart {}: {}", offset, err));
+            u64::MAX
+        }
+        Ok(position) => position,
+    }
+}
+
+/// Seeks to an offset relative to the end of the file.
+/// Returns the resulting position or u64::MAX if there is an error.
+/// Sets the rust error.
+/// @see https://doc.rust-lang.org/std/io/trait.Seek.html#tymethod.seek
+/// @see https://doc.rust-lang.org/std/io/enum.SeekFrom.html#variant.End
+#[no_mangle]
+pub extern "C" fn File_seekFromEnd(file: *mut File, offset: i64) -> u64 {
+    forget_rust_error();
+    let file = unsafe_mut(file);
+    match file.inner.seek(io::SeekFrom::End(offset)) {
+        Err(err) => {
+            remember_rust_error(format!("File_seekFromEnd {}: {}", offset, err));
+            u64::MAX
+        }
+        Ok(position) => position,
+    }
+}
+
+/// Seeks to an offset relative to the current position in the file.
+/// Returns the resulting position or u64::MAX if there is an error.
+/// Sets the rust error.
+/// @see https://doc.rust-lang.org/std/io/trait.Seek.html#tymethod.seek
+/// @see https://doc.rust-lang.org/std/io/enum.SeekFrom.html#variant.Current
+#[no_mangle]
+pub extern "C" fn File_seekFromCurrent(file: *mut File, offset: i64) -> u64 {
+    forget_rust_error();
+    let file = unsafe_mut(file);
+    match file.inner.seek(io::SeekFrom::End(offset)) {
+        Err(err) => {
+            remember_rust_error(format!("File_seekFromCurrent {}: {}", offset, err));
+            u64::MAX
+        }
+        Ok(position) => position,
+    }
 }

--- a/rust/stracciatella_c_api/src/c/fs.rs
+++ b/rust/stracciatella_c_api/src/c/fs.rs
@@ -9,7 +9,7 @@ use std::time;
 use stracciatella::fs;
 
 use crate::c::common::*;
-use crate::c::misc::VecCString;
+use crate::c::vec::VecCString;
 
 /// A directory in the filesystem that is automatically deleted.
 /// The contents of the directory are deleted before the directory is deleted.

--- a/rust/stracciatella_c_api/src/c/fs.rs
+++ b/rust/stracciatella_c_api/src/c/fs.rs
@@ -123,11 +123,11 @@ pub extern "C" fn Fs_readDirPaths(
             ptr::null_mut()
         }
         Ok(vec) => {
-            let vec = vec
+            let vec: Vec<_> = vec
                 .iter()
                 .map(|x| c_string_from_path_or_panic(&x))
                 .collect();
-            let c_vec = VecCString::from_vec(vec);
+            let c_vec = VecCString::from(vec);
             into_ptr(c_vec)
         }
     }

--- a/rust/stracciatella_c_api/src/c/fs.rs
+++ b/rust/stracciatella_c_api/src/c/fs.rs
@@ -9,7 +9,7 @@ use std::time;
 use stracciatella::fs;
 
 use crate::c::common::*;
-use crate::c::vec::VecCString;
+use crate::c::vec::{VecCString, VecU8};
 
 /// A directory in the filesystem that is automatically deleted.
 /// The contents of the directory are deleted before the directory is deleted.
@@ -204,6 +204,38 @@ pub extern "C" fn Fs_setReadOnly(path: *const c_char, readonly: bool) -> bool {
     });
     if let Err(err) = result {
         remember_rust_error(format!("Fs_setReadOnly {:?} {}: {}", path, readonly, err));
+    }
+    no_rust_error()
+}
+
+/// Reads all the bytes from a file.
+/// Returns null if there is an error.
+/// Sets the rust error.
+/// @see https://doc.rust-lang.org/std/fs/fn.read.html
+#[no_mangle]
+pub extern "C" fn Fs_read(path: *const c_char) -> *mut VecU8 {
+    forget_rust_error();
+    let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
+    match fs::read(&path) {
+        Err(err) => {
+            remember_rust_error(format!("Fs_read {:?}: {}", path, err));
+            ptr::null_mut()
+        }
+        Ok(vec) => into_ptr(VecU8::from(vec)),
+    }
+}
+
+/// Writes the bytes to a file.
+/// The file will be created if it does not exist.
+/// Sets the rust error.
+/// @see https://doc.rust-lang.org/std/fs/fn.write.html
+#[no_mangle]
+pub extern "C" fn Fs_write(path: *const c_char, buf: *const u8, buf_len: usize) -> bool {
+    forget_rust_error();
+    let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
+    let buf = unsafe_slice(buf, buf_len);
+    if let Err(err) = fs::write(&path, buf) {
+        remember_rust_error(format!("Fs_write {:?} {}: {}", path, buf_len, err));
     }
     no_rust_error()
 }

--- a/rust/stracciatella_c_api/src/c/librarydb.rs
+++ b/rust/stracciatella_c_api/src/c/librarydb.rs
@@ -34,8 +34,8 @@ pub extern "C" fn LibraryDB_push(
 ) -> bool {
     forget_rust_error();
     let ldb = unsafe_mut(ldb);
-    let data_dir = path_from_c_str_or_panic(unsafe_c_str(data_dir));
-    let library = path_from_c_str_or_panic(unsafe_c_str(library));
+    let data_dir = path_buf_from_c_str_or_panic(unsafe_c_str(data_dir));
+    let library = path_buf_from_c_str_or_panic(unsafe_c_str(library));
     if let Err(err) = ldb.add_library(&data_dir, &library) {
         remember_rust_error(format!(
             "LibraryDB_push {:?} {:?}: {}",

--- a/rust/stracciatella_c_api/src/c/logger.rs
+++ b/rust/stracciatella_c_api/src/c/logger.rs
@@ -10,8 +10,8 @@ use crate::c::common::*;
 /// Initializes the logger
 #[no_mangle]
 pub extern "C" fn Logger_initialize(log_file: *const c_char) {
-    let log_file = path_from_c_str_or_panic(unsafe_c_str(log_file));
-    Logger::init(log_file)
+    let log_file = path_buf_from_c_str_or_panic(unsafe_c_str(log_file));
+    Logger::init(&log_file)
 }
 
 /// Set log level

--- a/rust/stracciatella_c_api/src/c/misc.rs
+++ b/rust/stracciatella_c_api/src/c/misc.rs
@@ -167,6 +167,23 @@ pub extern "C" fn Env_currentDir() -> *mut c_char {
     }
 }
 
+/// Gets the path to the current executable.
+/// Sets the rust error.
+#[no_mangle]
+pub extern "C" fn Env_currentExe() -> *mut c_char {
+    forget_rust_error();
+    match env::current_exe() {
+        Err(err) => {
+            remember_rust_error(format!("Env_currentExe: {}", err));
+            ptr::null_mut()
+        }
+        Ok(path) => {
+            let c_path = c_string_from_path_or_panic(&path);
+            c_path.into_raw()
+        }
+    }
+}
+
 /// A wrapper around `Vec<CString>` for C.
 #[derive(Default)]
 pub struct VecCString {

--- a/rust/stracciatella_c_api/src/c/misc.rs
+++ b/rust/stracciatella_c_api/src/c/misc.rs
@@ -4,7 +4,6 @@
 
 use std::env;
 use std::ffi::CString;
-use std::path::PathBuf;
 use std::ptr;
 
 use stracciatella::config::find_stracciatella_home;
@@ -68,8 +67,8 @@ pub extern "C" fn findPathFromAssetsDir(
 ) -> *mut c_char {
     let assets_dir = get_assets_dir();
     let path = if !path.is_null() {
-        let path = path_from_c_str_or_panic(unsafe_c_str(path));
-        resolve_existing_components(path, Some(&assets_dir), caseless)
+        let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
+        resolve_existing_components(&path, Some(&assets_dir), caseless)
     } else {
         assets_dir
     };
@@ -93,8 +92,8 @@ pub extern "C" fn findPathFromStracciatellaHome(
 ) -> *mut c_char {
     if let Ok(mut path_buf) = find_stracciatella_home() {
         if !path.is_null() {
-            let path = path_from_c_str_or_panic(unsafe_c_str(path));
-            let path = resolve_existing_components(path, Some(&path_buf), caseless);
+            let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
+            let path = resolve_existing_components(&path, Some(&path_buf), caseless);
             path_buf = path;
         }
         if test_exists && !path_buf.exists() {
@@ -119,8 +118,8 @@ pub extern "C" fn checkIfRelativePathExists(
     path: *const c_char,
     caseless: bool,
 ) -> bool {
-    let base: PathBuf = path_from_c_str_or_panic(unsafe_c_str(base)).to_owned();
-    let path: PathBuf = path_from_c_str_or_panic(unsafe_c_str(path)).to_owned();
+    let base = path_buf_from_c_str_or_panic(unsafe_c_str(base));
+    let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
     let path = resolve_existing_components(&path, Some(&base), caseless);
     path.exists()
 }

--- a/rust/stracciatella_c_api/src/c/misc.rs
+++ b/rust/stracciatella_c_api/src/c/misc.rs
@@ -145,9 +145,9 @@ pub extern "C" fn findAvailableMods() -> *mut VecCString {
             }) // String
             .filter_map(|x| CString::new(x.as_bytes().to_owned()).ok()) // CString
             .collect();
-        into_ptr(VecCString::from_vec(mods))
+        into_ptr(VecCString::from(mods))
     } else {
-        into_ptr(VecCString::new())
+        into_ptr(VecCString::default())
     }
 }
 

--- a/rust/stracciatella_c_api/src/c/misc.rs
+++ b/rust/stracciatella_c_api/src/c/misc.rs
@@ -13,6 +13,7 @@ use stracciatella::get_assets_dir;
 use stracciatella::guess::guess_vanilla_version;
 
 use crate::c::common::*;
+use crate::c::vec::VecCString;
 
 /// Converts the launcher executable path to the game executable path.
 /// The executable is assumed to be in the same directory as the launcher.
@@ -218,42 +219,6 @@ pub extern "C" fn Env_currentExe() -> *mut c_char {
             c_path.into_raw()
         }
     }
-}
-
-/// A wrapper around `Vec<CString>` for C.
-#[derive(Default)]
-pub struct VecCString {
-    inner: Vec<CString>,
-}
-
-impl VecCString {
-    pub fn new() -> Self {
-        Self { inner: Vec::new() }
-    }
-    pub fn from_vec(vec: Vec<CString>) -> Self {
-        Self { inner: vec }
-    }
-}
-
-/// Deletes the vector.
-#[no_mangle]
-pub extern "C" fn VecCString_destroy(vec: *mut VecCString) {
-    let _drop_me = from_ptr(vec);
-}
-
-/// Returns the vector length.
-#[no_mangle]
-pub extern "C" fn VecCString_length(vec: *mut VecCString) -> size_t {
-    let vec = unsafe_ref(vec);
-    vec.inner.len()
-}
-
-/// Returns the string at the target index.
-/// The caller is responsible for the returned memory.
-#[no_mangle]
-pub extern "C" fn VecCString_get(vec: *mut VecCString, index: size_t) -> *mut c_char {
-    let vec = unsafe_ref(vec);
-    vec.inner[index].clone().into_raw()
 }
 
 #[cfg(test)]

--- a/rust/stracciatella_c_api/src/c/misc.rs
+++ b/rust/stracciatella_c_api/src/c/misc.rs
@@ -15,24 +15,6 @@ use stracciatella::guess::guess_vanilla_version;
 use crate::c::common::*;
 use crate::c::vec::VecCString;
 
-/// Converts the launcher executable path to the game executable path.
-/// The executable is assumed to be in the same directory as the launcher.
-/// The caller is responsible for the returned memory.
-#[no_mangle]
-pub extern "C" fn findJa2Executable(launcher_path_ptr: *const c_char) -> *mut c_char {
-    let launcher_path = str_from_c_str_or_panic(unsafe_c_str(launcher_path_ptr));
-    let is_exe = launcher_path.to_lowercase().ends_with(".exe");
-    let end_of_executable_slice = launcher_path.len() - if is_exe { 13 } else { 9 };
-    let mut executable_path = String::from(&launcher_path[0..end_of_executable_slice]);
-
-    if is_exe {
-        executable_path.push_str(if is_exe { ".exe" } else { "" });
-    }
-
-    let c_string = c_string_from_str(&executable_path);
-    c_string.into_raw()
-}
-
 /// Deletes a CString.
 /// The caller is no longer responsible for the memory.
 #[no_mangle]
@@ -229,29 +211,6 @@ mod tests {
     use std::fs;
 
     use tempfile::TempDir;
-
-    use crate::c::common::*;
-    use crate::c::misc::CString_destroy;
-
-    #[test]
-    fn find_ja2_executable_should_determine_game_path_from_launcher_path() {
-        macro_rules! t {
-            ($path:expr, $expected:expr) => {
-                let path = c_string_from_str($path);
-                let got = super::findJa2Executable(path.as_ptr());
-                assert_eq!(str_from_c_str_or_panic(unsafe_c_str(got)), $expected);
-                CString_destroy(got);
-            };
-        }
-        t!("/home/test/ja2-launcher", "/home/test/ja2");
-        t!(
-            "C:\\\\home\\\\test\\\\ja2-launcher.exe",
-            "C:\\\\home\\\\test\\\\ja2.exe"
-        );
-        t!("ja2-launcher", "ja2");
-        t!("ja2-launcher.exe", "ja2.exe");
-        t!("JA2-LAUNCHER.EXE", "JA2.exe");
-    }
 
     #[test]
     fn check_if_relative_path_exists() {

--- a/rust/stracciatella_c_api/src/c/mod.rs
+++ b/rust/stracciatella_c_api/src/c/mod.rs
@@ -9,6 +9,7 @@ pub mod librarydb;
 pub mod logger;
 pub mod misc;
 pub mod path;
+pub mod vec;
 
 pub mod error {
     //! This module contains error handling code for C.

--- a/rust/stracciatella_c_api/src/c/path.rs
+++ b/rust/stracciatella_c_api/src/c/path.rs
@@ -10,7 +10,7 @@ use crate::c::common::*;
 /// Returns null if there is no extension.
 #[no_mangle]
 pub extern "C" fn Path_extension(path: *const c_char) -> *mut c_char {
-    let path = path_from_c_str_or_panic(unsafe_c_str(path));
+    let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
     if let Some(extension) = path.extension() {
         let c_extension = c_string_from_path_or_panic(extension.as_ref());
         c_extension.into_raw()
@@ -23,7 +23,7 @@ pub extern "C" fn Path_extension(path: *const c_char) -> *mut c_char {
 /// Returns null if there is no filename.
 #[no_mangle]
 pub extern "C" fn Path_filename(path: *const c_char) -> *mut c_char {
-    let path = path_from_c_str_or_panic(unsafe_c_str(path));
+    let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
     if let Some(filename) = path.file_name() {
         let c_filename = c_string_from_path_or_panic(filename.as_ref());
         c_filename.into_raw()
@@ -35,7 +35,7 @@ pub extern "C" fn Path_filename(path: *const c_char) -> *mut c_char {
 /// Checks if the path is absolute.
 #[no_mangle]
 pub extern "C" fn Path_isAbsolute(path: *const c_char) -> bool {
-    let path = path_from_c_str_or_panic(unsafe_c_str(path));
+    let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
     path.is_absolute()
 }
 
@@ -43,7 +43,7 @@ pub extern "C" fn Path_isAbsolute(path: *const c_char) -> bool {
 /// Returns null if there is no parent path.
 #[no_mangle]
 pub extern "C" fn Path_parent(path: *const c_char) -> *mut c_char {
-    let path = path_from_c_str_or_panic(unsafe_c_str(path));
+    let path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
     if let Some(parent) = path.parent() {
         let c_parent = c_string_from_path_or_panic(parent);
         c_parent.into_raw()

--- a/rust/stracciatella_c_api/src/c/path.rs
+++ b/rust/stracciatella_c_api/src/c/path.rs
@@ -89,3 +89,13 @@ pub extern "C" fn Path_parent(path: *const c_char) -> *mut c_char {
         ptr::null_mut()
     }
 }
+
+/// Sets the filename of the path.
+#[no_mangle]
+pub extern "C" fn Path_setFilename(path: *const c_char, filename: *const c_char) -> *mut c_char {
+    let mut path = path_buf_from_c_str_or_panic(unsafe_c_str(path));
+    let filename = path_buf_from_c_str_or_panic(unsafe_c_str(filename));
+    path.set_file_name(filename.as_os_str());
+    let new_path = c_string_from_path_or_panic(&path);
+    new_path.into_raw()
+}

--- a/rust/stracciatella_c_api/src/c/vec.rs
+++ b/rust/stracciatella_c_api/src/c/vec.rs
@@ -54,3 +54,58 @@ pub extern "C" fn VecCString_push(vec: *mut VecCString, value: *const c_char) {
     let value = unsafe_c_str(value);
     vec.inner.push(value.to_owned())
 }
+
+/// A wrapper around `Vec<u8>` for C.
+#[derive(Default)]
+pub struct VecU8 {
+    inner: Vec<u8>,
+}
+
+impl From<Vec<u8>> for VecU8 {
+    fn from(vec: Vec<u8>) -> Self {
+        Self { inner: vec }
+    }
+}
+
+/// Creates an empty vector.
+/// coverity[+alloc]
+#[no_mangle]
+pub extern "C" fn VecU8_create() -> *mut VecU8 {
+    let vec = VecU8::default();
+    into_ptr(vec)
+}
+
+/// Destroys the vector.
+/// coverity[+free : arg-0]
+#[no_mangle]
+pub extern "C" fn VecU8_destroy(vec: *mut VecU8) {
+    let _drop_me = from_ptr(vec);
+}
+
+/// Returns the raw pointer to the vector data.
+#[no_mangle]
+pub extern "C" fn VecU8_as_ptr(vec: *mut VecU8) -> *const u8 {
+    let vec = unsafe_ref(vec);
+    vec.inner.as_ptr()
+}
+
+/// Returns the length of the vector.
+#[no_mangle]
+pub extern "C" fn VecU8_len(vec: *mut VecU8) -> usize {
+    let vec = unsafe_ref(vec);
+    vec.inner.len()
+}
+
+/// Returns the `u8` value at the vector index.
+#[no_mangle]
+pub extern "C" fn VecU8_get(vec: *mut VecU8, index: usize) -> u8 {
+    let vec = unsafe_ref(vec);
+    vec.inner[index]
+}
+
+/// Adds a `u8` value to the end of the vector.
+#[no_mangle]
+pub extern "C" fn VecU8_push(vec: *mut VecU8, value: u8) {
+    let vec = unsafe_mut(vec);
+    vec.inner.push(value)
+}

--- a/rust/stracciatella_c_api/src/c/vec.rs
+++ b/rust/stracciatella_c_api/src/c/vec.rs
@@ -1,0 +1,43 @@
+//! This module contains wrappers around [`Vec<T>`].
+//!
+//! [`Vec<T>`]: https://doc.rust-lang.org/std/vec/struct.Vec.html
+
+use std::ffi::CString;
+
+use crate::c::common::*;
+
+/// A wrapper around `Vec<CString>` for C.
+#[derive(Default)]
+pub struct VecCString {
+    pub inner: Vec<CString>,
+}
+
+impl VecCString {
+    pub fn new() -> Self {
+        Self { inner: Vec::new() }
+    }
+    pub fn from_vec(vec: Vec<CString>) -> Self {
+        Self { inner: vec }
+    }
+}
+
+/// Deletes the vector.
+#[no_mangle]
+pub extern "C" fn VecCString_destroy(vec: *mut VecCString) {
+    let _drop_me = from_ptr(vec);
+}
+
+/// Returns the vector length.
+#[no_mangle]
+pub extern "C" fn VecCString_length(vec: *mut VecCString) -> size_t {
+    let vec = unsafe_ref(vec);
+    vec.inner.len()
+}
+
+/// Returns the string at the target index.
+/// The caller is responsible for the returned memory.
+#[no_mangle]
+pub extern "C" fn VecCString_get(vec: *mut VecCString, index: size_t) -> *mut c_char {
+    let vec = unsafe_ref(vec);
+    vec.inner[index].clone().into_raw()
+}

--- a/rust/stracciatella_c_api/src/c/vec.rs
+++ b/rust/stracciatella_c_api/src/c/vec.rs
@@ -12,32 +12,45 @@ pub struct VecCString {
     pub inner: Vec<CString>,
 }
 
-impl VecCString {
-    pub fn new() -> Self {
-        Self { inner: Vec::new() }
-    }
-    pub fn from_vec(vec: Vec<CString>) -> Self {
+impl From<Vec<CString>> for VecCString {
+    fn from(vec: Vec<CString>) -> Self {
         Self { inner: vec }
     }
 }
 
-/// Deletes the vector.
+/// Creates an empty vector.
+/// coverity[+alloc]
+#[no_mangle]
+pub extern "C" fn VecCString_create() -> *mut VecCString {
+    let vec = VecCString::default();
+    into_ptr(vec)
+}
+
+/// Destroys the vector.
+/// coverity[+free : arg-0]
 #[no_mangle]
 pub extern "C" fn VecCString_destroy(vec: *mut VecCString) {
     let _drop_me = from_ptr(vec);
 }
 
-/// Returns the vector length.
+/// Returns the length of the vector.
 #[no_mangle]
-pub extern "C" fn VecCString_length(vec: *mut VecCString) -> size_t {
+pub extern "C" fn VecCString_len(vec: *mut VecCString) -> usize {
     let vec = unsafe_ref(vec);
     vec.inner.len()
 }
 
-/// Returns the string at the target index.
-/// The caller is responsible for the returned memory.
+/// Returns the string value at the vector index.
 #[no_mangle]
-pub extern "C" fn VecCString_get(vec: *mut VecCString, index: size_t) -> *mut c_char {
+pub extern "C" fn VecCString_get(vec: *mut VecCString, index: usize) -> *mut c_char {
     let vec = unsafe_ref(vec);
     vec.inner[index].clone().into_raw()
+}
+
+/// Adds a string value to the end of the vector.
+#[no_mangle]
+pub extern "C" fn VecCString_push(vec: *mut VecCString, value: *const c_char) {
+    let vec = unsafe_mut(vec);
+    let value = unsafe_c_str(value);
+    vec.inner.push(value.to_owned())
 }

--- a/rust/stracciatella_c_api/src/lib.rs
+++ b/rust/stracciatella_c_api/src/lib.rs
@@ -2,4 +2,5 @@
 //!
 //! [stracciatella]: ../stracciatella/index.html
 
+pub mod any_path;
 pub mod c;

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -469,12 +469,12 @@ bool DefaultContentManager::doesGameResExists(char const* filename) const
 	}
 	else
 	{
-		FILE* file = fopen(filename, "rb");
+		RustPointer<File> file(File_open(filename, FILE_OPEN_READ));
 		if (!file)
 		{
 			char path[512];
 			snprintf(path, lengthof(path), "%s/%s", m_dataDir.c_str(), filename);
-			file = fopen(path, "rb");
+			file.reset(File_open(filename, FILE_OPEN_READ));
 			if (!file)
 			{
 				RustPointer<LibraryFile> libFile(LibraryFile_open(m_libraryDB.get(), filename));
@@ -482,7 +482,6 @@ bool DefaultContentManager::doesGameResExists(char const* filename) const
 			}
 		}
 
-		fclose(file);
 		return true;
 	}
 }

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -376,12 +376,15 @@ SGPFile* DefaultContentManager::openTempFileForAppend(const char* filename) cons
 SGPFile* DefaultContentManager::openTempFileForReading(const char* filename) const
 {
 	std::string path = FileMan::joinPaths(NEW_TEMP_DIR, filename);
-
-	int         mode;
-	const char* fmode = GetFileOpenModeForReading(&mode);
-
-	int d = FileMan::openFileForReading(path.c_str(), mode);
-	return FileMan::getSGPFileFromFD(d, path.c_str(), fmode);
+	RustPointer<File> file(File_open(path.c_str(), FILE_OPEN_READ));
+	if (!file)
+	{
+		RustPointer<char> err(getRustError());
+		char buf[128];
+		snprintf(buf, sizeof(buf), "DefaultContentManager::openTempFileForReading: %s", err.get());
+		throw std::runtime_error(buf);
+	}
+	return FileMan::getSGPFileFromFile(file.release());
 }
 
 /** Delete temporary file. */
@@ -400,23 +403,20 @@ void DefaultContentManager::deleteTempFile(const char* filename) const
  * If file is not found, try to find the file in libraries located in 'Data' directory; */
 SGPFile* DefaultContentManager::openGameResForReading(const char* filename) const
 {
-	int         mode;
-	const char* fmode = GetFileOpenModeForReading(&mode);
-
-	int d = FileMan::openFileCaseInsensitive(m_externalizedDataPath, filename, mode);
-	if (d >= 0)
+	RustPointer<File> file = FileMan::openFileCaseInsensitive(m_externalizedDataPath, filename, FILE_OPEN_READ);
+	if (file)
 	{
-		return FileMan::getSGPFileFromFD(d, filename, fmode);
+		return FileMan::getSGPFileFromFile(file.release());
 	}
 	else
 	{
-		d = FileMan::openFileForReading(filename, mode);
-		if (d < 0)
+		file = FileMan::openFileForReading(filename);
+		if (!file)
 		{
 			// failed to open file in the local directory
 			// let's try Data
-			d = FileMan::openFileCaseInsensitive(m_dataDir, filename, mode);
-			if (d < 0)
+			file = FileMan::openFileCaseInsensitive(m_dataDir, filename, FILE_OPEN_READ);
+			if (!file)
 			{
 				// failed to open in the data dir
 				// let's try libraries
@@ -441,18 +441,28 @@ SGPFile* DefaultContentManager::openGameResForReading(const char* filename) cons
 			SLOGD("Opened file (current dir  ): %s", filename);
 		}
 	}
-
-	return FileMan::getSGPFileFromFD(d, filename, fmode);
+	if (!file)
+	{
+		RustPointer<char> err(getRustError());
+		char buf[128];
+		snprintf(buf, sizeof(buf), "DefaultContentManager::openGameResForReading: %s", err.get());
+		throw std::runtime_error(buf);
+	}
+	return FileMan::getSGPFileFromFile(file.release());
 }
 
 /** Open user's private file (e.g. saved game, settings) for reading. */
 SGPFile* DefaultContentManager::openUserPrivateFileForReading(const std::string& filename) const
 {
-	int         mode;
-	const char* fmode = GetFileOpenModeForReading(&mode);
-
-	int d = FileMan::openFileForReading(filename.c_str(), mode);
-	return FileMan::getSGPFileFromFD(d, filename.c_str(), fmode);
+	RustPointer<File> file = FileMan::openFileForReading(filename.c_str());
+	if (!file)
+	{
+		RustPointer<char> err(getRustError());
+		char buf[128];
+		snprintf(buf, sizeof(buf), "DefaultContentManager::openUserPrivateFileForReading: %s", err.get());
+		throw std::runtime_error(buf);
+	}
+	return FileMan::getSGPFileFromFile(file.release());
 }
 
 SGPFile* DefaultContentManager::openGameResForReading(const std::string& filename) const

--- a/src/externalized/ModPackContentManager.cc
+++ b/src/externalized/ModPackContentManager.cc
@@ -42,15 +42,12 @@ bool ModPackContentManager::doesGameResExists(char const* fileName) const
  * If not found, use the previous method. */
 SGPFile* ModPackContentManager::openGameResForReading(const char* filename) const
 {
-	int mode;
-	const char* fmode = GetFileOpenModeForReading(&mode);
-
 	for (const auto& folder : m_modResFolders)
 	{
-		int d = FileMan::openFileCaseInsensitive(folder, filename, mode);
-		if (d >= 0) {
+		RustPointer<File> file = FileMan::openFileCaseInsensitive(folder, filename, FILE_OPEN_READ);
+		if (file) {
 			SLOGI("opening mod's resource: %s", filename);
-			return FileMan::getSGPFileFromFD(d, filename, fmode);
+			return FileMan::getSGPFileFromFile(file.release());
 		}
 	}
 	return DefaultContentManager::openGameResForReading(filename);

--- a/src/game/Editor/Sector_Summary.cc
+++ b/src/game/Editor/Sector_Summary.cc
@@ -2177,10 +2177,12 @@ void WriteSectorSummaryUpdate(const char* const filename, const UINT8 ubLevel, S
 	STRING512 summary_filename;
 	snprintf(summary_filename, lengthof(summary_filename), DEVINFO_DIR "/%.*s.sum", (int)(ext - filename), filename);
 
-	FILE* const f = fopen(summary_filename, "wb");
-	Assert(f);
-	fwrite(sf, sizeof(*sf), 1, f);
-	fclose(f);
+	if (!Fs_write(summary_filename, reinterpret_cast<const uint8_t*>(sf), sizeof(*sf)))
+	{
+		RustPointer<char> err(getRustError());
+		SLOGA("WriteSectorSummaryUpdate: %s", err.get());
+		return;
+	}
 
 	--gusNumEntriesWithOutdatedOrNoSummaryInfo;
 	UpdateMasterProgress();

--- a/src/game/Editor/Sector_Summary.cc
+++ b/src/game/Editor/Sector_Summary.cc
@@ -1755,14 +1755,15 @@ static void CreateGlobalSummary(void)
 	FileMan::createDir(DEVINFO_DIR);
 
 	// Generate a simple readme file.
-	FILE* const f = fopen(DEVINFO_DIR "/readme.txt", "w");
-	Assert(f);
-	fputs(
+	const char* readme = ""
 		"This information is used in conjunction with the editor.\n"
-		"This directory or its contents shouldn't be included with final release.\n",
-		f
-	);
-	fclose(f);
+		"This directory or its contents shouldn't be included with final release.\n";
+	if (!Fs_write(DEVINFO_DIR "/readme.txt", reinterpret_cast<const uint8_t*>(readme), strlen(readme)))
+	{
+		RustPointer<char> err(getRustError());
+		SLOGA("CreateGlobalSummary: %s", err.get());
+		return;
+	}
 
 	LoadGlobalSummary();
 	RegenerateSummaryInfoForAllOutdatedMaps();

--- a/src/game/Editor/Sector_Summary.cc
+++ b/src/game/Editor/Sector_Summary.cc
@@ -2081,8 +2081,8 @@ static BOOLEAN LoadSummary(const INT32 x, const INT32 y, const UINT8 level, cons
 		FileRead(f_map, &dMajorMapVersion, sizeof(FLOAT));
 	}
 
-	FILE* const f_sum = fopen(summary_filename, "rb");
-	if (!f_sum)
+	RustPointer<File> file(File_open(summary_filename, FILE_OPEN_READ));
+	if (!file)
 	{
 		++gusNumEntriesWithOutdatedOrNoSummaryInfo;
 	}
@@ -2091,12 +2091,12 @@ static BOOLEAN LoadSummary(const INT32 x, const INT32 y, const UINT8 level, cons
 		/* Even if the info is outdated (but existing), allocate the structure, but
 		 * indicate that the info is bad. */
 		SUMMARYFILE* const sum = new SUMMARYFILE{};
-		if (fread(sum, sizeof(SUMMARYFILE), 1, f_sum) != 1)
+		if (!File_readExact(file.get(), reinterpret_cast<uint8_t*>(sum), sizeof(SUMMARYFILE)))
 		{
 			// failed, initialize and force update
 			*sum = SUMMARYFILE{};
 		}
-		fclose(f_sum);
+		file.reset(nullptr);
 
 		if (sum->ubSummaryVersion < MINIMUMVERSION ||
 				dMajorMapVersion      < getMajorMapVersion())

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -216,7 +216,7 @@ int Launcher::writeJsonFile() {
 
 void Launcher::populateChoices() {
 	RustPointer<VecCString> mods(findAvailableMods());
-	size_t nmods = VecCString_length(mods.get());
+	size_t nmods = VecCString_len(mods.get());
 	for (size_t i = 0; i < nmods; ++i) {
 		RustPointer<char> mod(VecCString_get(mods.get(), i));
 		addModMenuButton->insert(-1, mod.get(), 0, addMod, this, 0);

--- a/src/launcher/Launcher.h
+++ b/src/launcher/Launcher.h
@@ -16,7 +16,6 @@ public:
 private:
 	int argc;
 	char** argv;
-	std::string exePath;
 	RustPointer<EngineOptions> engine_options;
 
 	void populateChoices();

--- a/src/sgp/FileMan.cc
+++ b/src/sgp/FileMan.cc
@@ -693,7 +693,7 @@ FindAllFilesInDir(const std::string &dirPath, bool sortResults)
 		SLOGW("%s", msg.get());
 		return paths;
 	}
-	size_t len = VecCString_length(vec.get());
+	size_t len = VecCString_len(vec.get());
 	for (size_t i = 0; i < len; i++)
 	{
 		RustPointer<char> path(VecCString_get(vec.get(), i));

--- a/src/sgp/FileMan.cc
+++ b/src/sgp/FileMan.cc
@@ -47,11 +47,6 @@ enum FileOpenFlags
 
 static void SetFileManCurrentDirectory(char const* const pcDirectory);
 
-/** Get file open modes from our enumeration.
- * Abort program if conversion is not found.
- * @return file mode for fopen call and posix mode using parameter 'posixMode' */
-static const char* GetFileOpenModes(FileOpenFlags flags, int *posixMode);
-
 #if MACOS_USE_RESOURCES_FROM_BUNDLE && defined __APPLE__  && defined __MACH__
 
 void SetBinDataDirFromBundle(void)
@@ -107,13 +102,11 @@ std::string FileMan::switchTmpFolder(std::string home)
 }
 
 
-/** Open file in the given folder in case-insensitive manner.
- * @return file descriptor or -1 if file is not found. */
-int FileMan::openFileCaseInsensitive(const std::string &folderPath, const char *filename, int mode)
+RustPointer<File> FileMan::openFileCaseInsensitive(const std::string& folderPath, const char* filename, uint8_t open_options)
 {
 	std::string path = FileMan::joinPaths(folderPath, filename);
-	int d = open(path.c_str(), mode);
-	if (d < 0)
+	RustPointer<File> file(File_open(path.c_str(), open_options));
+	if (!file)
 	{
 #if CASE_SENSITIVE_FS
 		// on case-sensitive file system need to try to find another name
@@ -121,11 +114,11 @@ int FileMan::openFileCaseInsensitive(const std::string &folderPath, const char *
 		if(findObjectCaseInsensitive(folderPath.c_str(), filename, true, false, newFileName))
 		{
 			path = FileMan::joinPaths(folderPath, newFileName);
-			d = open(path.c_str(), mode);
+			file.reset(File_open(path.c_str(), open_options));
 		}
 #endif
 	}
-	return d;
+	return file;
 }
 
 void FileDelete(const std::string &path)
@@ -160,42 +153,11 @@ void FileDelete(char const* const path)
 }
 
 
-/** Get file open modes from reading. */
-const char* GetFileOpenModeForReading(int *posixMode)
-{
-	return GetFileOpenModes(FILE_ACCESS_READ, posixMode);
-}
-
-/** Get file open modes from our enumeration.
- * Abort program if conversion is not found.
- * @return file mode for fopen call and posix mode using parameter 'posixMode' */
-static const char* GetFileOpenModes(FileOpenFlags flags, int *posixMode)
-{
-	const char *cMode = NULL;
-
-#ifndef _WIN32
-	*posixMode = 0;
-#else
-	*posixMode = O_BINARY;
-#endif
-
-	switch (flags & (FILE_ACCESS_READWRITE | FILE_ACCESS_APPEND))
-	{
-		case FILE_ACCESS_READ:      cMode = "rb";  *posixMode |= O_RDONLY;            break;
-		case FILE_ACCESS_WRITE:     cMode = "wb";  *posixMode |= O_WRONLY;            break;
-		case FILE_ACCESS_READWRITE: cMode = "r+b"; *posixMode |= O_RDWR;              break;
-		case FILE_ACCESS_APPEND:    cMode = "ab";  *posixMode |= O_WRONLY | O_APPEND; break;
-
-		default: abort();
-	}
-	return cMode;
-}
-
 void FileClose(SGPFile* f)
 {
 	if (f->flags & SGPFILE_REAL)
 	{
-		fclose(f->u.file);
+		File_close(f->u.file);
 	}
 	else
 	{
@@ -209,7 +171,7 @@ void FileRead(SGPFile* const f, void* const pDest, size_t const uiBytesToRead)
 	BOOLEAN ret;
 	if (f->flags & SGPFILE_REAL)
 	{
-		ret = fread(pDest, uiBytesToRead, 1, f->u.file) == 1;
+		ret = File_readExact(f->u.file, reinterpret_cast<uint8_t*>(pDest), uiBytesToRead);
 	}
 	else
 	{
@@ -223,7 +185,7 @@ void FileRead(SGPFile* const f, void* const pDest, size_t const uiBytesToRead)
 void FileWrite(SGPFile* const f, void const* const pDest, size_t const uiBytesToWrite)
 {
 	if (!(f->flags & SGPFILE_REAL)) throw std::logic_error("Tried to write to library file");
-	if (fwrite(pDest, uiBytesToWrite, 1, f->u.file) != 1) throw std::runtime_error("Writing to file failed");
+	if (!File_writeAll(f->u.file, reinterpret_cast<const uint8_t*>(pDest), uiBytesToWrite)) throw std::runtime_error("Writing to file failed");
 }
 
 static int64_t SGPSeekRW(SDL_RWops *context, int64_t offset, int whence)
@@ -306,15 +268,12 @@ void FileSeek(SGPFile* const f, INT32 distance, FileSeekMode const how)
 	bool success;
 	if (f->flags & SGPFILE_REAL)
 	{
-		int whence;
 		switch (how)
 		{
-			case FILE_SEEK_FROM_START: whence = SEEK_SET; break;
-			case FILE_SEEK_FROM_END:   whence = SEEK_END; break;
-			default:                   whence = SEEK_CUR; break;
+			case FILE_SEEK_FROM_START: success = distance >= 0 && File_seekFromStart(f->u.file, static_cast<uint64_t>(distance)) != UINT64_MAX; break;
+			case FILE_SEEK_FROM_END:   success = File_seekFromEnd(f->u.file, distance) != UINT64_MAX; break;
+			default:                   success = File_seekFromCurrent(f->u.file, distance) != UINT64_MAX; break;
 		}
-
-		success = fseek(f->u.file, distance, whence) == 0;
 	}
 	else
 	{
@@ -326,7 +285,7 @@ void FileSeek(SGPFile* const f, INT32 distance, FileSeekMode const how)
 
 INT32 FileGetPos(const SGPFile* f)
 {
-	return f->flags & SGPFILE_REAL ? (INT32)ftell(f->u.file) : (INT32)LibraryFile_getPosition(f->u.lib);
+	return f->flags & SGPFILE_REAL ? (INT32)File_seekFromCurrent(f->u.file, 0) : (INT32)LibraryFile_getPosition(f->u.lib);
 }
 
 
@@ -334,12 +293,12 @@ UINT32 FileGetSize(const SGPFile* f)
 {
 	if (f->flags & SGPFILE_REAL)
 	{
-		struct stat sb;
-		if (fstat(fileno(f->u.file), &sb) != 0)
+		uint64_t len = File_len(f->u.file);
+		if (len == UINT64_MAX)
 		{
 			throw std::runtime_error("Getting file size failed");
 		}
-		return (UINT32)sb.st_size;
+		return (UINT32)len;
 	}
 	else
 	{
@@ -414,7 +373,7 @@ FileAttributes FileGetAttributes(const char* const filename)
 }
 
 
-FILE* GetRealFileHandleFromFileManFileHandle(const SGPFile* f)
+File* GetRealFileHandleFromFileManFileHandle(const SGPFile* f)
 {
 	return f->flags & SGPFILE_REAL ? f->u.file : nullptr;
 }
@@ -530,29 +489,13 @@ bool FileMan::findObjectCaseInsensitive(const char *directory, const char *name,
 #endif
 
 
-/** Convert file descriptor to HWFile.
- * Raise runtime_error if not possible. */
-SGPFile* FileMan::getSGPFileFromFD(int fd, const char *filename, const char *fmode)
+SGPFile* FileMan::getSGPFileFromFile(File* f)
 {
-	if (fd < 0)
-	{
-		char buf[128];
-		snprintf(buf, sizeof(buf), "Opening file '%s' failed", filename);
-		throw std::runtime_error(buf);
-	}
-
-	FILE* const f = fdopen(fd, fmode);
-	if (!f)
-	{
-		char buf[128];
-		snprintf(buf, sizeof(buf), "Opening file '%s' failed", filename);
-		throw std::runtime_error(buf);
-	}
-
-	SGPFile *file = new SGPFile{};
-	file->flags  = SGPFILE_REAL;
-	file->u.file = f;
-	return file;
+	Assert(f);
+	SGPFile *sgp_file = new SGPFile{};
+	sgp_file->flags  = SGPFILE_REAL;
+	sgp_file->u.file = f;
+	return sgp_file;
 }
 
 
@@ -561,16 +504,21 @@ SGPFile* FileMan::getSGPFileFromFD(int fd, const char *filename, const char *fmo
  * If file exists, it's content will be removed. */
 SGPFile* FileMan::openForWriting(const char *filename, bool truncate)
 {
-	int mode;
-	const char* fmode = GetFileOpenModes(FILE_ACCESS_WRITE, &mode);
-
-	if(truncate)
+	uint8_t open_options = FILE_OPEN_WRITE | FILE_OPEN_CREATE;
+	if (truncate)
 	{
-		mode |= O_TRUNC;
+		open_options |= FILE_OPEN_TRUNCATE;
 	}
 
-	int d = open3(filename, mode | O_CREAT, 0600);
-	return getSGPFileFromFD(d, filename, fmode);
+	RustPointer<File> file(File_open(filename, open_options));
+	if (!file)
+	{
+		RustPointer<char> err(getRustError());
+		char buf[128];
+		snprintf(buf, sizeof(buf), "FileMan::openForWriting: %s", err.get());
+		throw std::runtime_error(buf);
+	}
+	return getSGPFileFromFile(file.release());
 }
 
 
@@ -578,11 +526,15 @@ SGPFile* FileMan::openForWriting(const char *filename, bool truncate)
  * If file doesn't exist, it will be created. */
 SGPFile* FileMan::openForAppend(const char *filename)
 {
-	int         mode;
-	const char* fmode = GetFileOpenModes(FILE_ACCESS_APPEND, &mode);
-
-	int d = open3(filename, mode | O_CREAT, 0600);
-	return getSGPFileFromFD(d, filename, fmode);
+	RustPointer<File> file(File_open(filename, FILE_OPEN_APPEND | FILE_OPEN_CREATE));
+	if (!file)
+	{
+		RustPointer<char> err(getRustError());
+		char buf[128];
+		snprintf(buf, sizeof(buf), "FileMan::openForAppend: %s", err.get());
+		throw std::runtime_error(buf);
+	}
+	return getSGPFileFromFile(file.release());
 }
 
 
@@ -590,20 +542,29 @@ SGPFile* FileMan::openForAppend(const char *filename)
  * If file doesn't exist, it will be created. */
 SGPFile* FileMan::openForReadWrite(const char *filename)
 {
-	int         mode;
-	const char* fmode = GetFileOpenModes(FILE_ACCESS_READWRITE, &mode);
-
-	int d = open3(filename, mode | O_CREAT, 0600);
-	return getSGPFileFromFD(d, filename, fmode);
+	RustPointer<File> file(File_open(filename, FILE_OPEN_READ | FILE_OPEN_WRITE | FILE_OPEN_CREATE));
+	if (!file)
+	{
+		RustPointer<char> err(getRustError());
+		char buf[128];
+		snprintf(buf, sizeof(buf), "FileMan::openForReadWrite: %s", err.get());
+		throw std::runtime_error(buf);
+	}
+	return getSGPFileFromFile(file.release());
 }
 
 /** Open file for reading. */
 SGPFile* FileMan::openForReading(const char *filename)
 {
-	int         mode;
-	const char* fmode = GetFileOpenModes(FILE_ACCESS_READ, &mode);
-	int d = open3(filename, mode, 0600);
-	return getSGPFileFromFD(d, filename, fmode);
+	RustPointer<File> file(File_open(filename, FILE_OPEN_READ));
+	if (!file)
+	{
+		RustPointer<char> err(getRustError());
+		char buf[128];
+		snprintf(buf, sizeof(buf), "FileMan::openForReading: %s", err.get());
+		throw std::runtime_error(buf);
+	}
+	return getSGPFileFromFile(file.release());
 }
 
 /** Open file for reading. */
@@ -613,25 +574,9 @@ SGPFile* FileMan::openForReading(const std::string &filename)
 }
 
 /** Open file for reading.  Look file in folderPath in case-insensitive manner. */
-FILE* FileMan::openForReadingCaseInsensitive(const std::string &folderPath, const char *filename)
+RustPointer<File> FileMan::openForReadingCaseInsensitive(const std::string& folderPath, const char* filename)
 {
-	int mode;
-	const char* fmode = GetFileOpenModes(FILE_ACCESS_READ, &mode);
-
-	int d = openFileCaseInsensitive(folderPath, filename, mode);
-	if(d >= 0)
-	{
-		FILE* hFile = fdopen(d, fmode);
-		if (hFile == NULL)
-		{
-			close(d);
-		}
-		else
-		{
-			return hFile;
-		}
-	}
-	return NULL;
+	return openFileCaseInsensitive(folderPath, filename, FILE_OPEN_READ);
 }
 
 std::vector<std::string>
@@ -777,9 +722,9 @@ std::string FileMan::getFileNameWithoutExt(const std::string &path)
 	return getFileNameWithoutExt(path.c_str());
 }
 
-int FileMan::openFileForReading(const char *filename, int mode)
+RustPointer<File> FileMan::openFileForReading(const char* filename)
 {
-	return open(filename, mode);
+	return RustPointer<File>(File_open(filename, FILE_OPEN_READ));
 }
 
 /** Replace all \ with / */

--- a/src/sgp/FileMan.h
+++ b/src/sgp/FileMan.h
@@ -51,8 +51,8 @@ FileAttributes FileGetAttributes(const char* filename);
 
 /* Pass in the Fileman file handle of an OPEN file and it will return..
  * - if its a Real File, the return will be the handle of the REAL file
- * - if its a LIBRARY file, the return will be the handle of the LIBRARY */
-FILE* GetRealFileHandleFromFileManFileHandle(const SGPFile* hFile);
+ * - if its a LIBRARY file, the return will be null */
+File* GetRealFileHandleFromFileManFileHandle(const SGPFile* hFile);
 
 //Gets the amount of free space on the hard drive that the main executeablt is runnning from
 uint64_t GetFreeSpaceOnHardDriveWhereGameIsRunningFrom(void);
@@ -97,7 +97,7 @@ public:
 #endif
 
 	/** Open file in the 'Data' directory in case-insensitive manner. */
-	static FILE* openForReadingCaseInsensitive(const std::string &folderPath, const char *filename);
+	static RustPointer<File> openForReadingCaseInsensitive(const std::string& folderPath, const char* filename);
 
 	/* ------------------------------------------------------------
 	 * Other operations
@@ -130,15 +130,14 @@ public:
 	static std::string getFileNameWithoutExt(const char *path);
 	static std::string getFileNameWithoutExt(const std::string &path);
 
-	static int openFileForReading(const char *filename, int mode);
+	static RustPointer<File> openFileForReading(const char* filename);
 
 	/** Open file in the given folder in case-insensitive manner.
-	 * @return file descriptor or -1 if file is not found. */
-	static int openFileCaseInsensitive(const std::string &folderPath, const char *filename, int mode);
+	 * @return file descriptor or null if file is not found. */
+	static RustPointer<File> openFileCaseInsensitive(const std::string& folderPath, const char* filename, uint8_t open_options);
 
-	/** Convert file descriptor to HWFile.
-	 * Raise runtime_error if not possible. */
-	static SGPFile* getSGPFileFromFD(int fd, const char *filename, const char *fmode);
+	/** Convert File to HWFile. */
+	static SGPFile* getSGPFileFromFile(File* f);
 
 	/** Replace all \ with / */
 	static void slashifyPath(std::string &path);
@@ -176,8 +175,5 @@ FindFilesInDir(const std::string &dirPath,
  * @return List of paths (dir + filename). */
 std::vector<std::string>
 FindAllFilesInDir(const std::string &dirPath, bool sortResults = false);
-
-/** Get file open modes from reading. */
-const char* GetFileOpenModeForReading(int *posixMode);
 
 #endif

--- a/src/sgp/LoadSaveData_unittest.cc
+++ b/src/sgp/LoadSaveData_unittest.cc
@@ -4,6 +4,7 @@
 
 #include "LoadSaveData.h"
 
+#include "externalized/RustInterface.h"
 #include "externalized/TestUtils.h"
 
 
@@ -194,13 +195,12 @@ TEST(LoadSaveData, floatAndDoubleFormat)
 	ASSERT_EQ(sizeof(double), 8u);
 
 	{
-		char buf[100];
-		FILE *floats = fopen(floatsPath.c_str(), "rb");
-		EXPECT_EQ(fread(buf, sizeof(float), 5, floats), 5u);
-		fclose(floats);
+		RustPointer<VecU8> buf(Fs_read(floatsPath.c_str()));
+		ASSERT_TRUE(buf);
+		ASSERT_EQ(VecU8_len(buf.get()), sizeof(float) * 5);
 		float f;
 
-		char *S = buf;
+		const uint8_t* S = VecU8_as_ptr(buf.get());
 		EXTR_FLOAT(S, f); EXPECT_EQ(f, 0         );
 		EXTR_FLOAT(S, f); EXPECT_EQ(f, 1         );
 		EXTR_FLOAT(S, f); EXPECT_EQ(f, -1        );
@@ -209,13 +209,12 @@ TEST(LoadSaveData, floatAndDoubleFormat)
 	}
 
 	{
-		char buf[100];
-		FILE *doubles = fopen(doublesPath.c_str(), "rb");
-		EXPECT_EQ(fread(buf, sizeof(double), 5, doubles), 5u);
-		fclose(doubles);
+		RustPointer<VecU8> buf(Fs_read(doublesPath.c_str()));
+		ASSERT_TRUE(buf);
+		ASSERT_EQ(VecU8_len(buf.get()), sizeof(double) * 5);
 		double d;
 
-		char *S = buf;
+		const uint8_t* S = VecU8_as_ptr(buf.get());
 		EXTR_DOUBLE(S, d); EXPECT_EQ(d, 0         );
 		EXTR_DOUBLE(S, d); EXPECT_EQ(d, 1         );
 		EXTR_DOUBLE(S, d); EXPECT_EQ(d, -1        );

--- a/src/sgp/SGPFile.h
+++ b/src/sgp/SGPFile.h
@@ -16,6 +16,7 @@ enum SGPFileFlags
 	SGPFILE_REAL = 1U << 0
 };
 
+struct File;
 struct LibraryFile;
 
 struct SGPFile
@@ -23,7 +24,7 @@ struct SGPFile
 	SGPFileFlags flags;
 	union
 	{
-		FILE*       file;
+		File* file;
 		LibraryFile* lib;
 	} u;
 };

--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -257,7 +257,7 @@ try
 	}
 
 	//Get the real file handle of the file
-	FILE* hRealFileHandle = GetRealFileHandleFromFileManFileHandle(hFile);
+	File* hRealFileHandle = GetRealFileHandleFromFileManFileHandle(hFile);
 	if (hRealFileHandle == NULL)
 	{
 		SLOGE("SoundPlayStreamedFile(): Couldnt get a real file handle for '%s' in SoundPlayStreamedFile()", pFilename );


### PR DESCRIPTION
This PR aims to add support for all paths by rustifying them, needed for #937.

The strategy is to use utf8 strings without embedded nuls in the C++ code.
`AnyPath` converts to/from `Path` in a way that is compatible with `String` and `CString`.
