### PR TITLE
Quick fix for FPE in CalcBestThrow when MinAPsToThrow returns 0

### DIFF
--- a/src/game/Tactical/Points.cc
+++ b/src/game/Tactical/Points.cc
@@ -1685,12 +1685,10 @@ INT16 MinAPsToThrow(SOLDIERTYPE const& s, GridNo gridno, bool const add_turning_
 	if (!item)
 	{
 		SLOGW("MinAPsToThrow - in-hand item is missing");
-		return 0;
 	}
 	else if (!(item->getItemClass() & (IC_GRENADE | IC_THROWN))) // match MinAPsToAttack
 	{
 		SLOGW("MinAPsToThrow - in-hand item '%s' has unexpected item class 0x%x", item->getInternalName().c_str(), item->getItemClass());
-		return 0;
 	}
 
 	if (gridno != NOWHERE)


### PR DESCRIPTION
The FPE is a divide by zero while calculating iHitRate.

MinAPsToThrow warned and returned 0 on unexpected input, now it just warns.

It is unclear how a launcher should be trully handled:
1) GLAUNCHER has item class IC_LAUNCHER.
2) MinAPsToAttack calls MinAPsToShootOrStab for item class IC_LAUNCHER.
3) CalcBestThrow calls MinAPsToThrow and has the comment "NB grenade launcher is NOT a direct fire weapon!"

Fixes  #1006