### PR TITLE
Allowing more Town Sectors

### DIFF
--- a/src/game/Strategic/Strategic_Town_Loyalty.cc
+++ b/src/game/Strategic/Strategic_Town_Loyalty.cc
@@ -73,9 +73,10 @@
 // town loyalty table
 TOWN_LOYALTY gTownLoyalty[ NUM_TOWNS ];
 
+#define MAX_NUM_OF_TOWNS_SECTORS 50
 
 // Town names and locations
-TownSectorInfo g_town_sectors[40];
+TownSectorInfo g_town_sectors[MAX_NUM_OF_TOWNS_SECTORS];
 
 
 #define BASIC_COST_FOR_CIV_MURDER	(10 * GAIN_PTS_PER_LOYALTY_PT)

--- a/src/game/Strategic/Strategic_Town_Loyalty.cc
+++ b/src/game/Strategic/Strategic_Town_Loyalty.cc
@@ -73,10 +73,9 @@
 // town loyalty table
 TOWN_LOYALTY gTownLoyalty[ NUM_TOWNS ];
 
-#define MAX_NUM_OF_TOWNS_SECTORS 50
 
 // Town names and locations
-TownSectorInfo g_town_sectors[MAX_NUM_OF_TOWNS_SECTORS];
+std::vector<TownSectorInfo> g_town_sectors;
 
 
 #define BASIC_COST_FOR_CIV_MURDER	(10 * GAIN_PTS_PER_LOYALTY_PT)
@@ -678,19 +677,15 @@ void RemoveRandomItemsInSector(INT16 const sSectorX, INT16 const sSectorY, INT16
 
 void BuildListOfTownSectors()
 {
-	std::fill(std::begin(g_town_sectors), std::end(g_town_sectors), TownSectorInfo{});
-
-	TownSectorInfo* i = g_town_sectors;
 	for (INT32 x = 1; x != MAP_WORLD_X - 1; ++x)
 	{
 		for (INT32 y = 1; y != MAP_WORLD_Y - 1; ++y)
 		{
 			INT8 const town = StrategicMap[CALCULATE_STRATEGIC_INDEX(x, y)].bNameId;
 			if (town < FIRST_TOWN || NUM_TOWNS <= town) continue;
-
-			i->sector = SECTOR(x, y);
-			i->town   = town;
-			++i;
+			g_town_sectors.push_back(
+				TownSectorInfo{ SECTOR(x, y) , (UINT8)town }
+			);
 		}
 	}
 }

--- a/src/game/Strategic/Strategic_Town_Loyalty.h
+++ b/src/game/Strategic/Strategic_Town_Loyalty.h
@@ -2,6 +2,7 @@
 #define __STRATEGIC_TOWN_LOYALTY_H
 
 #include "JA2Types.h"
+#include <vector>
 
 
 // gain pts per real loyalty pt
@@ -85,10 +86,10 @@ struct TownSectorInfo
 	UINT8 sector;
 };
 
-extern TownSectorInfo g_town_sectors[];
+extern std::vector<TownSectorInfo> g_town_sectors;
 
 #define FOR_EACH_TOWN_SECTOR(iter) \
-	for (TownSectorInfo const* iter = g_town_sectors; iter->town != BLANK_SECTOR; ++iter)
+	for (auto iter = g_town_sectors.begin(); iter != g_town_sectors.end(); ++iter)
 
 #define FOR_EACH_SECTOR_IN_TOWN(iter, town_) \
 	FOR_EACH_TOWN_SECTOR(iter) if (iter->town != (town_)) continue; else


### PR DESCRIPTION
This is not an issue with vanilla, but for future map mods.

Before this change,  `g_town_sectors` in Strategic_Town_Loyalty [limits to 40](https://github.com/ja2-stracciatella/ja2-stracciatella/blob/36708ba01af1564cb6fd4e13cbc58533cd8d0e0d/src/game/Strategic/Strategic_Town_Loyalty.cc#L78). If the world has more than 39 town sectors, `BuildListOfTownSectors` will [iterate past the end of array](https://github.com/ja2-stracciatella/ja2-stracciatella/blob/36708ba01af1564cb6fd4e13cbc58533cd8d0e0d/src/game/Strategic/Strategic_Town_Loyalty.cc#L692), causing a "stack-based buffer overrun"  exception.

This change should bring no side-effects other than wasting a few more CPU cycles [iterating on empty elements](https://github.com/ja2-stracciatella/ja2-stracciatella/blob/36708ba01af1564cb6fd4e13cbc58533cd8d0e0d/src/game/Strategic/Strategic_Town_Loyalty.h#L91).

There are 36 town sectors in Vanilla, 40 in Wildfire maps. The new `MAX_NUM_OF_TOWNS_SECTORS`  value of 50 is chosen rather arbitrarily, so that is enough for Wildfire and not unnecessarily large.