### PR TITLE
Fixing error in TownSectorInfo construction

### DIFF
--- a/src/game/Strategic/Strategic_Town_Loyalty.cc
+++ b/src/game/Strategic/Strategic_Town_Loyalty.cc
@@ -684,7 +684,7 @@ void BuildListOfTownSectors()
 			INT8 const town = StrategicMap[CALCULATE_STRATEGIC_INDEX(x, y)].bNameId;
 			if (town < FIRST_TOWN || NUM_TOWNS <= town) continue;
 			g_town_sectors.push_back(
-				TownSectorInfo{ SECTOR(x, y) , (UINT8)town }
+				TownSectorInfo{ (UINT8)town, SECTOR(x, y) }
 			);
 		}
 	}


### PR DESCRIPTION
Fixing an embarrassing error in #1016 

The struct is:
```c++
struct TownSectorInfo
{
	UINT8 town;
	UINT8 sector;
};
```