### PR TITLE
Fix opening of unpacked files in data directory

### DIFF
--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -484,7 +484,7 @@ bool DefaultContentManager::doesGameResExists(char const* filename) const
 		{
 			char path[512];
 			snprintf(path, lengthof(path), "%s/%s", m_dataDir.c_str(), filename);
-			file.reset(File_open(filename, FILE_OPEN_READ));
+			file.reset(File_open(path, FILE_OPEN_READ));
 			if (!file)
 			{
 				RustPointer<LibraryFile> libFile(LibraryFile_open(m_libraryDB.get(), filename));


### PR DESCRIPTION
Unpacked files inside `data/` used to work. Now it doesn't because the file exist check is not using the full path.

The variable `path`  is unused otherwise, so I believe this (using `path`) was the intended behaviour. See c29759a3