### PR TITLE
Externalizing Town and Town Sectors data

### DIFF
--- a/assets/externalized/strategic-map-towns.json
+++ b/assets/externalized/strategic-map-towns.json
@@ -1,0 +1,95 @@
+/*
+ * This defines the towns and their sectors.
+ *
+ * Field definitions:
+ *  - townId:    The numeric ID of the town as set in codebase
+ *  - sectors:    List of sectors belonging to the town.
+ *  - townPoint:    Position of town names on the map. These are no longer PIXELS, but 10 * the X,Y position in SECTORS (fractions possible) to the X-CENTER of the town.
+ *  - isMilitiaTrainingAllowed:   Whether or not militia is allowed in town
+ */
+[
+	// OMERTA
+	{ 
+		"townId": 1,
+		"sectors": [ "A9", "A10" ],
+		"townPoint": { "x": 90, "y": 0 },
+		"isMilitiaTrainingAllowed": false
+	},
+	// DRASSEN
+	{ 
+		"townId": 2,
+		"sectors": [ "B13", "C13", "D13" ],
+		"townPoint": { "x": 125, "y": 40 },
+		"isMilitiaTrainingAllowed": true
+	},
+	// ALMA
+	{ 
+		"townId": 3,
+		"sectors": [ "H13", "H14", "I13", "I14" ],
+		"townPoint": { "x": 130, "y": 90 },
+		"isMilitiaTrainingAllowed": true
+	},
+	// GRUMM
+	{
+		"townId": 4,
+		"sectors": [ "G1", "G2", "H1", "H2" ],
+		"townPoint": { "x": 15, "y": 80 },
+		"isMilitiaTrainingAllowed": true
+	},
+	// TIXA
+	{
+		"townId": 5,
+		"sectors": [ "J9" ],
+		"townPoint": { "x": 85, "y": 100 },
+		"isMilitiaTrainingAllowed": false
+	},
+	// CAMBRIA
+	{
+		"townId": 6,
+		"sectors": [ "F8", "F9", "G8", "G9" ],
+		"townPoint": { "x": 95, "y": 70 },
+		"isMilitiaTrainingAllowed": true
+	},
+	// SAN_MONA
+	{
+		"townId": 7,
+		"sectors": [ "C5", "C6", "D4", "D5" ],
+		"townPoint": { "x": 45, "y": 40 },
+		"isMilitiaTrainingAllowed": false
+	},
+	// ESTONI
+	{
+		"townId": 8,
+		"sectors": [ "I6" ],
+		"townPoint": { "x": 55, "y": 90 },
+		"isMilitiaTrainingAllowed": false
+	},
+	// ORTA
+	{
+		"townId": 9,
+		"sectors": [ "K4" ],
+		"townPoint": { "x": 35, "y": 110 },
+		"isMilitiaTrainingAllowed": false
+	},
+	// BALIME
+	{
+		"townId": 10,
+		"sectors": [ "L11", "L12" ],
+		"townPoint": { "x": 110, "y": 120 },
+		"isMilitiaTrainingAllowed": true
+	},
+	// MEDUNA
+	{
+		"townId": 11,
+		"sectors": [ "N3", "N4", "N5", "O3", "O4", "P3" ],
+		"townPoint": { "x": 45, "y": 150 },
+		"isMilitiaTrainingAllowed": true
+	},
+	// CHITZENA
+	{ 
+		"townId": 12,
+		"sectors": [ "A2", "B2" ],
+		"townPoint": { "x": 15, "y": 20 },
+		"isMilitiaTrainingAllowed": true
+	}
+]

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <string>
 #include <string_theory/string>
+#include <map>
 #include <vector>
 
 /* XXX */
@@ -16,6 +17,7 @@ class GamePolicy;
 class IMPPolicy;
 class BloodCatPlacementsModel;
 class BloodCatSpawnsModel;
+class TownModel;
 struct AmmoTypeModel;
 struct CalibreModel;
 struct MagazineModel;
@@ -112,6 +114,8 @@ public:
 	virtual const std::vector<const BloodCatPlacementsModel*> & getBloodCatPlacements() const = 0;
 	virtual const std::vector<const BloodCatSpawnsModel*> & getBloodCatSpawns() const = 0;
 	virtual const BloodCatSpawnsModel* getBloodCatSpawnsOfSector(uint8_t sectorId) const = 0;
+	virtual const TownModel* getTown(int8_t townId) const = 0;
+	virtual const std::map<int8_t, const TownModel*>& getTowns() const = 0;
 
 	virtual const ST::string* getNewString(size_t stringId) const = 0;
 

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -29,6 +29,7 @@
 #include "policy/DefaultIMPPolicy.h"
 #include "strategic/BloodCatPlacementsModel.h"
 #include "strategic/BloodCatSpawnsModel.h"
+#include "strategic/TownModel.h"
 
 #include "Logger.h"
 
@@ -273,6 +274,7 @@ DefaultContentManager::~DefaultContentManager()
 
 	m_bloodCatPlacements.clear();
 	m_bloodCatSpawns.clear();
+	m_towns.clear();
 }
 
 const DealerInventory* DefaultContentManager::getBobbyRayNewInventory() const
@@ -1059,6 +1061,13 @@ bool DefaultContentManager::loadStrategicLayerData() {
 			BloodCatSpawnsModel::deserialize(obj)
 		);
 	}
+
+	json = readJsonDataFile("strategic-map-towns.json");
+	for (auto& element : json->GetArray()) {
+		auto town = TownModel::deserialize(element);
+		m_towns.insert(std::make_pair(town->townId, town));
+	}
+
 	return true;
 }
 
@@ -1082,4 +1091,15 @@ const BloodCatSpawnsModel* DefaultContentManager::getBloodCatSpawnsOfSector(uint
 		}
 	}
 	return NULL;
+}
+
+const TownModel* DefaultContentManager::getTown(int8_t townId) const
+{
+	auto iter = m_towns.find(townId);
+	return (iter != m_towns.end()) ? iter->second : NULL;
+}
+
+const std::map<int8_t, const TownModel*>& DefaultContentManager::getTowns() const
+{
+	return m_towns;
 }

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -145,6 +145,8 @@ public:
 	virtual const std::vector<const BloodCatPlacementsModel*>& getBloodCatPlacements() const;
 	virtual const std::vector<const BloodCatSpawnsModel*>& getBloodCatSpawns() const;
 	virtual const BloodCatSpawnsModel* getBloodCatSpawnsOfSector(uint8_t sectorId) const;
+	virtual const TownModel* getTown(int8_t townId) const;
+	virtual const std::map<int8_t, const TownModel*>& getTowns() const;
 
 protected:
 	std::string m_dataDir;
@@ -185,6 +187,7 @@ protected:
 
 	std::vector<const BloodCatPlacementsModel*> m_bloodCatPlacements;
 	std::vector<const BloodCatSpawnsModel*> m_bloodCatSpawns;
+	std::map<int8_t, const TownModel*> m_towns;
 
 	RustPointer<LibraryDB> m_libraryDB;
 

--- a/src/externalized/strategic/CMakeLists.txt
+++ b/src/externalized/strategic/CMakeLists.txt
@@ -4,6 +4,7 @@ set(JA2_SOURCES
     ${LOCAL_JA2_HEADERS}
     ${CMAKE_CURRENT_SOURCE_DIR}/BloodCatPlacementsModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/BloodCatSpawnsModel.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/TownModel.cc
     PARENT_SCOPE
 )
 set(JA2_INCLUDES

--- a/src/externalized/strategic/TownModel.cc
+++ b/src/externalized/strategic/TownModel.cc
@@ -22,7 +22,7 @@ TownModel* TownModel::deserialize(const rapidjson::Value& obj)
 	std::vector<uint8_t> sectorIDs;
 	for ( auto& s : obj["sectors"].GetArray() ) 
 	{
-		sectorIDs.push_back( SECTOR_FROM_COORDINATES( s.GetString() ) );
+		sectorIDs.push_back( SECTOR_FROM_SECTOR_SHORT_STRING( s.GetString() ) );
 	}
 
 	Assert( obj.HasMember("townPoint") && obj["townPoint"].IsObject() );

--- a/src/externalized/strategic/TownModel.cc
+++ b/src/externalized/strategic/TownModel.cc
@@ -1,0 +1,41 @@
+#include "TownModel.h"
+
+#include "JsonObject.h"
+
+TownModel::TownModel(int8_t townId_, std::vector<uint8_t> sectorIDs_, SGPPoint townPoint_, bool isMilitiaTrainingAllowed_)
+		: townId(townId_), sectorIDs(sectorIDs_), townPoint(townPoint_), isMilitiaTrainingAllowed(isMilitiaTrainingAllowed_) {}
+
+const uint8_t TownModel::getBaseSector() const
+{
+	int8_t minX = 99, minY = 99;
+	for ( auto sectorID : sectorIDs ) {
+		int8_t x = SECTORX(sectorID), y = SECTORY(sectorID);
+		if ( x < minX ) minX = x;
+		if ( y < minY ) minY = y;
+	}
+	return SECTOR( minX, minY );
+}
+
+TownModel* TownModel::deserialize(const rapidjson::Value& obj)
+{
+	Assert( obj.HasMember("sectors") && obj["sectors"].IsArray() );
+	std::vector<uint8_t> sectorIDs;
+	for ( auto& s : obj["sectors"].GetArray() ) 
+	{
+		sectorIDs.push_back( SECTOR_FROM_COORDINATES( s.GetString() ) );
+	}
+
+	Assert( obj.HasMember("townPoint") && obj["townPoint"].IsObject() );
+	auto tp = obj["townPoint"].GetObject();
+	SGPPoint townPoint = SGPPoint();
+	townPoint.iX = tp["x"].GetInt();
+	townPoint.iY = tp["y"].GetInt();
+
+	JsonObjectReader reader(obj);
+	return new TownModel(
+		reader.GetInt("townId"),
+		sectorIDs,
+		townPoint,
+		reader.getOptionalBool("isMilitiaTrainingAllowed")
+		);
+}

--- a/src/externalized/strategic/TownModel.h
+++ b/src/externalized/strategic/TownModel.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Campaign_Types.h"
+#include "JsonObject.h"
+
+#include <vector>
+
+class TownModel
+{
+public:
+	TownModel(int8_t townId_, std::vector<uint8_t> sectorIDs_, SGPPoint townPoint_, bool isMilitiaTrainingAllowed_ );
+
+	// Returns the top-left corner of the town on map. It may or may not belong to the town.
+	const uint8_t getBaseSector() const;
+	static TownModel* deserialize(const rapidjson::Value& obj);
+
+	int8_t townId;
+	std::vector<uint8_t> sectorIDs;
+	SGPPoint townPoint;
+	bool isMilitiaTrainingAllowed;
+};
+

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -47,6 +47,9 @@
 #include "Button_System.h"
 #include "Debug.h"
 #include "UILayout.h"
+#include "GameInstance.h"
+#include "DefaultContentManager.h"
+#include "externalized/strategic/TownModel.h"
 
 
 // zoom x and y coords for map scrolling
@@ -371,42 +374,12 @@ static UINT16* pMapDKGreenPalette;
 // heli pop up
 static SGPVObject* guiMapBorderHeliSectors;
 
+// base sectors (sector value for the upper left corner) of towns. List start at zero, indexed by (townId - 1)
+static std::vector<INT16> sBaseSectorList;
 
-static INT16 const sBaseSectorList[] =
-{
-	// NOTE: These co-ordinates must match the top left corner of the 3x3 town tiles cutouts in interface/militiamaps.sti!
-	SECTOR(  9, 1 ), // Omerta
-	SECTOR( 13, 2 ), // Drassen
-	SECTOR( 13, 8 ), // Alma
-	SECTOR(  1, 7 ), // Grumm
-	SECTOR(  8, 9 ), // Tixa
-	SECTOR(  8, 6 ), // Cambria
-	SECTOR(  4, 2 ), // San Mona
-	SECTOR(  5, 8 ), // Estoni
-	SECTOR(  3,10 ), // Orta
-	SECTOR( 11,11 ), // Balime
-	SECTOR(  3,14 ), // Meduna
-	SECTOR(  2, 1 ), // Chitzena
-};
-
-// position of town names on the map
+// position of town names on the map (list by townId, starting at 1)
 // these are no longer PIXELS, but 10 * the X,Y position in SECTORS (fractions possible) to the X-CENTER of the town
-static SGPPoint const pTownPoints[] =
-{
-	{ 0 ,  0 },
-	{ 90, 10}, // Omerta
-	{125, 40}, // Drassen
-	{130, 90}, // Alma
-	{ 15, 80}, // Grumm
-	{ 85,100}, // Tixa
-	{ 95, 70}, // Cambria
-	{ 45, 40}, // San Mona
-	{ 55, 90}, // Estoni
-	{ 35,110}, // Orta
-	{110,120}, // Balime
-	{ 45,150}, // Meduna
-	{ 15, 20}, // Chitzena
-};
+static std::vector<SGPPoint> pTownPoints;
 
 
 // map region
@@ -476,6 +449,18 @@ static SGPVObject* guiHelicopterIcon;
 
 void InitMapScreenInterfaceMap()
 {
+	sBaseSectorList.clear();
+	pTownPoints.clear();
+	pTownPoints.push_back(SGPPoint());
+
+	auto towns = GCM->getTowns();
+	for (auto& pair : GCM->getTowns()) 
+	{
+		auto town = pair.second;
+		sBaseSectorList.push_back(town->getBaseSector());
+		pTownPoints.push_back(town->townPoint);
+	}
+
 	MapScreenRect.set((MAP_VIEW_START_X+MAP_GRID_X - 2), ( MAP_VIEW_START_Y+MAP_GRID_Y - 1),
 				MAP_VIEW_START_X + MAP_VIEW_WIDTH - 1 + MAP_GRID_X , MAP_VIEW_START_Y+MAP_VIEW_HEIGHT-10+MAP_GRID_Y);
 }

--- a/src/game/Strategic/StrategicMap.cc
+++ b/src/game/Strategic/StrategicMap.cc
@@ -105,9 +105,13 @@
 #include "Items.h"
 #include "UILayout.h"
 #include "Logger.h"
+#include "ContentManager.h"
+#include "GameInstance.h"
+#include "externalized/strategic/TownModel.h"
 
 #include <algorithm>
 #include <iterator>
+#include <map>
 #include <stdexcept>
 
 //Used by PickGridNoToWalkIn
@@ -1284,18 +1288,14 @@ place_in_center:
 
 static void InitializeStrategicMapSectorTownNames(void)
 {
-	StrategicMap[2+2*MAP_WORLD_X].bNameId= StrategicMap[2+1*MAP_WORLD_X].bNameId= CHITZENA;
-	StrategicMap[5+3*MAP_WORLD_X].bNameId=StrategicMap[6+3*MAP_WORLD_X].bNameId=StrategicMap[5+4*MAP_WORLD_X].bNameId = StrategicMap[4+4*MAP_WORLD_X].bNameId =SAN_MONA;
-	StrategicMap[9+1*MAP_WORLD_X].bNameId=StrategicMap[10+1*MAP_WORLD_X].bNameId=OMERTA;
-	StrategicMap[13+2*MAP_WORLD_X].bNameId=StrategicMap[13+3*MAP_WORLD_X].bNameId=StrategicMap[13+4*MAP_WORLD_X].bNameId=DRASSEN;
-	StrategicMap[1+7*MAP_WORLD_X].bNameId=StrategicMap[1+8*MAP_WORLD_X].bNameId=StrategicMap[2+7*MAP_WORLD_X].bNameId= StrategicMap[2+8*MAP_WORLD_X].bNameId = StrategicMap[3+8*MAP_WORLD_X].bNameId = GRUMM;
-	StrategicMap[6+9*MAP_WORLD_X].bNameId=ESTONI;
-	StrategicMap[9+10*MAP_WORLD_X].bNameId=TIXA;
-	StrategicMap[8+6*MAP_WORLD_X].bNameId=StrategicMap[9+6*MAP_WORLD_X].bNameId=StrategicMap[8+7*MAP_WORLD_X].bNameId=StrategicMap[9+7*MAP_WORLD_X].bNameId= StrategicMap[8+8*MAP_WORLD_X].bNameId = CAMBRIA;
-	StrategicMap[13+9*MAP_WORLD_X].bNameId=StrategicMap[14+9*MAP_WORLD_X].bNameId=StrategicMap[13+8*MAP_WORLD_X].bNameId=StrategicMap[14+8*MAP_WORLD_X].bNameId=ALMA;
-	StrategicMap[4+11*MAP_WORLD_X].bNameId=ORTA;
-	StrategicMap[11+12*MAP_WORLD_X].bNameId= 	StrategicMap[12+12*MAP_WORLD_X].bNameId = BALIME;
-	StrategicMap[3+14*MAP_WORLD_X].bNameId=StrategicMap[4+14*MAP_WORLD_X].bNameId=StrategicMap[5+14*MAP_WORLD_X].bNameId=StrategicMap[3+15*MAP_WORLD_X].bNameId=StrategicMap[4+15*MAP_WORLD_X].bNameId= StrategicMap[3+16*MAP_WORLD_X].bNameId = MEDUNA;
+	for (auto& element: GCM->getTowns())
+	{
+		auto town = element.second;
+		for (auto sector : town->sectorIDs)
+		{
+			StrategicMap[ SECTOR_INFO_TO_STRATEGIC_INDEX(sector) ].bNameId = town->townId;
+		}
+	}
 }
 
 

--- a/src/game/Strategic/Town_Militia.cc
+++ b/src/game/Strategic/Town_Militia.cc
@@ -26,6 +26,9 @@
 #include "Debug.h"
 #include "ScreenIDs.h"
 #include "UILayout.h"
+#include "ContentManager.h"
+#include "GameInstance.h"
+#include "TownModel.h"
 
 #include <algorithm>
 #include <iterator>
@@ -931,31 +934,11 @@ BOOLEAN MilitiaTrainingAllowedInSector( INT16 sSectorX, INT16 sSectorY, INT8 bSe
 
 BOOLEAN MilitiaTrainingAllowedInTown( INT8 bTownId )
 {
-	switch ( bTownId )
-	{
-		case DRASSEN:
-		case ALMA:
-		case GRUMM:
-		case CAMBRIA:
-		case BALIME:
-		case MEDUNA:
-		case CHITZENA:
-			return(TRUE);
-
-		case OMERTA:
-		case ESTONI:
-		case SAN_MONA:
-		case TIXA:
-		case ORTA:
-			// can't keep militia in these towns
-			return(FALSE);
-
-		case BLANK_SECTOR:
-		default:
-			// not a town sector!
-			return(FALSE);
-
+	auto town = GCM->getTown(bTownId);
+	if (town == NULL) {
+		return false;
 	}
+	return town->isMilitiaTrainingAllowed;
 }
 
 


### PR DESCRIPTION
Externalization of Town and Town Sector data, in a similar manner as #1018. 

See #665 and #1011.

## Summary

- Externalizing basic town info. See assets/externalized/strategic-map-towns.json for the schema
- Adding TownModel class, which can be retrieved by `townId`
- Replacing the hard-coded tables of `InitializeStrategicMapSectorTownNames`, `sBaseSectorList`, `pTownPoints` and `MilitiaTrainingAllowedInTown`

##  What's not included

* Town names - they are defined in translation string files
* Is Town hidden - codebase has very specific logic for Tixa and Orta. It will require a lot of code change to generalize the logic
* Base sector - it is now calculated at init time

This PR conflicts with #1018. I will re-base when it is merged to master.