### PR TITLE
ja2_json.rs: fixed replacement var error message suggestion

### DIFF
--- a/rust/stracciatella/src/config/ja2_json.rs
+++ b/rust/stracciatella/src/config/ja2_json.rs
@@ -65,7 +65,7 @@ impl Ja2Json {
         let content = self.get_content()?;
 
         if let Some(data_dir) = content.data_dir {
-            warn!("`data_dir` option in ja2.json is deprecated, use `game_version` instead");
+            warn!("`data_dir` option in ja2.json is deprecated, use `game_dir` instead");
             engine_options.vanilla_game_dir = data_dir;
         }
 


### PR DESCRIPTION
fixes migration scenario when you still have data_dir.

edit: forgot to add [ci skip], so killed them manually.