### PR TITLE
Externalizing random NPC placements

### DIFF
--- a/assets/externalized/strategic-map-npc-placements.json
+++ b/assets/externalized/strategic-map-npc-placements.json
@@ -5,7 +5,7 @@
  *
  * Fields:
  *  - profileId:    The numeric ID of the NPC merc profile.
- *  - sectors:    Sectors in which the NPC can appear. If empty, the NPC will never appear. All of these sectors should to have NPC merc placed, or else the NPC may get "assigned" to sector but not appearing.
+ *  - sectors:    Sectors in which the NPC can appear. If empty, the NPC will never appear. All of these sectors should have the NPC merc preplaced, or else the NPC may get "assigned" to a sector but not appear.
  */
 [
 	{

--- a/assets/externalized/strategic-map-npc-placements.json
+++ b/assets/externalized/strategic-map-npc-placements.json
@@ -1,0 +1,21 @@
+/**
+ * Lists the sectors where randomly placed NPCs can appear. Each NPC here has his own corresponding code sections.
+ *
+ * Fields:
+ *  - profileId:    The numeric ID of the NPC merc profile.
+ *  - sectors:    Sectors in which the NPC can appear. All of these sectors should to have NPC merc+-+ placed, or else the NPC may get "assigned" to sector but not appearing.
+ */
+[
+	{
+		"profileId": 63,    // HAMOUS, together with his Ice-cream truck (PROF_ICECREAM, 162)
+		"sectors": [ "G6", "F12", "D7", "D3", "D9" ]
+	},
+	{
+		"profileId": 61,    // DEVIN
+		"sectors": [ "G9", "D13", "C5", "H2", "C6" ]
+	},
+	{
+		"profileId": 78,    // CARMEN
+		"sectors": [ "C5", "C13", "G9" ]
+	}
+]

--- a/assets/externalized/strategic-map-npc-placements.json
+++ b/assets/externalized/strategic-map-npc-placements.json
@@ -1,9 +1,11 @@
 /**
- * Lists the sectors where randomly placed NPCs can appear. Each NPC here has his own corresponding code sections.
+ * Lists the sectors where randomly placed NPCs can appear. 
+ * 
+ * Adding other NPCs here will not have any effect, as each NPC here requires his own corresponding sections in codebase.
  *
  * Fields:
  *  - profileId:    The numeric ID of the NPC merc profile.
- *  - sectors:    Sectors in which the NPC can appear. All of these sectors should to have NPC merc+-+ placed, or else the NPC may get "assigned" to sector but not appearing.
+ *  - sectors:    Sectors in which the NPC can appear. If empty, the NPC will never appear. All of these sectors should to have NPC merc placed, or else the NPC may get "assigned" to sector but not appearing.
  */
 [
 	{

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -21,6 +21,7 @@ class BloodCatPlacementsModel;
 class BloodCatSpawnsModel;
 class TownModel;
 class MovementCostsModel;
+class NpcPlacementModel;
 struct AmmoTypeModel;
 struct CalibreModel;
 struct MagazineModel;
@@ -120,6 +121,7 @@ public:
 	virtual const ST::string getTownName(uint8_t townId) const = 0;
 	virtual const ST::string getTownLocative(uint8_t townId) const = 0;
 	virtual const MovementCostsModel* getMovementCosts() const = 0;
+	virtual const NpcPlacementModel* getNpcPlacement(uint8_t profileId) const = 0;
 
 	virtual const ST::string* getNewString(size_t stringId) const = 0;
 

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -31,6 +31,7 @@
 #include "strategic/BloodCatSpawnsModel.h"
 #include "strategic/TownModel.h"
 #include "strategic/MovementCostsModel.h"
+#include "strategic/NpcPlacementModel.h"
 
 #include "Logger.h"
 
@@ -278,6 +279,7 @@ DefaultContentManager::~DefaultContentManager()
 	m_bloodCatPlacements.clear();
 	m_bloodCatSpawns.clear();
 	m_towns.clear();
+	m_npcPlacements.clear();
 
 	delete m_movementCosts;
 }
@@ -1063,7 +1065,8 @@ bool DefaultContentManager::loadStrategicLayerData() {
 	}
 
 	json = readJsonDataFile("strategic-bloodcat-spawns.json");
-	for (auto& element : json->GetArray()) {
+	for (auto& element : json->GetArray()) 
+	{
 		auto obj = JsonObjectReader(element);
 		m_bloodCatSpawns.push_back(
 			BloodCatSpawnsModel::deserialize(obj)
@@ -1071,16 +1074,24 @@ bool DefaultContentManager::loadStrategicLayerData() {
 	}
 
 	json = readJsonDataFile("strategic-map-towns.json");
-	for (auto& element : json->GetArray()) {
+	for (auto& element : json->GetArray()) 
+	{
 		auto town = TownModel::deserialize(element);
 		m_towns.insert(std::make_pair(town->townId, town));
 	}
+	
+	loadStringRes("strings/strategic-map-town-names", m_townNames);
+	loadStringRes("strings/strategic-map-town-name-locatives", m_townNameLocatives);
 
 	json = readJsonDataFile("strategic-map-movement-costs.json");
 	m_movementCosts = MovementCostsModel::deserialize(*json);
 
-	loadStringRes("strings/strategic-map-town-names", m_townNames);
-	loadStringRes("strings/strategic-map-town-name-locatives", m_townNameLocatives);
+	json = readJsonDataFile("strategic-map-npc-placements.json");
+	for (auto& element : json->GetArray())
+	{
+		auto placement = NpcPlacementModel::deserialize(element);
+		m_npcPlacements.insert(std::make_pair(placement->profileId, placement));
+	}
 
 	return true;
 }
@@ -1139,4 +1150,9 @@ const ST::string DefaultContentManager::getTownLocative(uint8_t townId) const
 const MovementCostsModel* DefaultContentManager::getMovementCosts() const
 {
 	return m_movementCosts;
+}
+
+const NpcPlacementModel* DefaultContentManager::getNpcPlacement(uint8_t profileId) const
+{
+	return m_npcPlacements.at(profileId);
 }

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -150,6 +150,7 @@ public:
 	virtual const ST::string getTownName(uint8_t townId) const override;
 	virtual const ST::string getTownLocative(uint8_t townId) const override;
 	virtual const MovementCostsModel* getMovementCosts() const override;
+	virtual const NpcPlacementModel* getNpcPlacement(uint8_t profileId) const override;
 
 protected:
 	std::string m_dataDir;
@@ -194,6 +195,7 @@ protected:
 	std::vector<const ST::string*> m_townNames;
 	std::vector<const ST::string*> m_townNameLocatives;
 	const MovementCostsModel *m_movementCosts;
+	std::map<uint8_t, const NpcPlacementModel*> m_npcPlacements;
 
 	RustPointer<LibraryDB> m_libraryDB;
 

--- a/src/externalized/strategic/CMakeLists.txt
+++ b/src/externalized/strategic/CMakeLists.txt
@@ -6,6 +6,7 @@ set(JA2_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/BloodCatSpawnsModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/TownModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/MovementCostsModel.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/NpcPlacementModel.cc
     PARENT_SCOPE
 )
 set(JA2_INCLUDES

--- a/src/externalized/strategic/NpcPlacementModel.cc
+++ b/src/externalized/strategic/NpcPlacementModel.cc
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "NpcPlacementModel.h"
 #include "Campaign_Types.h"
 
@@ -11,7 +9,12 @@ NpcPlacementModel* NpcPlacementModel::deserialize(const rapidjson::Value& elemen
 	std::vector<uint8_t> sectorIds;
 	for (auto& sector : element["sectors"].GetArray())
 	{
-		sectorIds.push_back(SECTOR_FROM_SECTOR_SHORT_STRING(sector.GetString()));
+		auto sectorString = sector.GetString();
+		if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
+		{
+			throw std::runtime_error("Invalid sector string");
+		}
+		sectorIds.push_back(SECTOR_FROM_SECTOR_SHORT_STRING(sectorString));
 	}
 	return new NpcPlacementModel(
 		element["profileId"].GetInt(),

--- a/src/externalized/strategic/NpcPlacementModel.cc
+++ b/src/externalized/strategic/NpcPlacementModel.cc
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "NpcPlacementModel.h"
+#include "Campaign_Types.h"
+
+NpcPlacementModel::NpcPlacementModel(uint8_t profileId_, std::vector<uint8_t> sectorIds_)
+	:profileId(profileId_), sectorIds(sectorIds_) {}
+
+NpcPlacementModel* NpcPlacementModel::deserialize(const rapidjson::Value& element)
+{
+	std::vector<uint8_t> sectorIds;
+	for (auto& sector : element["sectors"].GetArray())
+	{
+		sectorIds.push_back(SECTOR_FROM_SECTOR_SHORT_STRING(sector.GetString()));
+	}
+	return new NpcPlacementModel(
+		element["profileId"].GetInt(),
+		sectorIds
+	);
+}

--- a/src/externalized/strategic/NpcPlacementModel.h
+++ b/src/externalized/strategic/NpcPlacementModel.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "JsonObject.h"
+#include <vector>
+
+/**
+ * Placements of randomly-placed NPCs
+ */
+class NpcPlacementModel
+{
+public:
+	NpcPlacementModel(uint8_t profileId_, std::vector<uint8_t> sectorIds_);
+
+	static NpcPlacementModel* deserialize(const rapidjson::Value& element);
+
+	const uint8_t profileId;
+	const std::vector<uint8_t> sectorIds;
+};

--- a/src/game/Strategic/Campaign_Types.h
+++ b/src/game/Strategic/Campaign_Types.h
@@ -16,6 +16,23 @@ static inline UINT8 SECTOR(UINT8 const x, UINT8 const y)
 	return (y - 1) * 16 + x - 1;
 }
 
+static inline bool IS_VALID_SECTOR_SHORT_STRING(const char* shortString)
+{
+	size_t len = strlen(shortString);
+	if (len < 2 || len > 3) return false;
+
+	char y = shortString[0], x = shortString[1];
+	if (y < 'A' || y > 'P' || x < '1' || x > '9') return false;
+
+	if (len == 3) 
+	{
+		char x2 = shortString[2];
+		if (x != '1' || x2 < '0' || x2 > '6') return false;
+	}
+
+	return true;
+}
+
 //Macro to convert sector short strings such as A1 and P16, to the 0-255 SectorInfo[] index 
 static inline UINT8 SECTOR_FROM_SECTOR_SHORT_STRING(const char* coordinates)
 {

--- a/src/game/Strategic/Strategic_Event_Handler.cc
+++ b/src/game/Strategic/Strategic_Event_Handler.cc
@@ -28,6 +28,7 @@
 #include "ContentManager.h"
 #include "GameInstance.h"
 #include "policy/GamePolicy.h"
+#include "strategic/NpcPlacementModel.h"
 
 
 #define MEDUNA_ITEM_DROP_OFF_GRIDNO		10959
@@ -772,29 +773,10 @@ void HandleEarlyMorningEvents( void )
 			{
 				// ok, Devin's sector not loaded, so time to move!
 				// might be same sector as before, if so, oh well!
-				switch( Random( 5 ) )
-				{
-					case 0:
-						gMercProfiles[ DEVIN ].sSectorX = 9;
-						gMercProfiles[ DEVIN ].sSectorY = MAP_ROW_G;
-						break;
-					case 1:
-						gMercProfiles[ DEVIN ].sSectorX = 13;
-						gMercProfiles[ DEVIN ].sSectorY = MAP_ROW_D;
-						break;
-					case 2:
-						gMercProfiles[ DEVIN ].sSectorX = 5;
-						gMercProfiles[ DEVIN ].sSectorY = MAP_ROW_C;
-						break;
-					case 3:
-						gMercProfiles[ DEVIN ].sSectorX = 2;
-						gMercProfiles[ DEVIN ].sSectorY = MAP_ROW_H;
-						break;
-					case 4:
-						gMercProfiles[ DEVIN ].sSectorX = 6;
-						gMercProfiles[ DEVIN ].sSectorY = MAP_ROW_C;
-						break;
-				}
+				auto placement = GCM->getNpcPlacement(DEVIN);
+				auto sector = placement->sectorIds[ Random(placement->sectorIds.size()) ];
+				gMercProfiles[DEVIN].sSectorX = SECTORX(sector);
+				gMercProfiles[DEVIN].sSectorY = SECTORY(sector);
 			}
 		}
 	}
@@ -810,39 +792,12 @@ void HandleEarlyMorningEvents( void )
 	{
 		// ok, HAMOUS's sector not loaded, so time to move!
 		// might be same sector as before, if so, oh well!
-		switch( Random( 5 ) )
-		{
-			case 0:
-				gMercProfiles[ HAMOUS ].sSectorX = 6;
-				gMercProfiles[ HAMOUS ].sSectorY = MAP_ROW_G;
-				gMercProfiles[ PROF_ICECREAM ].sSectorX = 6;
-				gMercProfiles[ PROF_ICECREAM ].sSectorY = MAP_ROW_G;
-				break;
-			case 1:
-				gMercProfiles[ HAMOUS ].sSectorX = 12;
-				gMercProfiles[ HAMOUS ].sSectorY = MAP_ROW_F;
-				gMercProfiles[ PROF_ICECREAM ].sSectorX = 12;
-				gMercProfiles[ PROF_ICECREAM ].sSectorY = MAP_ROW_F;
-				break;
-			case 2:
-				gMercProfiles[ HAMOUS ].sSectorX = 7;
-				gMercProfiles[ HAMOUS ].sSectorY = MAP_ROW_D;
-				gMercProfiles[ PROF_ICECREAM ].sSectorX = 7;
-				gMercProfiles[ PROF_ICECREAM ].sSectorY = MAP_ROW_D;
-				break;
-			case 3:
-				gMercProfiles[ HAMOUS ].sSectorX = 3;
-				gMercProfiles[ HAMOUS ].sSectorY = MAP_ROW_D;
-				gMercProfiles[ PROF_ICECREAM ].sSectorX = 3;
-				gMercProfiles[ PROF_ICECREAM ].sSectorY = MAP_ROW_D;
-				break;
-			case 4:
-				gMercProfiles[ HAMOUS ].sSectorX = 9;
-				gMercProfiles[ HAMOUS ].sSectorY = MAP_ROW_D;
-				gMercProfiles[ PROF_ICECREAM ].sSectorX = 9;
-				gMercProfiles[ PROF_ICECREAM ].sSectorY = MAP_ROW_D;
-				break;
-		}
+		auto placement = GCM->getNpcPlacement(HAMOUS);
+		auto sector = placement->sectorIds[ Random(placement->sectorIds.size()) ];
+		gMercProfiles[HAMOUS].sSectorX = SECTORX(sector);
+		gMercProfiles[HAMOUS].sSectorY = SECTORY(sector);
+		gMercProfiles[PROF_ICECREAM].sSectorX = SECTORX(sector);
+		gMercProfiles[PROF_ICECREAM].sSectorY = SECTORY(sector);
 	}
 
 	// Does Rat take off?
@@ -903,21 +858,11 @@ void HandleEarlyMorningEvents( void )
 
 		if ( gMercProfiles[ CARMEN ].sSectorX != gWorldSectorX || gMercProfiles[ CARMEN ].sSectorY != gWorldSectorY )
 		{
-			switch( Random( 3 ) )
-			{
-				case 0:
-					gMercProfiles[ CARMEN ].sSectorX = 5;
-					gMercProfiles[ CARMEN ].sSectorY = MAP_ROW_C;
-					break;
-				case 1:
-					gMercProfiles[ CARMEN ].sSectorX = 13;
-					gMercProfiles[ CARMEN ].sSectorY = MAP_ROW_C;
-					break;
-				case 2:
-					gMercProfiles[ CARMEN ].sSectorX = 9;
-					gMercProfiles[ CARMEN ].sSectorY = MAP_ROW_G;
-					break;
-			}
+			auto placement = GCM->getNpcPlacement(CARMEN);
+			auto sector = placement->sectorIds[ Random(placement->sectorIds.size()) ];
+			gMercProfiles[CARMEN].sSectorX = SECTORX(sector);
+			gMercProfiles[CARMEN].sSectorY = SECTORY(sector);
+
 			// he should have $5000... unless the player forgot to meet him
 			if (gMercProfiles[ CARMEN ].uiMoney < 5000)
 			{

--- a/src/game/Strategic/Strategic_Event_Handler.cc
+++ b/src/game/Strategic/Strategic_Event_Handler.cc
@@ -774,9 +774,13 @@ void HandleEarlyMorningEvents( void )
 				// ok, Devin's sector not loaded, so time to move!
 				// might be same sector as before, if so, oh well!
 				auto placement = GCM->getNpcPlacement(DEVIN);
-				auto sector = placement->sectorIds[ Random(placement->sectorIds.size()) ];
-				gMercProfiles[DEVIN].sSectorX = SECTORX(sector);
-				gMercProfiles[DEVIN].sSectorY = SECTORY(sector);
+				auto sectors = placement->sectorIds;
+				if (!sectors.empty())
+				{
+					auto sector = placement->sectorIds[Random(sectors.size())];
+					gMercProfiles[DEVIN].sSectorX = SECTORX(sector);
+					gMercProfiles[DEVIN].sSectorY = SECTORY(sector);
+				}
 			}
 		}
 	}
@@ -793,11 +797,15 @@ void HandleEarlyMorningEvents( void )
 		// ok, HAMOUS's sector not loaded, so time to move!
 		// might be same sector as before, if so, oh well!
 		auto placement = GCM->getNpcPlacement(HAMOUS);
-		auto sector = placement->sectorIds[ Random(placement->sectorIds.size()) ];
-		gMercProfiles[HAMOUS].sSectorX = SECTORX(sector);
-		gMercProfiles[HAMOUS].sSectorY = SECTORY(sector);
-		gMercProfiles[PROF_ICECREAM].sSectorX = SECTORX(sector);
-		gMercProfiles[PROF_ICECREAM].sSectorY = SECTORY(sector);
+		auto sectors = placement->sectorIds;
+		if (!sectors.empty())
+		{
+			auto sector = placement->sectorIds[Random(sectors.size())];
+			gMercProfiles[HAMOUS].sSectorX = SECTORX(sector);
+			gMercProfiles[HAMOUS].sSectorY = SECTORY(sector);
+			gMercProfiles[PROF_ICECREAM].sSectorX = SECTORX(sector);
+			gMercProfiles[PROF_ICECREAM].sSectorY = SECTORY(sector);
+		}
 	}
 
 	// Does Rat take off?
@@ -859,9 +867,13 @@ void HandleEarlyMorningEvents( void )
 		if ( gMercProfiles[ CARMEN ].sSectorX != gWorldSectorX || gMercProfiles[ CARMEN ].sSectorY != gWorldSectorY )
 		{
 			auto placement = GCM->getNpcPlacement(CARMEN);
-			auto sector = placement->sectorIds[ Random(placement->sectorIds.size()) ];
-			gMercProfiles[CARMEN].sSectorX = SECTORX(sector);
-			gMercProfiles[CARMEN].sSectorY = SECTORY(sector);
+			auto sectors = placement->sectorIds;
+			if (!sectors.empty())
+			{
+				auto sector = placement->sectorIds[Random(sectors.size())];
+				gMercProfiles[CARMEN].sSectorX = SECTORX(sector);
+				gMercProfiles[CARMEN].sSectorY = SECTORY(sector);
+			}
 
 			// he should have $5000... unless the player forgot to meet him
 			if (gMercProfiles[ CARMEN ].uiMoney < 5000)


### PR DESCRIPTION
Quick PR to get NPC placements to work with map mod, but also a question to ask. I will further test and polish, if we agree on the approach.

See also #665 and #1011.

## Summary

- Some NPCs (e.g. DEVIN, CARMEN, HAMOUS (and his truck)) are randomly placed in several possible sectors
- Externalizing the random placements to JSON

## Question

The Strategic Event handler is very specific to JA2 storyline and campaign. There is not a lot of flexibility even by externalizing the sector list. Not saying we have to follow, but 1.13 allows overriding by Lua script.

Should we also introduce a scripting engine here?



