### PR TITLE
Skip Invalid Items on Maps

### DIFF
--- a/src/game/Tactical/Items.cc
+++ b/src/game/Tactical/Items.cc
@@ -93,9 +93,9 @@ void createAllHardcodedItemModels(std::vector<const ItemModel*> &items)
 	items[155] = new ItemModel(155, "STRUCTURE_EXPLOSION",        IC_BOMB,    24, INVALIDCURS, 1, 40,  41,  2, 450,  0,  /* fake struct xplod*/    0, -4, ITEM_DAMAGEABLE | ITEM_METAL | ITEM_NOT_BUYABLE);
 	items[156] = new ItemModel(156, "GREAT_BIG_EXPLOSION",        IC_BOMB,    25, INVALIDCURS, 1, 40,  41,  2, 450,  0,  /* fake vehicle xplod*/   0, -4, ITEM_DAMAGEABLE | ITEM_METAL | ITEM_NOT_BUYABLE);
 	items[157] = new ItemModel(157, "BIG_TEAR_GAS",               IC_GRENADE, 26, TOSSCURS,    1, 48,  6,   4, 0,    0,  /* BIG tear gas grenade*/ 0, -2, ITEM_DAMAGEABLE | ITEM_METAL | ITEM_REPAIRABLE | ITEM_NOT_BUYABLE);
-	items[158] = new ItemModel(158, "SMALL_CREATURE_GAS",         IC_GRENADE, 27, INVALIDCURS, 0, 0,   0,   0, 0,    0,  /* small creature gas */  0, 0,  0);
-	items[159] = new ItemModel(159, "LARGE_CREATURE_GAS",         IC_GRENADE, 28, INVALIDCURS, 0, 0,   0,   0, 0,    0,  /* big creature gas */    0, 0,  0);
-	items[160] = new ItemModel(160, "VERY_SMALL_CREATURE_GAS",    IC_GRENADE, 29, INVALIDCURS, 0, 0,   0,   0, 0,    0,  /* very sm creat gas */   0, 0,  0);
+	items[158] = new ItemModel(158, "SMALL_CREATURE_GAS",         IC_GRENADE, 27, INVALIDCURS, 0, 0,   0,   0, 0,    0,  /* small creature gas */  0, 0,  ITEM_NOT_EDITOR);
+	items[159] = new ItemModel(159, "LARGE_CREATURE_GAS",         IC_GRENADE, 28, INVALIDCURS, 0, 0,   0,   0, 0,    0,  /* big creature gas */    0, 0,  ITEM_NOT_EDITOR);
+	items[160] = new ItemModel(160, "VERY_SMALL_CREATURE_GAS",    IC_GRENADE, 29, INVALIDCURS, 0, 0,   0,   0, 0,    0,  /* very sm creat gas */   0, 0,  ITEM_NOT_EDITOR);
 
 	items[161] = new ItemModel(161, "FLAK_JACKET",                IC_ARMOUR,  0,  INVALIDCURS, 1, 66,  20,  0, 300,  2,  /* Flak jacket */         0, +2, IF_STANDARD_ARMOUR);
 	items[162] = new ItemModel(162, "FLAK_JACKET_18",             IC_ARMOUR,  1,  INVALIDCURS, 2, 18,  22,  0, 350,  0,  /* Flak jacket w X */     0, +1, IF_STANDARD_ARMOUR | ITEM_NOT_BUYABLE);

--- a/src/game/Tactical/World_Items.cc
+++ b/src/game/Tactical/World_Items.cc
@@ -272,10 +272,16 @@ void LoadWorldItemsFromMap(HWFILE const f)
 			// Check for matching item existance modes and only add if there is a match
 			if (wi.usFlags & (gGameOptions.fSciFi ? WORLD_ITEM_SCIFI_ONLY : WORLD_ITEM_REALISTIC_ONLY)) continue;
 
+			const ItemModel* item = GCM->getItem(o.usItem);
+			if (item->getFlags() & ITEM_NOT_EDITOR) {
+				// This item is not placable by Editor. Maybe the map was created for a different item set.
+				SLOGW(ST::format("Skipping non-Editor item #{}({}) at gridNo {}", item->getItemIndex(), item->getInternalName(), wi.sGridNo));
+				continue;
+			}
+
 			if (!gGameOptions.fGunNut)
 			{
 				// do replacements?
-				const ItemModel * item = GCM->getItem(o.usItem);
 				const WeaponModel *weapon = item->asWeapon();
 				const MagazineModel *mag = item->asAmmo();
 				if (weapon && weapon->isInBigGunList())


### PR DESCRIPTION
This is intended to improve map mod support (https://github.com/ja2-stracciatella/ja2-stracciatella/issues/1011#issuecomment-609579529). 

Some items in Wildfire re-use item IDs, that maps to internal items in Vanilla. (e.g. LAW rocket is item#160 which is "Creature Gas" in Vanilla). To better support WF maps, we skip those items, as such items just do not exists in Vanilla.

An assumption here is: if an item is marked `ITEM_NOT_EDITOR`, it is not supposed to placed in the map file as a world item. 

# Summary

- Adding the `ITEM_NOT_EDITOR` flag to the "creature gas" internal items. Before this PR they do show up in the Map Editor, but they should not.
- Add a check, so when loading from map file, `ITEM_NOT_EDITOR` items are not placed. A warning is logged, because it means the map is not used as it intended.

---

The WF map version of Drassen SAM site has a "LAW Rocket". It will be skipped:
![image](https://user-images.githubusercontent.com/63151803/79629441-7198f980-817c-11ea-9423-7fd1774a9e44.png)

