### PR TITLE
Fixing Key Name display in Map Editor

### DIFF
--- a/src/game/Tactical/Keys.h
+++ b/src/game/Tactical/Keys.h
@@ -31,7 +31,7 @@ struct KEY
 #define MAXLOCKDESCLENGTH		40
 struct LOCK
 {
-	UINT8  ubEditorName[ MAXLOCKDESCLENGTH ]; // name to display in editor
+	CHAR8  ubEditorName[ MAXLOCKDESCLENGTH ]; // name to display in editor
 	UINT16 usKeyItem; // key for this door uses which graphic (item #)?
 	UINT8  ubLockType; // regular, padlock, electronic, etc
 	UINT8  ubPickDifficulty; // difficulty to pick such a lock


### PR DESCRIPTION
See the below screenshots. One on top is 0.16.1, the other is HEAD.

![image](https://user-images.githubusercontent.com/63151803/79630429-d4da5a00-8183-11ea-86fe-afc39b1cf681.png)

This is because LOCK.ubEditorName has type of UINT8[]. Previously it could be interpreted as if it is `char[]`, but `ST::format` prints it as `true`.

https://github.com/ja2-stracciatella/ja2-stracciatella/blob/b22697bf9c53239ddf6d1c35e9ed4b195c0db6d7/src/game/Editor/EditorItems.cc#L322