### PR TITLE
cli: print usage string when invalid arguments are passed

### DIFF
--- a/rust/stracciatella/src/config/cli.rs
+++ b/rust/stracciatella/src/config/cli.rs
@@ -179,7 +179,7 @@ impl Cli {
 
                 Ok(())
             }
-            Err(f) => Err(f.to_string()),
+            Err(f) => Err(format!("{}\n{}", f.to_string(), &Cli::usage())),
         }
     }
 

--- a/rust/stracciatella/src/stracciatella.rs
+++ b/rust/stracciatella/src/stracciatella.rs
@@ -97,7 +97,11 @@ mod tests {
         let input = vec![String::from("ja2"), String::from("--testunknown")];
         assert_eq!(
             parse_args(&mut engine_options, &input).unwrap(),
-            "Unrecognized option: 'testunknown'"
+            format!(
+                "{}\n{}",
+                "Unrecognized option: 'testunknown'",
+                &Cli::usage()
+            )
         );
     }
 


### PR DESCRIPTION
fixes the the useless -h error antipattern:
> $ build/ja2 -h
> Unrecognized option: 'h'
> $