### PR TITLE
PathAI: fixed tautology warning

### DIFF
--- a/src/game/Tactical/PathAI.cc
+++ b/src/game/Tactical/PathAI.cc
@@ -1856,14 +1856,14 @@ ENDOFLOOP:
 		{
 
 			z=_z;
-
-			for (ubCnt=0; z != 0 && ubCnt < lengthof(guiPathingData); ubCnt++)
+			INT16 iCnt;
+			for (iCnt = 0; z != 0 && iCnt < lengthof(guiPathingData); iCnt++)
 			{
-				guiPathingData[ ubCnt ] = trailTree[z].stepDir;
+				guiPathingData[ iCnt ] = trailTree[z].stepDir;
 
 				z = trailTree[z].nextLink;
 			}
-
+			ubCnt = iCnt;
 			giPathDataSize = ubCnt;
 
 		}


### PR DESCRIPTION
> src/game/Tactical/PathAI.cc:1860:34: warning: result of comparison of constant 256 with expression of type 'UINT8' (aka 'unsigned char') is always true [-Wtautological-constant-out-of-range-compare]
>                         for (ubCnt=0; z != 0 && ubCnt < lengthof(guiPathingData); ubCnt++)

Prevents potential overflow.