### PR TITLE
Rerun build.rs when the header changes

### DIFF
--- a/rust/stracciatella_c_api/build.rs
+++ b/rust/stracciatella_c_api/build.rs
@@ -16,6 +16,7 @@ fn stracciatella_h() {
     cbindgen::generate(&crate_dir)
         .expect("Unable to generate bindings")
         .write_to_file(&header_path);
+    println!("cargo:rerun-if-changed={:?}", &header_path);
 }
 
 fn main() {


### PR DESCRIPTION
The header is removed when you do `make clean`.

Fixes #1039