### PR TITLE
Fix test parse_args_should_return_the_correct_canonical_game_dir_on_windows

### DIFF
--- a/rust/stracciatella/src/fs.rs
+++ b/rust/stracciatella/src/fs.rs
@@ -17,6 +17,7 @@ use crate::unicode::Nfc;
 //------------
 
 pub use std::fs::create_dir;
+pub use std::fs::create_dir_all;
 pub use std::fs::metadata;
 pub use std::fs::read;
 pub use std::fs::read_dir;

--- a/rust/stracciatella/src/stracciatella.rs
+++ b/rust/stracciatella/src/stracciatella.rs
@@ -71,14 +71,14 @@ pub fn get_assets_dir() -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
-    use std::fs::File;
     use std::io::prelude::*;
     use std::path::Path;
 
     use tempfile::TempDir;
 
     use crate::config::{find_stracciatella_home, VanillaVersion};
+    use crate::fs;
+    use crate::fs::File;
     use crate::*;
 
     #[test]
@@ -256,7 +256,10 @@ mod tests {
         ];
 
         assert_eq!(parse_args(&mut engine_options, &input), None);
-        assert_eq!(engine_options.vanilla_game_dir, temp_dir.path());
+        assert_eq!(
+            engine_options.vanilla_game_dir,
+            fs::canonicalize(temp_dir.path()).unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
canonicalize also converts big long names to short names.