### PR TITLE
Replace std::string with ST::string

### DIFF
--- a/src/externalized/AmmoTypeModel.cc
+++ b/src/externalized/AmmoTypeModel.cc
@@ -30,13 +30,13 @@ AmmoTypeModel* AmmoTypeModel::deserialize(JsonObjectReader &obj)
 
 
 const AmmoTypeModel* getAmmoType(const char *ammoTypeName,
-					const std::map<std::string, const AmmoTypeModel*> &ammoTypeMap)
+					const std::map<ST::string, const AmmoTypeModel*> &ammoTypeMap)
 {
-	std::map<std::string, const AmmoTypeModel*>::const_iterator it = ammoTypeMap.find(ammoTypeName);
+	std::map<ST::string, const AmmoTypeModel*>::const_iterator it = ammoTypeMap.find(ammoTypeName);
 	if(it != ammoTypeMap.end())
 	{
 		return it->second;
 	}
 
-	throw std::runtime_error(FormattedString("ammoType '%s' is not found", ammoTypeName));
+	throw std::runtime_error(FormattedString("ammoType '%s' is not found", ammoTypeName).to_std_string());
 }

--- a/src/externalized/AmmoTypeModel.h
+++ b/src/externalized/AmmoTypeModel.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <string_theory/string>
+
 #include <map>
 #include <stdint.h>
-#include <string>
+
 
 class JsonObject;
 class JsonObjectReader;
@@ -19,8 +21,8 @@ struct AmmoTypeModel
 	static AmmoTypeModel* deserialize(JsonObjectReader &obj);
 
 	uint16_t index;
-	std::string internalName;
+	ST::string internalName;
 };
 
 const AmmoTypeModel* getAmmoType(const char *calibreName,
-					const std::map<std::string, const AmmoTypeModel*> &calibreMap);
+					const std::map<ST::string, const AmmoTypeModel*> &calibreMap);

--- a/src/externalized/CalibreModel.cc
+++ b/src/externalized/CalibreModel.cc
@@ -61,13 +61,13 @@ const CalibreModel* CalibreModel::getNoCalibreObject()
 
 
 const CalibreModel* getCalibre(const char *calibreName,
-				const std::map<std::string, const CalibreModel*> &calibreMap)
+				const std::map<ST::string, const CalibreModel*> &calibreMap)
 {
-	std::map<std::string, const CalibreModel*>::const_iterator it = calibreMap.find(calibreName);
+	std::map<ST::string, const CalibreModel*>::const_iterator it = calibreMap.find(calibreName);
 	if(it != calibreMap.end())
 	{
 		return it->second;
 	}
 
-	throw std::runtime_error(FormattedString("calibre '%s' is not found", calibreName));
+	throw std::runtime_error(FormattedString("calibre '%s' is not found", calibreName).to_std_string());
 }

--- a/src/externalized/CalibreModel.h
+++ b/src/externalized/CalibreModel.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include "sgp/StrUtils.h"
+
+#include <string_theory/string>
+
 #include <map>
 #include <stdexcept>
 #include <stdint.h>
-#include <string>
-#include <string_theory/string>
-
-#include "sgp/StrUtils.h"
 
 class JsonObject;
 class JsonObjectReader;
@@ -34,12 +34,12 @@ struct CalibreModel
 	static const CalibreModel* getNoCalibreObject();
 
 	uint16_t index;
-	std::string internalName;
-	std::string burstSoundString;
+	ST::string internalName;
+	ST::string burstSoundString;
 	bool showInHelpText;
 	bool monsterWeapon;
 	int silencerSound;
 };
 
 const CalibreModel* getCalibre(const char *calibreName,
-				const std::map<std::string, const CalibreModel*> &calibreMap);
+				const std::map<ST::string, const CalibreModel*> &calibreMap);

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -10,7 +10,6 @@
 
 #include <map>
 #include <stdint.h>
-#include <string>
 #include <vector>
 
 
@@ -34,48 +33,48 @@ public:
 	virtual ~ContentManager() {};
 
 	/** Get map file path. */
-	virtual std::string getMapPath(const ST::string& mapName) const = 0;
+	virtual ST::string getMapPath(const ST::string& mapName) const = 0;
 
 	/** Get radar map resource name. */
-	virtual std::string getRadarMapResourceName(const std::string &mapName) const = 0;
+	virtual ST::string getRadarMapResourceName(const ST::string &mapName) const = 0;
 
 	/** Get tileset resource name. */
-	virtual std::string getTilesetResourceName(int number, std::string fileName) const = 0;
+	virtual ST::string getTilesetResourceName(int number, ST::string fileName) const = 0;
 
 	/** Get tileset db resource name. */
-	virtual std::string getTilesetDBResName() const = 0;
+	virtual ST::string getTilesetDBResName() const = 0;
 
 	/** Get directory for storing new map file. */
-	virtual std::string getNewMapFolder() const = 0;
+	virtual ST::string getNewMapFolder() const = 0;
 
 	/** Get all available maps. */
-	virtual std::vector<std::string> getAllMaps() const = 0;
+	virtual std::vector<ST::string> getAllMaps() const = 0;
 
 	/** Get all available tilecache. */
-	virtual std::vector<std::string> getAllTilecache() const = 0;
+	virtual std::vector<ST::string> getAllTilecache() const = 0;
 
 	/** Open map for reading. */
 	virtual SGPFile* openMapForReading(const ST::string& mapName) const = 0;
 
 	/** Open user's private file (e.g. saved game, settings) for reading. */
-	virtual SGPFile* openUserPrivateFileForReading(const std::string& filename) const = 0;
+	virtual SGPFile* openUserPrivateFileForReading(const ST::string& filename) const = 0;
 
 	/* Open a game resource file for reading. */
 	virtual SGPFile* openGameResForReading(const char* filename) const = 0;
-	virtual SGPFile* openGameResForReading(const std::string& filename) const = 0;
+	virtual SGPFile* openGameResForReading(const ST::string& filename) const = 0;
 
 	/* Checks if a game resource exists. */
 	virtual bool doesGameResExists(char const* filename) const = 0;
-	virtual bool doesGameResExists(const std::string &filename) const = 0;
+	virtual bool doesGameResExists(const ST::string &filename) const = 0;
 
 	/** Get folder for screenshots. */
-	virtual std::string getScreenshotFolder() const = 0;
+	virtual ST::string getScreenshotFolder() const = 0;
 
 	/** Get folder for video capture. */
-	virtual std::string getVideoCaptureFolder() const = 0;
+	virtual ST::string getVideoCaptureFolder() const = 0;
 
 	/** Get folder for saved games. */
-	virtual std::string getSavedGamesFolder() const = 0;
+	virtual ST::string getSavedGamesFolder() const = 0;
 
 	/** Load encrypted string from game resource file. */
 	virtual ST::string loadEncryptedString(const char* fileName, uint32_t seek_chars, uint32_t read_chars) const = 0;
@@ -87,9 +86,9 @@ public:
 
 	/** Get weapons with the give index. */
 	virtual const WeaponModel* getWeapon(uint16_t index) = 0;
-	virtual const WeaponModel* getWeaponByName(const std::string &internalName) = 0;
+	virtual const WeaponModel* getWeaponByName(const ST::string &internalName) = 0;
 
-	virtual const MagazineModel* getMagazineByName(const std::string &internalName) = 0;
+	virtual const MagazineModel* getMagazineByName(const ST::string &internalName) = 0;
 	virtual const MagazineModel* getMagazineByItemIndex(uint16_t itemIndex) = 0;
 	virtual const std::vector<const MagazineModel*>& getMagazines() const = 0;
 

--- a/src/externalized/DealerInventory.cc
+++ b/src/externalized/DealerInventory.cc
@@ -13,7 +13,7 @@ DealerInventory::DealerInventory(rapidjson::Document *json, const ItemSystem *it
 	{
 		if(!it->value.IsInt())
 		{
-			throw std::runtime_error(FormattedString("Property '%s' should have integer value", it->name.GetString()));
+			throw std::runtime_error(FormattedString("Property '%s' should have integer value", it->name.GetString()).to_std_string());
 		}
 		const ItemModel *item = itemSystem->getItemByName(it->name.GetString());
 		int count = it->value.GetInt();

--- a/src/externalized/DealerInventory.h
+++ b/src/externalized/DealerInventory.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <map>
-#include <string>
-
 #include "rapidjson/document.h"
+
+#include <map>
 
 struct ItemModel;
 class ItemSystem;

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -145,9 +145,9 @@ static ST::string LoadEncryptedData(ST::string& err_msg, STRING_ENC_TYPE encType
 }
 
 DefaultContentManager::DefaultContentManager(GameVersion gameVersion,
-						const std::string &configFolder,
-						const std::string &gameResRootPath,
-						const std::string &externalizedDataPath
+						const ST::string &configFolder,
+						const ST::string &gameResRootPath,
+						const ST::string &externalizedDataPath
 	)
 	:m_gameVersion(gameVersion),
 	mNormalGunChoice(ARMY_GUN_LEVELS),
@@ -173,7 +173,7 @@ DefaultContentManager::DefaultContentManager(GameVersion gameVersion,
 
 	// need to find precise names of the directories
 
-	std::string name;
+	ST::string name;
 	if(FileMan::findObjectCaseInsensitive(m_gameResRootPath.c_str(), BASEDATADIR, false, true, name))
 	{
 		m_dataDir = FileMan::joinPaths(m_gameResRootPath, name);
@@ -194,19 +194,19 @@ DefaultContentManager::DefaultContentManager(GameVersion gameVersion,
 }
 
 /** Get list of game resources. */
-std::vector<std::string> DefaultContentManager::getListOfGameResources() const
+std::vector<ST::string> DefaultContentManager::getListOfGameResources() const
 {
-	std::vector<std::string> libraries = GetResourceLibraries(m_dataDir);
+	std::vector<ST::string> libraries = GetResourceLibraries(m_dataDir);
 	return libraries;
 }
 
-void DefaultContentManager::initGameResouces(const std::string &stracciatellaHomeDir, const std::vector<std::string> &libraries)
+void DefaultContentManager::initGameResouces(const ST::string &stracciatellaHomeDir, const std::vector<ST::string> &libraries)
 {
 	for (auto it = libraries.begin(); it != libraries.end(); ++it)
 	{
 		if (!LibraryDB_push(m_libraryDB.get(), m_dataDir.c_str(), it->c_str()))
 		{
-			std::string message = FormattedString(
+			ST::string message = FormattedString(
 				"Library '%s' is not found in folder '%s'.\n\nPlease make sure that '%s' contains files of the original game.  You can change this path by editing file '%s/ja2.json'.\n",
 				it->c_str(), m_dataDir.c_str(), m_gameResRootPath.c_str(), stracciatellaHomeDir.c_str());
 			throw LibraryFileNotFoundException(message);
@@ -214,11 +214,11 @@ void DefaultContentManager::initGameResouces(const std::string &stracciatellaHom
 	}
 }
 
-void DefaultContentManager::addExtraResources(const std::string &baseDir, const std::string &library)
+void DefaultContentManager::addExtraResources(const ST::string &baseDir, const ST::string &library)
 {
 	if (!LibraryDB_push(m_libraryDB.get(), baseDir.c_str(), library.c_str())) {
 		RustPointer<char> error(getRustError());
-		std::string message = FormattedString(
+		ST::string message = FormattedString(
 			"Library '%s' is not found in folder '%s': %s",
 			library.c_str(), baseDir.c_str(), error.get());
 		throw LibraryFileNotFoundException(message);
@@ -295,9 +295,9 @@ const DealerInventory* DefaultContentManager::getBobbyRayUsedInventory() const
 }
 
 /** Get map file path. */
-std::string DefaultContentManager::getMapPath(const ST::string& mapName) const
+ST::string DefaultContentManager::getMapPath(const ST::string& mapName) const
 {
-	std::string result = MAPSDIR;
+	ST::string result = MAPSDIR;
 	result += '/';
 	result += mapName.c_str();
 
@@ -307,9 +307,9 @@ std::string DefaultContentManager::getMapPath(const ST::string& mapName) const
 }
 
 /** Get radar map resource name. */
-std::string DefaultContentManager::getRadarMapResourceName(const std::string &mapName) const
+ST::string DefaultContentManager::getRadarMapResourceName(const ST::string &mapName) const
 {
-	std::string result = RADARMAPSDIR;
+	ST::string result = RADARMAPSDIR;
 	result += "/";
 	result += mapName;
 
@@ -319,14 +319,14 @@ std::string DefaultContentManager::getRadarMapResourceName(const std::string &ma
 }
 
 /** Get tileset resource name. */
-std::string DefaultContentManager::getTilesetResourceName(int number, std::string fileName) const
+ST::string DefaultContentManager::getTilesetResourceName(int number, ST::string fileName) const
 {
 	return FormattedString("%s/%d/%s", TILESETSDIR, number, fileName.c_str());
 }
 
 
 /** Get tileset db resource name. */
-std::string DefaultContentManager::getTilesetDBResName() const
+ST::string DefaultContentManager::getTilesetDBResName() const
 {
 	return BINARYDATADIR "/ja2set.dat";
 }
@@ -338,19 +338,19 @@ SGPFile* DefaultContentManager::openMapForReading(const ST::string& mapName) con
 }
 
 /** Get directory for storing new map file. */
-std::string DefaultContentManager::getNewMapFolder() const
+ST::string DefaultContentManager::getNewMapFolder() const
 {
 	return FileMan::joinPaths(m_dataDir, MAPSDIR);
 }
 
 /** Get all available maps. */
-std::vector<std::string> DefaultContentManager::getAllMaps() const
+std::vector<ST::string> DefaultContentManager::getAllMaps() const
 {
 	return FindFilesInDir(MAPSDIR, "dat", true, true, true);
 }
 
 /** Get all available tilecache. */
-std::vector<std::string> DefaultContentManager::getAllTilecache() const
+std::vector<ST::string> DefaultContentManager::getAllTilecache() const
 {
 	return FindFilesInDir(m_tileDir, "jsd", true, false);
 }
@@ -358,21 +358,21 @@ std::vector<std::string> DefaultContentManager::getAllTilecache() const
 /** Open temporary file for writing. */
 SGPFile* DefaultContentManager::openTempFileForWriting(const char* filename, bool truncate) const
 {
-	std::string path = FileMan::joinPaths(NEW_TEMP_DIR, filename);
+	ST::string path = FileMan::joinPaths(NEW_TEMP_DIR, filename);
 	return FileMan::openForWriting(path.c_str(), truncate);
 }
 
 /** Open temporary file for appending. */
 SGPFile* DefaultContentManager::openTempFileForAppend(const char* filename) const
 {
-	std::string path = FileMan::joinPaths(NEW_TEMP_DIR, filename);
+	ST::string path = FileMan::joinPaths(NEW_TEMP_DIR, filename);
 	return FileMan::openForAppend(path.c_str());
 }
 
 /* Open temporary file for reading. */
 SGPFile* DefaultContentManager::openTempFileForReading(const char* filename) const
 {
-	std::string path = FileMan::joinPaths(NEW_TEMP_DIR, filename);
+	ST::string path = FileMan::joinPaths(NEW_TEMP_DIR, filename);
 	RustPointer<File> file(File_open(path.c_str(), FILE_OPEN_READ));
 	if (!file)
 	{
@@ -387,7 +387,7 @@ SGPFile* DefaultContentManager::openTempFileForReading(const char* filename) con
 /** Delete temporary file. */
 void DefaultContentManager::deleteTempFile(const char* filename) const
 {
-	std::string path = FileMan::joinPaths(NEW_TEMP_DIR, filename);
+	ST::string path = FileMan::joinPaths(NEW_TEMP_DIR, filename);
 	FileDelete(path);
 }
 
@@ -449,7 +449,7 @@ SGPFile* DefaultContentManager::openGameResForReading(const char* filename) cons
 }
 
 /** Open user's private file (e.g. saved game, settings) for reading. */
-SGPFile* DefaultContentManager::openUserPrivateFileForReading(const std::string& filename) const
+SGPFile* DefaultContentManager::openUserPrivateFileForReading(const ST::string& filename) const
 {
 	RustPointer<File> file = FileMan::openFileForReading(filename.c_str());
 	if (!file)
@@ -462,7 +462,7 @@ SGPFile* DefaultContentManager::openUserPrivateFileForReading(const std::string&
 	return FileMan::getSGPFileFromFile(file.release());
 }
 
-SGPFile* DefaultContentManager::openGameResForReading(const std::string& filename) const
+SGPFile* DefaultContentManager::openGameResForReading(const ST::string& filename) const
 {
 	return openGameResForReading(filename.c_str());
 }
@@ -493,23 +493,23 @@ bool DefaultContentManager::doesGameResExists(char const* filename) const
 	}
 }
 
-bool DefaultContentManager::doesGameResExists(const std::string &filename) const
+bool DefaultContentManager::doesGameResExists(const ST::string &filename) const
 {
 	return doesGameResExists(filename.c_str());
 }
 
-std::string DefaultContentManager::getScreenshotFolder() const
+ST::string DefaultContentManager::getScreenshotFolder() const
 {
 	return m_configFolder;
 }
 
-std::string DefaultContentManager::getVideoCaptureFolder() const
+ST::string DefaultContentManager::getVideoCaptureFolder() const
 {
 	return m_configFolder;
 }
 
 /** Get folder for saved games. */
-std::string DefaultContentManager::getSavedGamesFolder() const
+ST::string DefaultContentManager::getSavedGamesFolder() const
 {
 	return FileMan::joinPaths(m_configFolder, "SavedGames");
 }
@@ -577,23 +577,23 @@ const WeaponModel* DefaultContentManager::getWeapon(uint16_t itemIndex)
 	return getItem(itemIndex)->asWeapon();
 }
 
-const WeaponModel* DefaultContentManager::getWeaponByName(const std::string &internalName)
+const WeaponModel* DefaultContentManager::getWeaponByName(const ST::string &internalName)
 {
-	std::map<std::string, const WeaponModel*>::const_iterator it = m_weaponMap.find(internalName);
+	std::map<ST::string, const WeaponModel*>::const_iterator it = m_weaponMap.find(internalName);
 	if(it == m_weaponMap.end())
 	{
 		SLOGE("weapon '%s' is not found", internalName.c_str());
-		throw std::runtime_error(FormattedString("weapon '%s' is not found", internalName.c_str()));
+		throw std::runtime_error(FormattedString("weapon '%s' is not found", internalName.c_str()).to_std_string());
 	}
 	return it->second;//m_weaponMap[internalName];
 }
 
-const MagazineModel* DefaultContentManager::getMagazineByName(const std::string &internalName)
+const MagazineModel* DefaultContentManager::getMagazineByName(const ST::string &internalName)
 {
 	if(m_magazineMap.find(internalName) == m_magazineMap.end())
 	{
 		SLOGE("magazine '%s' is not found", internalName.c_str());
-		throw std::runtime_error(FormattedString("magazine '%s' is not found", internalName.c_str()));
+		throw std::runtime_error(FormattedString("magazine '%s' is not found", internalName.c_str()).to_std_string());
 	}
 	return m_magazineMap[internalName];
 }
@@ -631,7 +631,7 @@ const AmmoTypeModel* DefaultContentManager::getAmmoType(uint8_t index)
 bool DefaultContentManager::loadWeapons()
 {
 	AutoSGPFile f(openGameResForReading("weapons.json"));
-	std::string jsonData = FileMan::fileReadText(f);
+	ST::string jsonData = FileMan::fileReadText(f);
 
 	rapidjson::Document document;
 	if (document.Parse<rapidjson::kParseCommentsFlag>(jsonData.c_str()).HasParseError())
@@ -667,7 +667,7 @@ bool DefaultContentManager::loadWeapons()
 bool DefaultContentManager::loadMagazines()
 {
 	AutoSGPFile f(openGameResForReading("magazines.json"));
-	std::string jsonData = FileMan::fileReadText(f);
+	ST::string jsonData = FileMan::fileReadText(f);
 
 	rapidjson::Document document;
 	if (document.Parse<rapidjson::kParseCommentsFlag>(jsonData.c_str()).HasParseError())
@@ -704,7 +704,7 @@ bool DefaultContentManager::loadMagazines()
 bool DefaultContentManager::loadCalibres()
 {
 	AutoSGPFile f(openGameResForReading("calibres.json"));
-	std::string jsonData = FileMan::fileReadText(f);
+	ST::string jsonData = FileMan::fileReadText(f);
 
 	rapidjson::Document document;
 	if (document.Parse<rapidjson::kParseCommentsFlag>(jsonData.c_str()).HasParseError())
@@ -734,7 +734,7 @@ bool DefaultContentManager::loadCalibres()
 
 	for (const CalibreModel* calibre : m_calibres)
 	{
-		m_calibreMap.insert(std::make_pair(std::string(calibre->internalName), calibre));
+		m_calibreMap.insert(std::make_pair(ST::string(calibre->internalName), calibre));
 	}
 
 	return true;
@@ -743,7 +743,7 @@ bool DefaultContentManager::loadCalibres()
 bool DefaultContentManager::loadAmmoTypes()
 {
 	AutoSGPFile f(openGameResForReading("ammo_types.json"));
-	std::string jsonData = FileMan::fileReadText(f);
+	ST::string jsonData = FileMan::fileReadText(f);
 
 	rapidjson::Document document;
 	if (document.Parse<rapidjson::kParseCommentsFlag>(jsonData.c_str()).HasParseError())
@@ -773,7 +773,7 @@ bool DefaultContentManager::loadAmmoTypes()
 
 	for (const AmmoTypeModel* ammoType : m_ammoTypes)
 	{
-		m_ammoTypeMap.insert(std::make_pair(std::string(ammoType->internalName), ammoType));
+		m_ammoTypeMap.insert(std::make_pair(ST::string(ammoType->internalName), ammoType));
 	}
 
 	return true;
@@ -783,9 +783,9 @@ bool DefaultContentManager::loadMusicModeList(const MusicMode mode, rapidjson::V
 {
 	std::vector<const ST::string*>* musicModeList = new std::vector<const ST::string*>();
 
-	std::vector<std::string> utf8_encoded;
+	std::vector<ST::string> utf8_encoded;
 	JsonUtility::parseListStrings(array, utf8_encoded);
-	for (const std::string &str : utf8_encoded)
+	for (const ST::string &str : utf8_encoded)
 	{
 		musicModeList->push_back(new ST::string(str));
 		SLOGD("Loaded music %s", str.c_str());
@@ -799,7 +799,7 @@ bool DefaultContentManager::loadMusicModeList(const MusicMode mode, rapidjson::V
 bool DefaultContentManager::loadMusic()
 {
 	AutoSGPFile f(openGameResForReading("music.json"));
-	std::string jsonData = FileMan::fileReadText(f);
+	ST::string jsonData = FileMan::fileReadText(f);
 
 	rapidjson::Document document;
 	if (document.Parse<rapidjson::kParseCommentsFlag>(jsonData.c_str()).HasParseError()) {
@@ -840,7 +840,7 @@ bool DefaultContentManager::readWeaponTable(
 	std::vector<std::vector<const WeaponModel*> > & weaponTable)
 {
 	AutoSGPFile f(openGameResForReading(fileName));
-	std::string jsonData = FileMan::fileReadText(f);
+	ST::string jsonData = FileMan::fileReadText(f);
 
 	rapidjson::Document document;
 	if (document.Parse<rapidjson::kParseCommentsFlag>(jsonData.c_str()).HasParseError())
@@ -854,10 +854,10 @@ bool DefaultContentManager::readWeaponTable(
 		const rapidjson::Value& a = document;
 		for (rapidjson::SizeType i = 0; i < a.Size(); i++)
 		{
-			std::vector<std::string> weaponNames;
+			std::vector<ST::string> weaponNames;
 			if(JsonUtility::parseListStrings(a[i], weaponNames))
 			{
-				for (const std::string &weapon : weaponNames)
+				for (const ST::string &weapon : weaponNames)
 				{
 					weaponTable[i].push_back(getWeaponByName(weapon));
 				}
@@ -886,7 +886,7 @@ bool DefaultContentManager::loadArmyGunChoice()
 
 void DefaultContentManager::loadStringRes(const char *name, std::vector<const ST::string*> &strings) const
 {
-	std::string fullName(name);
+	ST::string fullName(name);
 
 	switch(m_gameVersion)
 	{
@@ -900,15 +900,15 @@ void DefaultContentManager::loadStringRes(const char *name, std::vector<const ST
 	case GameVersion::RUSSIAN_GOLD: fullName += "-rus";   break;
 	default:
 	{
-		throw std::runtime_error(FormattedString("unknown game version %d", m_gameVersion));
+		throw std::runtime_error(FormattedString("unknown game version %d", m_gameVersion).to_std_string());
 	}
 	}
 
 	fullName += ".json";
 	std::shared_ptr<rapidjson::Document> json(readJsonDataFile(fullName.c_str()));
-	std::vector<std::string> utf8_encoded;
+	std::vector<ST::string> utf8_encoded;
 	JsonUtility::parseListStrings(*json, utf8_encoded);
-	for (const std::string &str : utf8_encoded)
+	for (const ST::string &str : utf8_encoded)
 	{
 		strings.push_back(new ST::string(str));
 	}
@@ -952,14 +952,14 @@ bool DefaultContentManager::loadGameData()
 rapidjson::Document* DefaultContentManager::readJsonDataFile(const char *fileName) const
 {
 	AutoSGPFile f(openGameResForReading(fileName));
-	std::string jsonData = FileMan::fileReadText(f);
+	ST::string jsonData = FileMan::fileReadText(f);
 
 	rapidjson::Document *document = new rapidjson::Document();
 	if (document->Parse<rapidjson::kParseCommentsFlag>(jsonData.c_str()).HasParseError())
 	{
 		SLOGE("Failed to parse '%s'", fileName);
 		delete document;
-		throw std::runtime_error(FormattedString("Failed to parse '%s'", fileName));
+		throw std::runtime_error(FormattedString("Failed to parse '%s'", fileName).to_std_string());
 	}
 
 	return document;
@@ -1006,13 +1006,13 @@ const ItemModel* DefaultContentManager::getItem(uint16_t itemIndex) const
 	return m_items[itemIndex];
 }
 
-const ItemModel* DefaultContentManager::getItemByName(const std::string &internalName) const
+const ItemModel* DefaultContentManager::getItemByName(const ST::string &internalName) const
 {
-	std::map<std::string, const ItemModel*>::const_iterator it = m_itemMap.find(internalName);
+	std::map<ST::string, const ItemModel*>::const_iterator it = m_itemMap.find(internalName);
 	if(it == m_itemMap.end())
 	{
 		SLOGE("item '%s' is not found", internalName.c_str());
-		throw std::runtime_error(FormattedString("item '%s' is not found", internalName.c_str()));
+		throw std::runtime_error(FormattedString("item '%s' is not found", internalName.c_str()).to_std_string());
 	}
 	return it->second;
 }

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -12,7 +12,6 @@
 
 #include <map>
 #include <stdexcept>
-#include <string>
 #include <vector>
 
 
@@ -23,49 +22,49 @@ class DefaultContentManager : public ContentManager, public IGameDataLoader
 public:
 
 	DefaultContentManager(GameVersion gameVersion,
-				const std::string &configFolder,
-				const std::string &gameResRootPath,
-				const std::string &externalizedDataPath);
+				const ST::string &configFolder,
+				const ST::string &gameResRootPath,
+				const ST::string &externalizedDataPath);
 
 	virtual ~DefaultContentManager() override;
 
 	/** Get list of game resources. */
-	virtual std::vector<std::string> getListOfGameResources() const;
+	virtual std::vector<ST::string> getListOfGameResources() const;
 
 	/** Initialize game resources. */
-	virtual void initGameResouces(const std::string &stracciatellaHomeDir, const std::vector<std::string> &libraries);
-	virtual void addExtraResources(const std::string &baseDir, const std::string &library);
+	virtual void initGameResouces(const ST::string &stracciatellaHomeDir, const std::vector<ST::string> &libraries);
+	virtual void addExtraResources(const ST::string &baseDir, const ST::string &library);
 
 	/** Load the game data. */
 	bool loadGameData();
 
 	/** Get map file path. */
-	virtual std::string getMapPath(const ST::string& mapName) const override;
+	virtual ST::string getMapPath(const ST::string& mapName) const override;
 
 	/** Get radar map resource name. */
-	virtual std::string getRadarMapResourceName(const std::string &mapName) const override;
+	virtual ST::string getRadarMapResourceName(const ST::string &mapName) const override;
 
 	/** Get tileset resource name. */
-	virtual std::string getTilesetResourceName(int number, std::string fileName) const override;
+	virtual ST::string getTilesetResourceName(int number, ST::string fileName) const override;
 
 	/** Get tileset db resource name. */
-	virtual std::string getTilesetDBResName() const override;
+	virtual ST::string getTilesetDBResName() const override;
 
 	/** Open map for reading. */
 	virtual SGPFile* openMapForReading(const ST::string& mapName) const override;
 
 	/** Get directory for storing new map file. */
-	virtual std::string getNewMapFolder() const override;
+	virtual ST::string getNewMapFolder() const override;
 
 	/** Get all available maps. */
-	virtual std::vector<std::string> getAllMaps() const override;
+	virtual std::vector<ST::string> getAllMaps() const override;
 
 	/** Get all available tilecache. */
-	virtual std::vector<std::string> getAllTilecache() const override;
+	virtual std::vector<ST::string> getAllTilecache() const override;
 
 	/* Open a game resource file for reading. */
 	virtual SGPFile* openGameResForReading(const char* filename) const override;
-	virtual SGPFile* openGameResForReading(const std::string& filename) const override;
+	virtual SGPFile* openGameResForReading(const ST::string& filename) const override;
 
 	/** Open temporary file for writing. */
 	virtual SGPFile* openTempFileForWriting(const char* filename, bool truncate) const override;
@@ -80,25 +79,25 @@ public:
 	virtual void deleteTempFile(const char* filename) const override;
 
 	/** Open user's private file (e.g. saved game, settings) for reading. */
-	virtual SGPFile* openUserPrivateFileForReading(const std::string& filename) const override;
+	virtual SGPFile* openUserPrivateFileForReading(const ST::string& filename) const override;
 
 	/* Checks if a game resource exists. */
 	virtual bool doesGameResExists(char const* filename) const override;
-	virtual bool doesGameResExists(const std::string &filename) const override;
+	virtual bool doesGameResExists(const ST::string &filename) const override;
 
 	/** Get folder for screenshots. */
-	virtual std::string getScreenshotFolder() const override;
+	virtual ST::string getScreenshotFolder() const override;
 
 	/** Get folder for video capture. */
-	virtual std::string getVideoCaptureFolder() const override;
+	virtual ST::string getVideoCaptureFolder() const override;
 
-	const std::string& getDataDir() { return m_dataDir; }
-	const std::string& getTileDir() { return m_tileDir; }
+	const ST::string& getDataDir() { return m_dataDir; }
+	const ST::string& getTileDir() { return m_tileDir; }
 
-	const std::string& getExternalizedDataDir() { return m_externalizedDataPath; }
+	const ST::string& getExternalizedDataDir() { return m_externalizedDataPath; }
 
 	/** Get folder for saved games. */
-	virtual std::string getSavedGamesFolder() const override;
+	virtual ST::string getSavedGamesFolder() const override;
 
 	/** Load encrypted string from game resource file. */
 	virtual ST::string loadEncryptedString(const char* fileName, uint32_t seek_chars, uint32_t read_chars) const override;
@@ -113,9 +112,9 @@ public:
 
 	/** Get weapons with the give index. */
 	virtual const WeaponModel* getWeapon(uint16_t index) override;
-	virtual const WeaponModel* getWeaponByName(const std::string &internalName) override;
+	virtual const WeaponModel* getWeaponByName(const ST::string &internalName) override;
 
-	virtual const MagazineModel* getMagazineByName(const std::string &internalName) override;
+	virtual const MagazineModel* getMagazineByName(const ST::string &internalName) override;
 	virtual const MagazineModel* getMagazineByItemIndex(uint16_t itemIndex) override;
 	virtual const std::vector<const MagazineModel*>& getMagazines() const override;
 
@@ -126,7 +125,7 @@ public:
 	virtual const AmmoTypeModel* getAmmoType(uint8_t index) override;
 
 	virtual const ItemModel* getItem(uint16_t index) const override;
-	virtual const ItemModel* getItemByName(const std::string &internalName) const override;
+	virtual const ItemModel* getItemByName(const ST::string &internalName) const override;
 
 	virtual const std::vector<std::vector<const WeaponModel*> > & getNormalGunChoice() const override;
 	virtual const std::vector<std::vector<const WeaponModel*> > & getExtendedGunChoice() const override;
@@ -153,11 +152,11 @@ public:
 	virtual const NpcPlacementModel* getNpcPlacement(uint8_t profileId) const override;
 
 protected:
-	std::string m_dataDir;
-	std::string m_tileDir;
-	std::string m_configFolder;
-	std::string m_gameResRootPath;
-	std::string m_externalizedDataPath;
+	ST::string m_dataDir;
+	ST::string m_tileDir;
+	ST::string m_configFolder;
+	ST::string m_gameResRootPath;
+	ST::string m_externalizedDataPath;
 
 	const GameVersion m_gameVersion;
 
@@ -173,11 +172,11 @@ protected:
 	std::vector<AmmoTypeModel*> m_ammoTypes;
 
 	/** Mapping of calibre names to objects. */
-	std::map<std::string, const AmmoTypeModel*> m_ammoTypeMap;
-	std::map<std::string, const CalibreModel*> m_calibreMap;
-	std::map<std::string, const MagazineModel*> m_magazineMap;
-	std::map<std::string, const WeaponModel*> m_weaponMap;
-	std::map<std::string, const ItemModel*> m_itemMap;
+	std::map<ST::string, const AmmoTypeModel*> m_ammoTypeMap;
+	std::map<ST::string, const CalibreModel*> m_calibreMap;
+	std::map<ST::string, const MagazineModel*> m_magazineMap;
+	std::map<ST::string, const WeaponModel*> m_weaponMap;
+	std::map<ST::string, const ItemModel*> m_itemMap;
 	std::map<MusicMode, const std::vector<const ST::string*>*> m_musicMap;
 
 	std::vector<std::vector<const WeaponModel*> > mNormalGunChoice;
@@ -223,8 +222,8 @@ protected:
 class LibraryFileNotFoundException : public std::runtime_error
 {
 public:
-	LibraryFileNotFoundException(const std::string& what_arg)
-		:std::runtime_error(what_arg)
+	LibraryFileNotFoundException(const ST::string& what_arg)
+		:std::runtime_error(what_arg.to_std_string())
 	{
 	}
 };

--- a/src/externalized/DefaultContentManagerUT.cc
+++ b/src/externalized/DefaultContentManagerUT.cc
@@ -9,10 +9,10 @@
 /** Create DefaultContentManager for usage in unit testing. */
 DefaultContentManager * createDefaultCMForTesting()
 {
-	std::string extraDataDir = GetExtraDataDir();
-	std::string configFolderPath = FileMan::joinPaths(extraDataDir, "unittests");
-	std::string gameResRootPath = FileMan::joinPaths(extraDataDir, "unittests");
-	std::string externalizedDataPath = FileMan::joinPaths(extraDataDir, "externalized");
+	ST::string extraDataDir = GetExtraDataDir();
+	ST::string configFolderPath = FileMan::joinPaths(extraDataDir, "unittests");
+	ST::string gameResRootPath = FileMan::joinPaths(extraDataDir, "unittests");
+	ST::string externalizedDataPath = FileMan::joinPaths(extraDataDir, "externalized");
 
 	DefaultContentManager *cm;
 

--- a/src/externalized/DefaultContentManager_unittests.cc
+++ b/src/externalized/DefaultContentManager_unittests.cc
@@ -20,7 +20,7 @@ TEST(TempFiles, createFile)
 		AutoSGPFile file(cm->openTempFileForWriting("foo.txt", true));
 	}
 
-	std::vector<std::string> results = FindFilesInDir(TMPDIR, "txt", false, false);
+	std::vector<ST::string> results = FindFilesInDir(TMPDIR, "txt", false, false);
 	ASSERT_EQ(results.size(), 1u);
 	EXPECT_STREQ(results[0].c_str(), TMPDIR PS "foo.txt");
 
@@ -115,7 +115,7 @@ TEST(TempFiles, deleteFile)
 		AutoSGPFile file(cm->openTempFileForWriting("foo.txt", true));
 	}
 
-	std::vector<std::string> results = FindFilesInDir(TMPDIR, "txt", false, false);
+	std::vector<ST::string> results = FindFilesInDir(TMPDIR, "txt", false, false);
 	ASSERT_EQ(results.size(), 1u);
 
 	cm->deleteTempFile("foo.txt");

--- a/src/externalized/ItemModel.cc
+++ b/src/externalized/ItemModel.cc
@@ -61,7 +61,7 @@ ItemModel::ItemModel(uint16_t   itemIndex,
 // This could be default in C++11
 ItemModel::~ItemModel() {}
 
-const std::string& ItemModel::getInternalName() const  { return internalName;          }
+const ST::string& ItemModel::getInternalName() const  { return internalName;          }
 
 uint16_t        ItemModel::getItemIndex() const        { return itemIndex;             }
 uint32_t        ItemModel::getItemClass() const        { return usItemClass;           }

--- a/src/externalized/ItemModel.h
+++ b/src/externalized/ItemModel.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <string>
-
 #include "game/Tactical/Item_Types.h"
+
+#include <string_theory/string>
 
 class JsonObject;
 class JsonObjectReader;
@@ -37,7 +37,7 @@ struct ItemModel
 	// This could be default in C++11
 	virtual ~ItemModel();
 
-	const virtual std::string& getInternalName() const;
+	const virtual ST::string& getInternalName() const;
 
 	virtual uint16_t        getItemIndex() const;
 	virtual uint32_t        getItemClass() const;
@@ -84,7 +84,7 @@ struct ItemModel
 
 protected:
 	uint16_t   itemIndex;
-	std::string internalName;
+	ST::string internalName;
 	uint32_t   usItemClass;
 	uint8_t    ubClassIndex;
 	ItemCursor ubCursor;

--- a/src/externalized/ItemSystem.h
+++ b/src/externalized/ItemSystem.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <string>
+#include <string_theory/string>
 
 struct ItemModel;
 
 class ItemSystem
 {
 public:
-	virtual const ItemModel* getItemByName(const std::string &internalName) const = 0;
+	virtual const ItemModel* getItemByName(const ST::string &internalName) const = 0;
 };

--- a/src/externalized/JsonObject.h
+++ b/src/externalized/JsonObject.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <string>
-
 #include "rapidjson/document.h"
+#include <string_theory/string>
 
 class JsonObject
 {
@@ -19,7 +18,7 @@ public:
 	void AddMember(const char *name, uint16_t    value) { m_value.AddMember<uint16_t>(rapidjson::StringRef(name), value, m_alloc); }
 	void AddMember(const char *name, bool        value) { m_value.AddMember<bool>(rapidjson::StringRef(name), value, m_alloc); }
 
-	void AddMember(const char *name, const std::string &value)
+	void AddMember(const char *name, const ST::string &value)
 	{
 		m_value.AddMember(rapidjson::StringRef(name), rapidjson::StringRef(value.c_str()), m_alloc);
 	}

--- a/src/externalized/JsonUtility.cc
+++ b/src/externalized/JsonUtility.cc
@@ -9,7 +9,7 @@
 #include <sstream>
 
 /** Write list of strings to file. */
-bool JsonUtility::writeToFile(const char *name, const std::vector<std::string> &strings)
+bool JsonUtility::writeToFile(const char *name, const std::vector<ST::string> &strings)
 {
 	std::stringstream ss;
 	rapidjson::OStreamWrapper os(ss);
@@ -22,8 +22,8 @@ bool JsonUtility::writeToFile(const char *name, const std::vector<std::string> &
 	writer.EndArray();
 	ss << std::endl;
 
-	std::string buf = ss.str();
-	if (!Fs_write(name, reinterpret_cast<const uint8_t*>(buf.data()), buf.size()))
+	ST::string buf = ss.str();
+	if (!Fs_write(name, reinterpret_cast<const uint8_t*>(buf.c_str()), buf.size()))
 	{
 		RustPointer<char> err(getRustError());
 		SLOGE("JsonUtility::writeToFile: %s", err.get());
@@ -33,7 +33,7 @@ bool JsonUtility::writeToFile(const char *name, const std::vector<std::string> &
 }
 
 /** Parse json to a list of strings. */
-bool JsonUtility::parseJsonToListStrings(const char* jsonData, std::vector<std::string> &strings)
+bool JsonUtility::parseJsonToListStrings(const char* jsonData, std::vector<ST::string> &strings)
 {
 	rapidjson::Document document;
 
@@ -46,7 +46,7 @@ bool JsonUtility::parseJsonToListStrings(const char* jsonData, std::vector<std::
 }
 
 /** Parse value as list of strings. */
-bool JsonUtility::parseListStrings(const rapidjson::Value &value, std::vector<std::string> &strings)
+bool JsonUtility::parseListStrings(const rapidjson::Value &value, std::vector<ST::string> &strings)
 {
 	if(value.IsArray()) {
 		for (rapidjson::SizeType i = 0; i < value.Size(); i++)

--- a/src/externalized/JsonUtility.h
+++ b/src/externalized/JsonUtility.h
@@ -1,18 +1,19 @@
 #pragma once
 
-#include <vector>
-#include <string>
-
 #include "rapidjson/document.h"
+#include <string_theory/string>
+
+#include <vector>
+
 
 namespace JsonUtility
 {
 	/** Write list of strings to file. */
-	bool writeToFile(const char *name, const std::vector<std::string> &strings);
+	bool writeToFile(const char *name, const std::vector<ST::string> &strings);
 
 	/** Parse json to a list of strings. */
-	bool parseJsonToListStrings(const char* jsonData, std::vector<std::string> &strings);
+	bool parseJsonToListStrings(const char* jsonData, std::vector<ST::string> &strings);
 
 	/** Parse value as list of strings. */
-	bool parseListStrings(const rapidjson::Value &value, std::vector<std::string> &strings);
+	bool parseListStrings(const rapidjson::Value &value, std::vector<ST::string> &strings);
 }

--- a/src/externalized/JsonUtility_unittests.cc
+++ b/src/externalized/JsonUtility_unittests.cc
@@ -5,26 +5,26 @@
 TEST(JsonUtilityTest, parseListOfStrings)
 {
 	{
-		std::vector<std::string> strings;
+		std::vector<ST::string> strings;
 		ASSERT_TRUE(JsonUtility::parseJsonToListStrings("[]", strings));
 		ASSERT_EQ(strings.size(), 0u);
 	}
 
 	{
-		std::vector<std::string> strings;
+		std::vector<ST::string> strings;
 		ASSERT_FALSE(JsonUtility::parseJsonToListStrings("foo", strings));
 		ASSERT_EQ(strings.size(), 0u);
 	}
 
 	{
-		std::vector<std::string> strings;
+		std::vector<ST::string> strings;
 		ASSERT_TRUE(JsonUtility::parseJsonToListStrings("[\"foo\"]", strings));
 		ASSERT_EQ(strings.size(), 1u);
 		ASSERT_STREQ(strings[0].c_str(), "foo");
 	}
 
 	{
-		std::vector<std::string> strings;
+		std::vector<ST::string> strings;
 		ASSERT_TRUE(JsonUtility::parseJsonToListStrings("[\"foo\", \"bar\"]", strings));
 		ASSERT_EQ(strings.size(), 2u);
 		ASSERT_STREQ(strings[0].c_str(), "foo");

--- a/src/externalized/MagazineModel.cc
+++ b/src/externalized/MagazineModel.cc
@@ -51,8 +51,8 @@ void MagazineModel::serializeTo(JsonObject &obj) const
 
 MagazineModel* MagazineModel::deserialize(
 	JsonObjectReader &obj,
-	const std::map<std::string, const CalibreModel*> &calibreMap,
-	const std::map<std::string, const AmmoTypeModel*> &ammoTypeMap)
+	const std::map<ST::string, const CalibreModel*> &calibreMap,
+	const std::map<ST::string, const AmmoTypeModel*> &ammoTypeMap)
 {
 	int itemIndex                 = obj.GetInt("itemIndex");
 	const char *internalName      = obj.GetString("internalName");
@@ -82,7 +82,7 @@ MagazineModel* MagazineModel::deserialize(
 }
 
 
-const std::string & MagazineModel::getStandardReplacement() const
+const ST::string & MagazineModel::getStandardReplacement() const
 {
 	return standardReplacement;
 }

--- a/src/externalized/MagazineModel.h
+++ b/src/externalized/MagazineModel.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include "ItemModel.h"
+
+#include <string_theory/string>
+
 #include <map>
 #include <stdint.h>
-#include <string>
-
-#include "ItemModel.h"
 
 class JsonObject;
 class JsonObjectReader;
@@ -26,14 +27,14 @@ struct MagazineModel : ItemModel
 	virtual void serializeTo(JsonObject &obj) const;
 
 	static MagazineModel* deserialize(JsonObjectReader &obj,
-						const std::map<std::string, const CalibreModel*> &calibreMap,
-						const std::map<std::string, const AmmoTypeModel*> &ammoTypeMap);
+						const std::map<ST::string, const CalibreModel*> &calibreMap,
+						const std::map<ST::string, const AmmoTypeModel*> &ammoTypeMap);
 
 
 	/** Get standard replacement ammo name. */
-	virtual const std::string & getStandardReplacement() const;
+	virtual const ST::string & getStandardReplacement() const;
 
-	std::string standardReplacement;
+	ST::string standardReplacement;
 	const CalibreModel *calibre;
 	const uint16_t capacity;
 	const AmmoTypeModel *ammoType;

--- a/src/externalized/ModPackContentManager.cc
+++ b/src/externalized/ModPackContentManager.cc
@@ -8,11 +8,11 @@
 #define DEBUG_PRINT_OPENING_FILES (1)
 
 ModPackContentManager::ModPackContentManager(GameVersion gameVersion,
-						const std::vector<std::string> &modNames,
-						const std::vector<std::string> &modResFolders,
-						const std::string &configFolder,
-						const std::string &gameResRootPath,
-						const std::string &externalizedDataPath)
+						const std::vector<ST::string> &modNames,
+						const std::vector<ST::string> &modResFolders,
+						const ST::string &configFolder,
+						const ST::string &gameResRootPath,
+						const ST::string &externalizedDataPath)
 	:DefaultContentManager(gameVersion, configFolder, gameResRootPath, externalizedDataPath)
 {
 	m_modNames = modNames;
@@ -53,19 +53,19 @@ SGPFile* ModPackContentManager::openGameResForReading(const char* filename) cons
 	return DefaultContentManager::openGameResForReading(filename);
 }
 
-SGPFile* ModPackContentManager::openGameResForReading(const std::string& filename) const
+SGPFile* ModPackContentManager::openGameResForReading(const ST::string& filename) const
 {
 	return openGameResForReading(filename.c_str());
 }
 
 /** Get folder for saved games. */
-std::string ModPackContentManager::getSavedGamesFolder() const
+ST::string ModPackContentManager::getSavedGamesFolder() const
 {
-	std::string folderName("SavedGames");
+	ST::string folderName("SavedGames");
 	for (const auto& name : m_modNames)
 	{
-		folderName.push_back('-');
-		folderName.append(name);
+		folderName += '-';
+		folderName += name;
 	}
 	return FileMan::joinPaths(m_configFolder, folderName);
 }
@@ -73,8 +73,8 @@ std::string ModPackContentManager::getSavedGamesFolder() const
 /** Load dialogue quote from file. */
 ST::string* ModPackContentManager::loadDialogQuoteFromFile(const char* filename, int quote_number)
 {
-	std::string jsonFileName = std::string(filename) + ".json";
-	std::map<std::string, std::vector<std::string> >::iterator it = m_dialogQuotesMap.find(jsonFileName);
+	ST::string jsonFileName = ST::string(filename) + ".json";
+	std::map<ST::string, std::vector<ST::string> >::iterator it = m_dialogQuotesMap.find(jsonFileName);
 	if(it != m_dialogQuotesMap.end())
 	{
 		SLOGD("cached quote %d %s", quote_number, jsonFileName.c_str());
@@ -85,8 +85,8 @@ ST::string* ModPackContentManager::loadDialogQuoteFromFile(const char* filename,
 		if(doesGameResExists(jsonFileName.c_str()))
 		{
 			AutoSGPFile f(openGameResForReading(jsonFileName));
-			std::string jsonQuotes = FileMan::fileReadText(f);
-			std::vector<std::string> quotes;
+			ST::string jsonQuotes = FileMan::fileReadText(f);
+			std::vector<ST::string> quotes;
 			JsonUtility::parseJsonToListStrings(jsonQuotes.c_str(), quotes);
 			m_dialogQuotesMap[jsonFileName] = quotes;
 			return new ST::string(quotes[quote_number].c_str());

--- a/src/externalized/ModPackContentManager.h
+++ b/src/externalized/ModPackContentManager.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include <string_theory/string>
+
 #include <map>
-#include <string>
 #include <vector>
 
 #include "DefaultContentManager.h"
@@ -10,11 +11,11 @@ class ModPackContentManager : public DefaultContentManager
 {
 public:
 	ModPackContentManager(GameVersion gameVersion,
-				const std::vector<std::string> &modNames,
-				const std::vector<std::string> &modResFolders,
-				const std::string &configFolder,
-				const std::string &gameResRootPath,
-				const std::string &externalizedDataPath);
+				const std::vector<ST::string> &modNames,
+				const std::vector<ST::string> &modResFolders,
+				const ST::string &configFolder,
+				const ST::string &gameResRootPath,
+				const ST::string &externalizedDataPath);
 
 	virtual ~ModPackContentManager() override;
 
@@ -22,16 +23,16 @@ public:
 	virtual bool doesGameResExists(char const* fileName) const override;
 
 	virtual SGPFile* openGameResForReading(const char* filename) const override;
-	virtual SGPFile* openGameResForReading(const std::string& filename) const override;
+	virtual SGPFile* openGameResForReading(const ST::string& filename) const override;
 
 	/** Get folder for saved games. */
-	virtual std::string getSavedGamesFolder() const override;
+	virtual ST::string getSavedGamesFolder() const override;
 
 	/** Load dialogue quote from file. */
 	virtual ST::string* loadDialogQuoteFromFile(const char* filename, int quote_number) override;
 
 protected:
-	std::vector<std::string> m_modNames;
-	std::vector<std::string> m_modResFolders;
-	std::map<std::string, std::vector<std::string> > m_dialogQuotesMap;
+	std::vector<ST::string> m_modNames;
+	std::vector<ST::string> m_modResFolders;
+	std::map<ST::string, std::vector<ST::string> > m_dialogQuotesMap;
 };

--- a/src/externalized/TestUtils.cc
+++ b/src/externalized/TestUtils.cc
@@ -5,13 +5,13 @@
 
 SGPFile* OpenTestResourceForReading(const char *filePath)
 {
-	std::string extraDataDir = GetExtraDataDir();
+	ST::string extraDataDir = GetExtraDataDir();
 	return FileMan::openForReading(FileMan::joinPaths(extraDataDir, filePath));
 }
 
-std::string GetExtraDataDir()
+ST::string GetExtraDataDir()
 {
-	std::string extraDataDir = EXTRA_DATA_DIR;
+	ST::string extraDataDir = EXTRA_DATA_DIR;
 	if(extraDataDir.empty())
 	{
 		extraDataDir = ".";

--- a/src/externalized/TestUtils.h
+++ b/src/externalized/TestUtils.h
@@ -3,7 +3,7 @@
 #include "sgp/FileMan.h"
 
 /** Get location of directory with extra data. */
-std::string GetExtraDataDir();
+ST::string GetExtraDataDir();
 
 /** Open test resource file for reading. */
 SGPFile* OpenTestResourceForReading(const char *filePath);

--- a/src/externalized/VanillaWeapons_unittests.cc
+++ b/src/externalized/VanillaWeapons_unittests.cc
@@ -29,13 +29,13 @@ TEST(Items, bug120_cawsAmmo)
 
 	// test SAP clip parameters
 	const MagazineModel* sapClip = cm->getMagazineByName("CLIPCAWS_10_SAP");
-	EXPECT_EQ(sapClip->calibre->internalName, std::string("AMMOCAWS"));
-	EXPECT_EQ(sapClip->ammoType->internalName, std::string("AMMO_SUPER_AP"));
+	EXPECT_EQ(sapClip->calibre->internalName, ST::string("AMMOCAWS"));
+	EXPECT_EQ(sapClip->ammoType->internalName, ST::string("AMMO_SUPER_AP"));
 
 	// test FLECH clip parameters
 	const MagazineModel* flechClip = cm->getMagazineByName("CLIPCAWS_10_FLECH");
-	EXPECT_EQ(flechClip->calibre->internalName, std::string("AMMOCAWS"));
-	EXPECT_EQ(flechClip->ammoType->internalName, std::string("AMMO_BUCKSHOT"));
+	EXPECT_EQ(flechClip->calibre->internalName, ST::string("AMMOCAWS"));
+	EXPECT_EQ(flechClip->ammoType->internalName, ST::string("AMMO_BUCKSHOT"));
 
 	delete cm;
 }
@@ -47,13 +47,13 @@ TEST(Items, bug120_12gAmmo)
 
 	// test SAP clip parameters
 	const MagazineModel* clip = cm->getMagazineByName("CLIP12G_7");
-	EXPECT_EQ(clip->calibre->internalName,           std::string("AMMO12G"));
-	EXPECT_EQ(clip->ammoType->internalName,          std::string("AMMO_REGULAR"));
+	EXPECT_EQ(clip->calibre->internalName,           ST::string("AMMO12G"));
+	EXPECT_EQ(clip->ammoType->internalName,          ST::string("AMMO_REGULAR"));
 
 	// test FLECH clip parameters
 	const MagazineModel* clipBuckshot = cm->getMagazineByName("CLIP12G_7_BUCKSHOT");
-	EXPECT_EQ(clipBuckshot->calibre->internalName,           std::string("AMMO12G"));
-	EXPECT_EQ(clipBuckshot->ammoType->internalName,          std::string("AMMO_BUCKSHOT"));
+	EXPECT_EQ(clipBuckshot->calibre->internalName,           ST::string("AMMO12G"));
+	EXPECT_EQ(clipBuckshot->ammoType->internalName,          ST::string("AMMO_BUCKSHOT"));
 
 	delete cm;
 }

--- a/src/externalized/WeaponModels.cc
+++ b/src/externalized/WeaponModels.cc
@@ -100,7 +100,7 @@ void WeaponModel::serializeAttachments(JsonObject &obj) const
 }
 
 WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
-					const std::map<std::string, const CalibreModel*> &calibreMap)
+					const std::map<ST::string, const CalibreModel*> &calibreMap)
 {
 	WeaponModel *wep = NULL;
 	int itemIndex = obj.GetInt("itemIndex");
@@ -663,7 +663,7 @@ bool WeaponModel::canBeAttached(uint16_t attachment) const
 }
 
 /** Get standard replacement gun name. */
-const std::string & WeaponModel::getStandardReplacement() const
+const ST::string & WeaponModel::getStandardReplacement() const
 {
 	return standardReplacement;
 }

--- a/src/externalized/WeaponModels.h
+++ b/src/externalized/WeaponModels.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <stdint.h>
-
-#include <map>
-#include <string>
-
 // XXX
 #include "game/Tactical/Weapons.h"
 
 #include "ItemModel.h"
+
+#include <string_theory/string>
+
+#include <map>
+#include <stdint.h>
 
 class JsonObject;
 class JsonObjectReader;
@@ -31,7 +31,7 @@ struct WeaponModel : ItemModel
 	virtual void serializeTo(JsonObject &obj) const;
 
 	static WeaponModel* deserialize(JsonObjectReader &obj,
-	const std::map<std::string, const CalibreModel*> &calibreMap);
+	const std::map<ST::string, const CalibreModel*> &calibreMap);
 
 	virtual const WeaponModel* asWeapon() const   { return this; }
 
@@ -46,13 +46,13 @@ struct WeaponModel : ItemModel
 	virtual bool canBeAttached(uint16_t attachment) const;
 
 	/** Get standard replacement gun name. */
-	virtual const std::string & getStandardReplacement() const;
+	virtual const ST::string & getStandardReplacement() const;
 
 	int getRateOfFire() const;
 
-	std::string sound;
-	std::string burstSound;
-	std::string standardReplacement;
+	ST::string sound;
+	ST::string burstSound;
+	ST::string standardReplacement;
 	bool attachSilencer;
 	bool attachSniperScope;
 	bool attachLaserScope;

--- a/src/externalized/policy/DefaultIMPPolicy.cc
+++ b/src/externalized/policy/DefaultIMPPolicy.cc
@@ -1,17 +1,17 @@
 #include "DefaultIMPPolicy.h"
 
-#include <string>
-
 #include "ItemSystem.h"
 #include "JsonUtility.h"
+
+#include <string_theory/string>
 
 struct ItemModel;
 
 static void readListOfItems(rapidjson::Value &value, std::vector<const ItemModel *> &items, const ItemSystem *itemSystem)
 {
-	std::vector<std::string> strings;
+	std::vector<ST::string> strings;
 	JsonUtility::parseListStrings(value, strings);
-	for (const std::string &str : strings)
+	for (const ST::string &str : strings)
 	{
 		items.push_back(itemSystem->getItemByName(str));
 	}

--- a/src/externalized/policy/GamePolicy.h
+++ b/src/externalized/policy/GamePolicy.h
@@ -2,9 +2,6 @@
 
 #include <stdint.h>
 
-#include <string>
-#include <vector>
-
 enum UIMode
 {
 	UI_Tactical,

--- a/src/externalized/strategic/BloodCatSpawnsModel.cc
+++ b/src/externalized/strategic/BloodCatSpawnsModel.cc
@@ -19,7 +19,7 @@ const int8_t BloodCatSpawnsModel::getSpawnsByDifficulty(uint8_t difficultyLevel)
 		case DIF_LEVEL_HARD:
 			return bloodCatsSpawnsHard;
 		default:
-			throw std::runtime_error(FormattedString("Unsupported difficulty level: %d", difficultyLevel));
+			throw std::runtime_error(FormattedString("Unsupported difficulty level: %d", difficultyLevel).to_std_string());
 	}
 }
 

--- a/src/externalized/strategic/MovementCostsModel.cc
+++ b/src/externalized/strategic/MovementCostsModel.cc
@@ -1,12 +1,14 @@
 #include "MovementCostsModel.h"
 #include "Debug.h"
 #include "JsonObject.h"
+
+#include <string_theory/string>
+
 #include <map>
-#include <string>
 
 
 // helper functions
-void readTraversibiltyIntoVector(const rapidjson::Value& jsonArray, IntIntVector& vec, std::map<std::string, uint8_t>& mapping, size_t expectedRows, size_t expectedCols);
+void readTraversibiltyIntoVector(const rapidjson::Value& jsonArray, IntIntVector& vec, std::map<ST::string, uint8_t>& mapping, size_t expectedRows, size_t expectedCols);
 void readIntIntoVector(const rapidjson::Value& jsonArray, IntIntVector& vec, size_t expectedRows, size_t expectedCols);
 
 
@@ -40,10 +42,10 @@ const uint8_t MovementCostsModel::getTravelRating(uint8_t x, uint8_t y) const
 MovementCostsModel* MovementCostsModel::deserialize(const rapidjson::Document& root)
 {
 	Assert(root.HasMember("mapping") && root["mapping"].IsObject());
-	std::map<std::string, uint8_t> mapToEnum; // maps from traversibility short name to enum
+	std::map<ST::string, uint8_t> mapToEnum; // maps from traversibility short name to enum
 	for (auto& iter : root["mapping"].GetObject())
 	{
-		mapToEnum.insert(std::make_pair(std::string(iter.name.GetString()), iter.value.GetInt()));
+		mapToEnum.insert(std::make_pair(ST::string(iter.name.GetString()), iter.value.GetInt()));
 	}
 
 	Assert(root.HasMember("traverseWE") && root["traverseWE"].IsArray());
@@ -70,14 +72,14 @@ MovementCostsModel* MovementCostsModel::deserialize(const rapidjson::Document& r
 	);
 }
 
-void readTraversibiltyIntoVector(const rapidjson::Value& jsonArray, IntIntVector& vec, std::map<std::string, uint8_t>& mapping, size_t expectedRows, size_t expectedCols)
+void readTraversibiltyIntoVector(const rapidjson::Value& jsonArray, IntIntVector& vec, std::map<ST::string, uint8_t>& mapping, size_t expectedRows, size_t expectedCols)
 {
 	for (auto& r : jsonArray.GetArray())
 	{
 		auto row = std::vector<uint8_t>();
 		for (auto& c : r.GetArray())
 		{
-			row.push_back(mapping.at(std::string(c.GetString())));
+			row.push_back(mapping.at(ST::string(c.GetString())));
 		}
 		
 		if (row.size() != expectedCols) {

--- a/src/game/AniViewScreen.cc
+++ b/src/game/AniViewScreen.cc
@@ -283,11 +283,11 @@ static void BuildListFile(void)
 		SLOGE("BuildListFile: %s", err.get());
 		return;
 	}
-	std::string data(reinterpret_cast<const char*>(VecU8_as_ptr(vec.get())), VecU8_len(vec.get()));
+	ST::string data(reinterpret_cast<const char*>(VecU8_as_ptr(vec.get())), VecU8_len(vec.get()));
 	vec.reset(nullptr);
 
 	//count STIs inside header and verify each one's existance.
-	std::stringstream ss(data);
+	std::stringstream ss(data.c_str());
 	while (ss.getline(currFilename, 128))
 	{
 		numEntries++;
@@ -299,7 +299,7 @@ static void BuildListFile(void)
 	fOKFiles = TRUE;
 
 	cnt = 0;
-	ss.str(data);
+	ss.str(data.c_str());
 	while (ss.getline(currFilename, 128))
 	{
 		// Remove newline

--- a/src/game/Editor/LoadScreen.cc
+++ b/src/game/Editor/LoadScreen.cc
@@ -103,7 +103,7 @@ static BOOLEAN fEnteringLoadSaveScreen = TRUE;
 
 static MOUSE_REGION BlanketRegion;
 
-static std::string gMapFileForRemoval;
+static ST::string gMapFileForRemoval;
 
 enum{
 	IOSTATUS_NONE,
@@ -145,8 +145,8 @@ static void LoadSaveScreenEntry(void)
 	iTopFileShown = iTotalFiles = 0;
 	try
 	{
-		std::vector<std::string> files = GCM->getAllMaps();
-		for (const std::string &file : files)
+		std::vector<ST::string> files = GCM->getAllMaps();
+		for (const ST::string &file : files)
 		{
 			FileList = AddToFDlgList(FileList, file.c_str());
 			++iTotalFiles;
@@ -379,7 +379,7 @@ ScreenID LoadSaveScreenHandle(void)
 				iFDlgState = DIALOG_NONE;
 				return LOADSAVE_SCREEN;
 			}
-			std::string filename(GCM->getMapPath(gzFilename));
+			ST::string filename(GCM->getMapPath(gzFilename));
 			if ( GCM->doesGameResExists(filename.c_str()) )
 			{
 				gfFileExists = TRUE;

--- a/src/game/Editor/Sector_Summary.cc
+++ b/src/game/Editor/Sector_Summary.cc
@@ -1973,7 +1973,7 @@ static void SummarySaveMapCallback(GUI_BUTTON* btn, INT32 reason)
 		{
 			if( gubOverrideStatus == READONLY )
 			{
-				std::string path = GCM->getMapPath(gszDisplayName);
+				ST::string path = GCM->getMapPath(gszDisplayName);
 				if (!Fs_setReadOnly(path.c_str(), false))
 				{
 					RustPointer<char> msg(getRustError());
@@ -2007,7 +2007,7 @@ static void SummaryOverrideCallback(GUI_BUTTON* btn, INT32 reason)
 
 static void CalculateOverrideStatus(void)
 {
-	std::string filename;
+	ST::string filename;
 	gfOverrideDirty = FALSE;
 	gfOverride = FALSE;
 	if( gfTempFile )

--- a/src/game/GameRes.cc
+++ b/src/game/GameRes.cc
@@ -136,9 +136,9 @@ FLOAT getMajorMapVersion()
 }
 
 /** Get list of resource libraries. */
-std::vector<std::string> GetResourceLibraries(const std::string &dataDir)
+std::vector<ST::string> GetResourceLibraries(const ST::string &dataDir)
 {
-	std::vector<std::string> libraries = FindFilesInDir(dataDir, "slf", true, true);
+	std::vector<ST::string> libraries = FindFilesInDir(dataDir, "slf", true, true);
 
 	// for (int i = 0; i < libraries.size(); i++)
 	// {
@@ -402,7 +402,7 @@ char const* GetMLGFilename(MultiLanguageGraphic const id)
 		}
 	}
 
-	throw std::runtime_error(FormattedString("Multilanguage resource %d is not found", id));
+	throw std::runtime_error(FormattedString("Multilanguage resource %d is not found", id).to_std_string());
 }
 
 STRING_ENC_TYPE getStringEncType()

--- a/src/game/GameRes.h
+++ b/src/game/GameRes.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <string>
-#include <vector>
-
 /* Game resources */
 
 #include "Types.h"
@@ -10,6 +7,10 @@
 #include "stracciatella.h"
 
 #include "StringEncodingTypes.h"
+
+#include <string_theory/string>
+
+#include <vector>
 
 /** List of supported game versions (localizations). */
 using GameVersion = VanillaVersion;
@@ -58,7 +59,7 @@ char const* GetMLGFilename(MultiLanguageGraphic);
 void setGameVersion(GameVersion ver);
 
 /** Get list of resource libraries. */
-std::vector<std::string> GetResourceLibraries(const std::string &dataDir);
+std::vector<ST::string> GetResourceLibraries(const ST::string &dataDir);
 
 /**
  * Get encoding corrector for strings in data files.

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -611,7 +611,7 @@ void LoadSavedGame(UINT8 const save_slot_id)
 
 	char zSaveGameName[512];
 	CreateSavedGameFileNameFromNumber(save_slot_id, zSaveGameName);
-	AutoSGPFile f(GCM->openUserPrivateFileForReading(std::string(zSaveGameName)));
+	AutoSGPFile f(GCM->openUserPrivateFileForReading(zSaveGameName));
 
 	SAVED_GAME_HEADER SaveGameHeader;
 	bool stracLinuxFormat;
@@ -1300,7 +1300,7 @@ static void LoadSoldierStructure(HWFILE const f, UINT32 savegame_version, bool s
 
 void BackupSavedGame(UINT8 const ubSaveGameID)
 {
-	std::string backupdir = FileMan::joinPaths(GCM->getSavedGamesFolder().c_str(),"Backup");
+	ST::string backupdir = FileMan::joinPaths(GCM->getSavedGamesFolder().c_str(),"Backup");
 	FileMan::createDir(backupdir.c_str());
 	char zSourceSaveGameName[512];
 	char zSourceBackupSaveGameName[515];
@@ -1535,7 +1535,7 @@ static void LoadWatchedLocsFromSavedGame(HWFILE const hFile)
 
 void CreateSavedGameFileNameFromNumber(const UINT8 ubSaveGameID, char* const pzNewFileName)
 {
-	std::string dir = GCM->getSavedGamesFolder();
+	ST::string dir = GCM->getSavedGamesFolder();
 	char const* const ext = g_savegame_ext;
 
 	switch (ubSaveGameID)

--- a/src/game/Strategic/Auto_Resolve.cc
+++ b/src/game/Strategic/Auto_Resolve.cc
@@ -299,7 +299,7 @@ static void PlayAutoResolveSample(SoundID const usNum, UINT32 const ubVolume, UI
 	}
 }
 
-static void PlayAutoResolveSample(const std::string &sample, UINT32 const ubVolume, UINT32 const ubLoops, UINT32 const uiPan)
+static void PlayAutoResolveSample(const ST::string &sample, UINT32 const ubVolume, UINT32 const ubLoops, UINT32 const uiPan)
 {
 	if( gpAR->fSound )
 	{

--- a/src/game/Tactical/Gap.cc
+++ b/src/game/Tactical/Gap.cc
@@ -21,7 +21,7 @@ static void AudioGapListInit(const char* zSoundFile, AudioGapList* pGapList)
 	SLOGD("File is %s", zSoundFile);
 
 	// strip .wav and change to .gap
-	std::string sFileName(FileMan::replaceExtension(std::string(zSoundFile), ".gap"));
+	ST::string sFileName(FileMan::replaceExtension(ST::string(zSoundFile), ".gap"));
 
 	try
 	{

--- a/src/game/Tactical/Rotting_Corpses.cc
+++ b/src/game/Tactical/Rotting_Corpses.cc
@@ -513,7 +513,7 @@ try
 
 	// Get root filename... this removes path and extension
 	// Used to find struct data for this corpse...
-	std::string zFilename(FileMan::getFileNameWithoutExt(AniParams.zCachedFile));
+	ST::string zFilename(FileMan::getFileNameWithoutExt(AniParams.zCachedFile));
 
 	// Add structure data.....
 	CheckForAndAddTileCacheStructInfo(n, c->def.sGridNo, ani->sCachedTileID, GetCorpseStructIndex(pCorpseDef, TRUE));
@@ -1102,7 +1102,7 @@ INT16 FindNearestAvailableGridNoForCorpse( ROTTING_CORPSE_DEFINITION *pDef, INT8
 
 	// Get root filename... this removes path and extension
 	// Used to find struct data for this corpse...
-	std::string zFilename(FileMan::getFileNameWithoutExt(zCorpseFilenames[pDef->ubType]));
+	ST::string zFilename(FileMan::getFileNameWithoutExt(zCorpseFilenames[pDef->ubType]));
 
 	pStructureFileRef = GetCachedTileStructureRefFromFilename( zFilename.c_str() );
 

--- a/src/game/TileEngine/Lighting.cc
+++ b/src/game/TileEngine/Lighting.cc
@@ -46,6 +46,9 @@
 #include "GameInstance.h"
 #include "Logger.h"
 
+#include <string_theory/iostream>
+#include <string_theory/string>
+
 #include <algorithm>
 #include <iterator>
 #include <sstream>
@@ -199,15 +202,15 @@ void LoadShadeTablesFromTextFile()
 		}
 		if (vec)
 		{
-			std::string data(reinterpret_cast<const char*>(VecU8_as_ptr(vec.get())), VecU8_len(vec.get()));
+			ST::string data(reinterpret_cast<const char*>(VecU8_as_ptr(vec.get())), VecU8_len(vec.get()));
 			vec.reset(nullptr);
 
-			std::stringstream ss(data);
+			std::stringstream ss(data.c_str());
 			for( i = 0; i < 16; i++ )
 			{
 				for( j = 0; j < 3; j++ )
 				{
-					std::string str;
+					ST::string str;
 					if (ss >> str && sscanf(str.c_str(), "%d", &num) == 1)
 					{
 						gusShadeLevels[i][j] = (UINT16)num;

--- a/src/game/TileEngine/Overhead_Map.cc
+++ b/src/game/TileEngine/Overhead_Map.cc
@@ -104,7 +104,7 @@ void InitNewOverheadDB(TileSetID const ubTilesetID)
 			use_tileset = GENERIC_1;
 		}
 
-		std::string adjusted_file(GCM->getTilesetResourceName(use_tileset, std::string("t/") + filename));
+		ST::string adjusted_file(GCM->getTilesetResourceName(use_tileset, ST::string("t/") + filename));
 		SGPVObject* vo;
 		try
 		{
@@ -113,7 +113,7 @@ void InitNewOverheadDB(TileSetID const ubTilesetID)
 		catch (...)
 		{
 			// Load one we know about
-			vo = AddVideoObjectFromFile(GCM->getTilesetResourceName(0, std::string("t/") + "grass.sti").c_str());
+			vo = AddVideoObjectFromFile(GCM->getTilesetResourceName(0, ST::string("t/") + "grass.sti").c_str());
 		}
 
 		gSmTileSurf[i].vo = vo;

--- a/src/game/TileEngine/Radar_Screen.cc
+++ b/src/game/TileEngine/Radar_Screen.cc
@@ -84,7 +84,7 @@ void LoadRadarScreenBitmap(const char* const filename)
 	ClearOutRadarMapImage();
 
 	// Grab the Map image
-	std::string image_filename(GCM->getRadarMapResourceName(FileMan::replaceExtension(FileMan::getFileName(filename), ".sti")));
+	ST::string image_filename(GCM->getRadarMapResourceName(FileMan::replaceExtension(FileMan::getFileName(filename), ".sti")));
 
 	SGPVObject* const radar = AddVideoObjectFromFile(image_filename.c_str());
 	gusRadarImage = radar;

--- a/src/game/TileEngine/Tile_Cache.cc
+++ b/src/game/TileEngine/Tile_Cache.cc
@@ -17,7 +17,7 @@
 
 struct TILE_CACHE_STRUCT
 {
-	std::string rootName;
+	ST::string rootName;
 	STRUCTURE_FILE_REF* pStructureFileRef;
 };
 
@@ -44,9 +44,9 @@ void InitTileCache(void)
 	}
 
 	// Look for JSD files in the tile cache directory and load any we find
-	std::vector<std::string> jsdFiles = GCM->getAllTilecache();
+	std::vector<ST::string> jsdFiles = GCM->getAllTilecache();
 
-	for (const std::string &file : jsdFiles)
+	for (const ST::string &file : jsdFiles)
 	{
 		TILE_CACHE_STRUCT tc;
 		tc.rootName = FileMan::getFileNameWithoutExt(file);
@@ -144,7 +144,7 @@ INT32 GetCachedTile(const char* const filename)
 	strcpy(tce->zName, filename);
 	tce->sHits = 1;
 
-	std::string root_name(FileMan::getFileNameWithoutExt(filename));
+	ST::string root_name(FileMan::getFileNameWithoutExt(filename));
 	STRUCTURE_FILE_REF* const sfr = GetCachedTileStructureRefFromFilename(root_name.c_str());
 	tce->struct_file_ref = sfr;
 	if (sfr) AddZStripInfoToVObject(tce->pImagery->vo, sfr, TRUE, 0);

--- a/src/game/TileEngine/Tile_Surface.cc
+++ b/src/game/TileEngine/Tile_Surface.cc
@@ -34,7 +34,7 @@ try
 
 	// Load structure data, if any.
 	// Start by hacking the image filename into that for the structure data
-	std::string cStructureFilename(FileMan::replaceExtension(cFilename, ".jsd"));
+	ST::string cStructureFilename(FileMan::replaceExtension(cFilename, ".jsd"));
 
 	AutoStructureFileRef pStructureFileRef;
 	if (GCM->doesGameResExists( cStructureFilename ))
@@ -122,7 +122,7 @@ void SetRaisedObjectFlag(char const* const filename, TILE_IMAGERY* const t)
 	if (DEBRISWOOD != t->fType && t->fType != DEBRISWEEDS && t->fType != DEBRIS2MISC && t->fType != ANOTHERDEBRIS) return;
 
 	// Loop through array of RAISED objecttype imagery and set global value
-	std::string rootfile(FileMan::getFileNameWithoutExt(filename));
+	ST::string rootfile(FileMan::getFileNameWithoutExt(filename));
 	for (char const (*i)[9] = RaisedObjectFiles; i != endof(RaisedObjectFiles); ++i)
 	{
 		if (strcasecmp(*i, rootfile.c_str()) != 0) continue;

--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -232,7 +232,7 @@ try
 		}
 
 		// Adjust for tileset position
-		std::string adjusted_filename(GCM->getTilesetResourceName(tileset_to_add, filename));
+		ST::string adjusted_filename(GCM->getTilesetResourceName(tileset_to_add, filename));
 		AddTileSurface(adjusted_filename.c_str(), i, tileset_to_add);
 	}
 }
@@ -1339,7 +1339,7 @@ BOOLEAN SaveWorld(char const* const filename)
 try
 {
 	// Let's save map into Data/maps
-	std::string path = GCM->getNewMapFolder();
+	ST::string path = GCM->getNewMapFolder();
 	FileMan::createDir(path.c_str());
 	path = FileMan::joinPaths(path.c_str(), (const char*)filename);
 	AutoSGPFile f(FileMan::openForWriting(path.c_str()));

--- a/src/game/Utils/MapUtility.cc
+++ b/src/game/Utils/MapUtility.cc
@@ -83,8 +83,8 @@ ScreenID MapUtilScreenHandle()
 		// USING BRET's STUFF FOR LOOPING FILES/CREATING LIST, hence AddToFDlgList.....
 		try
 		{
-			std::vector<std::string> files = GCM->getAllMaps();
-			for (const std::string &file : files)
+			std::vector<ST::string> files = GCM->getAllMaps();
+			for (const ST::string &file : files)
 			{
 				FileList = AddToFDlgList(FileList, file.c_str());
 				++sFiles;
@@ -260,7 +260,7 @@ ScreenID MapUtilScreenHandle()
 			}
 		}
 
-		std::string zFilename2(GCM->getRadarMapResourceName(FileMan::replaceExtension(zFilename, ".sti")));
+		ST::string zFilename2(GCM->getRadarMapResourceName(FileMan::replaceExtension(zFilename, ".sti")));
 		WriteSTIFile( pDataPtr, pPalette, MINIMAP_X_SIZE, MINIMAP_Y_SIZE, zFilename2.c_str(), CONVERT_ETRLE_COMPRESS, 0 );
 	}
 

--- a/src/game/Utils/Sound_Control.cc
+++ b/src/game/Utils/Sound_Control.cc
@@ -407,7 +407,7 @@ UINT32 PlayLocationJA2Sample(UINT16 const grid_no, SoundID const idx, UINT32 con
 }
 
 
-UINT32 PlayLocationJA2Sample(UINT16 const grid_no, const std::string &sample, UINT32 const base_vol, UINT32 const loops)
+UINT32 PlayLocationJA2Sample(UINT16 const grid_no, const ST::string &sample, UINT32 const base_vol, UINT32 const loops)
 {
 	UINT32 const vol = SoundVolume(base_vol, grid_no);
 	UINT32 const pan = SoundDir(grid_no);

--- a/src/game/Utils/Sound_Control.h
+++ b/src/game/Utils/Sound_Control.h
@@ -1,10 +1,10 @@
 #ifndef SOUND_CONTROL_H
 #define SOUND_CONTROL_H
 
-#include <string>
-
 #include "JA2Types.h"
 #include "Random.h"
+
+#include <string_theory/string>
 
 
 #define FARLEFT	0
@@ -375,7 +375,7 @@ UINT32 PlayJA2Ambient(AmbientSoundID, UINT32 ubVolume, UINT32 ubLoops);
 UINT32 PlayLocationJA2SampleFromFile(UINT16 grid_no, const char* filename, UINT32 base_vol, UINT32 loops);
 
 UINT32 PlayLocationJA2Sample(UINT16 grid_no, SoundID, UINT32 base_vol, UINT32 loops);
-UINT32 PlayLocationJA2Sample(UINT16 grid_no, const std::string &sample, UINT32 base_vol, UINT32 loops);
+UINT32 PlayLocationJA2Sample(UINT16 grid_no, const ST::string &sample, UINT32 base_vol, UINT32 loops);
 UINT32 PlayLocationJA2StreamingSample(UINT16 grid_no, SoundID, UINT32 base_vol, UINT32 loops);
 UINT32 PlaySoldierJA2Sample(SOLDIERTYPE const* s, SoundID, UINT32 base_vol, UINT32 ubLoops, BOOLEAN fCheck);
 

--- a/src/launcher/main.cc
+++ b/src/launcher/main.cc
@@ -1,8 +1,8 @@
-#include <string>
-#include <FL/Fl.H>
-
 #include <Launcher.h>
 #include "RustInterface.h"
+
+#include <FL/Fl.H>
+
 
 int main(int argc, char* argv[]) {
 	Logger_initialize("ja2-launcher.log");

--- a/src/sgp/FileMan.cc
+++ b/src/sgp/FileMan.cc
@@ -81,13 +81,13 @@ void SetBinDataDirFromBundle(void)
 #endif
 
 /** Find config folder and switch into it. */
-std::string FileMan::switchTmpFolder(std::string home)
+ST::string FileMan::switchTmpFolder(ST::string home)
 {
 	// Create another directory and set is as the current directory for the process
 	// Temporary files will be created in this directory.
 	// ----------------------------------------------------------------------------
 
-	std::string tmpPath = FileMan::joinPaths(home, LOCAL_CURRENT_DIR);
+	ST::string tmpPath = FileMan::joinPaths(home, LOCAL_CURRENT_DIR);
 	if (mkdir(tmpPath.c_str(), 0700) != 0 && errno != EEXIST)
 	{
 		SLOGE("Unable to create tmp directory '%s'", tmpPath.c_str());
@@ -102,15 +102,15 @@ std::string FileMan::switchTmpFolder(std::string home)
 }
 
 
-RustPointer<File> FileMan::openFileCaseInsensitive(const std::string& folderPath, const char* filename, uint8_t open_options)
+RustPointer<File> FileMan::openFileCaseInsensitive(const ST::string& folderPath, const char* filename, uint8_t open_options)
 {
-	std::string path = FileMan::joinPaths(folderPath, filename);
+	ST::string path = FileMan::joinPaths(folderPath, filename);
 	RustPointer<File> file(File_open(path.c_str(), open_options));
 	if (!file)
 	{
 #if CASE_SENSITIVE_FS
 		// on case-sensitive file system need to try to find another name
-		std::string newFileName;
+		ST::string newFileName;
 		if(findObjectCaseInsensitive(folderPath.c_str(), filename, true, false, newFileName))
 		{
 			path = FileMan::joinPaths(folderPath, newFileName);
@@ -121,7 +121,7 @@ RustPointer<File> FileMan::openFileCaseInsensitive(const std::string& folderPath
 	return file;
 }
 
-void FileDelete(const std::string &path)
+void FileDelete(const ST::string &path)
 {
 	FileDelete(path.c_str());
 }
@@ -336,8 +336,8 @@ void FileMan::createDir(char const* const path)
 
 void EraseDirectory(char const* const dirPath)
 {
-	std::vector<std::string> paths = FindAllFilesInDir(dirPath);
-	for (std::vector<std::string>::const_iterator it(paths.begin()); it != paths.end(); ++it)
+	std::vector<ST::string> paths = FindAllFilesInDir(dirPath);
+	for (std::vector<ST::string>::const_iterator it(paths.begin()); it != paths.end(); ++it)
 	{
 		try
 		{
@@ -398,10 +398,10 @@ uint64_t GetFreeSpaceOnHardDriveWhereGameIsRunningFrom(void)
 }
 
 /** Join two path components. */
-std::string FileMan::joinPaths(const std::string &first, const char *second)
+ST::string FileMan::joinPaths(const ST::string &first, const char *second)
 {
-	std::string result = first;
-	if((result.length() == 0) || (result[result.length()-1] != PATH_SEPARATOR))
+	ST::string result = first;
+	if((result.size() == 0) || (result[result.size()-1] != PATH_SEPARATOR))
 	{
 		if(second[0] != PATH_SEPARATOR)
 		{
@@ -413,15 +413,15 @@ std::string FileMan::joinPaths(const std::string &first, const char *second)
 }
 
 /** Join two path components. */
-std::string FileMan::joinPaths(const std::string &first, const std::string &second)
+ST::string FileMan::joinPaths(const ST::string &first, const ST::string &second)
 {
 	return joinPaths(first, second.c_str());
 }
 
 /** Join two path components. */
-std::string FileMan::joinPaths(const char *first, const char *second)
+ST::string FileMan::joinPaths(const char *first, const char *second)
 {
-	return joinPaths(std::string(first), second);
+	return joinPaths(ST::string(first), second);
 }
 
 #if CASE_SENSITIVE_FS
@@ -429,7 +429,7 @@ std::string FileMan::joinPaths(const char *first, const char *second)
 /**
  * Find an object (file or subdirectory) in the given directory in case-independent manner.
  * @return true when found, return the found name using foundName. */
-bool FileMan::findObjectCaseInsensitive(const char *directory, const char *name, bool lookForFiles, bool lookForSubdirs, std::string &foundName)
+bool FileMan::findObjectCaseInsensitive(const char *directory, const char *name, bool lookForFiles, bool lookForSubdirs, ST::string &foundName)
 {
 	bool result = false;
 
@@ -442,15 +442,15 @@ bool FileMan::findObjectCaseInsensitive(const char *directory, const char *name,
 		// we have directory in the name
 		// let's find its correct name first
 		char newDirectory[128];
-		std::string actualSubdirName;
+		ST::string actualSubdirName;
 		strncpy(newDirectory, name, sizeof(newDirectory));
 		newDirectory[dirNameLen] = 0;
 
 		if(findObjectCaseInsensitive(directory, newDirectory, false, true, actualSubdirName))
 		{
 			// found subdirectory; let's continue the full search
-			std::string pathInSubdir;
-			std::string newDirectory = FileMan::joinPaths(directory, actualSubdirName.c_str());
+			ST::string pathInSubdir;
+			ST::string newDirectory = FileMan::joinPaths(directory, actualSubdirName.c_str());
 			if(findObjectCaseInsensitive(newDirectory.c_str(), splitter + 1,
 							lookForFiles, lookForSubdirs, pathInSubdir))
 			{
@@ -568,27 +568,27 @@ SGPFile* FileMan::openForReading(const char *filename)
 }
 
 /** Open file for reading. */
-SGPFile* FileMan::openForReading(const std::string &filename)
+SGPFile* FileMan::openForReading(const ST::string &filename)
 {
 	return openForReading(filename.c_str());
 }
 
 /** Open file for reading.  Look file in folderPath in case-insensitive manner. */
-RustPointer<File> FileMan::openForReadingCaseInsensitive(const std::string& folderPath, const char* filename)
+RustPointer<File> FileMan::openForReadingCaseInsensitive(const ST::string& folderPath, const char* filename)
 {
 	return openFileCaseInsensitive(folderPath, filename, FILE_OPEN_READ);
 }
 
-std::vector<std::string>
-FindFilesInDir(const std::string &dirPath,
-		const std::string &ext,
+std::vector<ST::string>
+FindFilesInDir(const ST::string &dirPath,
+		const ST::string &ext,
 		bool caseIncensitive,
 		bool returnOnlyNames,
 		bool sortResults)
 {
-	std::vector<std::string> ret;
-	std::vector<std::string> paths = FindAllFilesInDir(dirPath, sortResults);
-	for (std::string& path : paths)
+	std::vector<ST::string> ret;
+	std::vector<ST::string> paths = FindAllFilesInDir(dirPath, sortResults);
+	for (ST::string& path : paths)
 	{
 		RustPointer<char> path_ext(Path_extension(path.c_str()));
 		bool same_ext;
@@ -627,10 +627,10 @@ FindFilesInDir(const std::string &dirPath,
 	return ret;
 }
 
-std::vector<std::string>
-FindAllFilesInDir(const std::string &dirPath, bool sortResults)
+std::vector<ST::string>
+FindAllFilesInDir(const ST::string &dirPath, bool sortResults)
 {
-	std::vector<std::string> paths;
+	std::vector<ST::string> paths;
 	RustPointer<VecCString> vec(Fs_readDirPaths(dirPath.c_str(), false));
 	if (!vec)
 	{
@@ -654,37 +654,37 @@ FindAllFilesInDir(const std::string &dirPath, bool sortResults)
 	return paths;
 }
 
-std::string FileMan::replaceExtension(const std::string &path, const char *newExtensionWithDot)
+ST::string FileMan::replaceExtension(const ST::string &path, const char *newExtensionWithDot)
 {
 	// TODO switch to rust path extensions (treats the dot in a different way)
-	std::string filename = getFileName(path);
-	size_t n = filename.length();
+	ST::string filename = getFileName(path);
+	size_t n = filename.size();
 
 	if (filename != "." && filename != "..")
 	{
-		size_t dot = filename.find_last_of('.');
-		if (dot != std::string::npos)
+		auto dot = filename.find_last('.');
+		if (dot != -1)
 		{
-			filename.erase(dot);
+			filename = filename.substr(0, dot);
 		}
 	}
 	if (newExtensionWithDot[0] != '\0' && newExtensionWithDot[0] != '.')
 	{
-		filename.push_back('.');
+		filename += '.';
 	}
 	filename += newExtensionWithDot;
 
-	std::string newPath = path.substr(0, path.length() - n);
+	ST::string newPath = path.substr(0, path.size() - n);
 	newPath += filename;
 	return newPath;
 }
 
-std::string FileMan::getParentPath(const std::string &path, bool absolute)
+ST::string FileMan::getParentPath(const ST::string &path, bool absolute)
 {
 	RustPointer<char> parent(Path_parent(path.c_str()));
 	if (!parent)
 	{
-		return std::string();
+		return ST::string();
 	}
 	if (absolute && !Path_isAbsolute(path.c_str()))
 	{
@@ -701,23 +701,23 @@ std::string FileMan::getParentPath(const std::string &path, bool absolute)
 }
 
 /** Get filename from the path. */
-std::string FileMan::getFileName(const std::string &path)
+ST::string FileMan::getFileName(const ST::string &path)
 {
 	RustPointer<char> filename(Path_filename(path.c_str()));
 	if (!filename)
 	{
-		return std::string();
+		return ST::string();
 	}
-	return std::string(filename.get());
+	return ST::string(filename.get());
 }
 
 /** Get filename from the path without extension. */
-std::string FileMan::getFileNameWithoutExt(const char *path)
+ST::string FileMan::getFileNameWithoutExt(const char *path)
 {
 	return replaceExtension(getFileName(path), "");
 }
 
-std::string FileMan::getFileNameWithoutExt(const std::string &path)
+ST::string FileMan::getFileNameWithoutExt(const ST::string &path)
 {
 	return getFileNameWithoutExt(path.c_str());
 }
@@ -728,26 +728,19 @@ RustPointer<File> FileMan::openFileForReading(const char* filename)
 }
 
 /** Replace all \ with / */
-void FileMan::slashifyPath(std::string &path)
+void FileMan::slashifyPath(ST::string &path)
 {
-	size_t len = path.size();
-	for(size_t i = 0; i < len; i++)
-	{
-		if(path[i] == '\\')
-		{
-			path[i] = '/';
-		}
-	}
+	path = path.replace("\\", "/");
 }
 
 /** Read the whole file as text. */
-std::string FileMan::fileReadText(SGPFile* file)
+ST::string FileMan::fileReadText(SGPFile* file)
 {
 	uint32_t size = FileGetSize(file);
 	char *data = new char[size+1];
 	FileRead(file, data, size);
 	data[size] = 0;
-	std::string result(data);
+	ST::string result(data);
 	delete[] data;
 	return result;
 }
@@ -755,7 +748,7 @@ std::string FileMan::fileReadText(SGPFile* file)
 /** Check file existance. */
 bool FileMan::checkFileExistance(const char *folder, const char *fileName)
 {
-	std::string path = joinPaths(folder, fileName);
+	ST::string path = joinPaths(folder, fileName);
 	return Fs_exists(path.c_str());
 }
 

--- a/src/sgp/FileMan.h
+++ b/src/sgp/FileMan.h
@@ -1,11 +1,12 @@
 #ifndef FILEMAN_H
 #define FILEMAN_H
 
-#include <string>
-#include <vector>
-
 #include "sgp/SGPFile.h"
 #include "sgp/Types.h"
+
+#include <string_theory/string>
+
+#include <vector>
 
 #ifdef _WIN32
 #	define WIN32_LEAN_AND_MEAN
@@ -17,7 +18,7 @@
 /* Delete the file at path. Returns true iff deleting the file succeeded or
  * the file did not exist in the first place. */
 void FileDelete(char const* path);
-void FileDelete(const std::string &path);
+void FileDelete(const ST::string &path);
 
 void FileRead( SGPFile*, void*       pDest, size_t uiBytesToRead);
 void FileWrite(SGPFile*, void const* pDest, size_t uiBytesToWrite);
@@ -66,7 +67,7 @@ class FileMan
 public:
 
 	/** Find config folder and switch into it. */
-	static std::string switchTmpFolder(std::string homeDir);
+	static ST::string switchTmpFolder(ST::string homeDir);
 
 	/** Open file for writing.
 	 * If file is missing it will be created.
@@ -85,19 +86,19 @@ public:
 	static SGPFile* openForReading(const char *filename);
 
 	/** Open file for reading. */
-	static SGPFile* openForReading(const std::string &filename);
+	static SGPFile* openForReading(const ST::string &filename);
 
 	/** Read the whole file as text. */
-	static std::string fileReadText(SGPFile*);
+	static ST::string fileReadText(SGPFile*);
 
 #if CASE_SENSITIVE_FS
 	/** Find an object (file or subdirectory) in the given directory in case-independent manner.
 	 * @return true when found, return the found name using foundName. */
-	static bool findObjectCaseInsensitive(const char *directory, const char *name, bool lookForFiles, bool lookForSubdirs, std::string &foundName);
+	static bool findObjectCaseInsensitive(const char *directory, const char *name, bool lookForFiles, bool lookForSubdirs, ST::string &foundName);
 #endif
 
 	/** Open file in the 'Data' directory in case-insensitive manner. */
-	static RustPointer<File> openForReadingCaseInsensitive(const std::string& folderPath, const char* filename);
+	static RustPointer<File> openForReadingCaseInsensitive(const ST::string& folderPath, const char* filename);
 
 	/* ------------------------------------------------------------
 	 * Other operations
@@ -109,38 +110,38 @@ public:
 	static void createDir(char const* path);
 
 	/** Join two path components. */
-	static std::string joinPaths(const char *first, const char *second);
+	static ST::string joinPaths(const char *first, const char *second);
 
 	/** Join two path components. */
-	static std::string joinPaths(const std::string &first, const char *second);
+	static ST::string joinPaths(const ST::string &first, const char *second);
 
 	/** Join two path components. */
-	static std::string joinPaths(const std::string &first, const std::string &second);
+	static ST::string joinPaths(const ST::string &first, const ST::string &second);
 
 	/** Replace extension of a file. */
-	static std::string replaceExtension(const std::string &path, const char *newExtensionWithDot);
+	static ST::string replaceExtension(const ST::string &path, const char *newExtensionWithDot);
 
 	/** Get parent path (e.g. directory path from the full path). */
-	static std::string getParentPath(const std::string &path, bool absolute);
+	static ST::string getParentPath(const ST::string &path, bool absolute);
 
 	/** Get filename from the path. */
-	static std::string getFileName(const std::string &path);
+	static ST::string getFileName(const ST::string &path);
 
 	/** Get filename from the path without extension. */
-	static std::string getFileNameWithoutExt(const char *path);
-	static std::string getFileNameWithoutExt(const std::string &path);
+	static ST::string getFileNameWithoutExt(const char *path);
+	static ST::string getFileNameWithoutExt(const ST::string &path);
 
 	static RustPointer<File> openFileForReading(const char* filename);
 
 	/** Open file in the given folder in case-insensitive manner.
 	 * @return file descriptor or null if file is not found. */
-	static RustPointer<File> openFileCaseInsensitive(const std::string& folderPath, const char* filename, uint8_t open_options);
+	static RustPointer<File> openFileCaseInsensitive(const ST::string& folderPath, const char* filename, uint8_t open_options);
 
 	/** Convert File to HWFile. */
 	static SGPFile* getSGPFileFromFile(File* f);
 
 	/** Replace all \ with / */
-	static void slashifyPath(std::string &path);
+	static void slashifyPath(ST::string &path);
 
 	/** Check file existance. */
 	static bool checkFileExistance(const char *folder, const char *fileName);
@@ -161,9 +162,9 @@ private:
  * @param returnOnlyNames When True, return only names (without the directory path)
  * @param sortResults When True, sort found paths.
  * @return List of paths (dir + filename). */
-std::vector<std::string>
-FindFilesInDir(const std::string &dirPath,
-		const std::string &ext,
+std::vector<ST::string>
+FindFilesInDir(const ST::string &dirPath,
+		const ST::string &ext,
 		bool caseIncensitive,
 		bool returnOnlyNames,
 		bool sortResults = false);
@@ -173,7 +174,7 @@ FindFilesInDir(const std::string &dirPath,
  * @param dirPath Path to the directory
  * @param sortResults When True, sort found paths.
  * @return List of paths (dir + filename). */
-std::vector<std::string>
-FindAllFilesInDir(const std::string &dirPath, bool sortResults = false);
+std::vector<ST::string>
+FindAllFilesInDir(const ST::string &dirPath, bool sortResults = false);
 
 #endif

--- a/src/sgp/FileMan_unittest.cc
+++ b/src/sgp/FileMan_unittest.cc
@@ -6,24 +6,24 @@
 
 TEST(FileManTest, joinPaths)
 {
-	// std::string joinPaths(const char *first, const char *second);
+	// ST::string joinPaths(const char *first, const char *second);
 	{
-		std::string result;
+		ST::string result;
 
 		// ~~~ platform-specific separators
 
 		result = FileMan::joinPaths("foo", "bar");
 		EXPECT_STREQ(result.c_str(), "foo" PATH_SEPARATOR_STR "bar");
-		result = FileMan::joinPaths(std::string("foo"), std::string("bar"));
+		result = FileMan::joinPaths(ST::string("foo"), ST::string("bar"));
 		EXPECT_STREQ(result.c_str(), "foo" PATH_SEPARATOR_STR "bar");
-		result = FileMan::joinPaths(std::string("foo"), "bar");
+		result = FileMan::joinPaths(ST::string("foo"), "bar");
 		EXPECT_STREQ(result.c_str(), "foo" PATH_SEPARATOR_STR "bar");
 
 		result = FileMan::joinPaths("foo" PATH_SEPARATOR_STR, "bar");
 		EXPECT_STREQ(result.c_str(), "foo" PATH_SEPARATOR_STR "bar");
-		result = FileMan::joinPaths(std::string("foo" PATH_SEPARATOR_STR), std::string("bar"));
+		result = FileMan::joinPaths(ST::string("foo" PATH_SEPARATOR_STR), ST::string("bar"));
 		EXPECT_STREQ(result.c_str(), "foo" PATH_SEPARATOR_STR "bar");
-		result = FileMan::joinPaths(std::string("foo" PATH_SEPARATOR_STR), "bar");
+		result = FileMan::joinPaths(ST::string("foo" PATH_SEPARATOR_STR), "bar");
 		EXPECT_STREQ(result.c_str(), "foo" PATH_SEPARATOR_STR "bar");
 
 		// // XXX FAILS
@@ -52,9 +52,9 @@ TEST(FileManTest, FindFilesInDir)
 	// result on Linux: "unittests/find-files/lowercase-ext.txt"
 	// result on Win:   "unittests/find-files\lowercase-ext.txt"
 
-	std::string testDir = FileMan::joinPaths(GetExtraDataDir(), "unittests/find-files");
+	ST::string testDir = FileMan::joinPaths(GetExtraDataDir(), "unittests/find-files");
 
-	std::vector<std::string> results = FindFilesInDir(testDir, "txt", false, false);
+	std::vector<ST::string> results = FindFilesInDir(testDir, "txt", false, false);
 	ASSERT_EQ(results.size(), 1u);
 	EXPECT_STREQ(results[0].c_str(), FileMan::joinPaths(GetExtraDataDir(), "unittests/find-files" PS "lowercase-ext.txt").c_str());
 
@@ -102,11 +102,11 @@ TEST(FileManTest, RemoveAllFilesInDir)
 	ASSERT_NE(tempDir.get(), nullptr);
 	RustPointer<char> tempPath(TempDir_path(tempDir.get()));
 	ASSERT_NE(tempPath.get(), nullptr);
-	std::string subDir = FileMan::joinPaths(tempPath.get(), "subdir");
+	ST::string subDir = FileMan::joinPaths(tempPath.get(), "subdir");
 	ASSERT_EQ(Fs_createDir(subDir.c_str()), true);
 
-	std::string pathA = FileMan::joinPaths(tempPath.get(), "foo.txt");
-	std::string pathB = FileMan::joinPaths(tempPath.get(), "bar.txt");
+	ST::string pathA = FileMan::joinPaths(tempPath.get(), "foo.txt");
+	ST::string pathB = FileMan::joinPaths(tempPath.get(), "bar.txt");
 
 	SGPFile* fileA = FileMan::openForWriting(pathA.c_str());
 	ASSERT_NE(fileA, nullptr);
@@ -119,7 +119,7 @@ TEST(FileManTest, RemoveAllFilesInDir)
 	FileClose(fileA);
 	FileClose(fileB);
 
-	std::vector<std::string> results = FindAllFilesInDir(tempPath.get(), true);
+	std::vector<ST::string> results = FindAllFilesInDir(tempPath.get(), true);
 	ASSERT_EQ(results.size(), 2u);
 
 	EraseDirectory(tempPath.get());
@@ -137,7 +137,7 @@ TEST(FileManTest, ReadTextFile)
 	ASSERT_NE(tempDir.get(), nullptr);
 	RustPointer<char> tempPath(TempDir_path(tempDir.get()));
 	ASSERT_NE(tempPath.get(), nullptr);
-	std::string pathA = FileMan::joinPaths(tempPath.get(), "foo.txt");
+	ST::string pathA = FileMan::joinPaths(tempPath.get(), "foo.txt");
 
 	SGPFile* fileA = FileMan::openForWriting(pathA.c_str());
 	ASSERT_NE(fileA, nullptr);
@@ -146,7 +146,7 @@ TEST(FileManTest, ReadTextFile)
 
 	SGPFile* forReading = FileMan::openForReading(pathA.c_str());
 	ASSERT_NE(forReading, nullptr);
-	std::string content = FileMan::fileReadText(forReading);
+	ST::string content = FileMan::fileReadText(forReading);
 	ASSERT_STREQ(content.c_str(), "foo bar baz");
 	FileClose(forReading);
 }
@@ -205,7 +205,7 @@ TEST(FileManTest, ReplaceExtension)
 
 TEST(FileManTest, SlashifyPath)
 {
-	std::string test("foo\\bar\\baz");
+	ST::string test("foo\\bar\\baz");
 	FileMan::slashifyPath(test);
 	EXPECT_STREQ(test.c_str(), "foo/bar/baz");
 }

--- a/src/sgp/LoadSaveData_unittest.cc
+++ b/src/sgp/LoadSaveData_unittest.cc
@@ -144,8 +144,8 @@ TEST(LoadSaveData, floatAndDoubleFormat)
 	// as on Windows.  Otherwise, there will be problems with
 	// loading saved games made on Windows.
 
-	std::string floatsPath = FileMan::joinPaths(GetExtraDataDir(), "unittests/datatypes/floats.bin");
-	std::string doublesPath = FileMan::joinPaths(GetExtraDataDir(), "unittests/datatypes/doubles.bin");
+	ST::string floatsPath = FileMan::joinPaths(GetExtraDataDir(), "unittests/datatypes/floats.bin");
+	ST::string doublesPath = FileMan::joinPaths(GetExtraDataDir(), "unittests/datatypes/doubles.bin");
 
 	// // Test data were previously written with the following code.
 	// {

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -338,7 +338,7 @@ int main(int argc, char* argv[])
 		}
 	}
 
-	std::string exeFolder = FileMan::getParentPath(argv[0], true);
+	ST::string exeFolder = FileMan::getParentPath(argv[0], true);
 
 	RustPointer<EngineOptions> params(EngineOptions_create(argv, argc));
 	if (params == NULL) {
@@ -416,14 +416,14 @@ int main(int argc, char* argv[])
 	RustPointer<char> configFolderPath(EngineOptions_getStracciatellaHome(params.get()));
 	RustPointer<char> gameResRootPath(EngineOptions_getVanillaGameDir(params.get()));
 
-	std::string extraDataDir = EXTRA_DATA_DIR;
+	ST::string extraDataDir = EXTRA_DATA_DIR;
 	if(extraDataDir.empty())
 	{
 		// use location of the exe file
 		extraDataDir = exeFolder;
 	}
 
-	std::string externalizedDataPath = FileMan::joinPaths(extraDataDir, "externalized");
+	ST::string externalizedDataPath = FileMan::joinPaths(extraDataDir, "externalized");
 
 	FileMan::switchTmpFolder(configFolderPath.get());
 
@@ -432,12 +432,12 @@ int main(int argc, char* argv[])
 	uint32_t n = EngineOptions_getModsLength(params.get());
 	if(n > 0)
 	{
-		std::vector<std::string> modNames;
-		std::vector<std::string> modResFolders;
+		std::vector<ST::string> modNames;
+		std::vector<ST::string> modResFolders;
 		for (uint32_t i = 0; i < n; ++i)
 		{
 			RustPointer<char> modName(EngineOptions_getMod(params.get(), i));
-			std::string modResFolder = FileMan::joinPaths(FileMan::joinPaths(FileMan::joinPaths(extraDataDir, "mods"), modName.get()), "data");
+			ST::string modResFolder = FileMan::joinPaths(FileMan::joinPaths(FileMan::joinPaths(extraDataDir, "mods"), modName.get()), "data");
 			modNames.emplace_back(modName.get());
 			modResFolders.emplace_back(modResFolder);
 		}
@@ -474,7 +474,7 @@ int main(int argc, char* argv[])
 		SLOGI("------------------------------------------------------------------------------");
 	}
 
-	std::vector<std::string> libraries = cm->getListOfGameResources();
+	std::vector<ST::string> libraries = cm->getListOfGameResources();
 	cm->initGameResouces(configFolderPath.get(), libraries);
 
 	// free editor.slf has the lowest priority (last library) and is optional
@@ -571,7 +571,7 @@ int main(int argc, char* argv[])
 					const char *dialogFile, const char *outputFile)
 {
 	std::vector<ST::string*> quotes;
-	std::vector<std::string> quotes_str;
+	std::vector<ST::string> quotes_str;
 	cm->loadAllDialogQuotes(encType, dialogFile, quotes);
 	for(int i = 0; i < quotes.size(); i++)
 	{

--- a/src/sgp/StrUtils.cc
+++ b/src/sgp/StrUtils.cc
@@ -6,7 +6,7 @@
 #include "PlatformStrings.h"
 
 /** Build formatted string. */
-std::string FormattedString(const char* fmt, ...)
+ST::string FormattedString(const char* fmt, ...)
 {
 	char buf[512];
 	va_list ArgPtr;
@@ -16,5 +16,5 @@ std::string FormattedString(const char* fmt, ...)
 
 	buf[sizeof(buf) - 1] = 0;
 
-	return std::string(buf);
+	return ST::string(buf);
 }

--- a/src/sgp/StrUtils.h
+++ b/src/sgp/StrUtils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string>
+#include <string_theory/string>
 
 /** Build formatted string. */
-std::string FormattedString(const char* fmt, ...);
+ST::string FormattedString(const char* fmt, ...);

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -535,7 +535,7 @@ static void WriteTGAHeader(File* file)
 /* Create a file for a screenshot, which is guaranteed not to exist yet. */
 static RustPointer<File> CreateScreenshotFile(void)
 {
-	const std::string exec_dir = GCM->getScreenshotFolder();
+	const ST::string exec_dir = GCM->getScreenshotFolder();
 	while (true)
 	{
 		char filename[2048];
@@ -809,7 +809,7 @@ static void RefreshMovieCache(void)
 
 	PauseTime(TRUE);
 
-	const std::string exec_dir = GCM->getVideoCaptureFolder();
+	const ST::string exec_dir = GCM->getVideoCaptureFolder();
 
 	for (INT32 cnt = 0; cnt < giNumFrames; cnt++)
 	{


### PR DESCRIPTION
`std::string` was getting in the way, so I decided to replace it in one go to avoid intermediate changes. Now utf8 is enforced everywhere (that used std::string) except the native file chooser (path) in the launcher.