### PR TITLE
Fix Mine Text display

### DIFF
--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -3470,7 +3470,7 @@ static void BlitMineText(UINT8 const mine_idx, INT16 const sMapX, INT16 const sM
 		buf = SPrintMoney(PredictDailyIncomeFromAMine(mine_idx));
 
 		// if potential is not nil, show percentage of the two
-		UINT32 maxIncome = GetMaxPeriodicRemovalFromMine(mine_idx);
+		UINT32 maxIncome = GetMaxDailyRemovalFromMine(mine_idx);
 		if (maxIncome > 0)
 		{
 			UINT32 predictedIncome = PredictDailyIncomeFromAMine(mine_idx);


### PR DESCRIPTION
Mine income rates going beyond 100% in strategic map. The numerator is a daily rate, but the denominator is a periodic rate. 

Both should have been daily rate. Ref: https://github.com/ja2-stracciatella/ja2-stracciatella/commit/a3df1905455a29f21dbbca2647a0688a40c23e3d 

@flaviojs 