### PR TITLE
Externalizing SAM site locations

### DIFF
--- a/assets/externalized/strategic-map-sam-sites.json
+++ b/assets/externalized/strategic-map-sam-sites.json
@@ -1,0 +1,29 @@
+/**
+ * Defines the locations of SAM sites on map. There must be exactly 4 SAM sites
+ *
+ * You should not change the order or the sector of the SAM sites, or you may
+ * get inconsistencies with things like terrain types, NPC dialogues and
+ * airspace control.
+ *
+ * Fields:
+ *  - sector:    Sector where the SAM site is in. The game expects SAM sites in the order of D2, D15, I8 and N4.
+ *  - gridNos:    The 2 adjacent map tiles where the controller computer is. Damages to these gridNos can disable the SAM site.
+ */
+[
+    {   // SAM_SITE_ONE
+        "sector": "D2",
+        "gridNos": [ 10196, 10195 ]
+    },
+    {   // SAM_SITE_TWO
+        "sector": "D15",
+        "gridNos": [ 11295, 11135 ]
+    },
+    {   // SAM_SITE_THREE
+        "sector": "I8",
+        "gridNos": [ 16080, 15920 ]
+    },
+    {   // SAM_SITE_FOUR
+        "sector": "N4",
+        "gridNos": [ 11913, 11912 ]
+    }
+]

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -13,14 +13,15 @@
 #include <vector>
 
 
+class BloodCatPlacementsModel;
+class BloodCatSpawnsModel;
 class DealerInventory;
 class GamePolicy;
 class IMPPolicy;
-class BloodCatPlacementsModel;
-class BloodCatSpawnsModel;
-class TownModel;
 class MovementCostsModel;
 class NpcPlacementModel;
+class SamSiteModel;
+class TownModel;
 struct AmmoTypeModel;
 struct CalibreModel;
 struct MagazineModel;
@@ -116,6 +117,9 @@ public:
 	virtual const std::vector<const BloodCatPlacementsModel*> & getBloodCatPlacements() const = 0;
 	virtual const std::vector<const BloodCatSpawnsModel*> & getBloodCatSpawns() const = 0;
 	virtual const BloodCatSpawnsModel* getBloodCatSpawnsOfSector(uint8_t sectorId) const = 0;
+	virtual const std::vector<const SamSiteModel*>& getSamSites() const = 0;
+	virtual const int8_t findSamIDBySector(uint8_t sectorId) const = 0;
+	virtual const SamSiteModel* findSamSiteBySector(uint8_t sectorId) const = 0;
 	virtual const TownModel* getTown(int8_t townId) const = 0;
 	virtual const std::map<int8_t, const TownModel*>& getTowns() const = 0;
 	virtual const ST::string getTownName(uint8_t townId) const = 0;

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -29,6 +29,7 @@
 #include "policy/DefaultIMPPolicy.h"
 #include "strategic/BloodCatPlacementsModel.h"
 #include "strategic/BloodCatSpawnsModel.h"
+#include "strategic/SamSiteModel.h"
 #include "strategic/TownModel.h"
 #include "strategic/MovementCostsModel.h"
 #include "strategic/NpcPlacementModel.h"
@@ -266,6 +267,7 @@ DefaultContentManager::~DefaultContentManager()
 
 	m_bloodCatPlacements.clear();
 	m_bloodCatSpawns.clear();
+	m_samSites.clear();
 	m_towns.clear();
 	m_npcPlacements.clear();
 
@@ -1069,6 +1071,15 @@ bool DefaultContentManager::loadStrategicLayerData() {
 		);
 	}
 
+	json = readJsonDataFile("strategic-map-sam-sites.json");
+	for (auto& element : json->GetArray())
+	{
+		auto samSite = SamSiteModel::deserialize(element);
+		m_samSites.push_back(samSite);
+	}
+	SamSiteModel::validateData(m_samSites);
+	delete json;
+
 	json = readJsonDataFile("strategic-map-towns.json");
 	for (auto& element : json->GetArray()) 
 	{
@@ -1118,6 +1129,29 @@ const TownModel* DefaultContentManager::getTown(int8_t townId) const
 {
 	auto iter = m_towns.find(townId);
 	return (iter != m_towns.end()) ? iter->second : NULL;
+}
+
+const std::vector<const SamSiteModel*>& DefaultContentManager::getSamSites() const
+{
+	return m_samSites;
+}
+
+const int8_t DefaultContentManager::findSamIDBySector(uint8_t sectorId) const
+{
+	for (size_t i = 0; i < m_samSites.size(); i++)
+	{
+		if (m_samSites[i]->sectorId == sectorId)
+		{
+			return i;
+		}
+	}
+	return -1;
+}
+
+const SamSiteModel* DefaultContentManager::findSamSiteBySector(uint8_t sectorId) const
+{
+	auto i = findSamIDBySector(sectorId);
+	return (i > -1) ? m_samSites[i] : NULL;
 }
 
 const std::map<int8_t, const TownModel*>& DefaultContentManager::getTowns() const

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -145,6 +145,9 @@ public:
 	virtual const std::vector<const BloodCatPlacementsModel*>& getBloodCatPlacements() const override;
 	virtual const std::vector<const BloodCatSpawnsModel*>& getBloodCatSpawns() const override;
 	virtual const BloodCatSpawnsModel* getBloodCatSpawnsOfSector(uint8_t sectorId) const override;
+	virtual const std::vector<const SamSiteModel*>& getSamSites() const override;
+	virtual const int8_t findSamIDBySector(uint8_t sectorId) const override;
+	virtual const SamSiteModel* findSamSiteBySector(uint8_t sectorId) const override;
 	virtual const TownModel* getTown(int8_t townId) const  override;
 	virtual const std::map<int8_t, const TownModel*>& getTowns() const override;
 	virtual const ST::string getTownName(uint8_t townId) const override;
@@ -192,6 +195,7 @@ protected:
 
 	std::vector<const BloodCatPlacementsModel*> m_bloodCatPlacements;
 	std::vector<const BloodCatSpawnsModel*> m_bloodCatSpawns;
+	std::vector<const SamSiteModel*> m_samSites;
 	std::map<int8_t, const TownModel*> m_towns;
 	std::vector<const ST::string*> m_townNames;
 	std::vector<const ST::string*> m_townNameLocatives;

--- a/src/externalized/strategic/CMakeLists.txt
+++ b/src/externalized/strategic/CMakeLists.txt
@@ -4,9 +4,10 @@ set(JA2_SOURCES
     ${LOCAL_JA2_HEADERS}
     ${CMAKE_CURRENT_SOURCE_DIR}/BloodCatPlacementsModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/BloodCatSpawnsModel.cc
-    ${CMAKE_CURRENT_SOURCE_DIR}/TownModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/MovementCostsModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/NpcPlacementModel.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/SamSiteModel.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/TownModel.cc
     PARENT_SCOPE
 )
 set(JA2_INCLUDES

--- a/src/externalized/strategic/SamSiteModel.cc
+++ b/src/externalized/strategic/SamSiteModel.cc
@@ -1,0 +1,67 @@
+#include "SamSiteModel.h"
+
+#include "Campaign_Types.h"
+#include "StrategicMap.h"
+#include "WorldDef.h"
+
+#include <algorithm>
+
+
+const int8_t SAM_GRAPHIC_INDEX_NE_SW = 3;  // SAM computer terminal graphic for the "/" orientation
+const int8_t SAM_GRAPHIC_INDEX_NW_SE = 4;  // SAM computer terminal graphic for the "\" orientation
+
+SamSiteModel::SamSiteModel(uint8_t sectorId_, std::array<GridNo, 2> gridNos_)
+	: sectorId(sectorId_), gridNos(gridNos_) 
+{
+	Assert(gridNos[0] > gridNos[1]);
+	graphicIndex = (gridNos[0] - gridNos[1] == WORLD_COLS) ? SAM_GRAPHIC_INDEX_NE_SW : SAM_GRAPHIC_INDEX_NW_SE;
+}
+
+const bool SamSiteModel::doesSamExistHere(INT16 const x, INT16 const y, GridNo const gridNo) const
+{
+	return x == SECTORX(sectorId) 
+		&& y == SECTORY(sectorId) 
+		&& std::find(gridNos.begin(), gridNos.end(), gridNo) != gridNos.end()
+	;
+}
+
+SamSiteModel* SamSiteModel::deserialize(const rapidjson::Value& obj)
+{
+	const char* sector = obj["sector"].GetString();
+	if (!IS_VALID_SECTOR_SHORT_STRING(sector))
+	{
+		throw std::runtime_error("SAM site sector is not a valid string");
+	}
+	uint8_t sectorId = SECTOR_FROM_SECTOR_SHORT_STRING(sector);
+
+	auto g = obj["gridNos"].GetArray();
+	if (g.Size() != 2)
+	{
+		throw std::runtime_error("SAM site gridNos must be an array of 2 integers");
+	}
+	std::array<GridNo, 2> gridNoList = {
+		static_cast<GridNo>(g[0].GetInt()),
+		static_cast<GridNo>(g[1].GetInt()),
+	};
+
+	// sort descending, so gridNos[0] is always the lower tile
+	std::sort(gridNoList.begin(), gridNoList.end(), std::greater<int>());
+
+	auto diff = gridNoList[0] - gridNoList[1];
+	if (diff != 1 && diff != WORLD_COLS)
+	{
+		throw std::runtime_error("SAM site gridNos must be 2 adjacent tiles");
+	}
+
+	return new SamSiteModel(sectorId, gridNoList);
+}
+
+void SamSiteModel::validateData(const std::vector<const SamSiteModel*>& models)
+{
+	if (models.size() != NUMBER_OF_SAMS)
+	{
+		// Game saves, Skyrider and Meanwhile dialogues all assume 4 SAM sites
+		SLOGE(ST::format("There must be exactly {} SAM sites defined", NUMBER_OF_SAMS));
+		throw std::runtime_error("Unexpected number of SAM sites");
+	}
+}

--- a/src/externalized/strategic/SamSiteModel.h
+++ b/src/externalized/strategic/SamSiteModel.h
@@ -1,0 +1,22 @@
+#include "JA2Types.h"
+#include "JsonObject.h"
+
+#include <array>
+
+class SamSiteModel
+{
+public:
+	SamSiteModel(uint8_t sectorId_, std::array<GridNo, 2> gridNos_);
+	const bool doesSamExistHere(INT16 const x, INT16 const y, GridNo const gridno) const;
+
+	static SamSiteModel* deserialize(const rapidjson::Value& obj);
+	static void validateData(const std::vector<const SamSiteModel*>& models);
+
+	uint8_t sectorId;
+
+	// 2 gridNo of the SAM computer terminal. Always sorted in descending order, so the first element is the "anchor point".
+	std::array<GridNo, 2> gridNos;
+
+	//Use 3 if / orientation, 4 if \ orientation
+	int8_t graphicIndex;
+};

--- a/src/game/Strategic/Map_Screen_Helicopter.cc
+++ b/src/game/Strategic/Map_Screen_Helicopter.cc
@@ -1,44 +1,47 @@
-#include "Directories.h"
-#include "Font_Control.h"
-#include "MapScreen.h"
 #include "Map_Screen_Helicopter.h"
-#include "LaptopSave.h"
-#include "MessageBoxScreen.h"
-#include "Vehicles.h"
-#include "Finances.h"
-#include "Quests.h"
-#include "Game_Clock.h"
-#include "Queen_Command.h"
-#include "Strategic_Pathing.h"
-#include "Random.h"
-#include "Game_Event_Hook.h"
-#include "Dialogue_Control.h"
-#include "Message.h"
-#include "Strategic_Movement.h"
-#include "Soldier_Profile.h"
+
 #include "Assignments.h"
+#include "ContentManager.h"
+#include "Debug.h"
+#include "Dialogue_Control.h"
+#include "Directories.h"
+#include "Finances.h"
+#include "Font_Control.h"
+#include "GameInstance.h"
+#include "Game_Clock.h"
+#include "Game_Event_Hook.h"
+#include "Isometric_Utils.h"
+#include "LaptopSave.h"
+#include "MapScreen.h"
+#include "Map_Screen_Interface.h"
+#include "Map_Screen_Interface_Border.h"
+#include "Meanwhile.h"
+#include "Message.h"
+#include "MessageBoxScreen.h"
+#include "Overhead.h"
+#include "Player_Command.h"
 #include "PreBattle_Interface.h"
+#include "Queen_Command.h"
+#include "Quests.h"
+#include "Random.h"
+#include "RenderWorld.h"
+#include "SamSiteModel.h"
+#include "Scheduling.h"
+#include "Soldier_Create.h"
+#include "Soldier_Profile.h"
+#include "SoundMan.h"
+#include "Sound_Control.h"
+#include "Squads.h"
 #include "StrategicMap.h"
+#include "Strategic_Event_Handler.h"
+#include "Strategic_Movement.h"
+#include "Strategic_Pathing.h"
+#include "Text.h"
+#include "TileDat.h"
+#include "UILayout.h"
+#include "Vehicles.h"
 #include "WorldDef.h"
 #include "WorldMan.h"
-#include "TileDat.h"
-#include "Map_Screen_Interface.h"
-#include "Text.h"
-#include "Squads.h"
-#include "Player_Command.h"
-#include "Sound_Control.h"
-#include "Meanwhile.h"
-#include "Map_Screen_Interface_Border.h"
-#include "Strategic_Event_Handler.h"
-#include "Overhead.h"
-#include "Soldier_Create.h"
-#include "RenderWorld.h"
-#include "SoundMan.h"
-#include "Isometric_Utils.h"
-#include "Scheduling.h"
-#include "Debug.h"
-#include "UILayout.h"
-
 
 // the amounts of time to wait for hover stuff
 #define TIME_DELAY_FOR_HOVER_WAIT						10		// minutes
@@ -755,7 +758,8 @@ static void HandleSkyRiderMonologueAboutDrassenSAMSite(UINT32 const uiSpecialCod
 			SkyriderDialogue(MENTION_DRASSEN_SAM_SITE);
 			SkyriderDialogueWithSpecialEvent(SKYRIDER_MONOLOGUE_EVENT_DRASSEN_SAM_SITE, 1);
 
-			if (StrategicMap[SECTOR_INFO_TO_STRATEGIC_INDEX(pSamList[1])].fEnemyControlled)
+			auto samList = GCM->getSamSites();
+			if (StrategicMap[SECTOR_INFO_TO_STRATEGIC_INDEX(samList[SAM_SITE_TWO]->sectorId)].fEnemyControlled)
 			{
 				SkyriderDialogue(SECOND_HALF_OF_MENTION_DRASSEN_SAM_SITE);
 			}
@@ -888,6 +892,8 @@ void HandleAnimationOfSectors( void )
 	static BOOLEAN fOldShowEstoniRefuelHighLight = FALSE;
 	static BOOLEAN fOldShowOtherSAMHighLight = FALSE;
 
+	auto samList = GCM->getSamSites();
+
 	// find out which mode we are in and animate for that mode
 
 	// Drassen SAM site
@@ -895,7 +901,7 @@ void HandleAnimationOfSectors( void )
 	{
 		fOldShowDrassenSAMHighLight = TRUE;
 		// Drassen's SAM site is #2
-		HandleBlitOfSectorLocatorIcon(pSamList[1], LOCATOR_COLOR_RED);
+		HandleBlitOfSectorLocatorIcon(samList[SAM_SITE_TWO]->sectorId, LOCATOR_COLOR_RED);
 		fSkipSpeakersLocator = TRUE;
 	}
 	else if( fOldShowDrassenSAMHighLight )
@@ -921,9 +927,9 @@ void HandleAnimationOfSectors( void )
 	if( fShowOtherSAMHighLight )
 	{
 		fOldShowOtherSAMHighLight = TRUE;
-		HandleBlitOfSectorLocatorIcon(pSamList[0], LOCATOR_COLOR_RED);
-		HandleBlitOfSectorLocatorIcon(pSamList[2], LOCATOR_COLOR_RED);
-		HandleBlitOfSectorLocatorIcon(pSamList[3], LOCATOR_COLOR_RED);
+		HandleBlitOfSectorLocatorIcon(samList[SAM_SITE_ONE]->sectorId,   LOCATOR_COLOR_RED);
+		HandleBlitOfSectorLocatorIcon(samList[SAM_SITE_THREE]->sectorId, LOCATOR_COLOR_RED);
+		HandleBlitOfSectorLocatorIcon(samList[SAM_SITE_FOUR]->sectorId,  LOCATOR_COLOR_RED);
 		fSkipSpeakersLocator = TRUE;
 	}
 	else if( fOldShowOtherSAMHighLight )
@@ -1060,7 +1066,8 @@ static BOOLEAN HandleSAMSiteAttackOfHelicopterInSector(INT16 sSectorX, INT16 sSe
 
 	// get the condition of that SAM site (NOTE: SAM #s are 1-4, but indexes are 0-3!!!)
 	Assert( ubSamNumber <= NUMBER_OF_SAMS );
-	bSAMCondition = StrategicMap[ SECTOR_INFO_TO_STRATEGIC_INDEX( pSamList[ ubSamNumber - 1 ] ) ].bSAMCondition;
+	UINT8 ubSAMSectorID = GCM->getSamSites()[ubSamNumber - 1]->sectorId;
+	bSAMCondition = StrategicMap[ SECTOR_INFO_TO_STRATEGIC_INDEX(ubSAMSectorID) ].bSAMCondition;
 
 	// if the SAM site is too damaged to be a threat
 	if( bSAMCondition < MIN_CONDITION_FOR_SAM_SITE_TO_WORK )

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -1,59 +1,59 @@
+#include "Map_Screen_Interface_Map.h"
+
+#include "Air_Raid.h"
+#include "Assignments.h"
+#include "Button_System.h"
+#include "Campaign_Types.h"
+#include "ContentManager.h"
+#include "Debug.h"
 #include "Directories.h"
+#include "Finances.h"
 #include "Font.h"
 #include "Font_Control.h"
+#include "GameInstance.h"
+#include "Game_Clock.h"
 #include "HImage.h"
 #include "Interface.h"
+#include "Line.h"
 #include "Local.h"
 #include "MapScreen.h"
+#include "Map_Information.h"
+#include "Map_Screen_Helicopter.h"
 #include "Map_Screen_Interface.h"
-#include "Map_Screen_Interface_Map.h"
 #include "Map_Screen_Interface_Border.h"
+#include "MemMan.h"
 #include "Merc_Hiring.h"
+#include "Message.h"
+#include "Militia_Control.h"
 #include "Overhead.h"
+#include "Player_Command.h"
+#include "PreBattle_Interface.h"
+#include "Queen_Command.h"
 #include "Render_Dirty.h"
-#include "SysUtil.h"
+#include "SamSiteModel.h"
+#include "Soldier_Profile.h"
+#include "Squads.h"
 #include "StrategicMap.h"
+#include "Strategic_Mines.h"
+#include "Strategic_Movement.h"
 #include "Strategic_Pathing.h"
+#include "Strategic_Town_Loyalty.h"
+#include "SysUtil.h"
+#include "Tactical_Save.h"
 #include "Text.h"
 #include "Timer_Control.h"
-#include "VObject.h"
-#include "VSurface.h"
-#include "Video.h"
-#include "VObject_Blitters.h"
-#include "Assignments.h"
-#include "Squads.h"
-#include "Message.h"
-#include "Soldier_Profile.h"
-#include "Player_Command.h"
-#include "Strategic_Movement.h"
-#include "Queen_Command.h"
-#include "Campaign_Types.h"
-#include "Strategic_Town_Loyalty.h"
-#include "Strategic_Mines.h"
-#include "Vehicles.h"
-#include "Map_Screen_Helicopter.h"
-#include "Game_Clock.h"
-#include "Finances.h"
-#include "Line.h"
-#include "PreBattle_Interface.h"
-#include "Town_Militia.h"
-#include "Militia_Control.h"
-#include "Tactical_Save.h"
-#include "Map_Information.h"
-#include "Air_Raid.h"
-#include "MemMan.h"
-#include "Button_System.h"
-#include "Debug.h"
-#include "UILayout.h"
-#include "GameInstance.h"
-#include "ContentManager.h"
 #include "TownModel.h"
-
-#include <string_theory/format>
-#include <string_theory/string>
+#include "Town_Militia.h"
+#include "UILayout.h"
+#include "VObject.h"
+#include "VObject_Blitters.h"
+#include "VSurface.h"
+#include "Vehicles.h"
+#include "Video.h"
 
 #include <stdexcept>
-
+#include <string_theory/format>
+#include <string_theory/string>
 
 // zoom x and y coords for map scrolling
 INT32 iZoomX = 0;
@@ -4394,9 +4394,9 @@ static void DrawTownMilitiaForcesOnMap()
 	}
 
 	// now handle militia for sam sectors
-	FOR_EACH(INT16 const, i, pSamList)
+	for(auto s : GCM->getSamSites())
 	{
-		DrawMilitiaForcesForSector(*i);
+		DrawMilitiaForcesForSector(s->sectorId);
 	}
 
 	RestoreClipRegionToFullScreen();
@@ -4633,12 +4633,12 @@ static void ShowSAMSitesOnStrategicMap()
 	if (fShowAircraftFlag) BlitSAMGridMarkers();
 
 	BOOLEAN const* found = fSamSiteFound;
-	FOR_EACH(INT16 const, i, pSamList)
+	for (auto s : GCM->getSamSites())
 	{
 		// Has the sam site here been found?
 		if (!*found++) continue;
 
-		INT16 const sector = *i;
+		INT16 const sector = s->sectorId;
 		INT16 const sec_x  = SECTORX(sector);
 		INT16 const sec_y  = SECTORY(sector);
 
@@ -4694,7 +4694,7 @@ static void BlitSAMGridMarkers()
 	ClipBlitsToMapViewRegionForRectangleAndABit(uiDestPitchBYTES);
 
 	BOOLEAN const* found = fSamSiteFound;
-	FOR_EACH(INT16 const, i, pSamList)
+	for (auto s : GCM->getSamSites())
 	{
 		// Has the sam site here been found?
 		if (!*found++) continue;
@@ -4703,7 +4703,7 @@ static void BlitSAMGridMarkers()
 		INT16 y;
 		INT16 w;
 		INT16 h;
-		INT16 const sector = *i;
+		INT16 const sector = s->sectorId;
 		if (fZoomFlag)
 		{
 			GetScreenXYFromMapXYStationary(SECTORX(sector), SECTORY(sector), &x, &y);

--- a/src/game/Strategic/Meanwhile.cc
+++ b/src/game/Strategic/Meanwhile.cc
@@ -1,36 +1,41 @@
-#include "MapScreen.h"
 #include "Meanwhile.h"
-#include "PreBattle_Interface.h"
-#include "MessageBoxScreen.h"
-#include "StrategicMap.h"
-#include "Fade_Screen.h"
-#include "ScreenIDs.h"
-#include "JAScreens.h"
-#include "NPC.h"
-#include "Game_Event_Hook.h"
-#include "Game_Clock.h"
-#include "Tactical_Save.h"
-#include "Soldier_Profile.h"
-#include "Overhead.h"
-#include "Dialogue_Control.h"
+
 #include "Assignments.h"
-#include "Text.h"
-#include "GameSettings.h"
-#include "Interface_Control.h"
-#include "Interface_Items.h"
-#include "Map_Information.h"
-#include "Map_Screen_Interface_Map.h"
-#include "Map_Screen_Interface.h"
-#include "Music_Control.h"
-#include "ContentMusic.h"
-#include "Interface.h"
-#include "Game_Events.h"
-#include "Strategic_AI.h"
-#include "Interface_Dialogue.h"
-#include "Quests.h"
 #include "Campaign_Types.h"
-#include "Squads.h"
+#include "ContentManager.h"
+#include "ContentMusic.h"
+#include "Dialogue_Control.h"
+#include "Fade_Screen.h"
+#include "GameInstance.h"
+#include "GameSettings.h"
+#include "Game_Clock.h"
+#include "Game_Event_Hook.h"
+#include "Game_Events.h"
+#include "Interface.h"
+#include "Interface_Control.h"
+#include "Interface_Dialogue.h"
+#include "Interface_Items.h"
+#include "JAScreens.h"
+#include "MapScreen.h"
+#include "Map_Information.h"
+#include "Map_Screen_Helicopter.h"
+#include "Map_Screen_Interface.h"
+#include "Map_Screen_Interface_Map.h"
+#include "MessageBoxScreen.h"
+#include "Music_Control.h"
+#include "NPC.h"
+#include "Overhead.h"
+#include "PreBattle_Interface.h"
+#include "Quests.h"
 #include "Random.h"
+#include "SamSiteModel.h"
+#include "ScreenIDs.h"
+#include "Soldier_Profile.h"
+#include "Squads.h"
+#include "StrategicMap.h"
+#include "Strategic_AI.h"
+#include "Tactical_Save.h"
+#include "Text.h"
 
 #include <string_theory/format>
 #include <string_theory/string>
@@ -447,6 +452,7 @@ bool AreInMeanwhile()
 
 static void ProcessImplicationsOfMeanwhile(void)
 {
+	auto samList = GCM->getSamSites();
 	switch( gCurrentMeanwhileDef.ubMeanwhileID )
 	{
 		case END_OF_PLAYERS_FIRST_BATTLE:
@@ -513,9 +519,9 @@ static void ProcessImplicationsOfMeanwhile(void)
 
 		{
 			UINT8 sector;
-		case NW_SAM:      sector = pSamList[0]; goto send_troops_to_sam;
-		case NE_SAM:      sector = pSamList[1]; goto send_troops_to_sam;
-		case CENTRAL_SAM: sector = pSamList[2]; goto send_troops_to_sam;
+		case NW_SAM:      sector = samList[SAM_SITE_ONE]->sectorId; goto send_troops_to_sam;
+		case NE_SAM:      sector = samList[SAM_SITE_TWO]->sectorId; goto send_troops_to_sam;
+		case CENTRAL_SAM: sector = samList[SAM_SITE_THREE]->sectorId; goto send_troops_to_sam;
 send_troops_to_sam:
 			ExecuteStrategicAIAction(NPC_ACTION_SEND_TROOPS_TO_SAM, SECTORX(sector), SECTORY(sector));
 			break;

--- a/src/game/Strategic/StrategicMap.cc
+++ b/src/game/Strategic/StrategicMap.cc
@@ -1,113 +1,115 @@
-#include "Directories.h"
-#include "Font.h"
-#include "HImage.h"
-#include "Interface.h"
-#include "LoadSaveSectorInfo.h"
-#include "LoadSaveStrategicMapElement.h"
-#include "Local.h"
-#include "MapScreen.h"
-#include "Merc_Contract.h"
-#include "Merc_Hiring.h"
-#include "Radar_Screen.h"
 #include "StrategicMap.h"
-#include "Strategic.h"
-#include "Strategic_Mines.h"
-#include "Tactical_Turns.h"
-#include "Timer.h"
-#include "Timer_Control.h"
-#include "Types.h"
-#include "JAScreens.h"
-#include "Soldier_Control.h"
-#include "Overhead.h"
+
+#include "AI.h"
+#include "Ambient_Control.h"
+#include "Animated_ProgressBar.h"
+#include "Animation_Control.h"
+#include "Assignments.h"
+#include "Auto_Resolve.h"
+#include "Boxing.h"
+#include "Bullets.h"
+#include "Campaign_Types.h"
+#include "ContentManager.h"
+#include "ContentMusic.h"
+#include "Creature_Spreading.h"
+#include "Cursor_Control.h"
+#include "Cursors.h"
+#include "Debug.h"
+#include "Dialogue_Control.h"
+#include "Directories.h"
+#include "Enemy_Soldier_Save.h"
+#include "Environment.h"
+#include "Event_Pump.h"
+#include "Exit_Grids.h"
+#include "Explosion_Control.h"
+#include "Faces.h"
+#include "Fade_Screen.h"
+#include "FileMan.h"
+#include "Font.h"
+#include "Font_Control.h"
+#include "GameInstance.h"
+#include "GameLoop.h"
+#include "GameScreen.h"
+#include "GameSettings.h"
+#include "Game_Clock.h"
+#include "Game_Events.h"
+#include "HImage.h"
+#include "Handle_UI.h"
+#include "History.h"
+#include "Interface.h"
+#include "Interface_Dialogue.h"
 #include "Interface_Panels.h"
 #include "Isometric_Utils.h"
-#include "Ambient_Control.h"
-#include "VObject.h"
-#include "WorldDef.h"
-#include "WorldDat.h"
-#include "Text.h"
-#include "Soldier_Add.h"
-#include "Soldier_Macros.h"
-#include "Strategic_Pathing.h"
-#include "Soldier_Create.h"
-#include "Handle_UI.h"
-#include "Faces.h"
-#include "RenderWorld.h"
-#include "GameScreen.h"
-#include "Game_Clock.h"
-#include "Soldier_Init_List.h"
-#include "Strategic_Turns.h"
-#include "Merc_Entering.h"
-#include "Map_Information.h"
-#include "Assignments.h"
-#include "Message.h"
-#include "Font_Control.h"
-#include "Environment.h"
-#include "Game_Events.h"
-#include "Quests.h"
-#include "FileMan.h"
-#include "Animated_ProgressBar.h"
-#include "Music_Control.h"
-#include "ContentMusic.h"
-#include "Fade_Screen.h"
-#include "Strategic_Movement.h"
-#include "Campaign_Types.h"
-#include "Sys_Globals.h"
-#include "Exit_Grids.h"
-#include "Tactical_Save.h"
-#include "PathAI.h"
-#include "Animation_Control.h"
-#include "Squads.h"
-#include "WorldMan.h"
-#include "Strategic_Town_Loyalty.h"
-#include "Queen_Command.h"
-#include "Cursor_Control.h"
-#include "PreBattle_Interface.h"
-#include "Scheduling.h"
-#include "GameLoop.h"
-#include "Random.h"
-#include "AI.h"
-#include "OppList.h"
-#include "Keys.h"
-#include "Tactical_Placement_GUI.h"
-#include "Map_Screen_Helicopter.h"
-#include "Map_Edgepoints.h"
-#include "Player_Command.h"
-#include "Event_Pump.h"
-#include "Meanwhile.h"
-#include "Creature_Spreading.h"
-#include "SaveLoadMap.h"
-#include "Militia_Control.h"
-#include "GameSettings.h"
-#include "Dialogue_Control.h"
-#include "Town_Militia.h"
-#include "SysUtil.h"
-#include "Sound_Control.h"
-#include "Points.h"
-#include "Render_Dirty.h"
-#include "Loading_Screen.h"
-#include "Enemy_Soldier_Save.h"
-#include "Boxing.h"
-#include "NPC.h"
-#include "Strategic_Event_Handler.h"
-#include "MessageBoxScreen.h"
-#include "Interface_Dialogue.h"
-#include "History.h"
-#include "Bullets.h"
-#include "Physics.h"
-#include "Explosion_Control.h"
-#include "Auto_Resolve.h"
-#include "Cursors.h"
-#include "Video.h"
-#include "VSurface.h"
-#include "Debug.h"
-#include "ScreenIDs.h"
 #include "Items.h"
-#include "UILayout.h"
+#include "JAScreens.h"
+#include "Keys.h"
+#include "LoadSaveSectorInfo.h"
+#include "LoadSaveStrategicMapElement.h"
+#include "Loading_Screen.h"
+#include "Local.h"
 #include "Logger.h"
-#include "ContentManager.h"
-#include "GameInstance.h"
-#include "externalized/strategic/TownModel.h"
+#include "MapScreen.h"
+#include "Map_Edgepoints.h"
+#include "Map_Information.h"
+#include "Map_Screen_Helicopter.h"
+#include "Meanwhile.h"
+#include "Merc_Contract.h"
+#include "Merc_Entering.h"
+#include "Merc_Hiring.h"
+#include "Message.h"
+#include "MessageBoxScreen.h"
+#include "Militia_Control.h"
+#include "Music_Control.h"
+#include "NPC.h"
+#include "OppList.h"
+#include "Overhead.h"
+#include "PathAI.h"
+#include "Physics.h"
+#include "Player_Command.h"
+#include "Points.h"
+#include "PreBattle_Interface.h"
+#include "Queen_Command.h"
+#include "Quests.h"
+#include "Radar_Screen.h"
+#include "Random.h"
+#include "RenderWorld.h"
+#include "Render_Dirty.h"
+#include "SamSiteModel.h"
+#include "SaveLoadMap.h"
+#include "Scheduling.h"
+#include "ScreenIDs.h"
+#include "Soldier_Add.h"
+#include "Soldier_Control.h"
+#include "Soldier_Create.h"
+#include "Soldier_Init_List.h"
+#include "Soldier_Macros.h"
+#include "Sound_Control.h"
+#include "Squads.h"
+#include "Strategic.h"
+#include "Strategic_Event_Handler.h"
+#include "Strategic_Mines.h"
+#include "Strategic_Movement.h"
+#include "Strategic_Pathing.h"
+#include "Strategic_Town_Loyalty.h"
+#include "Strategic_Turns.h"
+#include "SysUtil.h"
+#include "Sys_Globals.h"
+#include "Tactical_Placement_GUI.h"
+#include "Tactical_Save.h"
+#include "Tactical_Turns.h"
+#include "Text.h"
+#include "Timer.h"
+#include "Timer_Control.h"
+#include "TownModel.h"
+#include "Town_Militia.h"
+#include "Types.h"
+#include "UILayout.h"
+#include "VObject.h"
+#include "VSurface.h"
+#include "Video.h"
+#include "WorldDat.h"
+#include "WorldDef.h"
+#include "WorldMan.h"
 
 #include <string_theory/format>
 #include <string_theory/string>
@@ -168,38 +170,6 @@ BOOLEAN fSamSiteFound[ NUMBER_OF_SAMS ]={
 	FALSE,
 	FALSE,
 };
-
-INT16 const pSamList[] =
-{
-	SEC_D2,
-	SEC_D15,
-	SEC_I8,
-	SEC_N4
-};
-
-INT16 pSamGridNoAList[ NUMBER_OF_SAMS ]={
-	10196,
-	11295,
-	16080,
-	11913,
-};
-
-INT16 pSamGridNoBList[ NUMBER_OF_SAMS ]={
-	10195,
-	11135,
-	15920,
-	11912,
-};
-
-// ATE: Update this w/ graphic used
-// Use 3 if / orientation, 4 if \ orientation
-INT8 gbSAMGraphicList[ NUMBER_OF_SAMS ]={
-	4,
-	3,
-	3,
-	4
-};
-
 
 UINT8 ubSAMControlledSectors[ MAP_WORLD_Y ][ MAP_WORLD_X ] = {
 //       1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16
@@ -398,9 +368,10 @@ void InitializeSAMSites()
 	g_merc_arrive_sector = START_SECTOR;
 
 	// All SAM sites start game in perfect working condition.
-	FOR_EACH(INT16 const, i, pSamList)
+	for (auto samSite : GCM->getSamSites())
 	{
-		StrategicMap[SECTOR_INFO_TO_STRATEGIC_INDEX(*i)].bSAMCondition = 100;
+		UINT8 ubSectorID = samSite->sectorId;
+		StrategicMap[SECTOR_INFO_TO_STRATEGIC_INDEX(ubSectorID)].bSAMCondition = 100;
 	}
 
 	UpdateAirspaceControl();
@@ -2411,7 +2382,6 @@ void SetupNewStrategicGame()
 // a -1 will be returned upon failure
 INT8 GetSAMIdFromSector( INT16 sSectorX, INT16 sSectorY, INT8 bSectorZ )
 {
-	INT8 bCounter = 0;
 	INT16 sSectorValue = 0;
 
 	// check if valid sector
@@ -2422,18 +2392,7 @@ INT8 GetSAMIdFromSector( INT16 sSectorX, INT16 sSectorY, INT8 bSectorZ )
 
 	// get the sector value
 	sSectorValue = SECTOR( sSectorX, sSectorY );
-
-	// run through list of sam sites
-	for( bCounter = 0; bCounter < 4; bCounter++ )
-	{
-		if( pSamList[ bCounter ] == sSectorValue )
-		{
-			return( bCounter );
-		}
-	}
-
-
-	return( -1 );
+	return GCM->findSamIDBySector(sSectorValue);
 }
 
 
@@ -2471,9 +2430,10 @@ bool CanGoToTacticalInSector(INT16 const x, INT16 const y, UINT8 const z)
 INT32 GetNumberOfSAMSitesUnderPlayerControl()
 {
 	INT32 n = 0;
-	FOR_EACH(INT16 const, i, pSamList)
+	for (auto samSite : GCM->getSamSites())
 	{
-		if (!StrategicMap[SECTOR_INFO_TO_STRATEGIC_INDEX(*i)].fEnemyControlled) ++n;
+		UINT8 ubSectorID = samSite->sectorId;
+		if (!StrategicMap[SECTOR_INFO_TO_STRATEGIC_INDEX(ubSectorID)].fEnemyControlled) ++n;
 	}
 	return n;
 }
@@ -2485,7 +2445,7 @@ void UpdateAirspaceControl( void )
 	UINT8 ubControllingSAM;
 	StrategicMapElement *pSAMStrategicMap = NULL;
 	BOOLEAN fEnemyControlsAir;
-
+	auto samList = GCM->getSamSites();
 
 	for( iCounterA = 1; iCounterA < ( INT32 )( MAP_WORLD_X - 1 ); iCounterA++ )
 	{
@@ -2496,7 +2456,8 @@ void UpdateAirspaceControl( void )
 
 			if ( ( ubControllingSAM >= 1 ) && ( ubControllingSAM <= NUMBER_OF_SAMS ) )
 			{
-				pSAMStrategicMap = &( StrategicMap[ SECTOR_INFO_TO_STRATEGIC_INDEX( pSamList[ ubControllingSAM - 1 ] ) ] );
+				UINT8 ubSector = samList[ubControllingSAM - 1]->sectorId;
+				pSAMStrategicMap = &( StrategicMap[ SECTOR_INFO_TO_STRATEGIC_INDEX( ubSector ) ] );
 
 				// if the enemies own the controlling SAM site, and it's in working condition
 				if( ( pSAMStrategicMap->fEnemyControlled ) && ( pSAMStrategicMap->bSAMCondition >= MIN_CONDITION_FOR_SAM_SITE_TO_WORK ) )
@@ -2564,11 +2525,8 @@ bool IsThisSectorASAMSector(INT16 const x, INT16 const y, INT8 const z)
 {
 	if (z != 0) return false;
 
-	FOR_EACH(INT16 const, i, pSamList)
-	{
-		if (*i == SECTOR(x, y)) return true;
-	}
-	return false;
+	UINT8 ubSector = SECTOR(x, y);
+	return (GCM->findSamIDBySector(ubSector) > -1);
 }
 
 

--- a/src/game/Strategic/StrategicMap.h
+++ b/src/game/Strategic/StrategicMap.h
@@ -43,11 +43,6 @@ static inline void SetWorldSectorInvalid()
 
 #define NUMBER_OF_SAMS 4
 
-
-extern INT16 const pSamList[NUMBER_OF_SAMS];
-extern INT16 pSamGridNoAList[ NUMBER_OF_SAMS ];
-extern INT16 pSamGridNoBList[ NUMBER_OF_SAMS ];
-
 extern BOOLEAN fFoundOrta;
 extern BOOLEAN fSamSiteFound[ NUMBER_OF_SAMS ];
 


### PR DESCRIPTION
This PR externalizes SAM site locations. The goal is to allow map mods to override SAM site locations. Though the SAM site list is now a `std::vector`, adding or removing SAM sites are not allowed.

See also #1011 and #665.

### Variables converted

- `pSamList[]`:  Now dynamically defined by JSON
- `pSamGridNoAList[]`:  This is the "anchor" tile of the SAM computer terminal. This is always the lower tile (the one with higher gridNo)
- `pSamGridNoBList[]`:  The other tile of the SAM computer
- `gbSAMGraphicList[]`:  It is now derived from SAM gridNos


### Variables not changed
- `fSamSiteFound[]`  Not changing for save compatibility

### Restrictions

Restrictions enforced in `SamSiteModel.cc`.

- Must define exactly 4 SAM sites
    - Breaks Saves, if more than 4 SAM sites
    - Breaks hard-coded references from Skyrider and Meanwhile dialogues, if fewer than 4 SAMs
- SAM gridNos must be 2 adjacent tiles

### What's not covered

- Airspace control table
- Hard-coded references to SAM sectors, such as `HandleSkyRiderMonologueAboutDrassenSAMSite()`, `ChooseSuitableGarrisonToProvideReinforcements()`
- Land type strings. SAM sectors (D2, I8, etc) are hard-coded-mapped to respective land type strings. It is another big chunk of work to externalize sector land type mappings. The land type display will be wrong if modder moved the SAMs sites to other sectors.
- A section of code in Assignments.cc commented out, saying: `/* No point in allowing SAM site repair any more.  Jan/13/99.  ARM` - _**Should all these be deleted?**_

### Testing

Manually tested in game.

1. Recruited Skyrider and he told us about Drassen SAM site
1. Verified other SAM sectors are not named as SAM sites
1. Took over Drassen SAM site.
1. Skyrider told us about other SAM sites. Those sectors are now named SAM sites.
1. Damaged SAM computer. SAM computer looks damaged. Confirm `bSAMCondition` reduced via logs.
1. Queen's Army re-took Drassen SAM site
1. Re-took Drassen SAM site. Confirmed the SAM computer in good condition.
