### PR TITLE
Remove meaningless Assertions on unsigned int

### DIFF
--- a/src/externalized/strategic/MovementCostsModel.cc
+++ b/src/externalized/strategic/MovementCostsModel.cc
@@ -17,25 +17,25 @@ MovementCostsModel::MovementCostsModel(IntIntVector traverseWE_, IntIntVector tr
 
 const uint8_t MovementCostsModel::getTraversibilityWestEast(uint8_t x, uint8_t y) const
 {
-	Assert(y < 16 && x <= 16 && y >= 0 && x >= 0);
+	Assert(y < 16 && x <= 16);
 	return traverseWE[y][x];
 }
 
 const uint8_t MovementCostsModel::getTraversibilityNorthSouth(uint8_t x, uint8_t y) const
 {
-	Assert(y <= 16 && x < 16 && y >= 0 && x >= 0);
+	Assert(y <= 16 && x < 16);
 	return traverseNS[y][x];
 }
 
 const uint8_t MovementCostsModel::getTraversibilityThrough(uint8_t x, uint8_t y) const
 {
-	Assert(y < 16 && x < 16 && y >= 0 && x >= 0);
+	Assert(y < 16 && x < 16);
 	return traverseThrough[y][x];
 }
 
 const uint8_t MovementCostsModel::getTravelRating(uint8_t x, uint8_t y) const
 {
-	Assert(y < 16 && x < 16 && y >= 0 && x >= 0);
+	Assert(y < 16 && x < 16);
 	return travelRatings[y][x];
 }
 

--- a/src/game/Editor/Cursor_Modes.cc
+++ b/src/game/Editor/Cursor_Modes.cc
@@ -83,8 +83,8 @@ void RemoveCursors()
 	{
 		RemoveBuildingLayout();
 	}
-	Assert( gSelectRegion.iTop >= 0 && gSelectRegion.iTop <= gSelectRegion.iBottom );
-	Assert( gSelectRegion.iLeft >= 0 && gSelectRegion.iLeft <= gSelectRegion.iRight );
+	Assert( gSelectRegion.iTop <= gSelectRegion.iBottom );
+	Assert( gSelectRegion.iLeft <= gSelectRegion.iRight );
 	for( y = gSelectRegion.iTop; y <= gSelectRegion.iBottom; y++ )
 	{
 		for( x = gSelectRegion.iLeft; x <= gSelectRegion.iRight; x++ )

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -3282,8 +3282,8 @@ static void DisplayDestinationOfHelicopter(void)
 		x = MAP_VIEW_START_X + ( MAP_GRID_X * sMapX ) + 1;
 		y = MAP_VIEW_START_Y + ( MAP_GRID_Y * sMapY ) + 3;
 
-		AssertMsg(0 <= x && x < SCREEN_WIDTH, String("DisplayDestinationOfHelicopter: Invalid x = %d.  Dest %d,%d", x, sMapX, sMapY));
-		AssertMsg(0 <= y && y < SCREEN_HEIGHT, String("DisplayDestinationOfHelicopter: Invalid y = %d.  Dest %d,%d", y, sMapX, sMapY));
+		AssertMsg( x < SCREEN_WIDTH, String("DisplayDestinationOfHelicopter: Invalid x = %d.  Dest %d,%d", x, sMapX, sMapY));
+		AssertMsg( y < SCREEN_HEIGHT, String("DisplayDestinationOfHelicopter: Invalid y = %d.  Dest %d,%d", y, sMapX, sMapY));
 
 		// clip blits to mapscreen region
 		ClipBlitsToMapViewRegion( );

--- a/src/game/Strategic/Strategic_Movement.cc
+++ b/src/game/Strategic/Strategic_Movement.cc
@@ -499,7 +499,7 @@ BOOLEAN AddWaypointStrategicIDToPGroup( GROUP *pGroup, UINT32 uiSectorID )
 //............................................................
 GROUP* CreateNewEnemyGroupDepartingFromSector( UINT32 uiSector, UINT8 ubNumAdmins, UINT8 ubNumTroops, UINT8 ubNumElites )
 {
-	AssertMsg( uiSector >= 0 && uiSector <= 255, String( "CreateNewEnemyGroup with out of range value of %d", uiSector ) );
+	AssertMsg( uiSector <= 255, String( "CreateNewEnemyGroup with out of range value of %d", uiSector ) );
 	GROUP* const pNew = new GROUP{};
 	pNew->pEnemyGroup = new ENEMYGROUP{};
 	pNew->pWaypoints = NULL;


### PR DESCRIPTION
New defects introduced in #1021.  Detected by Coverity.

This PR removes the meaningless assertions that compares unsigned int to 0.