### PR TITLE
Breaking possible Dead-loop in GenerateBuilding

### DIFF
--- a/src/game/TileEngine/Buildings.cc
+++ b/src/game/TileEngine/Buildings.cc
@@ -188,6 +188,12 @@ static BUILDING* GenerateBuilding(INT16 sDesiredSpot)
 
 		SLOGD("Roof code visits %d", sCurrGridNo);
 #endif
+		if (sCurrGridNo == sPrevGridNo)
+		{
+			// not progressing, we are just repeating the same gridNo
+			SLOGW(ST::format("Dead loop detected in GenerateBuilding. This may indicate a problem with the current map. Probably reached edge of map. (starting GridNo:{})", sStartGridNo));
+			break;
+		}
 
 		if (sCurrGridNo == sStartGridNo)
 		{


### PR DESCRIPTION
## Motivation

The game is stuck in a deadloop in [GenerateBuilding in TileEngine/Buildings.cc](https://github.com/ja2-stracciatella/ja2-stracciatella/blob/fea6115a26906ca08b461489a5eef6099f46f2e6/src/game/TileEngine/Buildings.cc#L42), when loading a Wildfire map (G9.dat). I cannot exactly tell if it is corrupted data or it is a limitation of vanilla JA2.

## Analysis

I knew nothing about the building function before this. Here is my take to explain it: 

When a map is loaded from .dat, the game tries to generate in-memory representation of buildings. It is mainly for rooftop-climbing. The algorithm is to: 
 - Scan through all map tiles, starting from top-left
 - Generate a building struct when we find a building/room
 - Then continue to walk, clockwise, the edges of building until we go back to the starting grid

The walk algorithm requires Pathing AI (PathAI.cc:RoofReachableTest) to "tag" all indoor grids as `MAPELEMENT_REACHABLE`. In this particular map, the PathAI seems to fail to tag the building tiles. This building happen to be not flat-roofed, i.e. no climbing. 

The algorithm fails here, and it eventually walks to the edge of map, and there is the check below to protect ourselves from going out of bounds:

https://github.com/ja2-stracciatella/ja2-stracciatella/blob/384ac0af222a7eb0c0d8d89f91047d8f3bb53f65/src/game/TileEngine/Isometric_Utils.cc#L344-L346 

However, that means the while-1 loop in GenerateBuilding is now a dead loop.

## Resolution

I am still trying to understand how Pathing AI works and why it fails in this map. I suspect it is because WF maps are much denser with less space and more obstacles.
 
I am proposing to fix by breaking the dead loop with a WARN log, because bad map data should not freeze the game. This warning should never appear on Vanilla maps.

For comparison, there is work-around to another similar problem in JA2.5:

https://github.com/Manuel-K/ja2-ub-comparison/blob/master/src_ub/game/TileEngine/Buildings.c#L117-L122
