### PR TITLE
Fixing an Out-of-Bounds check in PathAI

### DIFF
--- a/src/game/Tactical/PathAI.cc
+++ b/src/game/Tactical/PathAI.cc
@@ -980,6 +980,11 @@ INT32 FindBestPath(SOLDIERTYPE* s, INT16 sDestination, INT8 ubLevel, INT16 usMov
 
 			newLoc = curLoc + DirIncrementer[ubCnt];
 
+			if ( newLoc < 0 || newLoc >= GRIDSIZE )
+			{
+				SLOGW(ST::format("Path Finding algorithm tried to go out of bounds at {}, in an attempt to find path from {} to {}", newLoc, iOrigination, iDestination));
+				goto NEXTDIR;
+			}
 
 			if ( fVisitSpotsOnlyOnce && trailCostUsed[newLoc] == gubGlobalPathCount )
 			{
@@ -1257,12 +1262,6 @@ INT32 FindBestPath(SOLDIERTYPE* s, INT16 sDestination, INT8 ubLevel, INT16 usMov
 			else
 			{
 				nextCost = TRAVELCOST_FLAT;
-			}
-
-			if ( newLoc > GRIDSIZE )
-			{
-				// WHAT THE??? hack.
-				goto NEXTDIR;
 			}
 
 			// if contemplated tile is NOT final dest and someone there, disqualify route


### PR DESCRIPTION
## Motivation

Both editor and game crashes when trying to load the Wildfire version of Estoni I6.dat. The exception was array out-of-bounds when the algorithm attempts to access gridNo beyond `WORLD_MAX`(25600)


## Analysis 

The error is when the game tries to add a soldier to the map. The soldier is placed very close to bottom-left corner. In this case the soldier is at 24719, which is 5 tiles away from edge.

The algorithm then tries to find a "sweet spot" using FindBestPath without a destination. I believe the algorithm is doing a search a few tiles around the soldier placement tile.

There is a out-of-bounds check in code, but it never took effect. The check happens after the gridNo is used. Though I haven't tried, I suspect it to be reproducible by placing a soldier at the far bottom-left. 

This is an independent issue from #1063.