### PR TITLE
Adding null check in SynchronizeDoorStatusToStructureData

### DIFF
--- a/src/game/Tactical/Keys.cc
+++ b/src/game/Tactical/Keys.cc
@@ -1005,8 +1005,14 @@ static void SynchronizeDoorStatusToStructureData(DOOR_STATUS const& d)
 
 	// Swap!
 	STRUCTURE *base = FindBaseStructure(s);
-	base = SwapStructureForPartner(base);
-	RecompileLocalMovementCosts(base->sGridNo);
+	if (!base)
+	{
+		SLOGW(ST::format("Door structure data at {} was not found", d.sGridNo));
+		return;
+	}
+	INT16 sBaseGridNo = base->sGridNo;
+	SwapStructureForPartner(base);
+	RecompileLocalMovementCosts(sBaseGridNo);
 }
 
 


### PR DESCRIPTION
## Motivation

Loading save for Wildfire sector G8 causes a crash. The crash is caused by dereferencing a NULL point in SynchronizeDoorStatusToStructureData, which is part of load game.

## Analysis

When a game is loaded, it tries to synchronize the door states. If the state mis-matches, it will "swap" the structure with its "partner". I suppose that means switching between the closed and opened states of a door. 

In this case, the room is very packed and the door is placed such that the opened state of the door collides with a wall. Then SwapStructureForPartner returns NULL.


## Resolution

EDIT: The fix now takes reference from 4ee4f52838b and also 3d5ac56adfebf.

Adding a NULL check with a WARN log (like before 3d5ac56adfebf). Then using the GridNo before the Swap (like before 4ee4f52838b), as the swap can return NULL.

The root cause should be bad map data, but it need not crash the game. I am not sure how the door is handled elsewhere, like when the map is explored for the first time. My game load succeeded after adding NULL check. 

The door in question seems not rendered on the map at all. Mercs can walk through the tile, and there is no hand cursor to close door.
