### PR TITLE
Fixing an error with Town data

### DIFF
--- a/assets/externalized/strategic-map-towns.json
+++ b/assets/externalized/strategic-map-towns.json
@@ -32,7 +32,7 @@
 	// GRUMM
 	{
 		"townId": 4,
-		"sectors": [ "G1", "G2", "H1", "H2" ],
+		"sectors": [ "G1", "G2", "H1", "H2", "H3" ],
 		"townPoint": { "x": 15, "y": 80 },
 		"isMilitiaTrainingAllowed": true
 	},
@@ -46,7 +46,7 @@
 	// CAMBRIA
 	{
 		"townId": 6,
-		"sectors": [ "F8", "F9", "G8", "G9" ],
+		"sectors": [ "F8", "F9", "G8", "G9", "H8" ],
 		"townPoint": { "x": 95, "y": 70 },
 		"isMilitiaTrainingAllowed": true
 	},

--- a/assets/externalized/strategic-map-towns.json
+++ b/assets/externalized/strategic-map-towns.json
@@ -12,7 +12,7 @@
 	{ 
 		"townId": 1,
 		"sectors": [ "A9", "A10" ],
-		"townPoint": { "x": 90, "y": 0 },
+		"townPoint": { "x": 90, "y": 10 },
 		"isMilitiaTrainingAllowed": false
 	},
 	// DRASSEN


### PR DESCRIPTION
My bad. The town data I committed in #1020 has an error. Now the town sectors are exactly the same as 0.16.1.

![smap_0161](https://user-images.githubusercontent.com/63151803/81510064-bcec9500-9341-11ea-9bd9-445b91bbdb1b.png)
![smap_master](https://user-images.githubusercontent.com/63151803/81510066-beb65880-9341-11ea-8b40-be8d78f9f5c8.png)
