### PR TITLE
Externalizing Underground Sector Info

### DIFF
--- a/assets/externalized/strategic-map-underground-sectors.json
+++ b/assets/externalized/strategic-map-underground-sectors.json
@@ -1,0 +1,274 @@
+/*
+ * Defines the underground sectors that can be occupied by enemies, creatures,
+ * etc. It also contains the network of cave connections critical for strategic
+ * creature spreading, as we can't know how the levels connect without loading
+ * the maps. Any changes to the maps, require changes accordingly.
+ *
+ * Number of enemies and variances are specified as array of integer, in the
+ * form of [ n_EASY, n_MEDIUM, n_HARD]. defaults to [0,0,0] if not given.
+ *
+ * Variances can be specified to add per-game randomness. It is specified as
+ * arrays of integers: [ var_EASY,  var_MEDIUM, var_HARD]. also defaults to
+ * [0,0,0] if not given.
+ *
+ * The formula to calculate the number of enemies is: 
+ *    ( n_DIFLEVEL + Random(var_DIFLEVEL) )
+ * where Random is a function returning a random number between 0 and 
+ * (var_DIFLEVEL - 1) inclusively.
+ *
+ *
+ * Field definitions:
+ *  - sector:    Sector X,Y, such as A1 and P16
+ *  - sectorLevel:    Sector Z, an integer between 1 and 3
+ *  - adjacentSectors:    Directions to the adjacent sectors, as an array of directions, e.g. ["N","E","S","W"]
+ *  - numTroops:    The numbers of enemy troops in sector, as an array of 3 integers, e.g. [1,2,3] meaning: 1 enemy on DIF_LEVEL_EASY; 2 on DIF_LEVEL_MEDIUM; 3 on DIF_LEVEL_HARD
+ *  - numElites:    The numbers of enemy elites in sector, by game difficulty
+ *  - numCreatures:    The numbers of Crepitus in sector, by game difficulty. (SciFi mode only)
+ *  - numTroopsVariance:    The variance added to numTroops, by game difficulty.
+ *  - numElitesVariance:    The variance added to numElites.
+ *  - numCreaturesVariance:    The variance added to numCreatures.
+ */
+[
+    {
+        //Miguel's basement.  Nothing here.
+        "sector": "A10",
+        "sectorLevel": 1
+    },
+    {
+        //Chitzena mine.  Nothing here.
+        "sector": "B2",
+        "sectorLevel": 1
+    },
+    {
+        //San Mona mine.  Nothing here.
+        "sector": "D4",
+        "sectorLevel": 1
+    },
+    {
+        "sector": "D5",
+        "sectorLevel": 1
+    },
+    //Tixa
+    {
+        "sector": "J9",
+        "sectorLevel": 1,
+        "numTroops": [8, 11, 15]
+    },
+    //J9 feeding zone
+    {
+        "sector": "J9",
+        "sectorLevel": 2,
+        "numCreatures": [4, 6, 8],        // ubNumCreatures = (2 + gGameOptions.ubDifficultyLevel*2 + Random( 2 ))
+        "numCreaturesVariance": [2, 2, 2]
+    },
+    //Orta, K4
+    {
+        "sector": "K4",
+        "sectorLevel": 1,
+        "numTroops": [8, 10, 12],         // ubNumTroops = (6 + gGameOptions.ubDifficultyLevel*2 + Random( 3 ))
+        "numTroopsVariance": [3, 3, 3],
+        "numElites": [5, 6, 7],           // ubNumElites = (4 + gGameOptions.ubDifficultyLevel + Random( 2 ))
+        "numElitesVariance": [2, 2, 2]
+    },
+    // Meduna
+    //O3
+    {
+        "sector": "O3",
+        "sectorLevel": 1,
+        "adjacentSectors": ["S"],
+        "numTroops": [8, 10, 12],         // ubNumTroops = (6 + gGameOptions.ubDifficultyLevel*2 + Random( 3 ))
+        "numTroopsVariance": [3, 3, 3],
+        "numElites": [5, 6, 7],           // ubNumElites = (4 + gGameOptions.ubDifficultyLevel + Random( 2 ))
+        "numElitesVariance": [2, 2, 2]
+    },
+    //P3
+    {
+        "sector": "P3",
+        "sectorLevel": 1,
+        "adjacentSectors": ["N"],
+        "numElites": [8, 10, 14],
+        "numElitesVariance": [3, 5, 6]
+        /**
+        switch( gGameOptions.ubDifficultyLevel )
+        {
+            case DIF_LEVEL_EASY:
+                curr->ubNumElites = (UINT8)(8 + Random( 3 ));
+                break;
+            case DIF_LEVEL_MEDIUM:
+                curr->ubNumElites = (UINT8)(10 + Random( 5 ));
+                break;
+            case DIF_LEVEL_HARD:
+                curr->ubNumElites = (UINT8)(14 + Random( 6 ));
+                break;
+        }
+        */
+    },
+    //Do all of the mandatory underground mine sectors:
+    //Drassen's mine:
+    //D13_B1
+    {
+        "sector": "D13",
+        "sectorLevel": 1,
+        "adjacentSectors": ["S"]
+    },
+    //E13_B1
+    {
+        "sector": "E13",
+        "sectorLevel": 1,
+        "adjacentSectors": ["N"]
+    },
+    //E13_B2
+    {
+        "sector": "E13",
+        "sectorLevel": 2,
+        "adjacentSectors": ["S"]
+    },
+    //F13_B2
+    {
+        "sector": "F13",
+        "sectorLevel": 2,
+        "adjacentSectors": ["N", "S"]
+    },
+    //G13_B2
+    {
+        "sector": "G13",
+        "sectorLevel": 2,
+        "           ": ["N"]
+    },
+    //G13_B3
+    {
+        "sector": "G13",
+        "sectorLevel": 3,
+        "adjacentSectors": ["N"]
+    },
+    //F13_B3
+    {
+        "sector": "F13",
+        "sectorLevel": 3,
+        "adjacentSectors": ["S"]
+    },
+    //Cambria's mine
+    //H8_B1
+    {
+        "sector": "H8",
+        "sectorLevel": 1,
+        "adjacentSectors": ["E"]
+    },
+    //H9_B1
+    {
+        "sector": "H9",
+        "sectorLevel": 1,
+        "adjacentSectors": ["W"]
+    },
+    //H9_B2
+    {
+        "sector": "H9",
+        "sectorLevel": 2,
+        "adjacentSectors": ["W"]
+    },
+    //H8_B2
+    {
+        "sector": "H8",
+        "sectorLevel": 2,
+        "adjacentSectors": ["E"]
+    },
+    //H8_B3
+    {
+        "sector": "H8",
+        "sectorLevel": 3,
+        "adjacentSectors": ["S"]
+    },
+    //I8_B3
+    {
+        "sector": "I8",
+        "sectorLevel": 3,
+        "adjacentSectors": ["N","S"]
+    },
+    //J8_B3
+    {
+        "sector": "J8",
+        "sectorLevel": 3,
+        "adjacentSectors": ["N"]
+    },
+    //Alma's mine
+    //I14_B1
+    {
+        "sector": "I14",
+        "sectorLevel": 1,
+        "adjacentSectors": ["S"]
+    },
+    //J14_B1
+    {
+        "sector": "J14",
+        "sectorLevel": 1,
+        "adjacentSectors": ["N"]
+    },
+    //J14_B2
+    {
+        "sector": "J14",
+        "sectorLevel": 2,
+        "adjacentSectors": ["W"]
+    },
+    //J13_B2
+    {
+        "sector": "J13",
+        "sectorLevel": 2,
+        "adjacentSectors": ["E"]
+    },
+    //J13_B3
+    {
+        "sector": "J13",
+        "sectorLevel": 3,
+        "adjacentSectors": ["S"]
+    },
+    //K13_B3
+    {
+        "sector": "K13",
+        "sectorLevel": 3,
+        "adjacentSectors": ["N"]
+    },
+    //Grumm's mine
+    //H3_B1
+    {
+        "sector": "H3",
+        "sectorLevel": 1,
+        "adjacentSectors": ["S"]
+    },
+    //I3_B1
+    {
+        "sector": "I3",
+        "sectorLevel": 1,
+        "adjacentSectors": ["N"]
+    },
+    //I3_B2
+    {
+        "sector": "I3",
+        "sectorLevel": 2,
+        "adjacentSectors": ["N"]
+    },
+    //H3_B2
+    {
+        "sector": "H3",
+        "sectorLevel": 2,
+        "adjacentSectors": ["S","E"]
+    },
+    //H4_B2
+    {
+        "sector": "H4",
+        "sectorLevel": 2,
+        "adjacentSectors": ["W"]
+    },
+    //H4_B3
+    {
+        "sector": "H4",
+        "sectorLevel": 3,
+        "adjacentSectors": ["N"]
+    },
+    //G4_B3
+    {
+        "sector": "G4",
+        "sectorLevel": 3,
+        "adjacentSectors": ["S"]
+    }
+]
+

--- a/assets/externalized/strategic-map-underground-sectors.json
+++ b/assets/externalized/strategic-map-underground-sectors.json
@@ -8,12 +8,12 @@
  * form of [ n_EASY, n_MEDIUM, n_HARD]. defaults to [0,0,0] if not given.
  *
  * Variances can be specified to add per-game randomness. It is specified as
- * arrays of integers: [ var_EASY,  var_MEDIUM, var_HARD]. also defaults to
+ * arrays of integers: [ var_EASY,  var_MEDIUM, var_HARD ]. Also defaults to
  * [0,0,0] if not given.
  *
- * The formula to calculate the number of enemies is: 
+ * The formula to calculate the number of enemies is:
  *    ( n_DIFLEVEL + Random(var_DIFLEVEL) )
- * where Random is a function returning a random number between 0 and 
+ * where Random is a function returning a random number between 0 and
  * (var_DIFLEVEL - 1) inclusively.
  *
  *
@@ -58,16 +58,16 @@
     {
         "sector": "J9",
         "sectorLevel": 2,
-        "numCreatures": [4, 6, 8],        // ubNumCreatures = (2 + gGameOptions.ubDifficultyLevel*2 + Random( 2 ))
+        "numCreatures": [4, 6, 8],
         "numCreaturesVariance": [2, 2, 2]
     },
     //Orta, K4
     {
         "sector": "K4",
         "sectorLevel": 1,
-        "numTroops": [8, 10, 12],         // ubNumTroops = (6 + gGameOptions.ubDifficultyLevel*2 + Random( 3 ))
+        "numTroops": [8, 10, 12],
         "numTroopsVariance": [3, 3, 3],
-        "numElites": [5, 6, 7],           // ubNumElites = (4 + gGameOptions.ubDifficultyLevel + Random( 2 ))
+        "numElites": [5, 6, 7],
         "numElitesVariance": [2, 2, 2]
     },
     // Meduna
@@ -76,9 +76,9 @@
         "sector": "O3",
         "sectorLevel": 1,
         "adjacentSectors": ["S"],
-        "numTroops": [8, 10, 12],         // ubNumTroops = (6 + gGameOptions.ubDifficultyLevel*2 + Random( 3 ))
+        "numTroops": [8, 10, 12],
         "numTroopsVariance": [3, 3, 3],
-        "numElites": [5, 6, 7],           // ubNumElites = (4 + gGameOptions.ubDifficultyLevel + Random( 2 ))
+        "numElites": [5, 6, 7],
         "numElitesVariance": [2, 2, 2]
     },
     //P3
@@ -88,22 +88,7 @@
         "adjacentSectors": ["N"],
         "numElites": [8, 10, 14],
         "numElitesVariance": [3, 5, 6]
-        /**
-        switch( gGameOptions.ubDifficultyLevel )
-        {
-            case DIF_LEVEL_EASY:
-                curr->ubNumElites = (UINT8)(8 + Random( 3 ));
-                break;
-            case DIF_LEVEL_MEDIUM:
-                curr->ubNumElites = (UINT8)(10 + Random( 5 ));
-                break;
-            case DIF_LEVEL_HARD:
-                curr->ubNumElites = (UINT8)(14 + Random( 6 ));
-                break;
-        }
-        */
     },
-    //Do all of the mandatory underground mine sectors:
     //Drassen's mine:
     //D13_B1
     {

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -25,6 +25,7 @@ class NpcActionParamsModel;
 class NpcPlacementModel;
 class SamSiteModel;
 class TownModel;
+class UndergroundSectorModel;
 struct AmmoTypeModel;
 struct CalibreModel;
 struct MagazineModel;
@@ -127,6 +128,8 @@ public:
 	virtual const std::map<int8_t, const TownModel*>& getTowns() const = 0;
 	virtual const ST::string getTownName(uint8_t townId) const = 0;
 	virtual const ST::string getTownLocative(uint8_t townId) const = 0;
+	virtual const std::vector <const UndergroundSectorModel*> & getUndergroundSectors() const = 0;
+
 	virtual const MovementCostsModel* getMovementCosts() const = 0;
 	virtual const NpcPlacementModel* getNpcPlacement(uint8_t profileId) const = 0;
 	

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -155,6 +155,7 @@ public:
 	virtual const std::map<int8_t, const TownModel*>& getTowns() const override;
 	virtual const ST::string getTownName(uint8_t townId) const override;
 	virtual const ST::string getTownLocative(uint8_t townId) const override;
+	virtual const std::vector <const UndergroundSectorModel*>& getUndergroundSectors() const override;
 	virtual const MovementCostsModel* getMovementCosts() const override;
 	virtual const NpcPlacementModel* getNpcPlacement(uint8_t profileId) const override;
 
@@ -206,6 +207,7 @@ protected:
 	std::map<int8_t, const TownModel*> m_towns;
 	std::vector<const ST::string*> m_townNames;
 	std::vector<const ST::string*> m_townNameLocatives;
+	std::vector<const UndergroundSectorModel*> m_undergroundSectors;
 	const MovementCostsModel *m_movementCosts;
 	std::map<uint8_t, const NpcPlacementModel*> m_npcPlacements;
 

--- a/src/externalized/strategic/CMakeLists.txt
+++ b/src/externalized/strategic/CMakeLists.txt
@@ -9,6 +9,7 @@ set(JA2_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/NpcPlacementModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/SamSiteModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/TownModel.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/UndergroundSectorModel.cc
     PARENT_SCOPE
 )
 set(JA2_INCLUDES

--- a/src/externalized/strategic/UndergroundSectorModel.cc
+++ b/src/externalized/strategic/UndergroundSectorModel.cc
@@ -1,0 +1,126 @@
+#include "UndergroundSectorModel.h"
+
+#include "Random.h"
+
+UndergroundSectorModel::UndergroundSectorModel(uint8_t sectorId_, uint8_t sectorZ_, uint8_t adjacentSectors_, 
+	std::array<uint8_t, NUM_DIF_LEVELS> numTroops_, std::array<uint8_t, NUM_DIF_LEVELS> numElites_, std::array<uint8_t, NUM_DIF_LEVELS> numCreatures_, 
+	std::array<uint8_t, NUM_DIF_LEVELS> numTroopsVariance_, std::array<uint8_t, NUM_DIF_LEVELS> numElitesVariance_, std::array<uint8_t, NUM_DIF_LEVELS> numCreaturesVariance_) 
+		: sectorId(sectorId_), sectorZ(sectorZ_), adjacentSectors(adjacentSectors_),
+		numTroops(numTroops_), numElites(numElites_), numCreatures(numCreatures_),
+		numTroopsVariance(numTroopsVariance_), numElitesVariance(numElitesVariance_), numCreaturesVariance(numCreaturesVariance_) {}
+
+UNDERGROUND_SECTORINFO* UndergroundSectorModel::createUndergroundSectorInfo(uint8_t difficultyLevel) const
+{
+	UNDERGROUND_SECTORINFO* const u = new UNDERGROUND_SECTORINFO{};
+
+	u->ubSectorX = SECTORX(sectorId);
+	u->ubSectorY = SECTORY(sectorId);
+	u->ubSectorZ = sectorZ;
+	u->ubAdjacentSectors = adjacentSectors;
+
+	u->ubNumTroops    = numTroops[difficultyLevel - 1]    + Random(numTroopsVariance[difficultyLevel - 1]   );
+	u->ubNumElites    = numElites[difficultyLevel - 1]    + Random(numElitesVariance[difficultyLevel - 1]   );
+	u->ubNumCreatures = numCreatures[difficultyLevel - 1] + Random(numCreaturesVariance[difficultyLevel - 1]);
+
+	return u;
+}
+
+std::array<uint8_t, NUM_DIF_LEVELS> readIntArray(const rapidjson::Value& obj, const char* fieldName)
+{
+	std::array<uint8_t, NUM_DIF_LEVELS> vals = {};
+	if (!obj.HasMember(fieldName))
+	{
+		return vals;
+	}
+	auto arr = obj[fieldName].GetArray();
+	if (arr.Size() != NUM_DIF_LEVELS)
+	{
+		SLOGE(ST::format("The number of values in {} is not same as NUM_DIF_LEVELS({})", fieldName, NUM_DIF_LEVELS));
+		throw std::runtime_error("The number of elements does not match the number of difficulty levels");
+	}
+	for (auto i = 0; i < NUM_DIF_LEVELS; i++)
+	{
+		vals[i] = static_cast<uint8_t>(arr[i].GetUint());
+	}
+
+	return vals;
+}
+
+UndergroundSectorModel* UndergroundSectorModel::deserialize(const rapidjson::Value& obj)
+{
+	auto sectorString = obj["sector"].GetString();
+	if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
+	{
+		SLOGE(ST::format("'{}' is not valid sector", sectorString));
+		throw std::runtime_error("Not a valid sector");
+	}
+	uint8_t sectorId = SECTOR_FROM_SECTOR_SHORT_STRING(sectorString);
+	uint8_t sectorZ = obj["sectorLevel"].GetUint();
+	if (sectorZ == 0 || sectorZ > 3)
+	{
+		SLOGE("Sector level must be between 1 and 3");
+		throw std::runtime_error("Sector level is invalid");
+	}
+
+	uint8_t adjacencyFlag = NO_ADJACENT_SECTOR;
+	if (obj.HasMember("adjacentSectors") && obj["adjacentSectors"].IsArray())
+	{
+		auto adjacencies = obj["adjacentSectors"].GetArray();
+		for (auto& el : adjacencies)
+		{
+			const char* adj = el.GetString();
+			if (strlen(adj) != 1)
+			{
+				SLOGE(ST::format("'{}' is not a valid adjacency direction.", adj));
+				throw std::runtime_error("Not a valid adjacency direction");
+			}
+			switch (adj[0])
+			{
+			case DIRECTION_NORTH:
+				adjacencyFlag |= NORTH_ADJACENT_SECTOR;
+				break;
+			case DIRECTION_EAST:
+				adjacencyFlag |= EAST_ADJACENT_SECTOR;
+				break;
+			case DIRECTION_SOUTH:
+				adjacencyFlag |= SOUTH_ADJACENT_SECTOR;
+				break;
+			case DIRECTION_WEST:
+				adjacencyFlag |= WEST_ADJACENT_SECTOR;
+				break;
+			default:
+				SLOGE(ST::format("{} is not a valid direction.", adj[0]));
+				throw std::runtime_error("Invalid direction");
+			}
+		}
+	}
+	
+	return new UndergroundSectorModel(
+		sectorId, sectorZ, adjacencyFlag,
+		readIntArray(obj, "numTroops"), readIntArray(obj, "numElites"), readIntArray(obj, "numCreatures"),
+		readIntArray(obj, "numTroopsVariance"), readIntArray(obj, "numElitesVariance"), readIntArray(obj, "numCreaturesVariance")
+	);
+}
+
+void UndergroundSectorModel::validateData(const std::vector<const UndergroundSectorModel*> ugSectors)
+{
+	// check for existence of hard-coded references
+	// the list below is based on the occurrences of FindUnderGroundSector in codebase
+	std::array<uint8_t, 3> basementSectors[] = {
+		{ 13, 5,  1 },  // Draassen mine
+		{ 9,  8,  1 },  // Cambria mine
+		{ 14, 10, 1 },  // Alma mine
+		{ 4,  8,  2 }   // Grumm mine
+	};
+	for (auto basementLoc : basementSectors)
+	{
+		uint8_t sectorId = SECTOR(basementLoc[0], basementLoc[1]);
+		uint8_t sectorZ = basementLoc[2];
+		auto iter = std::find_if(ugSectors.begin(), ugSectors.end(), [sectorId, sectorZ](const UndergroundSectorModel* s) { return (s->sectorId == sectorId && s->sectorZ == sectorZ); });
+		if (iter == ugSectors.end())
+		{
+			SLOGW(ST::format("An underground sector is expected at ({},{},{}), but is not defined.", basementLoc[0], basementLoc[1], basementLoc[2]));
+			throw std::runtime_error("Missing underground sector definition");
+		}
+	}
+}

--- a/src/externalized/strategic/UndergroundSectorModel.cc
+++ b/src/externalized/strategic/UndergroundSectorModel.cc
@@ -36,7 +36,7 @@ std::array<uint8_t, NUM_DIF_LEVELS> readIntArray(const rapidjson::Value& obj, co
 	if (arr.Size() != NUM_DIF_LEVELS)
 	{
 		SLOGE(ST::format("The number of values in {} is not same as NUM_DIF_LEVELS({})", fieldName, NUM_DIF_LEVELS));
-		throw std::runtime_error("The number of elements does not match the number of difficulty levels");
+		throw std::runtime_error("");
 	}
 	for (auto i = 0; i < NUM_DIF_LEVELS; i++)
 	{
@@ -52,14 +52,14 @@ UndergroundSectorModel* UndergroundSectorModel::deserialize(const rapidjson::Val
 	if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
 	{
 		SLOGE(ST::format("'{}' is not valid sector", sectorString));
-		throw std::runtime_error("Not a valid sector");
+		throw std::runtime_error("");
 	}
 	uint8_t sectorId = SECTOR_FROM_SECTOR_SHORT_STRING(sectorString);
 	uint8_t sectorZ = obj["sectorLevel"].GetUint();
 	if (sectorZ == 0 || sectorZ > 3)
 	{
 		SLOGE("Sector level must be between 1 and 3");
-		throw std::runtime_error("Sector level is invalid");
+		throw std::runtime_error("");
 	}
 
 	uint8_t adjacencyFlag = NO_ADJACENT_SECTOR;
@@ -72,7 +72,7 @@ UndergroundSectorModel* UndergroundSectorModel::deserialize(const rapidjson::Val
 			if (strlen(adj) != 1)
 			{
 				SLOGE(ST::format("'{}' is not a valid adjacency direction.", adj));
-				throw std::runtime_error("Not a valid adjacency direction");
+				throw std::runtime_error("");
 			}
 			switch (adj[0])
 			{
@@ -90,7 +90,7 @@ UndergroundSectorModel* UndergroundSectorModel::deserialize(const rapidjson::Val
 				break;
 			default:
 				SLOGE(ST::format("{} is not a valid direction.", adj[0]));
-				throw std::runtime_error("Invalid direction");
+				throw std::runtime_error("");
 			}
 		}
 	}
@@ -120,7 +120,7 @@ void UndergroundSectorModel::validateData(const std::vector<const UndergroundSec
 		if (iter == ugSectors.end())
 		{
 			SLOGW(ST::format("An underground sector is expected at ({},{},{}), but is not defined.", basementLoc[0], basementLoc[1], basementLoc[2]));
-			throw std::runtime_error("Missing underground sector definition");
+			throw std::runtime_error("");
 		}
 	}
 }

--- a/src/externalized/strategic/UndergroundSectorModel.h
+++ b/src/externalized/strategic/UndergroundSectorModel.h
@@ -1,0 +1,39 @@
+#include "Campaign_Types.h"
+#include "GameSettings.h"
+#include "JA2Types.h"
+#include "JsonObject.h"
+
+#include <array>
+
+const char DIRECTION_NORTH = 'N';
+const char DIRECTION_SOUTH = 'S';
+const char DIRECTION_EAST = 'E';
+const char DIRECTION_WEST = 'W';
+
+// Definitions of underground sectors, useed by Campaign_Init. During init the data are converted to UNDERGROUND_SECTORINFO structures.
+class UndergroundSectorModel
+{
+public:
+	UndergroundSectorModel(
+		uint8_t sectorId_, uint8_t sectorZ_, uint8_t adjacentSectors_,
+		std::array<uint8_t, NUM_DIF_LEVELS> numTroops_, std::array<uint8_t, NUM_DIF_LEVELS> numElites_, std::array<uint8_t, NUM_DIF_LEVELS> numCreatures_,
+		std::array<uint8_t, NUM_DIF_LEVELS> numTroopsVariance_, std::array<uint8_t, NUM_DIF_LEVELS> numElitesVariance_, std::array<uint8_t, NUM_DIF_LEVELS> numCreaturesVariance_
+	);
+	UNDERGROUND_SECTORINFO* createUndergroundSectorInfo(uint8_t difficultyLevel) const;
+
+	static UndergroundSectorModel* deserialize(const rapidjson::Value& obj);
+	static void validateData(const std::vector<const UndergroundSectorModel*> ugSectors);
+
+	uint8_t sectorId;
+	uint8_t sectorZ;
+	uint8_t	adjacentSectors;
+
+protected:
+	std::array<uint8_t, NUM_DIF_LEVELS> numTroops;
+	std::array<uint8_t, NUM_DIF_LEVELS> numElites;
+	std::array<uint8_t, NUM_DIF_LEVELS> numCreatures;
+
+	std::array<uint8_t, NUM_DIF_LEVELS> numTroopsVariance;
+	std::array<uint8_t, NUM_DIF_LEVELS> numElitesVariance;
+	std::array<uint8_t, NUM_DIF_LEVELS> numCreaturesVariance;
+};

--- a/src/game/Strategic/Campaign_Init.cc
+++ b/src/game/Strategic/Campaign_Init.cc
@@ -1,32 +1,32 @@
-#include "Types.h"
 #include "Campaign_Init.h"
+
+#include "Campaign_Types.h"
+#include "ContentManager.h"
+#include "Creature_Spreading.h"
+#include "GameInstance.h"
+#include "GameSettings.h"
+#include "MemMan.h"
+#include "Overhead.h"
+#include "Queen_Command.h"
 #include "Quests.h"
 #include "Random.h"
-#include "Campaign_Types.h"
-#include "Queen_Command.h"
-#include "Overhead.h"
+#include "Strategic_AI.h"
 #include "Strategic_Mines.h"
 #include "Strategic_Movement.h"
 #include "Strategic_Movement_Costs.h"
 #include "Strategic_Status.h"
-#include "GameSettings.h"
-#include "Creature_Spreading.h"
-#include "Strategic_AI.h"
 #include "Tactical_Save.h"
-#include "MemMan.h"
+#include "Types.h"
+#include "UndergroundSectorModel.h"
 
 #include <algorithm>
 
 UNDERGROUND_SECTORINFO* gpUndergroundSectorInfoTail = NULL;
 
 
-static UNDERGROUND_SECTORINFO* NewUndergroundNode(UINT8 const x, UINT8 const y, UINT8 const z)
+static UNDERGROUND_SECTORINFO* AddUndergroundNode(const UndergroundSectorModel* ugInfo, UINT8 ubDifLevel)
 {
-	UNDERGROUND_SECTORINFO* const u = new UNDERGROUND_SECTORINFO{};
-	u->ubSectorX = x;
-	u->ubSectorY = y;
-	u->ubSectorZ = z;
-
+	UNDERGROUND_SECTORINFO* const u = ugInfo->createUndergroundSectorInfo(ubDifLevel);
 	UNDERGROUND_SECTORINFO*& tail = gpUndergroundSectorInfoTail;
 	*(tail ? &tail->next : &gpUndergroundSectorInfoHead) = u;
 	tail = u;
@@ -87,160 +87,15 @@ void TrashUndergroundSectorInfo()
 
 //Defines the sectors that can be occupied by enemies, creatures, etc.  It also
 //contains the network of cave connections critical for strategic creature spreading, as we can't
-//know how the levels connect without loading the maps.  This is completely hardcoded, and any
-//changes to the maps, require changes accordingly.
+//know how the levels connect without loading the maps.
 void BuildUndergroundSectorInfoList()
 {
-	UNDERGROUND_SECTORINFO *curr;
-
 	TrashUndergroundSectorInfo();
 
-	//Miguel's basement.  Nothing here.
-	curr = NewUndergroundNode( 10, 1, 1 );
-
-	//Chitzena mine.  Nothing here.
-	curr = NewUndergroundNode( 2, 2, 1 );
-
-	//San mona mine.  Nothing here.
-	curr = NewUndergroundNode( 4, 4, 1 );
-	curr = NewUndergroundNode( 5, 4, 1 );
-
-	//J9
-	curr = NewUndergroundNode( 9, 10, 1 );
-	switch( gGameOptions.ubDifficultyLevel )
+	for (auto ugInfo : GCM->getUndergroundSectors())
 	{
-		case DIF_LEVEL_EASY:
-			curr->ubNumTroops = 8;
-			break;
-		case DIF_LEVEL_MEDIUM:
-			curr->ubNumTroops = 11;
-			break;
-		case DIF_LEVEL_HARD:
-			curr->ubNumTroops = 15;
-			break;
+		AddUndergroundNode(ugInfo, gGameOptions.ubDifficultyLevel);
 	}
-	//J9 feeding zone
-	curr = NewUndergroundNode( 9, 10, 2 );
-	curr->ubNumCreatures = (UINT8)(2 + gGameOptions.ubDifficultyLevel*2 + Random( 2 ));
-
-	//K4
-	curr = NewUndergroundNode( 4, 11, 1 );
-	curr->ubNumTroops = (UINT8)(6 + gGameOptions.ubDifficultyLevel*2 + Random( 3 ));
-	curr->ubNumElites = (UINT8)(4 + gGameOptions.ubDifficultyLevel + Random( 2 ));
-
-	//O3
-	curr = NewUndergroundNode( 3, 15, 1 );
-	curr->ubNumTroops = (UINT8)(6 + gGameOptions.ubDifficultyLevel*2 + Random( 3 ));
-	curr->ubNumElites = (UINT8)(4 + gGameOptions.ubDifficultyLevel + Random( 2 ));
-	curr->ubAdjacentSectors |= SOUTH_ADJACENT_SECTOR;
-
-	//P3
-	curr = NewUndergroundNode( 3, 16, 1 );
-	switch( gGameOptions.ubDifficultyLevel )
-	{
-		case DIF_LEVEL_EASY:
-			curr->ubNumElites = (UINT8)(8 + Random( 3 ));
-			break;
-		case DIF_LEVEL_MEDIUM:
-			curr->ubNumElites = (UINT8)(10 + Random( 5 ));
-			break;
-		case DIF_LEVEL_HARD:
-			curr->ubNumElites = (UINT8)(14 + Random( 6 ));
-			break;
-	}
-	curr->ubAdjacentSectors |= NORTH_ADJACENT_SECTOR;
-
-	//Do all of the mandatory underground mine sectors
-
-	//Drassen's mine
-	//D13_B1
-	curr = NewUndergroundNode( 13, 4, 1 );
-	curr->ubAdjacentSectors |= SOUTH_ADJACENT_SECTOR;
-	//E13_B1
-	curr = NewUndergroundNode( 13, 5, 1 );
-	curr->ubAdjacentSectors |= NORTH_ADJACENT_SECTOR;
-	//E13_B2
-	curr = NewUndergroundNode( 13, 5, 2 );
-	curr->ubAdjacentSectors |= SOUTH_ADJACENT_SECTOR;
-	//F13_B2
-	curr = NewUndergroundNode( 13, 6, 2 );
-	curr->ubAdjacentSectors |= NORTH_ADJACENT_SECTOR | SOUTH_ADJACENT_SECTOR;
-	//G13_B2
-	curr = NewUndergroundNode( 13, 7, 2 );
-	curr->ubAdjacentSectors |= NORTH_ADJACENT_SECTOR;
-	//G13_B3
-	curr = NewUndergroundNode( 13, 7, 3 );
-	curr->ubAdjacentSectors |= NORTH_ADJACENT_SECTOR;
-	//F13_B3
-	curr = NewUndergroundNode( 13, 6, 3 );
-	curr->ubAdjacentSectors |= SOUTH_ADJACENT_SECTOR;
-
-	//Cambria's mine
-	//H8_B1
-	curr = NewUndergroundNode( 8, 8, 1 );
-	curr->ubAdjacentSectors |= EAST_ADJACENT_SECTOR;
-	//H9_B1
-	curr = NewUndergroundNode( 9, 8, 1 );
-	curr->ubAdjacentSectors |= WEST_ADJACENT_SECTOR;
-	//H9_B2
-	curr = NewUndergroundNode( 9, 8, 2 );
-	curr->ubAdjacentSectors |= WEST_ADJACENT_SECTOR;
-	//H8_B2
-	curr = NewUndergroundNode( 8, 8, 2 );
-	curr->ubAdjacentSectors |= EAST_ADJACENT_SECTOR;
-	//H8_B3
-	curr = NewUndergroundNode( 8, 8, 3 );
-	curr->ubAdjacentSectors |= SOUTH_ADJACENT_SECTOR;
-	//I8_B3
-	curr = NewUndergroundNode( 8, 9, 3 );
-	curr->ubAdjacentSectors |= NORTH_ADJACENT_SECTOR | SOUTH_ADJACENT_SECTOR;
-	//J8_B3
-	curr = NewUndergroundNode( 8, 10, 3 );
-	curr->ubAdjacentSectors |= NORTH_ADJACENT_SECTOR;
-
-	//Alma's mine
-	//I14_B1
-	curr = NewUndergroundNode( 14, 9, 1 );
-	curr->ubAdjacentSectors |= SOUTH_ADJACENT_SECTOR;
-	//J14_B1
-	curr = NewUndergroundNode( 14, 10, 1 );
-	curr->ubAdjacentSectors |= NORTH_ADJACENT_SECTOR;
-	//J14_B2
-	curr = NewUndergroundNode( 14, 10, 2 );
-	curr->ubAdjacentSectors |= WEST_ADJACENT_SECTOR;
-	//J13_B2
-	curr = NewUndergroundNode( 13, 10, 2 );
-	curr->ubAdjacentSectors |= EAST_ADJACENT_SECTOR;
-	//J13_B3
-	curr = NewUndergroundNode( 13, 10, 3 );
-	curr->ubAdjacentSectors |= SOUTH_ADJACENT_SECTOR;
-	//K13_B3
-	curr = NewUndergroundNode( 13, 11, 3 );
-	curr->ubAdjacentSectors |= NORTH_ADJACENT_SECTOR;
-
-	//Grumm's mine
-	//H3_B1
-	curr = NewUndergroundNode( 3, 8, 1 );
-	curr->ubAdjacentSectors |= SOUTH_ADJACENT_SECTOR;
-	//I3_B1
-	curr = NewUndergroundNode( 3, 9, 1 );
-	curr->ubAdjacentSectors |= NORTH_ADJACENT_SECTOR;
-	//I3_B2
-	curr = NewUndergroundNode( 3, 9, 2 );
-	curr->ubAdjacentSectors |= NORTH_ADJACENT_SECTOR;
-	//H3_B2
-	curr = NewUndergroundNode( 3, 8, 2 );
-	curr->ubAdjacentSectors |= SOUTH_ADJACENT_SECTOR | EAST_ADJACENT_SECTOR;
-	//H4_B2
-	curr = NewUndergroundNode( 4, 8, 2 );
-	curr->ubAdjacentSectors |= WEST_ADJACENT_SECTOR;
-	curr->uiFlags |= SF_PENDING_ALTERNATE_MAP;
-	//H4_B3
-	curr = NewUndergroundNode( 4, 8, 3 );
-	curr->ubAdjacentSectors |= NORTH_ADJACENT_SECTOR;
-	//G4_B3
-	curr = NewUndergroundNode( 4, 7, 3 );
-	curr->ubAdjacentSectors |= SOUTH_ADJACENT_SECTOR;
 }
 
 //This is the function that is called only once, when the player begins a new game.  This will calculate


### PR DESCRIPTION
Visiting an underground sector that has a map .DAT but not corresponding `UNDERGROUND_SECTORINFO`  crashes the game.

See also #1011 and #665.

### Summary

- Extracted data from Campaign_Init..cc:BuildUndergroundSectorInfoList to JSON
- Generalized the per-DIFLEVEL numbers of enemies as a "base num + random" formula
- Only changed Campaign Init - in-memory linked-list and Save/Load are not touched
- Validation to protect from crash due to missing data