### PR TITLE
Load Fact params from JSON

### DIFF
--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -1094,6 +1094,14 @@ bool DefaultContentManager::loadStrategicLayerData() {
 		);
 	}
 
+	json = readJsonDataFile("strategic-fact-params.json");
+	for (auto& element : json->GetArray())
+	{
+		auto params = FactParamsModel::deserialize(element);
+		m_factParams[params->fact] = params;
+	}
+	delete json;
+
 	json = readJsonDataFile("strategic-map-sam-sites.json");
 	for (auto& element : json->GetArray())
 	{


### PR DESCRIPTION
Missed this when I pulled changes into #1061.

With this commit now we actually load Fact params from JSON.