### PR TITLE
Fixing a typo in InitializeMines

### DIFF
--- a/src/game/Strategic/Strategic_Mines.cc
+++ b/src/game/Strategic/Strategic_Mines.cc
@@ -119,7 +119,7 @@ void InitializeMines( void )
 		pMineStatus->fSpokeToHeadMiner = FALSE;
 		pMineStatus->fMineHasProducedForPlayer = FALSE;
 		pMineStatus->fQueenRetookProducingMine = FALSE;
-		gMineStatus->fShutDownIsPermanent = FALSE;
+		pMineStatus->fShutDownIsPermanent = FALSE;
 	}
 
 	// randomize the exact size each mine.  The total production is always the same and depends on the game difficulty,


### PR DESCRIPTION
This has to be a typo, as this only initializes the value of the first element, and leaves the rest uninitialized