### PR TITLE
fix debian fltk omission

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
             - libsdl2-dev
             - fluid
             - libfltk1.3-dev
+            - libfltk-images1.3
             - fakeroot
         coverity_scan:
           project:
@@ -151,6 +152,7 @@ addons:
     - libsdl2-dev
     - fluid
     - libfltk1.3-dev
+    - libfltk-images1.3
     - fakeroot
     - mingw-w64
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,7 @@ set(CPACK_PACKAGE_INSTALL_DIRECTORY "JA2 Stracciatella")
 
 set(CPACK_DEBIAN_PACKAGE_SECTION "games")
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://ja2-stracciatella.github.io/")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libsdl2-2.0-0, libstdc++6, libgcc1, libc6")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libsdl2-2.0-0, libstdc++6, libgcc1, libc6, libfltk1.3-dev, libfltk-images1.3")
 
 set(CPACK_BUNDLE_NAME "JA2 Stracciatella")
 set(CPACK_BUNDLE_ICON "${CMAKE_CURRENT_SOURCE_DIR}/assets/icons/logo.icns")

--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -8,6 +8,15 @@
 - Rust and Cargo
 - Your systems compiler
 
+## Optional dependencies
+
+FLTK is required to build the GUI launcher. If it is not installed, a bundled copy will be used.
+If you do already have it, make sure the package also provides the libfltk_images library or in
+case of Debian and derivatives, install it manually (libfltk-images1.3).
+
+Stracciatella bundles a few other projects for development purposes. If you have them installed already,
+the system version will be used. This holds for: gtest, rapidjson and string theory.
+
 ## General Notes
 
 We use cmake as our build system, which is aimed at an out-of-source build. That means that you should call


### PR DESCRIPTION
debians splits the lib out, while the rest is just documentation. Since we use a system fltk on travis, the bundled one isn't used, so we have to deal with their split libraries.