### PR TITLE
Allow more time for nightly artifact upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,7 +140,7 @@ script:
 
 after_success:
   - if [ "$PUBLISH_BINARY" == "true" ] && [ "$SFTP_PASSWORD" != "" ]; then
-      travis_retry curl -v --connect-timeout 60 --max-time 150 --ftp-create-dirs -T $(echo ja2-stracciatella_*) -u $SFTP_USER:$SFTP_PASSWORD ftp://www61.your-server.de/$PUBLISH_DIR/;
+      travis_retry curl -v --connect-timeout 60 --max-time 300 --ftp-create-dirs -T $(echo ja2-stracciatella_*) -u $SFTP_USER:$SFTP_PASSWORD ftp://www61.your-server.de/$PUBLISH_DIR/;
     fi
 
 addons:


### PR DESCRIPTION
In recent nightly builds, the linux/mingw64-cross artifacts has zero bytes (https://github.com/ja2-stracciatella/ja2-stracciatella/issues/873#issuecomment-638665861)

The larger artifacts from nightly builds (linux and mingw64-cross) are 30+MB and readily take 120+s to upload. It may need more time if networks are busy.

