### PR TITLE
Externalizing mines

### DIFF
--- a/assets/externalized/strategic-mines.json
+++ b/assets/externalized/strategic-mines.json
@@ -9,6 +9,7 @@
  *  - entranceSector:    Sector of the mine entrance on the surface level.
  *  - associatedTownId:    ID of the associated town, refer to strategic-map-towns.json.
  *  - mineType:    Either "GOLD_MINE" or "SILVER_MINE".
+ *  - headMinerAssigned:    True if there is a specific head miner assigned (in merc profile) to the entrance sector. If not, a head miner will be randomly assigned. Either way, the mine entrance sector must have the head miner slot(s) placed, unless it is abandoned.
  *  - noDepletion:    Mines (Alma in Vanilla) can be set to never deplete, so there will always be head miner giving quest. Defaults to false, so the mine may be randomly chosen for depletion.
  *  - delayDepletion:    If the mine is chosen for depletion, delay it.
  *  - minimumMineProduction:    Production rate (money value per period) of the mine before any random increase.
@@ -42,6 +43,7 @@
         "entranceSector": "I14",
         "associatedTownId": 3,
         "mineType": "SILVER_MINE",
+        "headMinerAssigned": true, // Matt is always the head miner here
         "noDepletion": true, // Alma mine can't run out for quest-related reasons
         "isInfestible": true,
         "minimumMineProduction": 1500,

--- a/assets/externalized/strategic-mines.json
+++ b/assets/externalized/strategic-mines.json
@@ -1,0 +1,84 @@
+/**
+ * Definition of mines (in production or abandoned) on strategic map.
+ *
+ * NOTICE: changing the number of mines breaks save compatibility!
+ *
+ * NOTICE: changing the order of the mines breaks vanilla game quests.
+ *
+ * Field definitions:
+ *  - entranceSector:    Sector of the mine entrance on the surface level.
+ *  - associatedTownId:    ID of the associated town, refer to strategic-map-towns.json.
+ *  - mineType:    Either "GOLD_MINE" or "SILVER_MINE".
+ *  - noDepletion:    Mines (Alma in Vanilla) can be set to never deplete, so there will always be head miner giving quest. Defaults to false, so the mine may be randomly chosen for depletion.
+ *  - delayDepletion:    If the mine is chosen for depletion, delay it.
+ *  - minimumMineProduction:    Production rate (money value er period) of the mine before any random increase.
+ *  - isInfestible:    If it can be infected by Crepitus bugs. An infestible mine must have an associated creature lair.
+ *  - mineSectors:    List of underground sectors belonging to this mine. Sector defined as: ["<SECTORXY>", <LEVEL>]. These sectors must also be defined in strategic-map-underground-sectors.json.
+ *  - faceDisplayYOffset:    Y-offset to the screen position, where the head miner's face and text box should be in order to not obscure the mine he's in as it flashes. See IssueHeadMinerQuote()
+ */
+[
+    { // SAN_MONA
+        "entranceSector": "D4",
+        "associatedTownId": 7,
+        "mineType": "GOLD_MINE",
+        "minimumMineProduction": 0, // abandoned
+        "mineSectors": [
+            ["D4", 1], ["D5", 1]
+        ]
+    },
+    { // DRASSEN
+        "entranceSector": "D13",
+        "associatedTownId": 2,
+        "mineType": "SILVER_MINE",
+        "delayDepletion": true,
+        "isInfestible": true,
+        "minimumMineProduction": 1000,
+        "mineSectors": [
+            ["D13", 1], ["E13", 1]
+        ],
+        "faceDisplayYOffset": 135
+    },
+    { // ALMA
+        "entranceSector": "I14",
+        "associatedTownId": 3,
+        "mineType": "SILVER_MINE",
+        "noDepletion": true, // Alma mine can't run out for quest-related reasons
+        "isInfestible": true,
+        "minimumMineProduction": 1500,
+        "mineSectors": [
+            ["I14", 1], ["J14", 1]
+        ]
+    },
+    { // CAMBRIA
+        "entranceSector": "H8",
+        "associatedTownId": 6,
+        "mineType": "SILVER_MINE",
+        "isInfestible": true,
+        "minimumMineProduction": 1500,
+        "mineSectors": [
+            ["H8", 1], ["H9", 1]
+        ]
+    },
+    { // CHITZENA
+        "entranceSector": "B2",
+        "associatedTownId": 12,
+        "mineType": "SILVER_MINE",
+        "isInfestible": true,
+        "minimumMineProduction": 500,
+        "mineSectors": [
+            ["B2", 1]
+        ],
+        "faceDisplayYOffset": 117
+    },
+    { // GRUMM
+        "entranceSector": "H3",
+        "associatedTownId": 4,
+        "mineType": "GOLD_MINE",
+        "isInfestible": true,
+        "minimumMineProduction": 2000,
+        "mineSectors": [
+            ["H3", 1], ["I3", 1],
+            ["I3", 2], ["H3", 2], ["H4", 2]
+        ]
+    }
+]

--- a/assets/externalized/strategic-mines.json
+++ b/assets/externalized/strategic-mines.json
@@ -11,7 +11,7 @@
  *  - mineType:    Either "GOLD_MINE" or "SILVER_MINE".
  *  - noDepletion:    Mines (Alma in Vanilla) can be set to never deplete, so there will always be head miner giving quest. Defaults to false, so the mine may be randomly chosen for depletion.
  *  - delayDepletion:    If the mine is chosen for depletion, delay it.
- *  - minimumMineProduction:    Production rate (money value er period) of the mine before any random increase.
+ *  - minimumMineProduction:    Production rate (money value per period) of the mine before any random increase.
  *  - isInfestible:    If it can be infected by Crepitus bugs. An infestible mine must have an associated creature lair.
  *  - mineSectors:    List of underground sectors belonging to this mine. Sector defined as: ["<SECTORXY>", <LEVEL>]. These sectors must also be defined in strategic-map-underground-sectors.json.
  *  - faceDisplayYOffset:    Y-offset to the screen position, where the head miner's face and text box should be in order to not obscure the mine he's in as it flashes. See IssueHeadMinerQuote()

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -23,6 +23,7 @@ class FactParamsModel;
 class GamePolicy;
 class GarrisonGroupModel;
 class IMPPolicy;
+class MineModel;
 class MovementCostsModel;
 class NpcActionParamsModel;
 class NpcPlacementModel;
@@ -133,6 +134,9 @@ public:
 	virtual const std::vector<const BloodCatPlacementsModel*> & getBloodCatPlacements() const = 0;
 	virtual const std::vector<const BloodCatSpawnsModel*> & getBloodCatSpawns() const = 0;
 	virtual const BloodCatSpawnsModel* getBloodCatSpawnsOfSector(uint8_t sectorId) const = 0;
+	virtual const MineModel* getMineForSector(uint8_t sectorX, uint8_t sectorY, uint8_t sectorZ) const = 0;
+	virtual const MineModel* getMine(uint8_t mineId) const = 0;
+	virtual const std::vector<const MineModel*>& getMines() const = 0;
 	virtual const std::vector<const SamSiteModel*>& getSamSites() const = 0;
 	virtual const int8_t findSamIDBySector(uint8_t sectorId) const = 0;
 	virtual const SamSiteModel* findSamSiteBySector(uint8_t sectorId) const = 0;

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -159,6 +159,9 @@ public:
 	virtual const std::vector<const BloodCatPlacementsModel*>& getBloodCatPlacements() const override;
 	virtual const std::vector<const BloodCatSpawnsModel*>& getBloodCatSpawns() const override;
 	virtual const BloodCatSpawnsModel* getBloodCatSpawnsOfSector(uint8_t sectorId) const override;
+	virtual const MineModel* getMineForSector(uint8_t sectorX, uint8_t sectorY, uint8_t sectorZ) const override;
+	virtual const MineModel* getMine(uint8_t mineId) const override;
+	virtual const std::vector<const MineModel*>& getMines() const override;
 	virtual const std::vector<const SamSiteModel*>& getSamSites() const override;
 	virtual const int8_t findSamIDBySector(uint8_t sectorId) const override;
 	virtual const SamSiteModel* findSamSiteBySector(uint8_t sectorId) const override;
@@ -223,6 +226,7 @@ protected:
 
 	std::vector<const BloodCatPlacementsModel*> m_bloodCatPlacements;
 	std::vector<const BloodCatSpawnsModel*> m_bloodCatSpawns;
+	std::vector<const MineModel*> m_mines;
 	std::vector<const SamSiteModel*> m_samSites;
 	std::map<int8_t, const TownModel*> m_towns;
 	std::vector<const ST::string*> m_townNames;

--- a/src/externalized/JsonObject.h
+++ b/src/externalized/JsonObject.h
@@ -59,6 +59,11 @@ public:
 		return m_value[name].GetInt();
 	}
 
+	unsigned int GetUInt(const char* name) const
+	{
+		return m_value[name].GetUint();
+	}
+
 	bool GetBool(const char *name) const
 	{
 		return m_value[name].GetBool();

--- a/src/externalized/strategic/CMakeLists.txt
+++ b/src/externalized/strategic/CMakeLists.txt
@@ -5,6 +5,7 @@ set(JA2_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/BloodCatPlacementsModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/BloodCatSpawnsModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/FactParamsModel.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/MineModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/MovementCostsModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/NpcPlacementModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/SamSiteModel.cc

--- a/src/externalized/strategic/MineModel.cc
+++ b/src/externalized/strategic/MineModel.cc
@@ -5,17 +5,17 @@
 
 
 MineModel::MineModel(const uint8_t mineId_, const uint8_t entranceSector_, const uint8_t associatedTownId_, 
-	const uint8_t mineType_, const uint16_t minimumMineProduction_, 
+	const uint8_t mineType_, const uint16_t minimumMineProduction_, const bool headMinerAssigned_,
 	const bool noDepletion_, const bool delayDepletion_, const bool isInfestible_,
 	std::vector<std::array<uint8_t, 2>> mineSectors_, const int16_t faceDisplayYOffset_) :
 		mineId(mineId_), entranceSector(entranceSector_), associatedTownId(associatedTownId_),
-		mineType(mineType_), minimumMineProduction(minimumMineProduction_),
+		mineType(mineType_), minimumMineProduction(minimumMineProduction_), headMinerAssigned(headMinerAssigned_),
 		noDepletion(noDepletion_), delayDepletion(delayDepletion_), isInfestible(isInfestible_),
 		mineSectors(mineSectors_), faceDisplayYOffset(faceDisplayYOffset_) {}
 
 bool MineModel::isAbandoned() const
 {
-	return minimumMineProduction > 0;
+	return minimumMineProduction == 0;
 }
 
 uint8_t mineTypeFromString(std::string mineType)
@@ -68,7 +68,8 @@ MineModel* MineModel::deserialize(uint8_t index, const rapidjson::Value& json)
 		obj.GetUInt("associatedTownId"),
 		mineTypeFromString(obj.GetString("mineType")),
 		obj.GetUInt("minimumMineProduction"),
-		obj.getOptionalBool("hasHeadMinerQuest"),
+		obj.getOptionalBool("headMinerAssigned"),
+		obj.getOptionalBool("noDepletion"),
 		obj.getOptionalBool("delayDepletion"),
 		obj.getOptionalBool("isInfestible"),
 		mineSectors,

--- a/src/externalized/strategic/MineModel.cc
+++ b/src/externalized/strategic/MineModel.cc
@@ -1,0 +1,91 @@
+#include "MineModel.h"
+
+#include "Campaign_Types.h"
+#include "Strategic_Mines.h"
+
+
+MineModel::MineModel(const uint8_t mineId_, const uint8_t entranceSector_, const uint8_t associatedTownId_, 
+	const uint8_t mineType_, const uint16_t minimumMineProduction_, 
+	const bool noDepletion_, const bool delayDepletion_, const bool isInfestible_,
+	std::vector<std::array<uint8_t, 2>> mineSectors_, const int16_t faceDisplayYOffset_) :
+		mineId(mineId_), entranceSector(entranceSector_), associatedTownId(associatedTownId_),
+		mineType(mineType_), minimumMineProduction(minimumMineProduction_),
+		noDepletion(noDepletion_), delayDepletion(delayDepletion_), isInfestible(isInfestible_),
+		mineSectors(mineSectors_), faceDisplayYOffset(faceDisplayYOffset_) {}
+
+bool MineModel::isAbandoned() const
+{
+	return minimumMineProduction > 0;
+}
+
+uint8_t mineTypeFromString(std::string mineType)
+{
+	if (mineType == "GOLD_MINE") return GOLD_MINE;
+	if (mineType == "SILVER_MINE") return SILVER_MINE;
+	
+	SLOGE(ST::format("Unrecognized mine type: '{}'", mineType));
+	throw std::runtime_error("");
+}
+
+std::vector<std::array<uint8_t, 2>> readMineSectors(const rapidjson::Value& sectorsJson)
+{
+	std::vector<std::array<uint8_t, 2>> sectors;
+	for (auto& s: sectorsJson.GetArray())
+	{
+		auto sector = s.GetArray();
+		if (sector.Size() != 2) throw new std::runtime_error("Elements in mineSector must be arrays of 2");
+
+		auto sectorString = sector[0].GetString();
+		auto sectorLevel = sector[1].GetUint();
+		if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
+		{
+			throw new std::runtime_error("mineSector given is not a valid sector string");
+		}
+
+		sectors.push_back(std::array<uint8_t, 2> {
+			SECTOR_FROM_SECTOR_SHORT_STRING(sectorString),
+			static_cast<uint8_t>(sectorLevel)
+		});
+	}
+	return sectors;
+}
+
+MineModel* MineModel::deserialize(uint8_t index, const rapidjson::Value& json)
+{
+	auto obj = JsonObjectReader(json);
+	const char* entrance = obj.GetString("entranceSector");
+	if (!IS_VALID_SECTOR_SHORT_STRING(entrance))
+	{
+		SLOGE(ST::format("Invalid mine entrance sector: '{}'", entrance));
+		throw std::runtime_error("");
+	}
+
+	auto mineSectors = readMineSectors(json["mineSectors"]);
+
+	return new MineModel(
+		index,
+		SECTOR_FROM_SECTOR_SHORT_STRING(entrance),
+		obj.GetUInt("associatedTownId"),
+		mineTypeFromString(obj.GetString("mineType")),
+		obj.GetUInt("minimumMineProduction"),
+		obj.getOptionalBool("hasHeadMinerQuest"),
+		obj.getOptionalBool("delayDepletion"),
+		obj.getOptionalBool("isInfestible"),
+		mineSectors,
+		obj.getOptionalInt("faceDisplayYOffset")
+	);
+}
+
+void MineModel::validateData(std::vector<const MineModel*> models)
+{
+	if (models.size() != MAX_NUMBER_OF_MINES)
+	{
+		SLOGW(ST::format("There are {} mines defined. Expected {} mines. This breaks vanilla save compatability", models.size(), MAX_NUMBER_OF_MINES));
+	}
+	if (models.size() < MAX_NUMBER_OF_MINES)
+	{
+		// Mine-related quests use hard-coded enums and may run into problems.
+		SLOGE(ST::format("There are fewer than {} mines defined.", MAX_NUMBER_OF_MINES));
+		throw std::runtime_error("");
+	}
+}

--- a/src/externalized/strategic/MineModel.h
+++ b/src/externalized/strategic/MineModel.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "JsonObject.h"
+#include <array>
+#include <rapidjson/document.h>
+#include <string>
+#include <vector>
+
+class MineModel
+{
+public:
+	MineModel(const uint8_t mineId, const uint8_t entranceSector_, const uint8_t associatedTownId_, const uint8_t mineType_, const uint16_t minimumMineProduction_,
+		const bool noDepletion_, const bool delayDepletion_, const bool isInfestible_,
+		const std::vector<std::array<uint8_t, 2>> mineSectors_,
+		const int16_t faceDisplayYOffset);
+ 
+	bool isAbandoned() const;
+
+	const uint8_t mineId;
+	const uint8_t associatedTownId;
+	const uint8_t entranceSector;
+	const uint8_t mineType;
+	const uint16_t minimumMineProduction;
+	const bool noDepletion;
+	const bool delayDepletion;
+	const bool isInfestible;
+
+	const std::vector<std::array<uint8_t, 2>> mineSectors;
+
+	const int16_t faceDisplayYOffset;
+	
+	static MineModel* deserialize(uint8_t index, const rapidjson::Value& json);
+	static void validateData(std::vector<const MineModel*> models);
+};

--- a/src/externalized/strategic/MineModel.h
+++ b/src/externalized/strategic/MineModel.h
@@ -10,7 +10,7 @@ class MineModel
 {
 public:
 	MineModel(const uint8_t mineId, const uint8_t entranceSector_, const uint8_t associatedTownId_, const uint8_t mineType_, const uint16_t minimumMineProduction_,
-		const bool noDepletion_, const bool delayDepletion_, const bool isInfestible_,
+		const bool headMinerAssigned_, const bool noDepletion_, const bool delayDepletion_, const bool isInfestible_,
 		const std::vector<std::array<uint8_t, 2>> mineSectors_,
 		const int16_t faceDisplayYOffset);
  
@@ -21,6 +21,7 @@ public:
 	const uint8_t entranceSector;
 	const uint8_t mineType;
 	const uint16_t minimumMineProduction;
+	const bool headMinerAssigned;
 	const bool noDepletion;
 	const bool delayDepletion;
 	const bool isInfestible;

--- a/src/game/Strategic/Creature_Spreading.cc
+++ b/src/game/Strategic/Creature_Spreading.cc
@@ -31,6 +31,9 @@
 #include "MemMan.h"
 #include "Debug.h"
 #include "ScreenIDs.h"
+#include "GameInstance.h"
+#include "ContentManager.h"
+#include "MineModel.h"
 
 #include <algorithm>
 #include <stdexcept>
@@ -247,10 +250,11 @@ static void InitLairGrumm(void)
 static bool IsMineInfectible(MineID const id)
 { // If neither head miner was attacked, ore will/has run out nor enemy controlled
 	MINE_STATUS_TYPE const& m = gMineStatus[id];
+	auto mineData = GCM->getMine(id);
 	return
 		!m.fAttackedHeadMiner       &&
 		m.uiOreRunningOutPoint == 0 &&
-		!StrategicMap[SECTOR_INFO_TO_STRATEGIC_INDEX(gMineLocation[id].sector)].fEnemyControlled;
+		!StrategicMap[SECTOR_INFO_TO_STRATEGIC_INDEX(mineData->entranceSector)].fEnemyControlled;
 }
 
 

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -25,6 +25,7 @@
 #include "Merc_Hiring.h"
 #include "Message.h"
 #include "Militia_Control.h"
+#include "MineModel.h"
 #include "Overhead.h"
 #include "Player_Command.h"
 #include "PreBattle_Interface.h"
@@ -675,9 +676,10 @@ void DrawMap(void)
 		ShowSAMSitesOnStrategicMap();
 
 		// draw mine icons and descriptive text
-		for (INT32 i = 0; i < MAX_NUMBER_OF_MINES; ++i)
+		auto mines = GCM->getMines();
+		for (INT32 i = 0; i < mines.size(); ++i)
 		{
-			UINT8 const sector = gMineLocation[i].sector;
+			UINT8 const sector = mines[i]->entranceSector;
 			INT16 const x      = SECTORX(sector);
 			INT16 const y      = SECTORY(sector);
 			BlitMineIcon(x, y);
@@ -3558,15 +3560,14 @@ static void BlitMineGridMarkers(void)
 	ClipBlitsToMapViewRegionForRectangleAndABit(pitch);
 
 	UINT16 const color = Get16BPPColor(FROMRGB(100, 100, 100));
-	FOR_EACH(MINE_LOCATION_TYPE const, i, gMineLocation)
+	for (auto m : GCM->getMines())
 	{
 		INT16                     x;
 		INT16                     y;
 		INT16                     w;
 		INT16                     h;
-		MINE_LOCATION_TYPE const& m  = *i;
-		INT16              const  mx = SECTORX(m.sector);
-		INT16              const  my = SECTORY(m.sector);
+		INT16              const  mx = SECTORX(m->entranceSector);
+		INT16              const  my = SECTORY(m->entranceSector);
 		if (fZoomFlag)
 		{
 			GetScreenXYFromMapXYStationary(mx, my, &x, &y);

--- a/src/game/Strategic/StrategicMap.cc
+++ b/src/game/Strategic/StrategicMap.cc
@@ -765,9 +765,9 @@ void HandleQuestCodeOnSectorEntry( INT16 sNewSectorX, INT16 sNewSectorY, INT8 bN
 			{
 				ubMinersPlaced = 0;
 
-				if (ubThisMine != MINE_ALMA)
+				if (!thisMine->headMinerAssigned)
 				{
-					// Fred Morris is always in the first mine sector we enter, unless that's Alma (then he's randomized, too)
+					// Fred Morris is always in the first mine sector we enter, unless head miner here has been pre-determined (then he's randomized, too)
 					MERCPROFILESTRUCT& fred = GetProfile(FRED);
 					fred.sSectorX = sNewSectorX;
 					fred.sSectorY = sNewSectorY;
@@ -780,9 +780,9 @@ void HandleQuestCodeOnSectorEntry( INT16 sNewSectorX, INT16 sNewSectorY, INT8 bN
 				}
 
 				// assign the remaining (3) miners randomly
-				for ( ubMine = 0; ubMine < GCM->getMines().size(); ubMine++ )
+				for (auto ubMine : GCM->getMines())
 				{
-					if ( ubMine == ubThisMine || ubMine == MINE_ALMA || thisMine->isAbandoned() )
+					if ( ubMine->mineId == ubThisMine || ubMine->headMinerAssigned || ubMine->isAbandoned() )
 					{
 						// Alma always has Matt as a miner, and we have assigned Fred to the current mine
 						// and San Mona is abandoned
@@ -796,7 +796,7 @@ void HandleQuestCodeOnSectorEntry( INT16 sNewSectorX, INT16 sNewSectorY, INT8 bN
 					while( ubRandomMiner[ ubMiner ] == 0 );
 
 					MERCPROFILESTRUCT& p      = GetProfile(ubRandomMiner[ubMiner]);
-					UINT8 const        sector = GetMineSector(ubMine);
+					UINT8 const        sector = ubMine->entranceSector;
 					p.sSectorX = SECTORX(sector);
 					p.sSectorY = SECTORY(sector);
 					p.bSectorZ = 0;

--- a/src/game/Strategic/StrategicMap.cc
+++ b/src/game/Strategic/StrategicMap.cc
@@ -59,6 +59,7 @@
 #include "Message.h"
 #include "MessageBoxScreen.h"
 #include "Militia_Control.h"
+#include "MineModel.h"
 #include "Music_Control.h"
 #include "NPC.h"
 #include "OppList.h"
@@ -758,8 +759,9 @@ void HandleQuestCodeOnSectorEntry( INT16 sNewSectorX, INT16 sNewSectorY, INT8 bN
 		INT8 const ubThisMine = GetMineIndexForSector(sector);
 		if (ubThisMine != -1 && !CheckFact(FACT_MINERS_PLACED, 0))
 		{
-			// SET HEAD MINER LOCATIONS
-			if (ubThisMine != MINE_SAN_MONA) // San Mona is abandoned
+			auto thisMine = GCM->getMine(ubThisMine);
+			// SET HEAD MINER LOCATIONS, unless mine is abandoned
+			if (!thisMine->isAbandoned())
 			{
 				ubMinersPlaced = 0;
 
@@ -770,7 +772,7 @@ void HandleQuestCodeOnSectorEntry( INT16 sNewSectorX, INT16 sNewSectorY, INT8 bN
 					fred.sSectorX = sNewSectorX;
 					fred.sSectorY = sNewSectorY;
 					fred.bSectorZ = 0;
-					fred.bTown    = gMineLocation[ubThisMine].bAssociatedTown;
+					fred.bTown    = thisMine->associatedTownId;
 
 					// mark miner as placed
 					ubRandomMiner[ 0 ] = 0;
@@ -778,9 +780,9 @@ void HandleQuestCodeOnSectorEntry( INT16 sNewSectorX, INT16 sNewSectorY, INT8 bN
 				}
 
 				// assign the remaining (3) miners randomly
-				for ( ubMine = 0; ubMine < MAX_NUMBER_OF_MINES; ubMine++ )
+				for ( ubMine = 0; ubMine < GCM->getMines().size(); ubMine++ )
 				{
-					if ( ubMine == ubThisMine || ubMine == MINE_ALMA || ubMine == MINE_SAN_MONA )
+					if ( ubMine == ubThisMine || ubMine == MINE_ALMA || thisMine->isAbandoned() )
 					{
 						// Alma always has Matt as a miner, and we have assigned Fred to the current mine
 						// and San Mona is abandoned
@@ -798,7 +800,7 @@ void HandleQuestCodeOnSectorEntry( INT16 sNewSectorX, INT16 sNewSectorY, INT8 bN
 					p.sSectorX = SECTORX(sector);
 					p.sSectorY = SECTORY(sector);
 					p.bSectorZ = 0;
-					p.bTown = gMineLocation[ ubMine ].bAssociatedTown;
+					p.bTown = thisMine->associatedTownId;
 
 					// mark miner as placed
 					ubRandomMiner[ ubMiner ] = 0;

--- a/src/game/Strategic/Strategic_Mines.cc
+++ b/src/game/Strategic/Strategic_Mines.cc
@@ -134,11 +134,11 @@ void InitializeMines( void )
 		{
 			if (minesData[ubDepletedMineIndex]->delayDepletion)
 			{
-				ubMinDaysBeforeDepletion = 45;
+				ubMinDaysBeforeDepletion = 20;
 			}
 			else
 			{
-				ubMinDaysBeforeDepletion = 30;
+				ubMinDaysBeforeDepletion = 10;
 			}
 
 			// the mine that runs out has only enough ore for this many days of full production

--- a/src/game/Strategic/Strategic_Mines.cc
+++ b/src/game/Strategic/Strategic_Mines.cc
@@ -1,32 +1,34 @@
+#include "Strategic_Mines.h"
+
+#include "Campaign_Types.h"
+#include "ContentManager.h"
+#include "Creature_Spreading.h"
+#include "Debug.h"
+#include "Dialogue_Control.h"
+#include "FileMan.h"
+#include "Finances.h"
 #include "Font_Control.h"
+#include "GameInstance.h"
+#include "GameSettings.h"
+#include "Game_Clock.h"
+#include "Game_Event_Hook.h"
+#include "History.h"
 #include "LoadSaveData.h"
 #include "MapScreen.h"
-#include "Strategic_Mines.h"
-#include "Finances.h"
-#include "Strategic_Town_Loyalty.h"
-#include "Game_Clock.h"
-#include "StrategicMap.h"
+#include "Map_Screen_Interface.h"
+#include "Message.h"
+#include "MineModel.h"
+#include "Quests.h"
 #include "Random.h"
 #include "Soldier_Profile.h"
-#include "Dialogue_Control.h"
-#include "Map_Screen_Interface.h"
-#include "Quests.h"
-#include "Creature_Spreading.h"
-#include "Message.h"
-#include "Text.h"
-#include "Game_Event_Hook.h"
-#include "GameSettings.h"
+#include "StrategicMap.h"
 #include "Strategic_AI.h"
-#include "History.h"
-#include "Campaign_Types.h"
-#include "Debug.h"
-#include "FileMan.h"
+#include "Strategic_Town_Loyalty.h"
+#include "Text.h"
 #include "UILayout.h"
-#include "GameInstance.h"
-#include "ContentManager.h"
 
-// this .c file will handle the strategic level of mines and income from them
 
+// this .cc file handles the strategic level of mines and income from them
 
 #define REMOVAL_RATE_INCREMENT	250		// the smallest increment by which removal rate change during depletion (use round #s)
 
@@ -40,39 +42,7 @@
 
 
 // this table holds mine values that change during the course of the game and must be saved
-MINE_STATUS_TYPE gMineStatus[ MAX_NUMBER_OF_MINES ];
-
-// this table holds mine values that never change and don't need to be saved
-MINE_LOCATION_TYPE const gMineLocation[] =
-{
-	{ SEC_D4,  SAN_MONA },
-	{ SEC_D13, DRASSEN  },
-	{ SEC_I14, ALMA     },
-	{ SEC_H8,  CAMBRIA  },
-	{ SEC_B2,  CHITZENA },
-	{ SEC_H3,  GRUMM    }
-};
-
-// the are not being randomized at all at this time
-UINT8 gubMineTypes[]={
-	GOLD_MINE,	// SAN MONA
-	SILVER_MINE,	// DRASSEN
-	SILVER_MINE,	// ALMA
-	SILVER_MINE,	// CAMBRIA
-	SILVER_MINE,	// CHITZENA
-	GOLD_MINE,	// GRUMM
-};
-
-// These values also determine the most likely ratios of mine sizes after random production increases are done
-UINT32 guiMinimumMineProduction[]={
-	0,	// SAN MONA
-	1000,	// DRASSEN
-	1500,	// ALMA
-	1500,	// CAMBRIA
-	500,	// CHITZENA
-	2000,	// GRUMM
-};
-
+std::vector<MINE_STATUS_TYPE> gMineStatus;
 
 struct HEAD_MINER_TYPE
 {
@@ -102,24 +72,16 @@ void InitializeMines( void )
 	UINT8 ubMinDaysBeforeDepletion = 20;
 
 
-	// set up initial mine status
-	for( ubMineIndex = 0; ubMineIndex < MAX_NUMBER_OF_MINES; ubMineIndex++ )
+	// set up initial mine statu
+	gMineStatus.clear();
+	for (auto mine : GCM->getMines())
 	{
-		pMineStatus = &(gMineStatus[ ubMineIndex ]);
+		MINE_STATUS_TYPE pMineStatus{};
 
-		*pMineStatus = MINE_STATUS_TYPE{};
-
-		pMineStatus->ubMineType = gubMineTypes[ ubMineIndex ];
-		pMineStatus->uiMaxRemovalRate = guiMinimumMineProduction[ ubMineIndex ];
-		pMineStatus->fEmpty = (pMineStatus->uiMaxRemovalRate == 0) ? TRUE : FALSE;
-		pMineStatus->fRunningOut = FALSE;
-		pMineStatus->fWarnedOfRunningOut = FALSE;
-		pMineStatus->fShutDown = FALSE;
-		pMineStatus->fPrevInvadedByMonsters = FALSE;
-		pMineStatus->fSpokeToHeadMiner = FALSE;
-		pMineStatus->fMineHasProducedForPlayer = FALSE;
-		pMineStatus->fQueenRetookProducingMine = FALSE;
-		pMineStatus->fShutDownIsPermanent = FALSE;
+		pMineStatus.ubMineType = mine->mineType;//gubMineTypes[ubMineIndex];
+		pMineStatus.uiMaxRemovalRate = mine->minimumMineProduction; //guiMinimumMineProduction[ubMineIndex];
+		pMineStatus.fEmpty = (pMineStatus.uiMaxRemovalRate == 0) ? TRUE : FALSE;
+		gMineStatus.push_back(pMineStatus);
 	}
 
 	// randomize the exact size each mine.  The total production is always the same and depends on the game difficulty,
@@ -140,16 +102,17 @@ void InitializeMines( void )
 			return;
 	}
 
+	auto minesData = GCM->getMines();
 	while (ubMineProductionIncreases > 0)
 	{
 		// pick a producing mine at random and increase its production
 		do
 		{
-			ubMineIndex = ( UINT8 ) Random(MAX_NUMBER_OF_MINES);
+			ubMineIndex = ( UINT8 ) Random(minesData.size());
 		} while (gMineStatus[ubMineIndex].fEmpty);
 
 		// increase mine production by 20% of the base (minimum) rate
-		gMineStatus[ubMineIndex].uiMaxRemovalRate += (guiMinimumMineProduction[ubMineIndex] / 5);
+		gMineStatus[ubMineIndex].uiMaxRemovalRate += (minesData[ubMineIndex]->minimumMineProduction / 5);
 
 		ubMineProductionIncreases--;
 	}
@@ -158,24 +121,24 @@ void InitializeMines( void )
 	// choose which mine will run out of production.  This will never be the Alma mine or an empty mine (San Mona)...
 	do
 	{
-		ubDepletedMineIndex = ( UINT8 ) Random(MAX_NUMBER_OF_MINES);
-		// Alma mine can't run out for quest-related reasons (see Ian)
-	} while (gMineStatus[ubDepletedMineIndex].fEmpty || (ubDepletedMineIndex == MINE_ALMA));
+		ubDepletedMineIndex = ( UINT8 ) Random(minesData.size());
+		// Try next one if this mine can't run out for quest-related reasons (see Ian)
+	} while (gMineStatus[ubDepletedMineIndex].fEmpty || minesData[ubDepletedMineIndex]->noDepletion);
 
 
-	for( ubMineIndex = 0; ubMineIndex < MAX_NUMBER_OF_MINES; ubMineIndex++ )
+	for( ubMineIndex = 0; ubMineIndex < gMineStatus.size(); ubMineIndex++ )
 	{
 		pMineStatus = &(gMineStatus[ ubMineIndex ]);
 
 		if (ubMineIndex == ubDepletedMineIndex)
 		{
-			if ( ubDepletedMineIndex == MINE_DRASSEN )
+			if (minesData[ubDepletedMineIndex]->delayDepletion)
 			{
-				ubMinDaysBeforeDepletion = 20;
+				ubMinDaysBeforeDepletion = 45;
 			}
 			else
 			{
-				ubMinDaysBeforeDepletion = 10;
+				ubMinDaysBeforeDepletion = 30;
 			}
 
 			// the mine that runs out has only enough ore for this many days of full production
@@ -207,7 +170,7 @@ void HourlyMinesUpdate(void)
 	MINE_STATUS_TYPE *pMineStatus;
 
 	// check every non-empty mine
-	for( ubMineIndex = 0; ubMineIndex < MAX_NUMBER_OF_MINES; ubMineIndex++ )
+	for( ubMineIndex = 0; ubMineIndex < gMineStatus.size(); ubMineIndex++ )
 	{
 		pMineStatus = &(gMineStatus[ ubMineIndex ]);
 
@@ -259,7 +222,7 @@ void HourlyMinesUpdate(void)
 						if ( gubQuest[ QUEST_CREATURES ] == QUESTNOTSTARTED )
 						{
 							// start it now!
-							UINT8 const sector = gMineLocation[ubMineIndex].sector;
+							UINT8 const sector = GCM->getMine(ubMineIndex)->entranceSector;
 							StartQuest(QUEST_CREATURES, SECTORX(sector), SECTORY(sector));
 						}
 					}
@@ -280,7 +243,7 @@ INT32 GetTotalLeftInMine( INT8 bMineIndex )
 {
 	// returns the value of the mine
 
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < MAX_NUMBER_OF_MINES ) );
+	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size() ) );
 
 	return ( gMineStatus[ bMineIndex ].uiRemainingOreSupply );
 }
@@ -290,7 +253,7 @@ UINT32 GetMaxPeriodicRemovalFromMine( INT8 bMineIndex )
 {
 	// returns max amount that can be mined in a time period
 
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < MAX_NUMBER_OF_MINES ) );
+	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
 
 	// if mine is shut down
 	if ( gMineStatus[ bMineIndex ].fShutDown)
@@ -304,7 +267,7 @@ UINT32 GetMaxPeriodicRemovalFromMine( INT8 bMineIndex )
 
 UINT32 GetMaxDailyRemovalFromMine(INT8 const mine_id)
 {
-	Assert(0 <= mine_id && mine_id < MAX_NUMBER_OF_MINES);
+	Assert(0 <= mine_id && mine_id < gMineStatus.size());
 	MINE_STATUS_TYPE const& m = gMineStatus[mine_id];
 
 	if (m.fShutDown) return 0;
@@ -317,16 +280,15 @@ UINT32 GetMaxDailyRemovalFromMine(INT8 const mine_id)
 
 INT8 GetTownAssociatedWithMine( INT8 bMineIndex )
 {
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < MAX_NUMBER_OF_MINES ) );
-
-	return ( gMineLocation[ bMineIndex ].bAssociatedTown );
+	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < GCM->getMines().size() ) );
+	return GCM->getMine(bMineIndex)->associatedTownId;
 }
 
 
 static void AddMineHistoryEvent(UINT8 const event, UINT const mine_id)
 {
-	MINE_LOCATION_TYPE const& m = gMineLocation[mine_id];
-	AddHistoryToPlayersLog(event, m.bAssociatedTown, GetWorldTotalMin(), SECTORX(m.sector), SECTORY(m.sector));
+	auto m = GCM->getMine(mine_id);
+	AddHistoryToPlayersLog(event, m->associatedTownId, GetWorldTotalMin(), SECTORX(m->entranceSector), SECTORY(m->entranceSector));
 }
 
 
@@ -336,7 +298,7 @@ static UINT32 ExtractOreFromMine(INT8 bMineIndex, UINT32 uiAmount)
 	// will remove the ore from the mine and return the amount that was removed
 	UINT32 uiAmountExtracted = 0;
 
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < MAX_NUMBER_OF_MINES ) );
+	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
 
 	// if mine is shut down
 	if ( gMineStatus[ bMineIndex ].fShutDown)
@@ -408,7 +370,8 @@ static INT32 GetAvailableWorkForceForMineForPlayer(INT8 bMineIndex)
 
 	// return the loyalty of the town associated with the mine
 
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < MAX_NUMBER_OF_MINES ) );
+	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
+	auto mine = GCM->getMine(bMineIndex);
 
 	// if mine is shut down
 	if ( gMineStatus[ bMineIndex ].fShutDown)
@@ -423,7 +386,7 @@ static INT32 GetAvailableWorkForceForMineForPlayer(INT8 bMineIndex)
 	}
 
 
-	bTownId = gMineLocation[ bMineIndex ].bAssociatedTown;
+	bTownId = mine->associatedTownId;
 
 	UINT8 numSectors = GetTownSectorSize( bTownId );
 	Assert(numSectors > 0);
@@ -449,7 +412,8 @@ static INT32 GetAvailableWorkForceForMineForEnemy(INT8 bMineIndex)
 
 	// return the loyalty of the town associated with the mine
 
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < MAX_NUMBER_OF_MINES ) );
+	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < GCM->getMines().size()) );
+	auto mine = GCM->getMine(bMineIndex);
 
 	// if mine is shut down
 	if ( gMineStatus[ bMineIndex ].fShutDown)
@@ -457,7 +421,7 @@ static INT32 GetAvailableWorkForceForMineForEnemy(INT8 bMineIndex)
 		return ( 0 );
 	}
 
-	bTownId = gMineLocation[ bMineIndex ].bAssociatedTown;
+	bTownId = mine->associatedTownId;
 
 	UINT8 numSectors = GetTownSectorSize( bTownId );
 	Assert(numSectors > 0);
@@ -505,7 +469,7 @@ static INT32 MineAMine(INT8 bMineIndex)
 	INT32 iAmtExtracted = 0;
 
 
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < MAX_NUMBER_OF_MINES ) );
+	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
 
 	// is mine is empty
 	if( gMineStatus[ bMineIndex ].fEmpty)
@@ -573,7 +537,7 @@ void HandleIncomeFromMines( void )
 {
 	INT32 iIncome = 0;
 	// mine each mine, check if we own it and such
-	for (INT8 bCounter = 0; bCounter < MAX_NUMBER_OF_MINES; ++bCounter)
+	for (INT8 bCounter = 0; bCounter < gMineStatus.size(); ++bCounter)
 	{
 		// mine this mine
 		iIncome += MineAMine(bCounter);
@@ -606,7 +570,7 @@ INT32 PredictIncomeFromPlayerMines( void )
 	INT32 iTotal = 0;
 	INT8 bCounter = 0;
 
-	for( bCounter = 0; bCounter < MAX_NUMBER_OF_MINES; bCounter++ )
+	for( bCounter = 0; bCounter < gMineStatus.size(); bCounter++ )
 	{
 		// add up the total
 		iTotal += PredictDailyIncomeFromAMine( bCounter );
@@ -619,9 +583,9 @@ INT32 PredictIncomeFromPlayerMines( void )
 INT32 CalcMaxPlayerIncomeFromMines()
 {
 	INT32 total = 0;
-	FOR_EACH(MINE_STATUS_TYPE const, i, gMineStatus)
+	for (MINE_STATUS_TYPE i : gMineStatus)
 	{
-		total += MINE_PRODUCTION_NUMBER_OF_PERIODS * i->uiMaxRemovalRate;
+		total += MINE_PRODUCTION_NUMBER_OF_PERIODS * i.uiMaxRemovalRate;
 	}
 	return total;
 }
@@ -629,30 +593,24 @@ INT32 CalcMaxPlayerIncomeFromMines()
 
 INT8 GetMineIndexForSector(UINT8 const sector)
 {
-	for (size_t i = 0; i != lengthof(gMineLocation); ++i)
-	{
-		MINE_LOCATION_TYPE const& m = gMineLocation[i];
-		if (m.sector == sector) return static_cast<INT8>(i);
-	}
-	return -1;
+	return GetIdOfMineForSector(SECTORX(sector), SECTORY(sector), 0);
 }
 
 
 UINT8 GetMineSector(UINT8 const ubMineIndex)
 {
-	Assert(ubMineIndex < MAX_NUMBER_OF_MINES);
-	return gMineLocation[ubMineIndex].sector;
+	Assert(ubMineIndex < gMineStatus.size());
+	return GCM->getMine(ubMineIndex)->entranceSector;
 }
 
 
-// get the sector value for the mine associated with this town
+// get the Strategic Index for the mine associated with this town
 INT16 GetMineSectorForTown(INT8 const town_id)
 {
-	FOR_EACH(MINE_LOCATION_TYPE const, i, gMineLocation)
+	for (auto m : GCM->getMines())
 	{
-		MINE_LOCATION_TYPE const& m = *i;
-		if (m.bAssociatedTown != town_id) continue;
-		return SECTOR_INFO_TO_STRATEGIC_INDEX(m.sector);
+		if (m->associatedTownId != town_id) continue;
+		return SECTOR_INFO_TO_STRATEGIC_INDEX(m->entranceSector);
 	}
 	return -1;
 }
@@ -660,8 +618,9 @@ INT16 GetMineSectorForTown(INT8 const town_id)
 
 bool PlayerControlsMine(INT8 const mine_id)
 {
+	auto mine = GCM->getMine(mine_id);
 	return
-		!StrategicMap[SECTOR_INFO_TO_STRATEGIC_INDEX(gMineLocation[mine_id].sector)].fEnemyControlled &&
+		!StrategicMap[SECTOR_INFO_TO_STRATEGIC_INDEX(mine->entranceSector)].fEnemyControlled &&
 		/* Player only controls the actual mine after he has made arrangements to do
 		 * so with the head miner there. */
 		gMineStatus[mine_id].fSpokeToHeadMiner;
@@ -670,27 +629,27 @@ bool PlayerControlsMine(INT8 const mine_id)
 
 void SaveMineStatusToSaveGameFile(HWFILE const f)
 {
-	FOR_EACH(MINE_STATUS_TYPE const, i, gMineStatus)
+	for (MINE_STATUS_TYPE i : gMineStatus)
 	{
 		BYTE  data[44];
 		DataWriter d{data};
-		INJ_U8(  d, i->ubMineType)
+		INJ_U8(  d, i.ubMineType)
 		INJ_SKIP(d, 3)
-		INJ_U32( d, i->uiMaxRemovalRate)
-		INJ_U32( d, i->uiRemainingOreSupply)
-		INJ_U32( d, i->uiOreRunningOutPoint)
-		INJ_BOOL(d, i->fEmpty)
-		INJ_BOOL(d, i->fRunningOut)
-		INJ_BOOL(d, i->fWarnedOfRunningOut)
-		INJ_BOOL(d, i->fShutDownIsPermanent)
-		INJ_BOOL(d, i->fShutDown)
-		INJ_BOOL(d, i->fPrevInvadedByMonsters)
-		INJ_BOOL(d, i->fSpokeToHeadMiner)
-		INJ_BOOL(d, i->fMineHasProducedForPlayer)
-		INJ_BOOL(d, i->fQueenRetookProducingMine)
-		INJ_BOOL(d, i->fAttackedHeadMiner)
+		INJ_U32( d, i.uiMaxRemovalRate)
+		INJ_U32( d, i.uiRemainingOreSupply)
+		INJ_U32( d, i.uiOreRunningOutPoint)
+		INJ_BOOL(d, i.fEmpty)
+		INJ_BOOL(d, i.fRunningOut)
+		INJ_BOOL(d, i.fWarnedOfRunningOut)
+		INJ_BOOL(d, i.fShutDownIsPermanent)
+		INJ_BOOL(d, i.fShutDown)
+		INJ_BOOL(d, i.fPrevInvadedByMonsters)
+		INJ_BOOL(d, i.fSpokeToHeadMiner)
+		INJ_BOOL(d, i.fMineHasProducedForPlayer)
+		INJ_BOOL(d, i.fQueenRetookProducingMine)
+		INJ_BOOL(d, i.fAttackedHeadMiner)
 		INJ_SKIP(d, 2)
-		INJ_U32( d, i->uiTimePlayerProductionStarted)
+		INJ_U32( d, i.uiTimePlayerProductionStarted)
 		INJ_SKIP(d, 12)
 		Assert(d.getConsumed() == lengthof(data));
 
@@ -701,29 +660,32 @@ void SaveMineStatusToSaveGameFile(HWFILE const f)
 
 void LoadMineStatusFromSavedGameFile(HWFILE const f)
 {
-	FOR_EACH(MINE_STATUS_TYPE, i, gMineStatus)
+	//FOR_EACH(MINE_STATUS_TYPE, i, gMineStatus)
+	// TODO: what if number of mines changed/
+	gMineStatus.resize(GCM->getMines().size());
+	for (auto& i : gMineStatus)
 	{
 		BYTE  data[44];
 		FileRead(f, data, sizeof(data));
 
 		DataReader d{data};
-		EXTR_U8(  d, i->ubMineType)
+		EXTR_U8(  d, i.ubMineType)
 		EXTR_SKIP(d, 3)
-		EXTR_U32( d, i->uiMaxRemovalRate)
-		EXTR_U32( d, i->uiRemainingOreSupply)
-		EXTR_U32( d, i->uiOreRunningOutPoint)
-		EXTR_BOOL(d, i->fEmpty)
-		EXTR_BOOL(d, i->fRunningOut)
-		EXTR_BOOL(d, i->fWarnedOfRunningOut)
-		EXTR_BOOL(d, i->fShutDownIsPermanent)
-		EXTR_BOOL(d, i->fShutDown)
-		EXTR_BOOL(d, i->fPrevInvadedByMonsters)
-		EXTR_BOOL(d, i->fSpokeToHeadMiner)
-		EXTR_BOOL(d, i->fMineHasProducedForPlayer)
-		EXTR_BOOL(d, i->fQueenRetookProducingMine)
-		EXTR_BOOL(d, i->fAttackedHeadMiner)
+		EXTR_U32( d, i.uiMaxRemovalRate)
+		EXTR_U32( d, i.uiRemainingOreSupply)
+		EXTR_U32( d, i.uiOreRunningOutPoint)
+		EXTR_BOOL(d, i.fEmpty)
+		EXTR_BOOL(d, i.fRunningOut)
+		EXTR_BOOL(d, i.fWarnedOfRunningOut)
+		EXTR_BOOL(d, i.fShutDownIsPermanent)
+		EXTR_BOOL(d, i.fShutDown)
+		EXTR_BOOL(d, i.fPrevInvadedByMonsters)
+		EXTR_BOOL(d, i.fSpokeToHeadMiner)
+		EXTR_BOOL(d, i.fMineHasProducedForPlayer)
+		EXTR_BOOL(d, i.fQueenRetookProducingMine)
+		EXTR_BOOL(d, i.fAttackedHeadMiner)
 		EXTR_SKIP(d, 2)
-		EXTR_U32( d, i->uiTimePlayerProductionStarted)
+		EXTR_U32( d, i.uiTimePlayerProductionStarted)
 		EXTR_SKIP(d, 12)
 		Assert(d.getConsumed() == lengthof(data));
 	}
@@ -732,7 +694,7 @@ void LoadMineStatusFromSavedGameFile(HWFILE const f)
 
 void ShutOffMineProduction( INT8 bMineIndex )
 {
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < MAX_NUMBER_OF_MINES ) );
+	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size() ) );
 
 	if ( !gMineStatus[ bMineIndex ].fShutDown )
 	{
@@ -744,7 +706,7 @@ void ShutOffMineProduction( INT8 bMineIndex )
 
 void RestartMineProduction( INT8 bMineIndex )
 {
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < MAX_NUMBER_OF_MINES ) );
+	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
 
 	if ( !gMineStatus[ bMineIndex ].fShutDownIsPermanent )
 	{
@@ -759,7 +721,7 @@ void RestartMineProduction( INT8 bMineIndex )
 
 static void MineShutdownIsPermanent(INT8 bMineIndex)
 {
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < MAX_NUMBER_OF_MINES ) );
+	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
 
 	gMineStatus[ bMineIndex ].fShutDownIsPermanent = TRUE;
 }
@@ -767,7 +729,7 @@ static void MineShutdownIsPermanent(INT8 bMineIndex)
 
 BOOLEAN IsMineShutDown( INT8 bMineIndex )
 {
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < MAX_NUMBER_OF_MINES ) );
+	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
 
 	return(gMineStatus[ bMineIndex ].fShutDown);
 }
@@ -778,15 +740,15 @@ static UINT8 GetHeadMinerIndexForMine(INT8 bMineIndex)
 	UINT8 ubMinerIndex = 0;
 	UINT16 usProfileId = 0;
 
-
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < MAX_NUMBER_OF_MINES ) );
+	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < GCM->getMines().size() ) );
+	auto mine = GCM->getMine(bMineIndex);
 
 	// loop through all head miners, checking which town they're associated with, looking for one that matches this mine
 	for (ubMinerIndex = 0; ubMinerIndex < NUM_HEAD_MINERS; ubMinerIndex++)
 	{
 		usProfileId = gHeadMinerData[ ubMinerIndex ].usProfileId;
 
-		if (gMercProfiles[ usProfileId ].bTown == gMineLocation[ bMineIndex ].bAssociatedTown)
+		if (gMercProfiles[ usProfileId ].bTown == mine->associatedTownId)
 		{
 			return(ubMinerIndex);
 		}
@@ -800,11 +762,12 @@ static UINT8 GetHeadMinerIndexForMine(INT8 bMineIndex)
 
 void IssueHeadMinerQuote(INT8 const mine_idx, HeadMinerQuote const quote_type)
 {
-	Assert(0 <= mine_idx && mine_idx < MAX_NUMBER_OF_MINES);
+	Assert(0 <= mine_idx && mine_idx < GCM->getMines().size());
 	Assert(quote_type < NUM_HEAD_MINER_STRATEGIC_QUOTES);
 	Assert(CheckFact(FACT_MINERS_PLACED, 0));
 
 	HEAD_MINER_TYPE const& miner_data = gHeadMinerData[GetHeadMinerIndexForMine(mine_idx)];
+	auto mineData = GCM->getMine(mine_idx);
 
 	// Make sure the miner isn't dead
 	MERCPROFILESTRUCT const& p = GetProfile(miner_data.usProfileId);
@@ -825,19 +788,11 @@ void IssueHeadMinerQuote(INT8 const mine_idx, HeadMinerQuote const quote_type)
 	 * not obscure the mine he's in as it flashes */
 	INT16 const x = DEFAULT_EXTERN_PANEL_X_POS;
 	INT16       y = DEFAULT_EXTERN_PANEL_Y_POS;
-	switch (mine_idx)
+	if (mineData->faceDisplayYOffset)
 	{
-		case MINE_GRUMM:    break;
-		case MINE_CAMBRIA:  break;
-		case MINE_ALMA:     break;
-		case MINE_DRASSEN:  y = STD_SCREEN_Y + 135; break;
-		case MINE_CHITZENA: y = STD_SCREEN_Y + 117; break;
-
-		case MINE_SAN_MONA: // There's no head miner in San Mona, this is an error!
-		default:
-			Assert(FALSE);
-			break;
+		y = STD_SCREEN_Y + mineData->faceDisplayYOffset;
 	}
+
 	SetExternMapscreenSpeechPanelXY(x, y);
 
 	/* Cause this quote to come up for this profile id and an indicator to flash
@@ -851,20 +806,18 @@ void IssueHeadMinerQuote(INT8 const mine_idx, HeadMinerQuote const quote_type)
 
 UINT8 GetHeadMinersMineIndex( UINT8 ubMinerProfileId)
 {
-	UINT8 ubMineIndex;
-
 	// find which mine this guy represents
-	for( ubMineIndex = 0; ubMineIndex < MAX_NUMBER_OF_MINES; ubMineIndex++ )
+	for (auto mine : GCM->getMines())
 	{
-		if (gMineLocation[ ubMineIndex ].bAssociatedTown == gMercProfiles[ ubMinerProfileId ].bTown)
+		if (mine->associatedTownId == gMercProfiles[ubMinerProfileId].bTown)
 		{
-			return(ubMineIndex);
+			return mine->mineId;
 		}
 	}
 
-	// not found!  Illegal profile id receieved or something is very wrong
-	Assert(FALSE);
-	return( 0 );
+	// not found!
+	SLOGA("Illegal profile id receieved or something is very wrong");
+	return 0;
 }
 
 
@@ -901,11 +854,10 @@ BOOLEAN IsHisMineEmpty( UINT8 ubMinerProfileId )
 
 BOOLEAN IsHisMineDisloyal( UINT8 ubMinerProfileId )
 {
-	UINT8 ubMineIndex;
+	UINT8 ubMineIndex = GetHeadMinersMineIndex( ubMinerProfileId );
+	UINT8 ubAssociatedTown = GCM->getMine(ubMineIndex)->associatedTownId;
 
-	ubMineIndex = GetHeadMinersMineIndex( ubMinerProfileId );
-
-	if (gTownLoyalty[ gMineLocation[ ubMineIndex ].bAssociatedTown ].ubRating < LOW_MINE_LOYALTY_THRESHOLD)
+	if (gTownLoyalty[ubAssociatedTown].ubRating < LOW_MINE_LOYALTY_THRESHOLD)
 	{
 		// pretty disloyal
 		return(TRUE);
@@ -971,7 +923,7 @@ BOOLEAN IsHisMineAtMaxProduction( UINT8 ubMinerProfileId )
 
 void QueenHasRegainedMineSector(INT8 bMineIndex)
 {
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < MAX_NUMBER_OF_MINES ) );
+	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
 
 	if (gMineStatus[ bMineIndex ].fMineHasProducedForPlayer)
 	{
@@ -985,7 +937,7 @@ BOOLEAN HasAnyMineBeenAttackedByMonsters(void)
 	UINT8 ubMineIndex;
 
 	// find which mine this guy represents
-	for( ubMineIndex = 0; ubMineIndex < MAX_NUMBER_OF_MINES; ubMineIndex++ )
+	for( ubMineIndex = 0; ubMineIndex < gMineStatus.size(); ubMineIndex++ )
 	{
 		if (!MineClearOfMonsters( ubMineIndex ) || gMineStatus[ ubMineIndex ].fPrevInvadedByMonsters)
 		{
@@ -1041,37 +993,12 @@ BOOLEAN HasHisMineBeenProducingForPlayerForSomeTime( UINT8 ubMinerProfileId )
 
 INT8 GetIdOfMineForSector(INT16 const x, INT16 const y, INT8 const z)
 {
-	UINT8 const sector = SECTOR(x, y);
-	switch (z)
+	auto mine = GCM->getMineForSector(x, y, z);
+	if (mine != NULL)
 	{
-		case 0:
-			return GetMineIndexForSector(sector);
-
-		case 1:
-			switch (sector)
-			{
-				case SEC_H3:
-				case SEC_I3:  return MINE_GRUMM;
-				case SEC_H8:
-				case SEC_H9:  return MINE_CAMBRIA;
-				case SEC_I14:
-				case SEC_J14: return MINE_ALMA;
-				case SEC_D13:
-				case SEC_E13: return MINE_DRASSEN;
-				case SEC_B2:  return MINE_CHITZENA;
-				case SEC_D4:
-				case SEC_D5:  return MINE_SAN_MONA;
-			}
-			break;
-
-		case 2:
-			switch (sector)
-			{
-				case SEC_I3:
-				case SEC_H3:
-				case SEC_H4: return MINE_GRUMM;
-			}
+		return mine->mineId;
 	}
+
 	return -1;
 }
 
@@ -1082,7 +1009,7 @@ BOOLEAN AreThereMinersInsideThisMine( UINT8 ubMineIndex )
 	MINE_STATUS_TYPE *pMineStatus;
 
 
-	Assert(ubMineIndex < MAX_NUMBER_OF_MINES);
+	Assert(ubMineIndex < gMineStatus.size());
 
 	pMineStatus = &(gMineStatus[ ubMineIndex ]);
 

--- a/src/game/Strategic/Strategic_Mines.cc
+++ b/src/game/Strategic/Strategic_Mines.cc
@@ -660,8 +660,8 @@ void SaveMineStatusToSaveGameFile(HWFILE const f)
 
 void LoadMineStatusFromSavedGameFile(HWFILE const f)
 {
-	//FOR_EACH(MINE_STATUS_TYPE, i, gMineStatus)
-	// TODO: what if number of mines changed/
+	// Save game breaks if the number of mines changes, as we do not
+	// store the number of mines when the game was saved.
 	gMineStatus.resize(GCM->getMines().size());
 	for (auto& i : gMineStatus)
 	{

--- a/src/game/Strategic/Strategic_Mines.cc
+++ b/src/game/Strategic/Strategic_Mines.cc
@@ -78,8 +78,8 @@ void InitializeMines( void )
 	{
 		MINE_STATUS_TYPE pMineStatus{};
 
-		pMineStatus.ubMineType = mine->mineType;//gubMineTypes[ubMineIndex];
-		pMineStatus.uiMaxRemovalRate = mine->minimumMineProduction; //guiMinimumMineProduction[ubMineIndex];
+		pMineStatus.ubMineType = mine->mineType;
+		pMineStatus.uiMaxRemovalRate = mine->minimumMineProduction;
 		pMineStatus.fEmpty = (pMineStatus.uiMaxRemovalRate == 0) ? TRUE : FALSE;
 		gMineStatus.push_back(pMineStatus);
 	}

--- a/src/game/Strategic/Strategic_Mines.cc
+++ b/src/game/Strategic/Strategic_Mines.cc
@@ -243,7 +243,7 @@ INT32 GetTotalLeftInMine( INT8 bMineIndex )
 {
 	// returns the value of the mine
 
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size() ) );
+	Assert(bMineIndex >= 0 && bMineIndex < gMineStatus.size());
 
 	return ( gMineStatus[ bMineIndex ].uiRemainingOreSupply );
 }
@@ -253,7 +253,7 @@ UINT32 GetMaxPeriodicRemovalFromMine( INT8 bMineIndex )
 {
 	// returns max amount that can be mined in a time period
 
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
+	Assert(bMineIndex >= 0 && bMineIndex < gMineStatus.size());
 
 	// if mine is shut down
 	if ( gMineStatus[ bMineIndex ].fShutDown)
@@ -298,7 +298,7 @@ static UINT32 ExtractOreFromMine(INT8 bMineIndex, UINT32 uiAmount)
 	// will remove the ore from the mine and return the amount that was removed
 	UINT32 uiAmountExtracted = 0;
 
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
+	Assert(bMineIndex >= 0 && bMineIndex < gMineStatus.size());
 
 	// if mine is shut down
 	if ( gMineStatus[ bMineIndex ].fShutDown)
@@ -370,7 +370,7 @@ static INT32 GetAvailableWorkForceForMineForPlayer(INT8 bMineIndex)
 
 	// return the loyalty of the town associated with the mine
 
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
+	Assert(bMineIndex >= 0 && bMineIndex < gMineStatus.size());
 	auto mine = GCM->getMine(bMineIndex);
 
 	// if mine is shut down
@@ -469,7 +469,7 @@ static INT32 MineAMine(INT8 bMineIndex)
 	INT32 iAmtExtracted = 0;
 
 
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
+	Assert(bMineIndex >= 0 && bMineIndex < gMineStatus.size());
 
 	// is mine is empty
 	if( gMineStatus[ bMineIndex ].fEmpty)
@@ -694,7 +694,7 @@ void LoadMineStatusFromSavedGameFile(HWFILE const f)
 
 void ShutOffMineProduction( INT8 bMineIndex )
 {
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size() ) );
+	Assert(bMineIndex >= 0 && bMineIndex < gMineStatus.size());
 
 	if ( !gMineStatus[ bMineIndex ].fShutDown )
 	{
@@ -706,7 +706,7 @@ void ShutOffMineProduction( INT8 bMineIndex )
 
 void RestartMineProduction( INT8 bMineIndex )
 {
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
+	Assert(bMineIndex >= 0 && bMineIndex < gMineStatus.size());
 
 	if ( !gMineStatus[ bMineIndex ].fShutDownIsPermanent )
 	{
@@ -721,7 +721,7 @@ void RestartMineProduction( INT8 bMineIndex )
 
 static void MineShutdownIsPermanent(INT8 bMineIndex)
 {
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
+	Assert(bMineIndex >= 0 && bMineIndex < gMineStatus.size());
 
 	gMineStatus[ bMineIndex ].fShutDownIsPermanent = TRUE;
 }
@@ -729,7 +729,7 @@ static void MineShutdownIsPermanent(INT8 bMineIndex)
 
 BOOLEAN IsMineShutDown( INT8 bMineIndex )
 {
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
+	Assert(bMineIndex >= 0 && bMineIndex < gMineStatus.size());
 
 	return(gMineStatus[ bMineIndex ].fShutDown);
 }
@@ -923,7 +923,7 @@ BOOLEAN IsHisMineAtMaxProduction( UINT8 ubMinerProfileId )
 
 void QueenHasRegainedMineSector(INT8 bMineIndex)
 {
-	Assert( ( bMineIndex >= 0 ) && ( bMineIndex < gMineStatus.size()) );
+	Assert(bMineIndex >= 0 && bMineIndex < gMineStatus.size());
 
 	if (gMineStatus[ bMineIndex ].fMineHasProducedForPlayer)
 	{

--- a/src/game/Strategic/Strategic_Mines.h
+++ b/src/game/Strategic/Strategic_Mines.h
@@ -46,13 +46,7 @@ enum HeadMinerQuote
 };
 
 
-// the strategic mine structures
-struct MINE_LOCATION_TYPE
-{
-	UINT8 sector;          // Sector the mine is in
-	INT8  bAssociatedTown; // Associated town of this mine
-};
-
+// the strategic mine structures	
 struct MINE_STATUS_TYPE
 {
 	UINT8    ubMineType;								// type of mine (silver or gold)
@@ -163,7 +157,6 @@ BOOLEAN AreThereMinersInsideThisMine( UINT8 ubMineIndex );
 // use this to determine whether or not the player has spoken to a head miner
 BOOLEAN SpokenToHeadMiner( UINT8 ubMineIndex );
 
-extern MINE_LOCATION_TYPE const gMineLocation[MAX_NUMBER_OF_MINES];
-extern MINE_STATUS_TYPE         gMineStatus[MAX_NUMBER_OF_MINES];
+extern std::vector<MINE_STATUS_TYPE> gMineStatus;
 
 #endif


### PR DESCRIPTION
For #665, so we can customize mines, incomes, etc. Head miners are not covered in this PR.

## Externalized data

- Mine sectors - surface and underground (`gMineLocation`, GetIdOfMineForSector)
- Mine income   (`guiMinimumMineProduction`)
- Town ID (`gMineLocation`)
- Other misc attributes such as mineral type (`gubMineTypes`), and some special attributes mentioned below

## Generalizations

1. `mineId == MINE_SAN_MONA` => `mine.isAbandoned`
2. `mineId == MINE_ALMA` => `mine.noDepletion` / `mine.headMinerAssigned`
    Alma mine always has Matt as head miner, and is never selected for depletion, due to quests
2. `ubDepletedMineIndex == MINE_DRASSEN`: `mine.delayDepletion`
   If Drassen mine is chosen for depletion, we will delay the depletion. I believe this is for early-game game balance

## Save compatibility

The save file does not carry the number of mines defined. So any change to the number of mines breaks saves. This is checked in validation and noted in JSON,


