### PR TITLE
Fixing head miner assignment

### DIFF
--- a/src/game/Strategic/StrategicMap.cc
+++ b/src/game/Strategic/StrategicMap.cc
@@ -800,7 +800,7 @@ void HandleQuestCodeOnSectorEntry( INT16 sNewSectorX, INT16 sNewSectorY, INT8 bN
 					p.sSectorX = SECTORX(sector);
 					p.sSectorY = SECTORY(sector);
 					p.bSectorZ = 0;
-					p.bTown = thisMine->associatedTownId;
+					p.bTown = ubMine->associatedTownId;
 
 					// mark miner as placed
 					ubRandomMiner[ ubMiner ] = 0;


### PR DESCRIPTION
Bug introduced in #1098. Head miner all assigned to the same (wrong) town ID. 

This affects nightly and master since #1098. 

