### PR TITLE
Externalizing Creature Lairs and Spreading

### DIFF
--- a/assets/externalized/strategic-map-creature-lairs.json
+++ b/assets/externalized/strategic-map-creature-lairs.json
@@ -5,9 +5,9 @@
  *  - lairId:    A unique numeric ID for the lair. Must be an integer greater than zero.
  *  - associatedMineId:    Creature lair must be located and associated with one mine.
  *  - entranceSector:    Where the lair entrance is located. There must be an alternate map file (*_a.dat), which will be activated at lair initialization.
- *  - sectors:    An ordered list of sectors making up the lair, specified as an array of [sector, sectorZ, habitatType]. This list should start with the innermost sector, which is the QUEEN_LAIR. The creatures will spread out outwards. Each sector must have a corresponding map file and defined in strategic-map-underground-sectors.json; "habitatType" must be one of: QUEEN_LAIR, LAIR, LAIR_ENTRANCE, INNER_MINE, OUTER_MINE, FEEDING_GROUNDS or MINE_EXIT. See Creature_Spreading.h for details.
+ *  - sectors:    This should be a consecutive, non-branching, ordered list of underground sectors making up the lair, specified as an array of [sector, sectorZ, habitatType]. This list should start with the innermost sector, which is the QUEEN_LAIR. The creatures will spread out outwards. Each sector must have a corresponding map file and defined in strategic-map-underground-sectors.json; "habitatType" must be one of: QUEEN_LAIR, LAIR, LAIR_ENTRANCE, INNER_MINE, OUTER_MINE, FEEDING_GROUNDS or MINE_EXIT. See Creature_Spreading.h for details.
  *  - warpExit:    Destination for the "Travel to surface?" warp from deep underground
- *  - attackSectors: List of town sectors and enemy insertion. Used by creatures to make town attacks
+ *  - attackSectors: List of town sectors and enemy insertion. Used by creatures to make town attacks. Each entry can have four fields: 1) sector, which should be a nearby town sector; 2) chance, which is an integer weight on how likely the sector is chosen for the next attack; 3) insertionCode: any one from the INSERTION_CODE_* enum but without the prefix, such as "GRIDNO", "NORTH", "CENTER"; 4) insertionGridNo: optional GridNo, required only if the insertionCode is "GRIDNO"
  */
 [
     {

--- a/assets/externalized/strategic-map-creature-lairs.json
+++ b/assets/externalized/strategic-map-creature-lairs.json
@@ -1,0 +1,181 @@
+/*
+ * Defines all the possible Crepitus creature lairs and spreading. There can be at most 1 lair activated in each (Sci-Fi) game.
+ *
+ * Field definitions:
+ *  - lairId:    A unique numeric ID for the lair. Must be an integer greater than zero.
+ *  - associatedMineId:    Creature lair must be located and associated with one mine.
+ *  - entranceSector:    Where the lair entrance is located. There must be an alternate map file (*_a.dat), which will be activated at lair initialization.
+ *  - sectors:    An ordered list of sectors making up the lair, specified as an array of [sector, sectorZ, habitatType]. This list should start with the innermost sector, which is the QUEEN_LAIR. The creatures will spread out outwards. Each sector must have a corresponding map file and defined in strategic-map-underground-sectors.json; "habitatType" must be one of: QUEEN_LAIR, LAIR, LAIR_ENTRANCE, INNER_MINE, OUTER_MINE, FEEDING_GROUNDS or MINE_EXIT. See Creature_Spreading.h for details.
+ *  - warpExit:    Destination for the "Travel to surface?" warp from deep underground
+ *  - attackSectors: List of town sectors and enemy insertion. Used by creatures to make town attacks
+ */
+[
+    {
+        "associatedMineId": 1, // Drassen
+        "lairId": 1,
+        "sectors": [
+            [ "F13", 3, "QUEEN_LAIR" ],
+            [ "G13", 3, "LAIR" ],
+            [ "G13", 2, "LAIR_ENTRANCE" ],
+            [ "F13", 2, "INNER_MINE" ],
+            [ "E13", 2, "INNER_MINE" ],
+            [ "E13", 1, "OUTER_MINE" ],
+            [ "D13", 1, "MINE_EXIT" ]
+        ],
+        "entranceSector": [ "E13", 1 ],
+        "warpExit": {
+            "sector": "D13",
+            "gridNo": 20700
+        },
+        "attackSectors": [
+            {
+                "sector": "D13",
+                "chance": 45,
+                "insertionCode": "GRIDNO",
+                "insertionGridNo": 20703
+            },
+            {
+                "sector": "C13",
+                "chance": 25,
+                "insertionCode": "SOUTH"
+            },
+            {
+                "sector": "B13",
+                "chance": 30,
+                "insertionCode": "SOUTH"
+            }
+        ]
+    },
+    {
+        "lairId": 2,
+        "associatedMineId": 3, // Cambria
+        "sectors": [
+            [ "J8", 3, "QUEEN_LAIR" ],
+            [ "I8", 3, "LAIR" ],
+            [ "H8", 3, "LAIR" ],
+            [ "H8", 2, "LAIR_ENTRANCE" ],
+            [ "H9", 2, "INNER_MINE" ],
+            [ "H9", 1, "OUTER_MINE" ],
+            [ "H8", 1, "MINE_EXIT" ]
+        ],
+        "entranceSector": [ "H9", 1 ],
+        "warpExit": {
+            "sector": "H8",
+            "gridNo": 13002
+        },
+        "attackSectors": [
+            {
+                "sector": "H8",
+                "chance": 35,
+                "insertionCode": "GRIDNO",
+                "insertionGridNo": 13005
+            },
+            {
+                "sector": "G8",
+                "chance": 20,
+                "insertionCode": "SOUTH"
+            },
+            {
+                "sector": "F8",
+                "chance": 15,
+                "insertionCode": "SOUTH"
+            },
+            {
+                "sector": "G9",
+                "chance": 15,
+                "insertionCode": "WEST"
+            },
+            {
+                "sector": "F9",
+                "chance": 15,
+                "insertionCode": "SOUTH"
+            }
+        ]
+    },
+    {
+        "lairId": 3,
+        "associatedMineId": 2, // Alma
+        "sectors": [
+            [ "K13", 3, "QUEEN_LAIR" ],
+            [ "J13", 3, "LAIR" ],
+            [ "J13", 2, "LAIR_ENTRANCE" ],
+            [ "J14", 2, "INNER_MINE" ],
+            [ "J14", 1, "OUTER_MINE" ],
+            [ "I14", 1, "MINE_EXIT" ]
+        ],
+        "entranceSector": [ "J14", 1 ],
+        "warpExit": {
+            "sector": "I14",
+            "gridNo": 9085
+        },
+        "attackSectors": [
+            {
+                "sector": "I14",
+                "chance": 45,
+                "insertionCode": "GRIDNO",
+                "insertionGridNo": 9726
+            },
+            {
+                "sector": "I13",
+                "chance": 20,
+                "insertionCode": "EAST"
+            },
+            {
+                "sector": "H14",
+                "chance": 20,
+                "insertionCode": "SOUTH"
+            },
+            {
+                "sector": "H13",
+                "chance": 15,
+                "insertionCode": "EAST"
+            }
+        ]
+    },
+    {
+        "lairId": 4,
+        "associatedMineId": 5, // Grumm
+        "sectors": [
+            [ "G4", 3, "QUEEN_LAIR" ],
+            [ "H4", 3, "LAIR" ],
+            [ "H4", 2, "LAIR_ENTRANCE" ],
+            [ "H3", 2, "INNER_MINE" ],
+            [ "I3", 2, "INNER_MINE" ],
+            [ "I3", 1, "OUTER_MINE" ],
+            [ "H3", 1, "MINE_EXIT" ]
+        ],
+        "entranceSector": [ "H4", 2 ],
+        "warpExit": {
+            "sector": "H3",
+            "gridNo": 9822
+        },
+        "attackSectors": [
+            {
+                "sector": "H3",
+                "chance": 35,
+                "insertionCode": "GRIDNO",
+                "insertionGridNo": 10303
+            },
+            {
+                "sector": "H2",
+                "chance": 20,
+                "insertionCode": "EAST"
+            },
+            {
+                "sector": "G2",
+                "chance": 15,
+                "insertionCode": "SOUTH"
+            },
+            {
+                "sector": "H1",
+                "chance": 15,
+                "insertionCode": "EAST"
+            },
+            {
+                "sector": "G1",
+                "chance": 15,
+                "insertionCode": "SOUTH"
+            }
+        ]
+    }
+]

--- a/assets/externalized/strategic-mines.json
+++ b/assets/externalized/strategic-mines.json
@@ -13,7 +13,6 @@
  *  - noDepletion:    Mines (Alma in Vanilla) can be set to never deplete, so there will always be head miner giving quest. Defaults to false, so the mine may be randomly chosen for depletion.
  *  - delayDepletion:    If the mine is chosen for depletion, delay it.
  *  - minimumMineProduction:    Production rate (money value per period) of the mine before any random increase.
- *  - isInfestible:    If it can be infected by Crepitus bugs. An infestible mine must have an associated creature lair.
  *  - mineSectors:    List of underground sectors belonging to this mine. Sector defined as: ["<SECTORXY>", <LEVEL>]. These sectors must also be defined in strategic-map-underground-sectors.json.
  *  - faceDisplayYOffset:    Y-offset to the screen position, where the head miner's face and text box should be in order to not obscure the mine he's in as it flashes. See IssueHeadMinerQuote()
  */
@@ -32,7 +31,6 @@
         "associatedTownId": 2,
         "mineType": "SILVER_MINE",
         "delayDepletion": true,
-        "isInfestible": true,
         "minimumMineProduction": 1000,
         "mineSectors": [
             ["D13", 1], ["E13", 1]
@@ -45,7 +43,6 @@
         "mineType": "SILVER_MINE",
         "headMinerAssigned": true, // Matt is always the head miner here
         "noDepletion": true, // Alma mine can't run out for quest-related reasons
-        "isInfestible": true,
         "minimumMineProduction": 1500,
         "mineSectors": [
             ["I14", 1], ["J14", 1]
@@ -55,7 +52,6 @@
         "entranceSector": "H8",
         "associatedTownId": 6,
         "mineType": "SILVER_MINE",
-        "isInfestible": true,
         "minimumMineProduction": 1500,
         "mineSectors": [
             ["H8", 1], ["H9", 1]
@@ -65,7 +61,6 @@
         "entranceSector": "B2",
         "associatedTownId": 12,
         "mineType": "SILVER_MINE",
-        "isInfestible": true,
         "minimumMineProduction": 500,
         "mineSectors": [
             ["B2", 1]
@@ -76,7 +71,6 @@
         "entranceSector": "H3",
         "associatedTownId": 4,
         "mineType": "GOLD_MINE",
-        "isInfestible": true,
         "minimumMineProduction": 2000,
         "mineSectors": [
             ["H3", 1], ["I3", 1],

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -135,7 +135,7 @@ public:
 	virtual const std::vector<const BloodCatPlacementsModel*> & getBloodCatPlacements() const = 0;
 	virtual const std::vector<const BloodCatSpawnsModel*> & getBloodCatSpawns() const = 0;
 	virtual const BloodCatSpawnsModel* getBloodCatSpawnsOfSector(uint8_t sectorId) const = 0;
-	virtual const std::vector<const CreatureLairModel*> getCreatureLairs() const = 0;
+	virtual const std::vector<const CreatureLairModel*>& getCreatureLairs() const = 0;
 	virtual const CreatureLairModel* getCreatureLair(uint8_t lairId) const = 0;
 	virtual const CreatureLairModel* getCreatureLairByMineId(uint8_t mineId) const = 0;
 	virtual const MineModel* getMineForSector(uint8_t sectorX, uint8_t sectorY, uint8_t sectorZ) const = 0;

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -18,6 +18,7 @@
 class ArmyCompositionModel;
 class BloodCatPlacementsModel;
 class BloodCatSpawnsModel;
+class CreatureLairModel;
 class DealerInventory;
 class FactParamsModel;
 class GamePolicy;
@@ -134,6 +135,9 @@ public:
 	virtual const std::vector<const BloodCatPlacementsModel*> & getBloodCatPlacements() const = 0;
 	virtual const std::vector<const BloodCatSpawnsModel*> & getBloodCatSpawns() const = 0;
 	virtual const BloodCatSpawnsModel* getBloodCatSpawnsOfSector(uint8_t sectorId) const = 0;
+	virtual const std::vector<const CreatureLairModel*> getCreatureLairs() const = 0;
+	virtual const CreatureLairModel* getCreatureLair(uint8_t lairId) const = 0;
+	virtual const CreatureLairModel* getCreatureLairByMineId(uint8_t mineId) const = 0;
 	virtual const MineModel* getMineForSector(uint8_t sectorX, uint8_t sectorY, uint8_t sectorZ) const = 0;
 	virtual const MineModel* getMine(uint8_t mineId) const = 0;
 	virtual const std::vector<const MineModel*>& getMines() const = 0;

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -1315,7 +1315,7 @@ const BloodCatSpawnsModel* DefaultContentManager::getBloodCatSpawnsOfSector(uint
 	return NULL;
 }
 
-const std::vector<const CreatureLairModel*> DefaultContentManager::getCreatureLairs() const
+const std::vector<const CreatureLairModel*>& DefaultContentManager::getCreatureLairs() const
 {
 	return m_creatureLairs;
 }

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -33,6 +33,7 @@
 #include "policy/DefaultIMPPolicy.h"
 #include "strategic/BloodCatPlacementsModel.h"
 #include "strategic/BloodCatSpawnsModel.h"
+#include "strategic/CreatureLairModel.h"
 #include "strategic/FactParamsModel.h"
 #include "strategic/MineModel.h"
 #include "strategic/SamSiteModel.h"
@@ -311,6 +312,7 @@ DefaultContentManager::~DefaultContentManager()
 
 	deleteElements(m_bloodCatPlacements);
 	deleteElements(m_bloodCatSpawns);
+	deleteElements(m_creatureLairs);
 	deleteElements(m_factParams);
 	deleteElements(m_mines);
 	deleteElements(m_npcActionParams);
@@ -1205,6 +1207,15 @@ bool DefaultContentManager::loadStrategicLayerData() {
 	}
 	delete json;
 
+	json = readJsonDataFile("strategic-map-creature-lairs.json");
+	for (auto& element : json->GetArray())
+	{
+		m_creatureLairs.push_back(
+			CreatureLairModel::deserialize(element)
+		);
+	}
+	delete json;
+
 	json = readJsonDataFile("strategic-fact-params.json");
 	for (auto& element : json->GetArray())
 	{
@@ -1265,6 +1276,7 @@ bool DefaultContentManager::loadStrategicLayerData() {
 	}
 	delete json;
 
+	CreatureLairModel::validateData(m_creatureLairs, m_undergroundSectors, m_mines.size());
 	return true;
 }
 
@@ -1298,6 +1310,35 @@ const BloodCatSpawnsModel* DefaultContentManager::getBloodCatSpawnsOfSector(uint
 		if ( spawns->sectorId == sectorId )
 		{
 			return spawns;
+		}
+	}
+	return NULL;
+}
+
+const std::vector<const CreatureLairModel*> DefaultContentManager::getCreatureLairs() const
+{
+	return m_creatureLairs;
+}
+
+const CreatureLairModel* DefaultContentManager::getCreatureLair(uint8_t lairId) const
+{
+	for (auto lair : m_creatureLairs)
+	{
+		if (lair->lairId == lairId)
+		{
+			return lair;
+		}
+	}
+	return NULL;
+}
+
+const CreatureLairModel* DefaultContentManager::getCreatureLairByMineId(uint8_t mineId) const
+{
+	for (auto lair : m_creatureLairs)
+	{
+		if (lair->associatedMineId == mineId) 
+		{
+			return lair;
 		}
 	}
 	return NULL;

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -159,7 +159,7 @@ public:
 	virtual const std::vector<const BloodCatPlacementsModel*>& getBloodCatPlacements() const override;
 	virtual const std::vector<const BloodCatSpawnsModel*>& getBloodCatSpawns() const override;
 	virtual const BloodCatSpawnsModel* getBloodCatSpawnsOfSector(uint8_t sectorId) const override;
-	virtual const std::vector<const CreatureLairModel*> getCreatureLairs() const override;
+	virtual const std::vector<const CreatureLairModel*>& getCreatureLairs() const override;
 	virtual const CreatureLairModel* getCreatureLair(uint8_t lairId) const override;
 	virtual const CreatureLairModel* getCreatureLairByMineId(uint8_t mineId) const override;
 	virtual const MineModel* getMineForSector(uint8_t sectorX, uint8_t sectorY, uint8_t sectorZ) const override;

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -159,6 +159,9 @@ public:
 	virtual const std::vector<const BloodCatPlacementsModel*>& getBloodCatPlacements() const override;
 	virtual const std::vector<const BloodCatSpawnsModel*>& getBloodCatSpawns() const override;
 	virtual const BloodCatSpawnsModel* getBloodCatSpawnsOfSector(uint8_t sectorId) const override;
+	virtual const std::vector<const CreatureLairModel*> getCreatureLairs() const override;
+	virtual const CreatureLairModel* getCreatureLair(uint8_t lairId) const override;
+	virtual const CreatureLairModel* getCreatureLairByMineId(uint8_t mineId) const override;
 	virtual const MineModel* getMineForSector(uint8_t sectorX, uint8_t sectorY, uint8_t sectorZ) const override;
 	virtual const MineModel* getMine(uint8_t mineId) const override;
 	virtual const std::vector<const MineModel*>& getMines() const override;
@@ -226,6 +229,7 @@ protected:
 
 	std::vector<const BloodCatPlacementsModel*> m_bloodCatPlacements;
 	std::vector<const BloodCatSpawnsModel*> m_bloodCatSpawns;
+	std::vector<const CreatureLairModel*> m_creatureLairs;
 	std::vector<const MineModel*> m_mines;
 	std::vector<const SamSiteModel*> m_samSites;
 	std::map<int8_t, const TownModel*> m_towns;

--- a/src/externalized/strategic/CMakeLists.txt
+++ b/src/externalized/strategic/CMakeLists.txt
@@ -4,6 +4,7 @@ set(JA2_SOURCES
     ${LOCAL_JA2_HEADERS}
     ${CMAKE_CURRENT_SOURCE_DIR}/BloodCatPlacementsModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/BloodCatSpawnsModel.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/CreatureLairModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/FactParamsModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/MineModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/MovementCostsModel.cc

--- a/src/externalized/strategic/CreatureLairModel.cc
+++ b/src/externalized/strategic/CreatureLairModel.cc
@@ -1,0 +1,259 @@
+#include "CreatureLairModel.h"
+
+#include "Campaign_Types.h"
+#include "Creature_Spreading.h"
+#include "Random.h"
+#include <set>
+
+
+CreatureLairModel::CreatureLairModel(const uint8_t lairId_, const uint8_t associatedMineId_, const uint8_t entranceSector_, const uint8_t entranceSectorLevel_, const std::vector<CreatureLairSector> lairSectors_, const std::vector<CreatureAttackSector> attackSectors_, const uint8_t warpExitSector_, const uint16_t warpExitGridNo_)
+	: lairId(lairId_), associatedMineId(associatedMineId_), 
+	entranceSector(entranceSector_), entranceSectorLevel(entranceSectorLevel_), 
+	lairSectors(lairSectors_), attackSectors(attackSectors_),
+	warpExitSector(warpExitSector_), warpExitGridNo(warpExitGridNo_) {}
+
+uint8_t creatureHabitatFromString(std::string habitat)
+{
+	if (habitat == "QUEEN_LAIR") return QUEEN_LAIR;
+	if (habitat == "LAIR") return LAIR;
+	if (habitat == "LAIR_ENTRANCE") return LAIR_ENTRANCE;
+	if (habitat == "INNER_MINE") return INNER_MINE;
+	if (habitat == "OUTER_MINE") return OUTER_MINE;
+	if (habitat == "FEEDING_GROUNDS") return FEEDING_GROUNDS;
+	if (habitat == "MINE_EXIT") return MINE_EXIT;
+
+	SLOGE(ST::format("Unrecognized creature habitat: '{}'", habitat));
+	throw std::runtime_error("");
+}
+
+InsertionCode insertionCodeFromString(std::string code)
+{
+	if (code == "NORTH") return INSERTION_CODE_NORTH;
+	if (code == "SOUTH") return INSERTION_CODE_SOUTH;
+	if (code == "EAST") return INSERTION_CODE_EAST;
+	if (code == "WEST") return INSERTION_CODE_WEST;
+	if (code == "GRIDNO") return INSERTION_CODE_GRIDNO;
+	if (code == "ARRIVING_GAME") return INSERTION_CODE_ARRIVING_GAME;
+	if (code == "CHOPPER") return INSERTION_CODE_CHOPPER;
+	if (code == "PRIMARY_EDGEINDEX") return INSERTION_CODE_PRIMARY_EDGEINDEX;
+	if (code == "SECONDARY_EDGEINDEX") return INSERTION_CODE_SECONDARY_EDGEINDEX;
+	if (code == "CENTER") return INSERTION_CODE_CENTER;
+
+	SLOGE(ST::format("Unrecognized insertion code: '{}'", code));
+	throw std::runtime_error("");
+}
+
+std::vector<CreatureLairSector> readLairSectors(const rapidjson::Value& json)
+{
+	std::vector<CreatureLairSector> sectors;
+	for (auto& el : json.GetArray())
+	{
+		auto arr = el.GetArray();
+		auto sectorString = arr[0].GetString();
+		if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
+		{
+			throw new std::runtime_error("Creature lair sector is invalid");
+		}
+
+		CreatureLairSector sec = {};
+		sec.sectorId = SECTOR_FROM_SECTOR_SHORT_STRING(sectorString);
+		sec.sectorLevel = arr[1].GetUint();
+		sec.habitatType = creatureHabitatFromString(arr[2].GetString());
+
+		sectors.push_back(sec);
+	}
+
+	if (sectors.size() == 0)
+	{
+		SLOGE(ST::format("Lair has no lair sectors"));
+		throw std::runtime_error("");
+	}
+
+	return sectors;
+}
+
+std::vector<CreatureAttackSector> readAttackSectors(const rapidjson::Value& json)
+{
+	std::vector<CreatureAttackSector> attacks;
+	for (auto& el : json.GetArray())
+	{
+		JsonObjectReader obj(el);
+
+		auto sectorString = obj.GetString("sector");
+		if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
+		{
+			throw new std::runtime_error("Creature attack sector is invalid");
+		}
+
+		CreatureAttackSector sectorAttack;
+		sectorAttack.chance = obj.GetUInt("chance");
+		sectorAttack.insertionCode = insertionCodeFromString(obj.GetString("insertionCode"));
+		sectorAttack.insertionGridNo = obj.getOptionalInt("insertionGridNo");
+		sectorAttack.sectorId = SECTOR_FROM_SECTOR_SHORT_STRING(sectorString);
+		attacks.push_back(sectorAttack);
+	}
+
+	if (attacks.size() == 0)
+	{
+		SLOGE(ST::format("Lair has no town attack sectors"));
+		throw std::runtime_error("");
+	}
+
+	return attacks;
+}
+
+bool CreatureLairModel::isSectorInLair(uint8_t sectorX, uint8_t sectorY, uint8_t sectorZ) const
+{
+	uint8_t sectorId = SECTOR(sectorX, sectorY);
+	for (auto sec : lairSectors)
+	{
+		if (sec.sectorId == sectorId && sec.sectorLevel == sectorZ)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+const CreatureAttackSector* CreatureLairModel::chooseTownSectorToAttack() const
+{
+	unsigned int totalChance = 0;
+	for (auto sec : attackSectors)
+	{
+		totalChance += sec.chance;
+	}
+
+	int random = Random(totalChance);
+	for (auto& sec : attackSectors)
+	{
+		random -= sec.chance;
+		if (random < 0)
+		{
+			return &sec;
+		}
+	}
+
+	SLOGA("Some coding error with the random selection logic. We should never reach here");
+	return NULL;
+}
+
+const CreatureAttackSector* CreatureLairModel::getTownAttackDetails(uint8_t sectorId) const
+{
+	for (auto& sec : attackSectors)
+	{
+		if (sec.sectorId == sectorId) 
+		{
+			return &sec;
+		}
+	}
+	return NULL;
+}
+
+CreatureLairModel* CreatureLairModel::deserialize(const rapidjson::Value& json)
+{
+	JsonObjectReader obj(json);
+
+	auto entrance = json["entranceSector"].GetArray();
+	auto sectorString = entrance[0].GetString();
+	if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
+	{
+		throw new std::runtime_error("Entrance sector is invalid");
+	}
+	uint8_t entranceSector = SECTOR_FROM_SECTOR_SHORT_STRING(sectorString);
+	uint8_t entranceSectorLevel = entrance[1].GetUint();
+
+	auto warpExit = JsonObjectReader(json["warpExit"]);
+	sectorString = warpExit.GetString("sector");
+	if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
+	{
+		throw new std::runtime_error("Warp exit sector is invalid");
+	}
+	uint8_t warpExitSector = SECTOR_FROM_SECTOR_SHORT_STRING(sectorString);
+	uint16_t warpExitGridNo = warpExit.GetUInt("gridNo");
+
+	return new CreatureLairModel(
+		obj.GetUInt("lairId"),
+		obj.GetUInt("associatedMineId"),
+		entranceSector, entranceSectorLevel,
+		readLairSectors(json["sectors"]),
+		readAttackSectors(json["attackSectors"]),
+		warpExitSector, warpExitGridNo
+	);
+}
+
+void CreatureLairModel::validateData(const std::vector<const CreatureLairModel*> lairs, const std::vector<const UndergroundSectorModel*> ugSectors, const uint8_t numMines)
+{
+	std::set<uint8_t> distinctLairIds;
+	for (auto lair : lairs)
+	{
+		// checkd for valid lairId, 0 is reserved
+		if (lair->lairId < 1)
+		{
+			SLOGE(ST::format("lairID {} is invalid. Must be greater than 0"));
+			throw std::runtime_error("");
+		}
+
+		// make sure we do not define the same lairId more than once
+		if (distinctLairIds.find(lair->lairId) != distinctLairIds.end())
+		{
+			SLOGE(ST::format("lairID {} is already defined before"));
+			throw std::runtime_error("");
+		}
+		distinctLairIds.insert(lair->lairId);
+
+		// if the mineId is valid
+		if (lair->associatedMineId > numMines)
+		{
+			SLOGE(ST::format("Invalid mineId {}", lair->associatedMineId));
+			throw std::runtime_error("");
+		}
+		
+		// The first lair sector in list should be QUEEN_LAIR
+		if (lair->lairSectors.size() < 1 || lair->lairSectors[0].habitatType != QUEEN_LAIR)
+		{
+			SLOGW(ST::format("The list of lair sectors should be non-empty and begins with the QUEEN_LAIR. Lair ID: {}", lair->lairId));
+		}
+
+		// all lair sectors should be adjacent and defined as underground sector
+		int8_t x = 0, y = 0, z = -1;
+		for (auto sec : lair->lairSectors)
+		{
+			if (z != -1)
+			{
+				int distance = abs(SECTORX(sec.sectorId) - x) + abs(SECTORY(sec.sectorId) - y) + abs(sec.sectorLevel - z);
+				if (distance != 1)
+				{
+					SLOGW(ST::format("The current lair sector ({},{}) is not adjacent to the previous. This may indicate data issues", sec.sectorId, sec.sectorLevel));
+				}
+			}
+			x = SECTORX(sec.sectorId);
+			y = SECTORY(sec.sectorId);
+			z = sec.sectorLevel;
+		}
+
+		// all underground sectors must also lbe defined with UndergroundSectorModel
+		bool isDefined = false;
+		for (auto sec : lair->lairSectors)
+		{
+			if (sec.sectorLevel == 0)
+			{
+				SLOGW(ST::format("Lair sector ({}) is not in the underground. There may cause problems.", sec.sectorId));
+				continue;
+			}
+			bool isDefined = false;
+			for (auto ug : ugSectors)
+			{
+				if (ug->sectorId == sec.sectorId && ug->sectorZ == sec.sectorLevel)
+				{
+					isDefined = true;
+					break;
+				}
+			}
+			if (!isDefined)
+			{
+				SLOGE(ST::format("Underground lair sector ({},{}) is not defined as underground sectors. Make sure the data in consistent with strategic-map-underground-sectors.json.", sec.sectorId, sec.sectorLevel));
+				throw std::runtime_error("");
+			}
+		}
+	}
+}

--- a/src/externalized/strategic/CreatureLairModel.cc
+++ b/src/externalized/strategic/CreatureLairModel.cc
@@ -181,7 +181,7 @@ CreatureLairModel* CreatureLairModel::deserialize(const rapidjson::Value& json)
 	);
 }
 
-void CreatureLairModel::validateData(const std::vector<const CreatureLairModel*> lairs, const std::vector<const UndergroundSectorModel*> ugSectors, const uint8_t numMines)
+void CreatureLairModel::validateData(const std::vector<const CreatureLairModel*>& lairs, const std::vector<const UndergroundSectorModel*>& ugSectors, const uint8_t numMines)
 {
 	std::set<uint8_t> distinctLairIds;
 	for (auto lair : lairs)

--- a/src/externalized/strategic/CreatureLairModel.cc
+++ b/src/externalized/strategic/CreatureLairModel.cc
@@ -211,7 +211,7 @@ void CreatureLairModel::validateData(const std::vector<const CreatureLairModel*>
 		// The first lair sector in list should be QUEEN_LAIR
 		if (lair->lairSectors.size() < 1 || lair->lairSectors[0].habitatType != QUEEN_LAIR)
 		{
-			SLOGW(ST::format("The list of lair sectors should be non-empty and begins with the QUEEN_LAIR. Lair ID: {}", lair->lairId));
+			SLOGW(ST::format("The list of lair sectors should be non-empty and begin with the QUEEN_LAIR. Lair ID: {}", lair->lairId));
 		}
 
 		// all lair sectors should be adjacent and defined as underground sector
@@ -231,13 +231,13 @@ void CreatureLairModel::validateData(const std::vector<const CreatureLairModel*>
 			z = sec.sectorLevel;
 		}
 
-		// all underground sectors must also lbe defined with UndergroundSectorModel
+		// all underground sectors must also be defined with UndergroundSectorModel
 		bool isDefined = false;
 		for (auto sec : lair->lairSectors)
 		{
 			if (sec.sectorLevel == 0)
 			{
-				SLOGW(ST::format("Lair sector ({}) is not in the underground. There may cause problems.", sec.sectorId));
+				SLOGW(ST::format("Lair sector ({}) is not in the underground. This may cause problems.", sec.sectorId));
 				continue;
 			}
 			bool isDefined = false;
@@ -251,7 +251,7 @@ void CreatureLairModel::validateData(const std::vector<const CreatureLairModel*>
 			}
 			if (!isDefined)
 			{
-				SLOGE(ST::format("Underground lair sector ({},{}) is not defined as underground sectors. Make sure the data in consistent with strategic-map-underground-sectors.json.", sec.sectorId, sec.sectorLevel));
+				SLOGE(ST::format("Underground lair sector ({},{}) is not defined as an underground sector. Make sure the data is consistent with strategic-map-underground-sectors.json.", sec.sectorId, sec.sectorLevel));
 				throw std::runtime_error("");
 			}
 		}

--- a/src/externalized/strategic/CreatureLairModel.h
+++ b/src/externalized/strategic/CreatureLairModel.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "JsonObject.h"
+#include "Strategic.h"
+#include "UndergroundSectorModel.h"
+
+#include <array>
+#include <rapidjson/document.h>
+#include <string>
+#include <vector>
+
+struct CreatureAttackSector
+{
+        uint8_t sectorId;
+        uint8_t chance;
+        InsertionCode insertionCode;
+        int16_t insertionGridNo;
+};
+
+struct CreatureLairSector
+{
+        uint8_t sectorId;
+        uint8_t sectorLevel;
+        uint8_t habitatType;
+};
+
+class CreatureLairModel
+{
+public:
+        CreatureLairModel(const uint8_t lairId_, const uint8_t associatedMineId_, 
+                const uint8_t entranceSector_, const uint8_t entranceSectorLevel_,
+                const std::vector<CreatureLairSector> lairSectors_,
+                const std::vector<CreatureAttackSector> attackSectors_,
+                const uint8_t warpExitSector_, const uint16_t warpExitGridNo_);
+        
+        const uint8_t lairId;
+        const uint8_t associatedMineId;
+
+        // underground sector where the lair entrance is at
+        const uint8_t entranceSector;
+
+        // sector Z of the lair entrance
+        const uint8_t entranceSectorLevel;
+
+        // underground sectors making up the lair, the list always starts from the innermost sector, i.e. the creature queen location
+        const std::vector<CreatureLairSector> lairSectors;
+
+        // town sectors that may be attacked by creatures
+        const std::vector<CreatureAttackSector> attackSectors;
+
+        // destination sector of the "travel to surface" warp
+        const uint8_t warpExitSector;
+
+        // destination gridNo of the "travel to surface" warp
+        const uint16_t warpExitGridNo;
+
+        // returns if the given sector is part of the lair
+        bool isSectorInLair(uint8_t sectorX, uint8_t sectorY, uint8_t sectorZ) const;
+
+        // randomly choose a town sector to attack, returns the placement details of the attack
+        const CreatureAttackSector* chooseTownSectorToAttack() const;
+
+        // returns the placeent details of an attack to the specific sector
+        const CreatureAttackSector* getTownAttackDetails(uint8_t sectorId) const;
+
+        static CreatureLairModel* deserialize(const rapidjson::Value& json);
+        static void validateData(const std::vector<const CreatureLairModel*> lairs, const std::vector<const UndergroundSectorModel*> ugSectors, uint8_t numMines);
+};

--- a/src/externalized/strategic/CreatureLairModel.h
+++ b/src/externalized/strategic/CreatureLairModel.h
@@ -64,5 +64,5 @@ public:
         const CreatureAttackSector* getTownAttackDetails(uint8_t sectorId) const;
 
         static CreatureLairModel* deserialize(const rapidjson::Value& json);
-        static void validateData(const std::vector<const CreatureLairModel*> lairs, const std::vector<const UndergroundSectorModel*> ugSectors, uint8_t numMines);
+        static void validateData(const std::vector<const CreatureLairModel*>& lairs, const std::vector<const UndergroundSectorModel*>& ugSectors, uint8_t numMines);
 };

--- a/src/externalized/strategic/MineModel.cc
+++ b/src/externalized/strategic/MineModel.cc
@@ -6,11 +6,11 @@
 
 MineModel::MineModel(const uint8_t mineId_, const uint8_t entranceSector_, const uint8_t associatedTownId_, 
 	const uint8_t mineType_, const uint16_t minimumMineProduction_, const bool headMinerAssigned_,
-	const bool noDepletion_, const bool delayDepletion_, const bool isInfestible_,
+	const bool noDepletion_, const bool delayDepletion_,
 	std::vector<std::array<uint8_t, 2>> mineSectors_, const int16_t faceDisplayYOffset_) :
 		mineId(mineId_), entranceSector(entranceSector_), associatedTownId(associatedTownId_),
 		mineType(mineType_), minimumMineProduction(minimumMineProduction_), headMinerAssigned(headMinerAssigned_),
-		noDepletion(noDepletion_), delayDepletion(delayDepletion_), isInfestible(isInfestible_),
+		noDepletion(noDepletion_), delayDepletion(delayDepletion_),
 		mineSectors(mineSectors_), faceDisplayYOffset(faceDisplayYOffset_) {}
 
 bool MineModel::isAbandoned() const
@@ -71,7 +71,6 @@ MineModel* MineModel::deserialize(uint8_t index, const rapidjson::Value& json)
 		obj.getOptionalBool("headMinerAssigned"),
 		obj.getOptionalBool("noDepletion"),
 		obj.getOptionalBool("delayDepletion"),
-		obj.getOptionalBool("isInfestible"),
 		mineSectors,
 		obj.getOptionalInt("faceDisplayYOffset")
 	);

--- a/src/externalized/strategic/MineModel.h
+++ b/src/externalized/strategic/MineModel.h
@@ -10,7 +10,7 @@ class MineModel
 {
 public:
 	MineModel(const uint8_t mineId, const uint8_t entranceSector_, const uint8_t associatedTownId_, const uint8_t mineType_, const uint16_t minimumMineProduction_,
-		const bool headMinerAssigned_, const bool noDepletion_, const bool delayDepletion_, const bool isInfestible_,
+		const bool headMinerAssigned_, const bool noDepletion_, const bool delayDepletion_,
 		const std::vector<std::array<uint8_t, 2>> mineSectors_,
 		const int16_t faceDisplayYOffset);
  
@@ -24,7 +24,6 @@ public:
 	const bool headMinerAssigned;
 	const bool noDepletion;
 	const bool delayDepletion;
-	const bool isInfestible;
 
 	const std::vector<std::array<uint8_t, 2>> mineSectors;
 

--- a/src/externalized/strategic/UndergroundSectorModel.h
+++ b/src/externalized/strategic/UndergroundSectorModel.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "Campaign_Types.h"
 #include "GameSettings.h"
 #include "JA2Types.h"

--- a/src/game/Strategic/Creature_Spreading.h
+++ b/src/game/Strategic/Creature_Spreading.h
@@ -41,6 +41,18 @@ enum{
 	CREATURE_BATTLE_CODE_PREBATTLEINTERFACE,
 	CREATURE_BATTLE_CODE_AUTORESOLVE,
 };
+
+enum
+{
+	QUEEN_LAIR,		//where the queen lives.  Highly protected
+	LAIR,			//part of the queen's lair -- lots of babies and defending mothers
+	LAIR_ENTRANCE,		//where the creatures access the mine.
+	INNER_MINE,		//parts of the mines that aren't close to the outside world
+	OUTER_MINE,		//area's where miners work, close to towns, creatures love to eat :)
+	FEEDING_GROUNDS,	//creatures love to populate these sectors :)
+	MINE_EXIT,		//the area that creatures can initiate town attacks if lots of monsters.
+};
+
 extern UINT8 gubCreatureBattleCode;
 
 void DetermineCreatureTownComposition(UINT8 ubNumCreatures,


### PR DESCRIPTION
Fixes #1087.

See also #1095 and #665.

## Summary

- Extracted JSON data from Creature_Spreading.cc (`strategic-map-creature-lairs.json`)
- Removed `isInfestible` from Mine. It is redundant. The existence of a CreatureLairModel means the same.

### Model fields data

_All data come from Creature_Spreading.cc_

- InitLair`${TOWN}` => `"sectors"`
- InitCreatureQuest: `curr->uiFlags |= SF_PENDING_ALTERNATE_MAP;` => `"entranceSector"`
- ChooseTownSectorToAttack => `"attackSectors"`
- MineClearOfMonsters => MineModel::`mineSectors` (#1098)
- GetWarpOutOfMineCodes => `"warpExit"`

## Does not cover

 - Hard-coded Tixa dungeon references (in StrategicMap.cc, etc)