### PR TITLE
Fixing the Ammo GUI in Editor

### DIFF
--- a/src/game/Editor/Item_Statistics.cc
+++ b/src/game/Editor/Item_Statistics.cc
@@ -714,11 +714,11 @@ static void SetupAmmoGUI(void)
 {
 	ST::string str = ST::format("{}", gpItem->ubNumberOfObjects);
 	AddTextInputField( 485, EDITOR_TASKBAR_POS_Y + 20, 25, 15, MSYS_PRIORITY_NORMAL, str, 1, INPUTTYPE_NUMERICSTRICT );
-	str += ST::format("{}", gpItem->bTrap);
+	str = ST::format("{}", gpItem->bTrap);
 	AddTextInputField( 485, EDITOR_TASKBAR_POS_Y + 40, 25, 15, MSYS_PRIORITY_NORMAL, str, 2, INPUTTYPE_NUMERICSTRICT );
 	if( gpEditingItemPool )
 	{
-		str += ST::format("{}", 100 - GetWorldItem(gpEditingItemPool->iItemIndex).ubNonExistChance);
+		str = ST::format("{}", 100 - GetWorldItem(gpEditingItemPool->iItemIndex).ubNonExistChance);
 		AddTextInputField( 485, EDITOR_TASKBAR_POS_Y + 80, 25, 15, MSYS_PRIORITY_NORMAL, str, 3, INPUTTYPE_NUMERICSTRICT );
 	}
 }

--- a/src/game/Editor/Item_Statistics.cc
+++ b/src/game/Editor/Item_Statistics.cc
@@ -842,7 +842,7 @@ static void SetupEquipGUI(void)
 	AddTextInputField( 485, EDITOR_TASKBAR_POS_Y + 40, 25, 15, MSYS_PRIORITY_NORMAL, str, 2, INPUTTYPE_NUMERICSTRICT );
 	if( gpEditingItemPool )
 	{
-		str += ST::format("{}", 100 - GetWorldItem(gpEditingItemPool->iItemIndex).ubNonExistChance);
+		str = ST::format("{}", 100 - GetWorldItem(gpEditingItemPool->iItemIndex).ubNonExistChance);
 		AddTextInputField( 485, EDITOR_TASKBAR_POS_Y + 80, 25, 15, MSYS_PRIORITY_NORMAL, str, 3, INPUTTYPE_NUMERICSTRICT );
 	}
 }


### PR DESCRIPTION
In master/nightly, the textboxes in Ammo GUI seem to be "overflowing" to the next fields, so that first value is "1" (correct), second value is "10" (expected: 0), third value is "10100" (expected: 100).

Ref: https://github.com/ja2-stracciatella/ja2-stracciatella/commit/ebbe2b9bd1fd7f09f6608a6912c00af67194f9f3#diff-9b758624bbb8452e17a64953641ff01dL715-L720