### PR TITLE
Translations: Fix json syntax in shipping destinations

### DIFF
--- a/assets/externalized/strings/shipping-destinations-fr.json
+++ b/assets/externalized/strings/shipping-destinations-fr.json
@@ -1,19 +1,19 @@
 [
-	"Austin",			//Austin, Texas, USA
-	"Bagdad",			//Baghdad, Iraq (Suddam Hussein's home)
-	"Drassen",			//The main place in JA2 that you can receive items.  The other towns are dummy names...
-	"Hong Kong",		//Hong Kong, Hong Kong
-	"Beyrouth",			//Beirut, Lebanon	(Middle East)
-	"Londres",			//London, England
-	"Los Angeles",	//Los Angeles, California, USA (SW corner of USA)
-	"Meduna",			//Meduna -- the other airport in JA2 that you can receive items.
-	"Metavira",		//The island of Metavira was the fictional location used by JA1
-	"Miami",				//Miami, Florida, USA (SE corner of USA)
-	"Moscou",			//Moscow, USSR
-	"New-York",		//New York, New York, USA
-	"Ottawa",			//Ottawa, Ontario, Canada -- where JA2 was made!
-	"Paris",				//Paris, France
-	"Tripoli",			//Tripoli, Libya (eastern Mediterranean)
-	"Tokyo",				//Tokyo, Japan
-	"Vancouver"		//Vancouver, British Columbia, Canada (west coast near US border)
+	"Austin",      //Austin, Texas, USA
+	"Bagdad",      //Baghdad, Iraq (Suddam Hussein's home)
+	"Drassen",     //The main place in JA2 that you can receive items.  The other towns are dummy names...
+	"Hong Kong",   //Hong Kong, Hong Kong
+	"Beyrouth",    //Beirut, Lebanon	(Middle East)
+	"Londres",     //London, England
+	"Los Angeles", //Los Angeles, California, USA (SW corner of USA)
+	"Meduna",      //Meduna -- the other airport in JA2 that you can receive items.
+	"Metavira",    //The island of Metavira was the fictional location used by JA1
+	"Miami",       //Miami, Florida, USA (SE corner of USA)
+	"Moscou",      //Moscow, USSR
+	"New-York",    //New York, New York, USA
+	"Ottawa",      //Ottawa, Ontario, Canada -- where JA2 was made!
+	"Paris",       //Paris, France
+	"Tripoli",     //Tripoli, Libya (eastern Mediterranean)
+	"Tokyo",       //Tokyo, Japan
+	"Vancouver"    //Vancouver, British Columbia, Canada (west coast near US border)
 ]

--- a/assets/externalized/strings/shipping-destinations-ger.json
+++ b/assets/externalized/strings/shipping-destinations-ger.json
@@ -1,19 +1,19 @@
 [
-	"Austin",			//Austin, Texas, USA
-	"Bagdad",			//Baghdad, Iraq (Suddam Hussein's home)
-	"Drassen",			//The main place in JA2 that you can receive items. The other towns are dummy names...
-	"Hong Kong",		//Hong Kong, Hong Kong
-	"Beirut",			//Beirut, Lebanon	(Middle East)
-	"London",			//London, England
-	"Los Angeles",	//Los Angeles, California, USA (SW corner of USA)
-	"Meduna",			//Meduna -- the other airport in JA2 that you can receive items.
-	"Metavira",		//The island of Metavira was the fictional location used by JA1
-	"Miami",				//Miami, Florida, USA (SE corner of USA)
-	"Moskau",			//Moscow, USSR
-	"New York",		//New York, New York, USA
-	"Ottawa",			//Ottawa, Ontario, Canada -- where JA2 was made!
-	"Paris",				//Paris, France
-	"Tripolis",		//Tripoli, Libya (eastern Mediterranean)
-	"Tokio",				//Tokyo, Japan
-	"Vancouver",		//Vancouver, British Columbia, Canada (west coast near US border)
+	"Austin",      //Austin, Texas, USA
+	"Bagdad",      //Baghdad, Iraq (Suddam Hussein's home)
+	"Drassen",     //The main place in JA2 that you can receive items. The other towns are dummy names...
+	"Hong Kong",   //Hong Kong, Hong Kong
+	"Beirut",      //Beirut, Lebanon	(Middle East)
+	"London",      //London, England
+	"Los Angeles", //Los Angeles, California, USA (SW corner of USA)
+	"Meduna",      //Meduna -- the other airport in JA2 that you can receive items.
+	"Metavira",    //The island of Metavira was the fictional location used by JA1
+	"Miami",       //Miami, Florida, USA (SE corner of USA)
+	"Moskau",      //Moscow, USSR
+	"New York",    //New York, New York, USA
+	"Ottawa",      //Ottawa, Ontario, Canada -- where JA2 was made!
+	"Paris",       //Paris, France
+	"Tripolis",    //Tripoli, Libya (eastern Mediterranean)
+	"Tokio",       //Tokyo, Japan
+	"Vancouver"    //Vancouver, British Columbia, Canada (west coast near US border)
 ]

--- a/assets/externalized/strings/shipping-destinations-it.json
+++ b/assets/externalized/strings/shipping-destinations-it.json
@@ -1,19 +1,19 @@
 [
-	"Austin",			//Austin, Texas, USA
-	"Baghdad",			//Baghdad, Iraq (Suddam Hussein's home)
-	"Drassen",			//The main place in JA2 that you can receive items.  The other towns are dummy names...
-	"Hong Kong",		//Hong Kong, Hong Kong
-	"Beirut",			//Beirut, Lebanon	(Middle East)
-	"Londra",			//London, England
-	"Los Angeles",	//Los Angeles, California, USA (SW corner of USA)
-	"Meduna",			//Meduna -- the other airport in JA2 that you can receive items.
-	"Metavira",		//The island of Metavira was the fictional location used by JA1
-	"Miami",				//Miami, Florida, USA (SE corner of USA)
-	"Mosca",			//Moscow, USSR
-	"New York",		//New York, New York, USA
-	"Ottawa",			//Ottawa, Ontario, Canada -- where JA2 was made!
-	"Parigi",				//Paris, France
-	"Tripoli",			//Tripoli, Libya (eastern Mediterranean)
-	"Tokyo",				//Tokyo, Japan
-	"Vancouver"		//Vancouver, British Columbia, Canada (west coast near US border)
+	"Austin",      //Austin, Texas, USA
+	"Baghdad",     //Baghdad, Iraq (Suddam Hussein's home)
+	"Drassen",     //The main place in JA2 that you can receive items.  The other towns are dummy names...
+	"Hong Kong",   //Hong Kong, Hong Kong
+	"Beirut",      //Beirut, Lebanon	(Middle East)
+	"Londra",      //London, England
+	"Los Angeles", //Los Angeles, California, USA (SW corner of USA)
+	"Meduna",      //Meduna -- the other airport in JA2 that you can receive items.
+	"Metavira",    //The island of Metavira was the fictional location used by JA1
+	"Miami",       //Miami, Florida, USA (SE corner of USA)
+	"Mosca",       //Moscow, USSR
+	"New York",    //New York, New York, USA
+	"Ottawa",      //Ottawa, Ontario, Canada -- where JA2 was made!
+	"Parigi",      //Paris, France
+	"Tripoli",     //Tripoli, Libya (eastern Mediterranean)
+	"Tokyo",       //Tokyo, Japan
+	"Vancouver"    //Vancouver, British Columbia, Canada (west coast near US border)
 ]

--- a/assets/externalized/strings/shipping-destinations-pl.json
+++ b/assets/externalized/strings/shipping-destinations-pl.json
@@ -1,19 +1,19 @@
 [
-	"Austin",			//Austin, Texas, USA
-	"Bagdad",			//Baghdad, Iraq (Suddam Hussein's home)
-	"Drassen",			//The main place in JA2 that you can receive items.  The other towns are dummy names...
-	"Hong Kong",		//Hong Kong, Hong Kong
-	"Bejrut",			//Beirut, Lebanon	(Middle East)
-	"Londyn",			//London, England
-	"Los Angeles",	//Los Angeles, California, USA (SW corner of USA)
-	"Meduna",			//Meduna -- the other airport in JA2 that you can receive items.
-	"Metavira",		//The island of Metavira was the fictional location used by JA1
-	"Miami",				//Miami, Florida, USA (SE corner of USA)
-	"Moskwa",			//Moscow, USSR
-	"Nowy Jork",		//New York, New York, USA
-	"Ottawa",			//Ottawa, Ontario, Canada -- where JA2 was made!
-	"Paryż",				//Paris, France
-	"Trypolis",			//Tripoli, Libya (eastern Mediterranean)
-	"Tokio",				//Tokyo, Japan
-	"Vancouver",		//Vancouver, British Columbia, Canada (west coast near US border)
+	"Austin",      //Austin, Texas, USA
+	"Bagdad",      //Baghdad, Iraq (Suddam Hussein's home)
+	"Drassen",     //The main place in JA2 that you can receive items.  The other towns are dummy names...
+	"Hong Kong",   //Hong Kong, Hong Kong
+	"Bejrut",      //Beirut, Lebanon	(Middle East)
+	"Londyn",      //London, England
+	"Los Angeles", //Los Angeles, California, USA (SW corner of USA)
+	"Meduna",      //Meduna -- the other airport in JA2 that you can receive items.
+	"Metavira",    //The island of Metavira was the fictional location used by JA1
+	"Miami",       //Miami, Florida, USA (SE corner of USA)
+	"Moskwa",      //Moscow, USSR
+	"Nowy Jork",   //New York, New York, USA
+	"Ottawa",      //Ottawa, Ontario, Canada -- where JA2 was made!
+	"Paryż",       //Paris, France
+	"Trypolis",    //Tripoli, Libya (eastern Mediterranean)
+	"Tokio",       //Tokyo, Japan
+	"Vancouver"    //Vancouver, British Columbia, Canada (west coast near US border)
 ]

--- a/assets/externalized/strings/shipping-destinations-rus.json
+++ b/assets/externalized/strings/shipping-destinations-rus.json
@@ -1,19 +1,19 @@
 [
-	"Остин",		//Austin, Texas, USA
-	"Багдад",		//Baghdad, Iraq (Suddam Hussein's home)
-	"Драссен",		//The main place in JA2 that you can receive items.  The other towns are dummy names...
-	"Гонконг",		//Hong Kong, Hong Kong
-	"Бейрут",		//Beirut, Lebanon	(Middle East)
-	"Лондон",		//London, England
+	"Остин",	//Austin, Texas, USA
+	"Багдад",	//Baghdad, Iraq (Suddam Hussein's home)
+	"Драссен",	//The main place in JA2 that you can receive items.  The other towns are dummy names...
+	"Гонконг",	//Hong Kong, Hong Kong
+	"Бейрут",	//Beirut, Lebanon	(Middle East)
+	"Лондон",	//London, England
 	"Лос Анджелес",	//Los Angeles, California, USA (SW corner of USA)
-	"Медуна",		//Meduna -- the other airport in JA2 that you can receive items.
-	"Метавира",		//The island of Metavira was the fictional location used by JA1
-	"Майами",		//Miami, Florida, USA (SE corner of USA)
-	"Москва",		//Moscow, USSR
-	"Нью-Йорк",		//New York, New York, USA
-	"Оттава",		//Ottawa, Ontario, Canada -- where JA2 was made!
-	"Париж",		//Paris, France
-	"Триполи",		//Tripoli, Libya (eastern Mediterranean)
-	"Токио",		//Tokyo, Japan
-	"Ванкувер"		//Vancouver, British Columbia, Canada (west coast near US border)
+	"Медуна",	//Meduna -- the other airport in JA2 that you can receive items.
+	"Метавира",	//The island of Metavira was the fictional location used by JA1
+	"Майами",	//Miami, Florida, USA (SE corner of USA)
+	"Москва",	//Moscow, USSR
+	"Нью-Йорк",	//New York, New York, USA
+	"Оттава",	//Ottawa, Ontario, Canada -- where JA2 was made!
+	"Париж",	//Paris, France
+	"Триполи",	//Tripoli, Libya (eastern Mediterranean)
+	"Токио",	//Tokyo, Japan
+	"Ванкувер"	//Vancouver, British Columbia, Canada (west coast near US border)
 ]


### PR DESCRIPTION
[ERROR] externalized/DefaultContentManager.cc: Failed to parse 'strings/shipping-destinations-ger.json'