### PR TITLE
Adding unit test to parse every JSON in externalized dir

### DIFF
--- a/src/externalized/DefaultContentManagerUT.cc
+++ b/src/externalized/DefaultContentManagerUT.cc
@@ -1,41 +1,39 @@
 #include "DefaultContentManagerUT.h"
 
-#include "GameRes.h"
 #include "sgp/FileMan.h"
-
-#include "externalized/DefaultContentManager.h"
 #include "externalized/TestUtils.h"
 
-class DefaultContentManagerUT : public DefaultContentManager
-{
-public:
-	DefaultContentManagerUT(GameVersion gameVersion,
-				const ST::string& configFolder,
-				const ST::string& gameResRootPath,
-				const ST::string& externalizedDataPath)
-		: DefaultContentManager(gameVersion, configFolder, gameResRootPath, externalizedDataPath)
-	{}
-	virtual void init()
-	{
-		// externalized data is used in the tests
-		if (!Vfs_addDir(m_vfs.get(), VFS_ORDER_STRACCIATELLA, m_externalizedDataPath.c_str()))
-		{
-			RustPointer<char> err{getRustError()};
-			SLOGE(ST::format("DefaultContentManagerUT::init '{}': {}", m_externalizedDataPath, err.get()));
-			throw std::runtime_error("Failed to add stracciatella dir");
-		}
-	}
-};
+DefaultContentManagerUT::DefaultContentManagerUT(GameVersion gameVersion,
+			const ST::string& configFolder,
+			const ST::string& gameResRootPath,
+			const ST::string& externalizedDataPath)
+	: DefaultContentManager(gameVersion, configFolder, gameResRootPath, externalizedDataPath)
+{}
 
-/** Create DefaultContentManager for usage in unit testing. */
-DefaultContentManager * createDefaultCMForTesting()
+void DefaultContentManagerUT::init()
+{
+	// externalized data is used in the tests
+	if (!Vfs_addDir(m_vfs.get(), VFS_ORDER_STRACCIATELLA, m_externalizedDataPath.c_str()))
+	{
+		RustPointer<char> err{getRustError()};
+		SLOGE(ST::format("DefaultContentManagerUT::init '{}': {}", m_externalizedDataPath, err.get()));
+		throw std::runtime_error("Failed to add stracciatella dir");
+	}
+}
+
+rapidjson::Document* DefaultContentManagerUT::_readJsonDataFile(const char* fileName) const
+{
+	return DefaultContentManager::readJsonDataFile(fileName);
+}
+
+DefaultContentManagerUT* DefaultContentManagerUT::createDefaultCMForTesting()
 {
 	ST::string extraDataDir = GetExtraDataDir();
 	ST::string configFolderPath = FileMan::joinPaths(extraDataDir, "unittests");
 	ST::string gameResRootPath = FileMan::joinPaths(extraDataDir, "unittests");
 	ST::string externalizedDataPath = FileMan::joinPaths(extraDataDir, "externalized");
 
-	DefaultContentManager* cm = new DefaultContentManagerUT(GameVersion::ENGLISH,
+	DefaultContentManagerUT* cm = new DefaultContentManagerUT(GameVersion::ENGLISH,
 					configFolderPath,
 					gameResRootPath, externalizedDataPath);
 	cm->init();

--- a/src/externalized/DefaultContentManagerUT.h
+++ b/src/externalized/DefaultContentManagerUT.h
@@ -1,6 +1,20 @@
 #pragma once
 
-class DefaultContentManager;
+#include "GameRes.h"
+#include "externalized/DefaultContentManager.h"
 
-/** Create DefaultContentManager for usage in unit testing. */
-DefaultContentManager * createDefaultCMForTesting();
+class DefaultContentManagerUT : public DefaultContentManager
+{
+public:
+	DefaultContentManagerUT(GameVersion gameVersion, const ST::string& configFolder, const ST::string& gameResRootPath, const ST::string& externalizedDataPath);
+	
+	virtual void init();
+
+	// expose this method to unit tests
+	rapidjson::Document* _readJsonDataFile(const char* fileName) const;
+
+	/** Create DefaultContentManager for usage in unit testing. */
+	static DefaultContentManagerUT* createDefaultCMForTesting();
+};
+
+

--- a/src/externalized/DefaultContentManager_unittests.cc
+++ b/src/externalized/DefaultContentManager_unittests.cc
@@ -7,14 +7,6 @@
 
 #include "gtest/gtest.h"
 
-#ifdef __cpp_lib_filesystem
-#include <filesystem>
-namespace fs = std::filesystem;
-#else
-#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
-#include <experimental/filesystem> // remove when we are on C++ 17
-namespace fs = std::experimental::filesystem;
-#endif
 
 #define TMPDIR "temp"
 
@@ -143,27 +135,13 @@ TEST(ExternalizedData, readAllData)
 	ASSERT_TRUE(cm->loadGameData());
 }
 
-std::vector<ST::string> recursivelyListAllFiles(ST::string dir, std::string suffix)
-{
-	std::vector<ST::string> files;
-	for (auto& p : fs::recursive_directory_iterator(dir.to_std_string()))
-	{
-		ST::string path = ST::string(p.path());
-		if (path.ends_with(suffix))
-		{
-			files.push_back(path);
-		}
-	}
-	return files;
-}
-
 TEST(ExternalizedData, readEveryFile)
 {
 	// Not all files (e.g. translations) are covered by the previous test
 	DefaultContentManagerUT* cm = DefaultContentManagerUT::createDefaultCMForTesting();
 
 	ST::string dataPath = ST::format("{}/externalized", GetExtraDataDir());
-	std::vector<ST::string> results = recursivelyListAllFiles(dataPath, ".json");
+	std::vector<ST::string> results = FindFilesInDir(dataPath, "json", true, false, false, true);
 	for (ST::string f : results)
 	{
 		auto json = cm->_readJsonDataFile(f.c_str());

--- a/src/externalized/VanillaWeapons_unittests.cc
+++ b/src/externalized/VanillaWeapons_unittests.cc
@@ -13,7 +13,7 @@
 
 TEST(Items, weaponsLoading)
 {
-	DefaultContentManager * cm = createDefaultCMForTesting();
+	DefaultContentManager * cm = DefaultContentManagerUT::createDefaultCMForTesting();
 	ASSERT_TRUE(cm != NULL);
 	ASSERT_TRUE(cm->loadGameData());
 	EXPECT_TRUE(cm->getWeaponByName("MP5K") != NULL);
@@ -24,7 +24,7 @@ TEST(Items, weaponsLoading)
 
 TEST(Items, bug120_cawsAmmo)
 {
-	DefaultContentManager * cm = createDefaultCMForTesting();
+	DefaultContentManager * cm = DefaultContentManagerUT::createDefaultCMForTesting();
 	ASSERT_TRUE(cm->loadGameData());
 
 	// test SAP clip parameters
@@ -42,7 +42,7 @@ TEST(Items, bug120_cawsAmmo)
 
 TEST(Items, bug120_12gAmmo)
 {
-	DefaultContentManager * cm = createDefaultCMForTesting();
+	DefaultContentManager * cm = DefaultContentManagerUT::createDefaultCMForTesting();
 	ASSERT_TRUE(cm->loadGameData());
 
 	// test SAP clip parameters
@@ -60,7 +60,7 @@ TEST(Items, bug120_12gAmmo)
 
 TEST(Items, bug120_cawsDefaultMag)
 {
-	DefaultContentManager * cm = createDefaultCMForTesting();
+	DefaultContentManager * cm = DefaultContentManagerUT::createDefaultCMForTesting();
 	ASSERT_TRUE(cm->loadGameData());
 
 	GCM = cm;
@@ -83,7 +83,7 @@ TEST(Items, bug120_cawsDefaultMag)
 
 TEST(Items, bug120_spas15DefaultMag)
 {
-	DefaultContentManager * cm = createDefaultCMForTesting();
+	DefaultContentManager * cm = DefaultContentManagerUT::createDefaultCMForTesting();
 	ASSERT_TRUE(cm->loadGameData());
 
 	GCM = cm;

--- a/src/sgp/FileMan.h
+++ b/src/sgp/FileMan.h
@@ -123,22 +123,25 @@ private:
  * @param dirPath Path to the directory
  * @param extension Extension (e.g. "txt")
  * @param caseIncensitive When True, do case-insensitive search even of case-sensitive file-systems.
- * @param returnOnlyNames When True, return only names (without the directory path)
+ * @param returnOnlyNames When True, return only names (without the directory path) except when resursive is True
  * @param sortResults When True, sort found paths.
+ * @param recursive When True, recurse into subs. Function returns full path regardless of returnOnlyNames
  * @return List of paths (dir + filename) or filenames. */
 std::vector<ST::string>
 FindFilesInDir(const ST::string& dirPath,
 		const ST::string& ext,
-		bool caseIncensitive,
+		bool caseInsensitive,
 		bool returnOnlyNames,
-		bool sortResults = false);
+		bool sortResults = false,
+		bool recursive = false);
 
 /**
  * Find all files in a directory.
  * @param dirPath Path to the directory
  * @param sortResults When True, sort found paths.
+ * @param recursive When True, recurse into subs.
  * @return List of paths (dir + filename). */
 std::vector<ST::string>
-FindAllFilesInDir(const ST::string& dirPath, bool sortResults = false);
+FindAllFilesInDir(const ST::string& dirPath, bool sortResults = false, bool recursive = false);
 
 #endif


### PR DESCRIPTION
To prevent JSON syntax errors. Some files are not always processed in loadGameData(), in particular the localization files.

No other JSON problems found other than those already addressed in [#1115](https://github.com/ja2-stracciatella/ja2-stracciatella/pull/1115/files?w=1).