### PR TITLE
Attempt to improve GitHub CI build time

### DIFF
--- a/.github/scripts/ci-build.sh
+++ b/.github/scripts/ci-build.sh
@@ -5,9 +5,6 @@
 # Requires the following environment variables:
 #   CI_REF - full reference of the current branch, tag, or pull request
 #   CI_TARGET - target we are building for: linux/mingw/mac
-# Required for publishing (nightly and releases):
-#   SFTP_USER - ftp username for uploads (secret)
-#   SFTP_PASSWORD - ftp password for uploads (secret)
 # Unused environment variables:
 #   CI_NAME - name of the job
 #   CI_OS - host runner image: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners
@@ -15,71 +12,52 @@
 set -e
 set -x
 
-echo "## prepare environment ##"
+echo "## check environment ##"
 if [[ "${CI_REF}" == "refs/heads/nightly" ]]; then
   echo "-- NIGHTLY --"
-  export PUBLISH_BINARY="true"
-  export PUBLISH_DIR="nightlies"
   export BUILD_TYPE="ReleaseWithDebInfo"
   export VERSION_TAG="$(date +%Y%m%d)"
 elif [[ "${CI_REF}" == "refs/tags/"* ]]; then
   echo "-- RELEASE --"
-  export PUBLISH_BINARY="true"
-  export PUBLISH_DIR="releases"
   export BUILD_TYPE="ReleaseWithDebInfo"
   # assumes that the version is already set up correctly
 elif [[ "${CI_REF}" == "refs/pull/"* ]]; then
   export PULL_REQUEST=$(echo "${CI_REF}" | cut -d '/' -f 3)
   echo "-- PULL REQUEST ${PULL_REQUEST} --"
-  export PUBLISH_BINARY="false" # secrets are not available in pull requests
-  export PUBLISH_DIR="pull-requests/${PULL_REQUEST}"
   export VERSION_TAG="${PULL_REQUEST}pullrequest"
   export BUILD_TYPE="Debug"
 else
   echo "-- QUICK BUILD --"
-  export PUBLISH_BINARY="false"
   export BUILD_TYPE="Debug"
 fi
 export BUILD_CMD="cmake --build . --config ${BUILD_TYPE}"
 export BUILD_TOOL_ARGS="-- -j 4"
 export CONFIGURE_CMD="cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DVERSION_TAG=${VERSION_TAG}"
 if [[ "${BUILD_TYPE}" != "Debug" ]]; then
-   export CONFIGURE_CMD="${CONFIGURE_CMD} -DWITH_EDITOR_SLF=ON"
-fi
-if [[ "${PUBLISH_BINARY}" == "true" && "${SFTP_PASSWORD}" == "" ]]; then
-  echo "Upload credentials are not set up"
-  exit 1
+  export CONFIGURE_CMD="${CONFIGURE_CMD} -DWITH_EDITOR_SLF=ON"
 fi
 
 export RUN_TESTS=true
 export RUN_INSTALL_TEST=true
-export RUSTUP_INIT_ARGS="-y --no-modify-path --default-toolchain=$(cat ./rust-toolchain)"
+export RUSTUP_INIT_ARGS="-y --no-modify-path --default-toolchain=$(cat ./rust-toolchain) --profile=minimal"
 if [[ "$CI_TARGET" == "linux" ]]; then
-  sudo apt-get -yq update
-  sudo apt-get -yq install build-essential libsdl2-dev libfltk1.3-dev ccache
   export CONFIGURE_CMD="${CONFIGURE_CMD} -DCMAKE_INSTALL_PREFIX=/usr -DEXTRA_DATA_DIR=/usr/share/ja2 -DCPACK_GENERATOR=DEB"
-  export BUILD_TOOL_ARGS="-- -j 4"
+
 elif [[ "$CI_TARGET" == "linux-mingw64" ]]; then
   # cross compiling
-  sudo apt-get -yq update
-  sudo apt-get -yq install build-essential mingw-w64 ccache
   export CONFIGURE_CMD="${CONFIGURE_CMD} -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain-mingw.cmake -DCPACK_GENERATOR=ZIP"
-  export RUSTUP_INIT_ARGS="${RUSTUP_INIT_ARGS} --target=x86_64-pc-windows-gnu"
+  export RUSTUP_INIT_ARGS="${RUSTUP_INIT_ARGS} --target=x86ST_64-pc-windows-gnu --profile=minimal"
   export RUN_TESTS=false
-  export BUILD_TOOL_ARGS="-- -j 4"
+
 elif [[ "$CI_TARGET" == "msys2-mingw32" ]]; then
-  # FIXME upgrades disabled until there is a fix for https://github.com/msys2/MSYS2-packages/issues/1141
-  #pacman -Syu --noconfirm --needed # assumes the runtime has already been updated
-  pacman -S --noconfirm --needed base-devel unzip
-  pacman -S --noconfirm --needed mingw-w64-i686-toolchain mingw-w64-i686-cmake mingw-w64-i686-SDL2 mingw-w64-i686-fltk
   export CMAKE_GENERATOR="MSYS Makefiles"
   export CONFIGURE_CMD="${CONFIGURE_CMD} -DCPACK_GENERATOR=ZIP"
   export RUSTUP_HOME="$(cygpath -w ~/.rustup)"
   export CARGO_HOME="$(cygpath -w ~/.cargo)"
   export RUSTUP_INIT_ARGS="${RUSTUP_INIT_ARGS}-i686-pc-windows-gnu --default-host=i686-pc-windows-gnu"
   export RUN_INSTALL_TEST=false # no sudo
+
 elif [[ "$CI_TARGET" == "mac" ]]; then
-  brew install --HEAD ccache
   export CONFIGURE_CMD="${CONFIGURE_CMD} -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain-macos.cmake -DCPACK_GENERATOR=Bundle"
   export BUILD_TOOL_ARGS="-- -j 4"
 else
@@ -87,32 +65,13 @@ else
   exit 1
 fi
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- $RUSTUP_INIT_ARGS
-if [[ "$CI_TARGET" == "linux-mingw64" ]]; then
-  # XXX currently rustup-init fails to add the target, so add it manually
-  rustup target add x86_64-pc-windows-gnu
-fi
-export PATH=$PATH:$HOME/.cargo/bin
-rustup show
-env
-which rustc
-rustc -V
-which cargo
-cargo -V
-cargo clippy -- -V
-cargo fmt -- -V
-which cmake
-cmake --version
-
 echo "## configure, build, package ##"
-mkdir ci-build
+mkdir -p ci-build
 cd ci-build
 $CONFIGURE_CMD ..
 cat ./CMakeCache.txt
 $BUILD_CMD $BUILD_TOOL_ARGS
 $BUILD_CMD --target package
-
-command -v ccache && ccache -s
 
 echo "## test ##"
 if [[ "$RUN_TESTS" == "true" ]]; then
@@ -129,37 +88,10 @@ if [[ "$RUN_TESTS" == "true" ]]; then
   fi
 fi
 
-echo "## publish ##"
-for file in ja2-stracciatella_*; do
-  echo "$file"
-  if [[ "$file" == *".deb" ]]; then
-    dpkg -c "$file"
-  elif [[ "$file" == *".zip" ]]; then
-    unzip -l "$file"
-  elif [[ "$file" == *".dmg" ]]; then
-    # based on https://ss64.com/osx/hdiutil.html
-    hdiutil verify "$file"
-    device=""
-    while IFS=$'\n' read -r line; do
-      echo "$line"
-      if [[ "$line" != "/dev/"* ]]; then
-        continue # expected <dev node><tab><content hint><tab><mount point>
-      fi
-      IFS=$'\t' read -ra arr <<< "$line"
-      if [[ "$device" == "" ]]; then
-        device="${arr[0]%"${arr[0]##*[![:space:]]}"}" # remove trailing whitespace
-      fi
-      if [[ "${arr[2]}" != "" ]]; then
-        ls -laR "${arr[2]}"
-      fi
-    done <<< "$(hdiutil attach "$file")"
-    hdiutil detach "$device"
-  else
-    echo "TODO list contents"
-  fi
-  if [[ "$PUBLISH_BINARY" == "true" ]]; then
-    curl -v --retry 3 --connect-timeout 60 --max-time 150 --ftp-create-dirs -T "$file" -u $SFTP_USER:$SFTP_PASSWORD ftp://www61.your-server.de/$PUBLISH_DIR/
-  fi
-done
+# print ccache cache statistics
+echo "## print statistics"
+command -v ccache &&
+  ccache -s ||
+  echo "ccache not installed"
 
 echo "## done ##"

--- a/.github/scripts/ci-publish.sh
+++ b/.github/scripts/ci-publish.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Publish package artifacts to SFTP
+#
+# Requires the following environment variables:
+#   CI_REF - full reference of the current branch, tag, or pull request
+# Required for publishing (nightly and releases):
+#   SFTP_USER - ftp username for uploads (secret)
+#   SFTP_PASSWORD - ftp password for uploads (secret)
+
+set -e
+set -x
+
+echo "## check environment ##"
+if [[ "${CI_REF}" == "refs/heads/nightly" ]]; then
+  echo "-- NIGHTLY --"
+  export PUBLISH_BINARY="true"
+  export PUBLISH_DIR="nightlies"
+elif [[ "${CI_REF}" == "refs/tags/"* ]]; then
+  echo "-- RELEASE --"
+  export PUBLISH_BINARY="true"
+  export PUBLISH_DIR="releases"
+  # assumes that the version is already set up correctly
+elif [[ "${CI_REF}" == "refs/pull/"* ]]; then
+  export PULL_REQUEST=$(echo "${CI_REF}" | cut -d '/' -f 3)
+  echo "-- PULL REQUEST ${PULL_REQUEST} --"
+  export PUBLISH_BINARY="false" # secrets are not available in pull requests
+else
+  echo "-- QUICK BUILD --"
+  export PUBLISH_BINARY="false"
+fi
+
+if [[ "${PUBLISH_BINARY}" == "true" && "${SFTP_PASSWORD}" == "" ]]; then
+  echo "Upload credentials are not set up"
+  exit 1
+fi
+
+echo "## publish ##"
+for file in ja2-stracciatella_*; do
+  echo "$file"
+  if [[ "$file" == *".deb" ]]; then
+    dpkg -c "$file"
+  elif [[ "$file" == *".zip" ]]; then
+    unzip -l "$file"
+  elif [[ "$file" == *".dmg" ]]; then
+    # based on https://ss64.com/osx/hdiutil.html
+    hdiutil verify "$file"
+    device=""
+    while IFS=$'\n' read -r line; do
+      echo "$line"
+      if [[ "$line" != "/dev/"* ]]; then
+        continue # expected <dev node><tab><content hint><tab><mount point>
+      fi
+      IFS=$'\t' read -ra arr <<<"$line"
+      if [[ "$device" == "" ]]; then
+        device="${arr[0]%"${arr[0]##*[![:space:]]}"}" # remove trailing whitespace
+      fi
+      if [[ "${arr[2]}" != "" ]]; then
+        ls -laR "${arr[2]}"
+      fi
+    done <<<"$(hdiutil attach "$file")"
+    hdiutil detach "$device"
+  else
+    echo "TODO list contents"
+  fi
+  if [[ "$PUBLISH_BINARY" == "true" ]]; then
+    curl -v --retry 3 \
+      --connect-timeout 60 --max-time 300 \
+      --ftp-create-dirs -T "$file" -u $SFTP_USER:$SFTP_PASSWORD \
+      ftp://www61.your-server.de/$PUBLISH_DIR/
+  else
+    echo "Skipped"
+  fi
+done
+
+echo "## done ##"

--- a/.github/scripts/ci-setup.sh
+++ b/.github/scripts/ci-setup.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Set up the CI environment
+#
+# Requires the following environment variables:64
+#   CI_TARGET - target we are building for: linux/linux-mingw/mac
+
+set -e
+set -x
+
+echo "## prepare environment ##"
+export RUSTUP_INIT_ARGS="-y --no-modify-path --default-toolchain=$(cat ./rust-toolchain) --profile=minimal"
+if [[ "$CI_TARGET" == "linux" ]]; then
+    sudo apt-get -yq update
+    sudo apt-get -yq install build-essential libsdl2-dev libfltk1.3-dev ccache
+
+elif [[ "$CI_TARGET" == "linux-mingw64" ]]; then
+    # cross compiling
+    sudo apt-get -yq update
+    sudo apt-get -yq install build-essential mingw-w64
+    sudo apt-get -yq install ccache
+
+elif [[ "$CI_TARGET" == "msys2-mingw32" ]]; then
+    # FIXME upgrades disabled until there is a fix for https://github.com/msys2/MSYS2-packages/issues/1141
+    #pacman -Syu --noconfirm --needed # assumes the runtime has already been updated
+    pacman -S --noconfirm --needed base-devel unzip
+    pacman -S --noconfirm --needed mingw-w64-i686-toolchain mingw-w64-i686-cmake mingw-w64-i686-SDL2 mingw-w64-i686-fltk
+
+elif [[ "$CI_TARGET" == "mac" ]]; then
+    brew install ccache
+
+else
+    echo "unexpected target ${CI_TARGET}"
+    exit 1
+fi
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- $RUSTUP_INIT_ARGS
+if [[ "$CI_TARGET" == "linux-mingw64" ]]; then
+    # XXX currently rustup-init fails to add the target, so add it manually
+    rustup target add x86_64-pc-windows-gnu
+fi
+export PATH=$PATH:$HOME/.cargo/bin
+
+rustup component add clippy rustfmt
+rustup show
+env
+which rustc
+rustc -V
+which cargo
+cargo -V
+cargo clippy -- -V
+cargo fmt -- -V
+which cmake
+cmake --version
+command -v ccache && ccache -V

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
-
         - name: Linux
           os: ubuntu-16.04
           target: linux
@@ -43,20 +42,36 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Caching for ccache and rust
+    - name: Cache C++ build output
       uses: actions/cache@v2
       with:
-        path: | 
-          ~/.rustup
+        path: |
           ~/.ccache
-          ~/.cargo
-        key: ${{ matrix.cfg.target }}-v1-${{ hashFiles('rust/Cargo.lock') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('cmake') }}
+        key: ${{ matrix.cfg.target }}-ccache-v1-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ${{ matrix.cfg.target }}-v1-${{ hashFiles('rust/Cargo.lock') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('cmake') }}
-          ${{ matrix.cfg.target }}-v1-${{ hashFiles('rust/Cargo.lock') }}-
-          ${{ matrix.cfg.target }}-v1-
+          ${{ matrix.cfg.target }}-ccache-v1-${{ github.ref }}-
+          ${{ matrix.cfg.target }}-ccache-v1-refs/heads/master-
+          ${{ matrix.cfg.target }}-ccache-v1-
 
-    - name: Build with bash
+    - name: Cache Rust deps and build output
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo
+          ~/.rustup
+          ${{ github.workspace }}/ci-build/dependencies/lib-stracciatella/target
+        key: ${{ matrix.cfg.target }}-rust-v1-${{ hashFiles('rust') }}
+        restore-keys: |
+          ${{ matrix.cfg.target }}-rust-v1-${{ hashFiles('rust') }}
+          ${{ matrix.cfg.target }}-rust-v1-
+
+    - name: Set up environment
+      shell: bash
+      run: ${{ github.workspace }}/.github/scripts/ci-setup.sh 2>&1
+      env:
+        CI_TARGET: ${{ matrix.cfg.target }}
+
+    - name: Build and run tests
       shell: bash
       run: ${{ github.workspace }}/.github/scripts/ci-build.sh 2>&1
       env:
@@ -66,6 +81,10 @@ jobs:
         CI_REF: ${{ github.ref }}
         SFTP_USER: ${{ secrets.SFTP_USER }}
         SFTP_PASSWORD: ${{ secrets.SFTP_PASSWORD }}
+
+    - name: Publish packages
+      shell: bash
+      run: ${{ github.workspace }}/.github/scripts/ci-publish.sh 2>&1
 
     - name: Collect artifacts
       shell: bash

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -41,7 +41,20 @@ jobs:
       run: ''
 
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
+
+    - name: Caching for ccache and rust
+      uses: actions/cache@v2
+      with:
+        path: | 
+          ~/.rustup
+          ~/.ccache
+          ~/.cargo
+        key: ${{ matrix.cfg.target }}-v1-${{ hashFiles('rust/Cargo.lock') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('cmake') }}
+        restore-keys: |
+          ${{ matrix.cfg.target }}-v1-${{ hashFiles('rust/Cargo.lock') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('cmake') }}
+          ${{ matrix.cfg.target }}-v1-${{ hashFiles('rust/Cargo.lock') }}-
+          ${{ matrix.cfg.target }}-v1-
 
     - name: Build with bash
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ endmacro()
 
 ## Project Setup
 
+find_program(CCACHE_PROGRAM "ccache")
+if(CCACHE_PROGRAM)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 project(ja2-stracciatella)
 set(JA2_BINARY "ja2")
 set(LAUNCHER_BINARY "ja2-launcher")


### PR DESCRIPTION
Attempt to improve on #1101 and #1102. Only covers GitHub CI builds.

## Summary of changes

- Split the `ci-build.sh` script into 3 steps - setup, build and publish
- Add `ccache` to the CI build process (https://ccache.dev)
    - CMake will make use of it if installed
- Cache  C++ objects with `ccache` (`~/.ccache`)
    - Prefers the last build from same Git branch, falls back to last master build
- Cache Rust deps and output
    - Cache `~/.cargo`, `~/.rustup` and `$PROJECT_DIR/dependencies/lib-stracciatella/target`
    - Assuming Rust code not changed often, cache is used only if the entire `rust/` directory is untouched
- Add concurrency in make (`-j 4`)
- `rustup` with `minimal` [profile](https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html#profiles); install `rustfmt` and `clippy` separately

## Results

- Linux build with primed cache takes ~3 minutes (using system-provided libfltk)
- MinGW and Mac builds with primed cache take ~6 minutes