### PR TITLE
Fix msys2-mingw build on AppVeyor

### DIFF
--- a/.github/scripts/ci-build.sh
+++ b/.github/scripts/ci-build.sh
@@ -53,7 +53,7 @@ elif [[ "$CI_TARGET" == "msys2-mingw32" ]]; then
   export CONFIGURE_CMD="${CONFIGURE_CMD} -DCPACK_GENERATOR=ZIP"
   export RUSTUP_HOME="$(cygpath -w ~/.rustup)"
   export CARGO_HOME="$(cygpath -w ~/.cargo)"
-  export PATH=$PATH:$HOME/.cargo/bin
+  export PATH="$PATH:$HOME/.cargo/bin"
   export RUN_INSTALL_TEST=false # no sudo
 
 elif [[ "$CI_TARGET" == "mac" ]]; then

--- a/.github/scripts/ci-build.sh
+++ b/.github/scripts/ci-build.sh
@@ -46,7 +46,6 @@ if [[ "$CI_TARGET" == "linux" ]]; then
 elif [[ "$CI_TARGET" == "linux-mingw64" ]]; then
   # cross compiling
   export CONFIGURE_CMD="${CONFIGURE_CMD} -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain-mingw.cmake -DCPACK_GENERATOR=ZIP"
-  export RUSTUP_INIT_ARGS="${RUSTUP_INIT_ARGS} --target=x86ST_64-pc-windows-gnu --profile=minimal"
   export RUN_TESTS=false
 
 elif [[ "$CI_TARGET" == "msys2-mingw32" ]]; then
@@ -54,7 +53,7 @@ elif [[ "$CI_TARGET" == "msys2-mingw32" ]]; then
   export CONFIGURE_CMD="${CONFIGURE_CMD} -DCPACK_GENERATOR=ZIP"
   export RUSTUP_HOME="$(cygpath -w ~/.rustup)"
   export CARGO_HOME="$(cygpath -w ~/.cargo)"
-  export RUSTUP_INIT_ARGS="${RUSTUP_INIT_ARGS}-i686-pc-windows-gnu --default-host=i686-pc-windows-gnu"
+  export PATH=$PATH:$HOME/.cargo/bin
   export RUN_INSTALL_TEST=false # no sudo
 
 elif [[ "$CI_TARGET" == "mac" ]]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,9 @@ for:
           rem C:\msys64\msys2_shell.cmd -defterm -no-start -c "pacman -Syu --noconfirm --needed"
       - cmd: |
           rem build, package, test, publish in msys2
+          C:\msys64\msys2_shell.cmd -defterm -no-start -mingw32 -here -c "bash .github/scripts/ci-setup.sh"
           C:\msys64\msys2_shell.cmd -defterm -no-start -mingw32 -here -c "bash .github/scripts/ci-build.sh"
+          C:\msys64\msys2_shell.cmd -defterm -no-start -mingw32 -here -c "bash .github/scripts/ci-publish.sh"
     test_script:
       - cmd: rem test_script override
     after_test:


### PR DESCRIPTION
AppVeyor build broken since #1118, because the script `.github/scripts/ci-buidl.sh` was split. I didn't realize it has been used by AppVeyor msys2-mingw build.