### PR TITLE
Clean up SET_PALETTEREP_ID

### DIFF
--- a/src/game/Editor/EditorMercs.cc
+++ b/src/game/Editor/EditorMercs.cc
@@ -267,45 +267,45 @@ void ProcessMercEditing(void)
 
 	// Handle changes to the merc colors
 	SOLDIERTYPE& s = *g_selected_merc;
-	ST::string soldier_pal;
-	ST::string placement_pal;
+	ST::string* soldier_pal;
+	ST::string* placement_pal;
 	UINT8 ubType;
 	switch (iEditWhichStat)
 	{
 		case 0:
 		case 1:
 			ubType        = EDIT_COLOR_HEAD;
-			soldier_pal   = s.HeadPal;
-			placement_pal = gpSelected->pDetailedPlacement->HeadPal;
+			soldier_pal   = &s.HeadPal;
+			placement_pal = &gpSelected->pDetailedPlacement->HeadPal;
 			break;
 
 		case 2:
 		case 3:
 			ubType        = EDIT_COLOR_SKIN;
-			soldier_pal   = s.SkinPal;
-			placement_pal = gpSelected->pDetailedPlacement->SkinPal;
+			soldier_pal   = &s.SkinPal;
+			placement_pal = &gpSelected->pDetailedPlacement->SkinPal;
 			break;
 
 		case 4:
 		case 5:
 			ubType        = EDIT_COLOR_VEST;
-			soldier_pal   = s.VestPal;
-			placement_pal = gpSelected->pDetailedPlacement->VestPal;
+			soldier_pal   = &s.VestPal;
+			placement_pal = &gpSelected->pDetailedPlacement->VestPal;
 			break;
 
 		case 6:
 		case 7:
 			ubType        = EDIT_COLOR_PANTS;
-			soldier_pal   = s.PantsPal;
-			placement_pal = gpSelected->pDetailedPlacement->PantsPal;
-			break;
+			soldier_pal   = &s.PantsPal;
+			placement_pal = &gpSelected->pDetailedPlacement->PantsPal;
+			break; 
 
 		default:
 			iEditMercMode = EDIT_MERC_NONE;
 			return;
 	}
 
-	UINT8 ubPaletteRep = GetPaletteRepIndexFromID(soldier_pal);
+	UINT8 ubPaletteRep = GetPaletteRepIndexFromID(*soldier_pal);
 	const INT32 start = iEditColorStart[ubType];
 	const UINT8 range = gubpNumReplacementsPerRange[ubType];
 	if (iEditWhichStat & 1)
@@ -317,8 +317,8 @@ void ProcessMercEditing(void)
 		ubPaletteRep = (ubPaletteRep > start ? ubPaletteRep - 1 : start + range - 1);
 	}
 
-	SET_PALETTEREP_ID(soldier_pal, gpPalRep[ubPaletteRep].ID);
-	placement_pal = soldier_pal;
+	soldier_pal->set(gpPalRep[ubPaletteRep].ID);
+	placement_pal->set(gpPalRep[ubPaletteRep].ID);
 	CreateSoldierPalettes(s);
 
 	iEditMercMode = EDIT_MERC_NONE;
@@ -2415,8 +2415,8 @@ void SetEnemyColorCode(UINT8 const colour_code)
 	sel.pBasicPlacement->ubSoldierClass = colour_code;
 	if (dp) dp->ubSoldierClass = colour_code;
 	SOLDIERTYPE& s = *sel.pSoldier;
-	SET_PALETTEREP_ID(s.VestPal,  vest);
-	SET_PALETTEREP_ID(s.PantsPal, pants);
+	s.VestPal  = vest;
+	s.PantsPal = pants;
 	CreateSoldierPalettes(s);
 }
 

--- a/src/game/JAScreens.cc
+++ b/src/game/JAScreens.cc
@@ -284,7 +284,7 @@ static void CyclePaletteReplacement(SOLDIERTYPE& s, ST::string& pal)
 	const UINT8 ubEndRep = ubStartRep + gubpNumReplacementsPerRange[ubType];
 
 	if (ubPaletteRep == ubEndRep) ubPaletteRep = ubStartRep;
-	SET_PALETTEREP_ID(pal, gpPalRep[ubPaletteRep].ID);
+	pal = gpPalRep[ubPaletteRep].ID;
 
 	CreateSoldierPalettes(s);
 }

--- a/src/game/Strategic/Strategic_Movement.cc
+++ b/src/game/Strategic/Strategic_Movement.cc
@@ -1062,10 +1062,10 @@ static void AddCorpsesToBloodcatLair(INT16 sSectorX, INT16 sSectorY)
 	Corpse.sHeightAdjustment = 0;
 	Corpse.bVisible          = TRUE;
 
-	SET_PALETTEREP_ID ( Corpse.HeadPal,  "BROWNHEAD" );
-	SET_PALETTEREP_ID ( Corpse.VestPal,  "YELLOWVEST" );
-	SET_PALETTEREP_ID ( Corpse.SkinPal,  "PINKSKIN" );
-	SET_PALETTEREP_ID ( Corpse.PantsPal, "GREENPANTS" );
+	Corpse.HeadPal  = "BROWNHEAD";
+	Corpse.VestPal  = "YELLOWVEST";
+	Corpse.SkinPal  = "PINKSKIN";
+	Corpse.PantsPal = "GREENPANTS";
 
 
 	Corpse.bDirection = (INT8)Random(8);

--- a/src/game/Tactical/Overhead_Types.h
+++ b/src/game/Tactical/Overhead_Types.h
@@ -292,9 +292,4 @@ enum BoxingStates
 
 #define PaletteRepID_LENGTH 30
 
-
-// MACROS
-// This will set an animation ID
-#define SET_PALETTEREP_ID( a, b )			( (a) = (b) )
-
 #endif

--- a/src/game/Tactical/Rotting_Corpses.cc
+++ b/src/game/Tactical/Rotting_Corpses.cc
@@ -638,10 +638,10 @@ BOOLEAN TurnSoldierIntoCorpse(SOLDIERTYPE& s)
 		Corpse.sHeightAdjustment = s.sHeightAdjustment - WALL_HEIGHT;
 	}
 
-	SET_PALETTEREP_ID(Corpse.HeadPal,  s.HeadPal);
-	SET_PALETTEREP_ID(Corpse.VestPal,  s.VestPal);
-	SET_PALETTEREP_ID(Corpse.SkinPal,  s.SkinPal);
-	SET_PALETTEREP_ID(Corpse.PantsPal, s.PantsPal);
+	Corpse.HeadPal  = s.HeadPal;
+	Corpse.VestPal  = s.VestPal;
+	Corpse.SkinPal  = s.SkinPal;
+	Corpse.PantsPal = s.PantsPal;
 
 	if (s.bCamo != 0)
 	{

--- a/src/game/Tactical/Soldier_Create.cc
+++ b/src/game/Tactical/Soldier_Create.cc
@@ -494,10 +494,10 @@ static void TacticalCopySoldierFromProfile(SOLDIERTYPE& s, SOLDIERCREATE_STRUCT 
 	ProfileID         const  pid = c.ubProfile;
 	MERCPROFILESTRUCT const& p   = GetProfile(pid);
 
-	SET_PALETTEREP_ID(s.HeadPal,  p.HAIR);
-	SET_PALETTEREP_ID(s.VestPal,  p.VEST);
-	SET_PALETTEREP_ID(s.SkinPal,  p.SKIN);
-	SET_PALETTEREP_ID(s.PantsPal, p.PANTS);
+	s.HeadPal  = p.HAIR;
+	s.VestPal  = p.VEST;
+	s.SkinPal  = p.SKIN;
+	s.PantsPal = p.PANTS;
 
 	s.ubProfile       = pid;
 	s.ubScheduleID    = c.ubScheduleID;
@@ -652,16 +652,16 @@ static void GeneratePaletteForSoldier(SOLDIERTYPE* pSoldier, UINT8 ubSoldierClas
 	switch( skin )
 	{
 		case PINKSKIN:
-			SET_PALETTEREP_ID( pSoldier->SkinPal,  "PINKSKIN" );
+			pSoldier->SkinPal = "PINKSKIN";
 			break;
 		case TANSKIN:
-			SET_PALETTEREP_ID( pSoldier->SkinPal,  "TANSKIN" );
+			pSoldier->SkinPal = "TANSKIN";
 			break;
 		case DARKSKIN:
-			SET_PALETTEREP_ID( pSoldier->SkinPal,  "DARKSKIN" );
+			pSoldier->SkinPal = "DARKSKIN";
 			break;
 		case BLACKSKIN:
-			SET_PALETTEREP_ID( pSoldier->SkinPal,  "BLACKSKIN" );
+			pSoldier->SkinPal = "BLACKSKIN";
 			break;
 		default:
 			SLOGA("Skin type not accounted for." );
@@ -672,11 +672,11 @@ static void GeneratePaletteForSoldier(SOLDIERTYPE* pSoldier, UINT8 ubSoldierClas
 	hair = ChooseHairColor( pSoldier, skin );
 	switch( hair )
 	{
-		case BROWNHEAD: SET_PALETTEREP_ID( pSoldier->HeadPal, "BROWNHEAD" ); break;
-		case BLACKHEAD: SET_PALETTEREP_ID( pSoldier->HeadPal, "BLACKHEAD" ); break;
-		case WHITEHEAD: SET_PALETTEREP_ID( pSoldier->HeadPal, "WHITEHEAD" ); break;
-		case BLONDEHEAD:SET_PALETTEREP_ID( pSoldier->HeadPal, "BLONDHEAD" ); break;
-		case REDHEAD:   SET_PALETTEREP_ID( pSoldier->HeadPal, "REDHEAD"   ); break;
+		case BROWNHEAD:  pSoldier->HeadPal = "BROWNHEAD"; break;
+		case BLACKHEAD:  pSoldier->HeadPal = "BLACKHEAD"; break;
+		case WHITEHEAD:  pSoldier->HeadPal = "WHITEHEAD"; break;
+		case BLONDEHEAD: pSoldier->HeadPal = "BLONDHEAD"; break;
+		case REDHEAD:    pSoldier->HeadPal = "REDHEAD"  ; break;
 		default:
 			SLOGA("Hair type not accounted for.");
 			break;
@@ -686,38 +686,38 @@ static void GeneratePaletteForSoldier(SOLDIERTYPE* pSoldier, UINT8 ubSoldierClas
 	switch( ubSoldierClass )
 	{
 		case SOLDIER_CLASS_ADMINISTRATOR:
-			SET_PALETTEREP_ID( pSoldier->VestPal, "YELLOWVEST"  );
-			SET_PALETTEREP_ID( pSoldier->PantsPal, "GREENPANTS"   );
+			pSoldier->VestPal  = "YELLOWVEST";
+			pSoldier->PantsPal = "GREENPANTS";
 			pSoldier->ubSoldierClass = ubSoldierClass;
 			return;
 		case SOLDIER_CLASS_ELITE:
-			SET_PALETTEREP_ID( pSoldier->VestPal, "BLACKSHIRT"  );
-			SET_PALETTEREP_ID( pSoldier->PantsPal, "BLACKPANTS"   );
+			pSoldier->VestPal  = "BLACKSHIRT";
+			pSoldier->PantsPal = "BLACKPANTS";
 			pSoldier->ubSoldierClass = ubSoldierClass;
 			return;
 		case SOLDIER_CLASS_ARMY:
-			SET_PALETTEREP_ID( pSoldier->VestPal, "REDVEST"  );
-			SET_PALETTEREP_ID( pSoldier->PantsPal, "GREENPANTS"   );
+			pSoldier->VestPal  = "REDVEST";
+			pSoldier->PantsPal = "GREENPANTS";
 			pSoldier->ubSoldierClass = ubSoldierClass;
 			return;
 		case SOLDIER_CLASS_GREEN_MILITIA:
-			SET_PALETTEREP_ID( pSoldier->VestPal, "GREENVEST"  );
-			SET_PALETTEREP_ID( pSoldier->PantsPal, "BEIGEPANTS"   );
+			pSoldier->VestPal  = "GREENVEST";
+			pSoldier->PantsPal = "BEIGEPANTS";
 			pSoldier->ubSoldierClass = ubSoldierClass;
 			return;
 		case SOLDIER_CLASS_REG_MILITIA:
-			SET_PALETTEREP_ID( pSoldier->VestPal, "JEANVEST"  );
-			SET_PALETTEREP_ID( pSoldier->PantsPal, "BEIGEPANTS"   );
+			pSoldier->VestPal  = "JEANVEST";
+			pSoldier->PantsPal = "BEIGEPANTS";
 			pSoldier->ubSoldierClass = ubSoldierClass;
 			return;
 		case SOLDIER_CLASS_ELITE_MILITIA:
-			SET_PALETTEREP_ID( pSoldier->VestPal, "BLUEVEST"  );
-			SET_PALETTEREP_ID( pSoldier->PantsPal, "BEIGEPANTS"   );
+			pSoldier->VestPal  = "BLUEVEST";
+			pSoldier->PantsPal = "BEIGEPANTS";
 			pSoldier->ubSoldierClass = ubSoldierClass;
 			return;
 		case SOLDIER_CLASS_MINER:
-			SET_PALETTEREP_ID( pSoldier->VestPal, "greyVEST"  );
-			SET_PALETTEREP_ID( pSoldier->PantsPal, "BEIGEPANTS"   );
+			pSoldier->VestPal  = "greyVEST";
+			pSoldier->PantsPal = "BEIGEPANTS";
 			pSoldier->ubSoldierClass = ubSoldierClass;
 			return;
 	}
@@ -739,27 +739,27 @@ static void GeneratePaletteForSoldier(SOLDIERTYPE* pSoldier, UINT8 ubSoldierClas
 			if( Random( 100 ) < 30 )
 			{
 				//30% chance that the civilian will choose a gaudy yellow shirt with pants.
-				SET_PALETTEREP_ID( pSoldier->VestPal, "GYELLOWSHIRT" );
+				pSoldier->VestPal = "GYELLOWSHIRT";
 				switch( Random( 3 ) )
 				{
-					case 0:	SET_PALETTEREP_ID( pSoldier->PantsPal, "TANPANTS"   ); break;
-					case 1: SET_PALETTEREP_ID( pSoldier->PantsPal, "BEIGEPANTS" ); break;
-					case 2: SET_PALETTEREP_ID( pSoldier->PantsPal, "GREENPANTS" ); break;
+					case 0:	pSoldier->PantsPal = "TANPANTS"  ; break;
+					case 1:	pSoldier->PantsPal = "BEIGEPANTS"; break;
+					case 2:	pSoldier->PantsPal = "GREENPANTS"; break;
 				}
 			}
 			else
 			{
 				//70% chance that the civilian will choose jeans with a shirt.
-				SET_PALETTEREP_ID( pSoldier->PantsPal, "JEANPANTS" );
+				pSoldier->PantsPal = "JEANPANTS";
 				switch( Random( 7 ) )
 				{
-					case 0:	SET_PALETTEREP_ID( pSoldier->VestPal, "WHITEVEST"   ); break;
-					case 1: SET_PALETTEREP_ID( pSoldier->VestPal, "BLACKSHIRT"  ); break;
-					case 2: SET_PALETTEREP_ID( pSoldier->VestPal, "PURPLESHIRT" ); break;
-					case 3: SET_PALETTEREP_ID( pSoldier->VestPal, "BLUEVEST"    ); break;
-					case 4: SET_PALETTEREP_ID( pSoldier->VestPal, "BROWNVEST"   ); break;
-					case 5: SET_PALETTEREP_ID( pSoldier->VestPal, "JEANVEST"    ); break;
-					case 6: SET_PALETTEREP_ID( pSoldier->VestPal, "REDVEST"     ); break;
+					case 0:	pSoldier->VestPal = "WHITEVEST"  ; break;
+					case 1:	pSoldier->VestPal = "BLACKSHIRT" ; break;
+					case 2:	pSoldier->VestPal = "PURPLESHIRT"; break;
+					case 3:	pSoldier->VestPal = "BLUEVEST"   ; break;
+					case 4:	pSoldier->VestPal = "BROWNVEST"  ; break;
+					case 5:	pSoldier->VestPal = "JEANVEST"   ; break;
+					case 6:	pSoldier->VestPal = "REDVEST"    ; break;
 				}
 			}
 			return;
@@ -768,37 +768,37 @@ static void GeneratePaletteForSoldier(SOLDIERTYPE* pSoldier, UINT8 ubSoldierClas
 		switch( Random( 3 ) )
 		{
 			case 0:
-				SET_PALETTEREP_ID( pSoldier->PantsPal, "GREENPANTS" );
+				pSoldier->PantsPal = "GREENPANTS";
 				switch( Random( 4 ) )
 				{
-					case 0: SET_PALETTEREP_ID( pSoldier->VestPal, "YELLOWVEST" ); break;
-					case 1: SET_PALETTEREP_ID( pSoldier->VestPal, "WHITEVEST"  ); break;
-					case 2: SET_PALETTEREP_ID( pSoldier->VestPal, "BROWNVEST"  ); break;
-					case 3: SET_PALETTEREP_ID( pSoldier->VestPal, "GREENVEST"  ); break;
+					case 0: pSoldier->VestPal = "YELLOWVEST"; break;
+					case 1: pSoldier->VestPal = "WHITEVEST" ; break;
+					case 2: pSoldier->VestPal = "BROWNVEST" ; break;
+					case 3: pSoldier->VestPal = "GREENVEST" ; break;
 				}
 				break;
 			case 1:
-				SET_PALETTEREP_ID( pSoldier->PantsPal, "TANPANTS" );
+				pSoldier->PantsPal = "TANPANTS";
 				switch( Random( 8 ) )
 				{
-					case 0: SET_PALETTEREP_ID( pSoldier->VestPal, "YELLOWVEST" ); break;
-					case 1: SET_PALETTEREP_ID( pSoldier->VestPal, "WHITEVEST"  ); break;
-					case 2: SET_PALETTEREP_ID( pSoldier->VestPal, "BLACKSHIRT" ); break;
-					case 3: SET_PALETTEREP_ID( pSoldier->VestPal, "BLUEVEST"   ); break;
-					case 4: SET_PALETTEREP_ID( pSoldier->VestPal, "BROWNVEST"  ); break;
-					case 5: SET_PALETTEREP_ID( pSoldier->VestPal, "GREENVEST"  ); break;
-					case 6: SET_PALETTEREP_ID( pSoldier->VestPal, "JEANVEST"   ); break;
-					case 7: SET_PALETTEREP_ID( pSoldier->VestPal, "REDVEST"    ); break;
+					case 0: pSoldier->VestPal = "YELLOWVEST"; break;
+					case 1: pSoldier->VestPal = "WHITEVEST" ; break;
+					case 2: pSoldier->VestPal = "BLACKSHIRT"; break;
+					case 3: pSoldier->VestPal = "BLUEVEST"  ; break;
+					case 4: pSoldier->VestPal = "BROWNVEST" ; break;
+					case 5: pSoldier->VestPal = "GREENVEST" ; break;
+					case 6: pSoldier->VestPal = "JEANVEST"  ; break;
+					case 7: pSoldier->VestPal = "REDVEST"   ; break;
 				}
 				break;
 			case 2:
-				SET_PALETTEREP_ID( pSoldier->PantsPal, "BLUEPANTS" );
+				pSoldier->PantsPal = "BLUEPANTS";
 				switch( Random( 4 ) )
 				{
-					case 0: SET_PALETTEREP_ID( pSoldier->VestPal, "YELLOWVEST" ); break;
-					case 1: SET_PALETTEREP_ID( pSoldier->VestPal, "WHITEVEST"  ); break;
-					case 2: SET_PALETTEREP_ID( pSoldier->VestPal, "REDVEST"    ); break;
-					case 3: SET_PALETTEREP_ID( pSoldier->VestPal, "BLACKSHIRT" ); break;
+					case 0: pSoldier->VestPal = "YELLOWVEST"; break;
+					case 1: pSoldier->VestPal = "WHITEVEST" ; break;
+					case 2: pSoldier->VestPal = "REDVEST"   ; break;
+					case 3: pSoldier->VestPal = "BLACKSHIRT"; break;
 				}
 				break;
 		}
@@ -1632,10 +1632,10 @@ static void UpdateStaticDetailedPlacementWithProfileInformation(SOLDIERCREATE_ST
 
 	MERCPROFILESTRUCT& p = GetProfile(ubProfile);
 
-	SET_PALETTEREP_ID(spp->HeadPal,  p.HAIR);
-	SET_PALETTEREP_ID(spp->VestPal,  p.VEST);
-	SET_PALETTEREP_ID(spp->SkinPal,  p.SKIN);
-	SET_PALETTEREP_ID(spp->PantsPal, p.PANTS);
+	spp->HeadPal  = p.HAIR;
+	spp->VestPal  = p.VEST;
+	spp->SkinPal  = p.SKIN;
+	spp->PantsPal = p.PANTS;
 
 	spp->name = p.zNickname;
 

--- a/src/game/Tactical/Tactical_Save.cc
+++ b/src/game/Tactical/Tactical_Save.cc
@@ -946,10 +946,10 @@ void AddDeadSoldierToUnLoadedSector(INT16 const x, INT16 const y, UINT8 const z,
 	c.sGridNo           = grid_no;
 	c.sHeightAdjustment = s->sHeightAdjustment;
 	c.bVisible          = TRUE;
-	SET_PALETTEREP_ID(c.HeadPal,  s->HeadPal);
-	SET_PALETTEREP_ID(c.VestPal,  s->VestPal);
-	SET_PALETTEREP_ID(c.SkinPal,  s->SkinPal);
-	SET_PALETTEREP_ID(c.PantsPal, s->PantsPal);
+	c.HeadPal           = s->HeadPal;
+	c.VestPal           = s->VestPal;
+	c.SkinPal           = s->SkinPal;
+	c.PantsPal          = s->PantsPal;
 	c.bDirection        = s->bDirection;
 	c.uiTimeOfDeath     = GetWorldTotalMin();
 	c.usFlags           = flags_for_rotting_corpse;


### PR DESCRIPTION
Cleans up and removes `SET_PALETTEREP_ID`. Replaces with `=` assignment, or `.set()`.

Fixes #1113 and follows up on https://github.com/ja2-stracciatella/ja2-stracciatella/pull/1049#discussion_r415354629. This should clear the one remaining bug before [0.17.x](https://github.com/ja2-stracciatella/ja2-stracciatella/issues?q=is%3Aopen+is%3Aissue+milestone%3Av0.17)

# Summary

I took the patch from https://github.com/ja2-stracciatella/ja2-stracciatella/issues/1113#issuecomment-641044901. On a second thought, I think there is nothing wrong with doing `ST::string::set`. It is part of the public API.

Then I went through each usage of `SET_PALETTEREP_ID`. All other usages are fine with a simple `=` assignment. So I replaced all of them and it should clear things up.