### PR TITLE
Explicitly stop the music before returning to main menu

### DIFF
--- a/src/game/Strategic/Game_Init.cc
+++ b/src/game/Strategic/Game_Init.cc
@@ -60,6 +60,7 @@
 #include "SoundMan.h"
 #include "Debug.h"
 #include "ScreenIDs.h"
+#include "Music_Control.h"
 
 #include "ContentManager.h"
 #include "GameInstance.h"
@@ -373,7 +374,8 @@ void ReStartingGame()
 	//Reset the sectors
 	SetWorldSectorInvalid();
 
-	SoundStopAll( );
+	SetMusicMode(MUSIC_NONE);
+	SoundStopAll();
 
 	//we are going to restart a game so initialize the variable so we can initialize a new game
 	gubScreenCount = 0;


### PR DESCRIPTION
Fixes #87. This regression is probably as old as Stracciatella itself.

# Analysis

The music transition is implemented with end-of-sound callbacks. So the next music will start after the current music has faded out. However, during `ReStartingGame()` (called when returning to main menu), it calls `SoundStopAll()`, which forcefully closes all channels and skips the callback.

Then, when main menu comes up, it still think there is a music playing, so it will try to fade out the current music and wait for the callback which will never come.

See the channel state transitions here. It should be case `2`:
https://github.com/ja2-stracciatella/ja2-stracciatella/blob/6f1e2e71c022dea7727495e47e1d14154adb4e57/src/sgp/SoundMan.cc#L32-L45

# Fix

The fix is to properly stop the music before calling `SoundStopAll()`, which will stop the music anyways.