### PR TITLE
Supporting more data directories

### DIFF
--- a/rust/stracciatella_c_api/src/c/misc.rs
+++ b/rust/stracciatella_c_api/src/c/misc.rs
@@ -113,7 +113,7 @@ pub extern "C" fn checkIfRelativePathExists(
 #[no_mangle]
 pub extern "C" fn findAvailableMods() -> *mut VecCString {
     let mut entries: Vec<_> = Vec::new();
-    
+
     // list all directories under assets dir
     let mut assets_path = get_assets_dir();
     assets_path.push("mods");
@@ -128,10 +128,10 @@ pub extern "C" fn findAvailableMods() -> *mut VecCString {
             paths.for_each(|p| entries.push(p));
         }
     }
-          
+
     let mut mods: Vec<_> = entries
-        .into_iter() 
-        .filter_map(|x| x.ok())  // DirEntry
+        .into_iter()
+        .filter_map(|x| x.ok()) // DirEntry
         .filter_map(|x| {
             if let Ok(metadata) = x.metadata() {
                 if metadata.is_dir() {

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -224,7 +224,7 @@ void DefaultContentManager::AddVFSLayer(VFS_ORDER order, const ST::string path, 
 
 void DefaultContentManager::init()
 {
-	AddVFSLayer(VFS_ORDER::ASSETS_USERHOME, m_userHomeDir);
+	AddVFSLayer(VFS_ORDER::ASSETS_USERHOME, FileMan::joinPaths(m_userHomeDir, "data"));
 	AddVFSLayer(VFS_ORDER::ASSETS_STRACCIATELLA, m_externalizedDataPath);
 	AddVFSLayer(VFS_ORDER::ASSETS_VANILLA, m_dataDir);
 	

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -15,11 +15,15 @@
 #include <stdexcept>
 #include <vector>
 
-enum : int32_t {
-	VFS_ORDER_MOD = 100,
-	VFS_ORDER_STRACCIATELLA = 200,
-	VFS_ORDER_VANILLA = 300,
-	VFS_ORDER_FALLBACK = 400,
+enum VFS_ORDER : int32_t {
+	MOD_USERHOME           = 100, // mods under user home directory
+	MOD_STRACCIATELLA      = 110, // mods under stracciatella assets directory
+	
+	ASSETS_USERHOME        = 200, // assets in user home directory
+	ASSETS_STRACCIATELLA   = 210, // assets shipped with stracciatella
+	ASSETS_VANILLA         = 220, // vanilla game data
+
+	FALLBACK               = 400,
 };
 
 
@@ -28,7 +32,7 @@ class DefaultContentManager : public ContentManager, public IGameDataLoader
 public:
 
 	DefaultContentManager(GameVersion gameVersion,
-				const ST::string &configFolder,
+				const ST::string &userHomeDir,
 				const ST::string &gameResRootPath,
 				const ST::string &externalizedDataPath);
 
@@ -179,7 +183,7 @@ public:
 protected:
 	ST::string m_dataDir;
 	ST::string m_tileDir;
-	ST::string m_configFolder;
+	ST::string m_userHomeDir;
 	ST::string m_gameResRootPath;
 	ST::string m_externalizedDataPath;
 
@@ -260,6 +264,7 @@ protected:
 	bool loadTacticalLayerData();
 
 	rapidjson::Document* readJsonDataFile(const char *fileName) const;
+	void AddVFSLayer(VFS_ORDER order, const ST::string path, const bool throwOnError = true);
 };
 
 class LibraryFileNotFoundException : public std::runtime_error

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -16,8 +16,7 @@
 #include <vector>
 
 enum VFS_ORDER : int32_t {
-	MOD_USERHOME           = 100, // mods under user home directory
-	MOD_STRACCIATELLA      = 110, // mods under stracciatella assets directory
+	MOD                    = 100, // assets overriden by mods
 	
 	ASSETS_USERHOME        = 200, // assets in user home directory
 	ASSETS_STRACCIATELLA   = 210, // assets shipped with stracciatella

--- a/src/externalized/DefaultContentManagerUT.cc
+++ b/src/externalized/DefaultContentManagerUT.cc
@@ -13,12 +13,7 @@ DefaultContentManagerUT::DefaultContentManagerUT(GameVersion gameVersion,
 void DefaultContentManagerUT::init()
 {
 	// externalized data is used in the tests
-	if (!Vfs_addDir(m_vfs.get(), VFS_ORDER_STRACCIATELLA, m_externalizedDataPath.c_str()))
-	{
-		RustPointer<char> err{getRustError()};
-		SLOGE(ST::format("DefaultContentManagerUT::init '{}': {}", m_externalizedDataPath, err.get()));
-		throw std::runtime_error("Failed to add stracciatella dir");
-	}
+	AddVFSLayer(VFS_ORDER::ASSETS_STRACCIATELLA, m_externalizedDataPath);
 }
 
 rapidjson::Document* DefaultContentManagerUT::_readJsonDataFile(const char* fileName) const

--- a/src/externalized/ModPackContentManager.cc
+++ b/src/externalized/ModPackContentManager.cc
@@ -31,14 +31,14 @@ void ModPackContentManager::loadMod(ST::string modName)
 	ST::string modResFolder = FileMan::joinPaths({ m_userHomeDir, "mods", modName, "data" });
 	if (FileMan::checkPathExistance(modResFolder))
 	{
-		AddVFSLayer(VFS_ORDER::MOD_USERHOME, modResFolder);
+		AddVFSLayer(VFS_ORDER::MOD, modResFolder);
 		isLoaded = true;
 	}
 	
 	modResFolder = FileMan::joinPaths({m_assetsRootPath, "mods", modName, "data"});
 	if (FileMan::checkPathExistance(modResFolder))
 	{
-		AddVFSLayer(VFS_ORDER::MOD_STRACCIATELLA, modResFolder);
+		AddVFSLayer(VFS_ORDER::MOD, modResFolder);
 		isLoaded = true;
 	}
 

--- a/src/externalized/ModPackContentManager.cc
+++ b/src/externalized/ModPackContentManager.cc
@@ -10,31 +10,52 @@
 
 ModPackContentManager::ModPackContentManager(GameVersion gameVersion,
 						const std::vector<ST::string> &modNames,
-						const std::vector<ST::string> &modResFolders,
+						const ST::string &assetsRootPath,
 						const ST::string &configFolder,
 						const ST::string &gameResRootPath,
 						const ST::string &externalizedDataPath)
 	:DefaultContentManager(gameVersion, configFolder, gameResRootPath, externalizedDataPath)
 {
 	m_modNames = modNames;
-	m_modResFolders = modResFolders;
+	m_assetsRootPath = assetsRootPath;
 }
 
 ModPackContentManager::~ModPackContentManager()
 {
 }
 
+void ModPackContentManager::loadMod(ST::string modName)
+{
+	bool isLoaded = false;
+
+	ST::string modResFolder = FileMan::joinPaths({ m_userHomeDir, "mods", modName, "data" });
+	if (FileMan::checkPathExistance(modResFolder))
+	{
+		AddVFSLayer(VFS_ORDER::MOD_USERHOME, modResFolder);
+		isLoaded = true;
+	}
+	
+	modResFolder = FileMan::joinPaths({m_assetsRootPath, "mods", modName, "data"});
+	if (FileMan::checkPathExistance(modResFolder))
+	{
+		AddVFSLayer(VFS_ORDER::MOD_STRACCIATELLA, modResFolder);
+		isLoaded = true;
+	}
+
+	if (!isLoaded)
+	{
+		SLOGE(ST::format("Unable to locate data directory of mod '{}'", modName));
+		throw std::runtime_error("Failed to load mod");
+	}
+	
+	SLOGI(ST::format("Loaded mod '{}'", modName));
+}
+
 void ModPackContentManager::init()
 {
-	for (const ST::string& dir : m_modResFolders)
+	for (const ST::string& modName :m_modNames)
 	{
-		SLOGI(ST::format("Vfs with mod dir ({}) '{}'", VFS_ORDER_MOD, dir));
-		if (!Vfs_addDir(m_vfs.get(), VFS_ORDER_MOD, dir.c_str()))
-		{
-			RustPointer<char> err{getRustError()};
-			SLOGE(ST::format("ModPackContentManager::init '{}': {}", dir, err.get()));
-			throw std::runtime_error("Failed to add mod dir");
-		}
+		loadMod(modName);
 	}
 	DefaultContentManager::init();
 }
@@ -48,7 +69,7 @@ ST::string ModPackContentManager::getSavedGamesFolder() const
 		folderName += '-';
 		folderName += name;
 	}
-	return FileMan::joinPaths(m_configFolder, folderName);
+	return FileMan::joinPaths(m_userHomeDir, folderName);
 }
 
 /** Load dialogue quote from file. */

--- a/src/externalized/ModPackContentManager.h
+++ b/src/externalized/ModPackContentManager.h
@@ -12,7 +12,7 @@ class ModPackContentManager : public DefaultContentManager
 public:
 	ModPackContentManager(GameVersion gameVersion,
 				const std::vector<ST::string> &modNames,
-				const std::vector<ST::string> &modResFolders,
+				const ST::string &assetsRootPath,
 				const ST::string &configFolder,
 				const ST::string &gameResRootPath,
 				const ST::string &externalizedDataPath);
@@ -30,7 +30,14 @@ public:
 	virtual ST::string* loadDialogQuoteFromFile(const char* filename, int quote_number) override;
 
 protected:
+	// path to the assets shipped with Stracciatella
+	ST::string m_assetsRootPath;
+
+	// list of enabled mods
 	std::vector<ST::string> m_modNames;
-	std::vector<ST::string> m_modResFolders;
+
 	std::map<ST::string, std::vector<ST::string> > m_dialogQuotesMap;
+
+	// locate the directory of the mod and add to VFS
+	void loadMod(const ST::string modName);
 };

--- a/src/sgp/FileMan.cc
+++ b/src/sgp/FileMan.cc
@@ -328,6 +328,18 @@ ST::string FileMan::joinPaths(const ST::string& first, const ST::string& second)
 	return path.get();
 }
 
+ST::string FileMan::joinPaths(const std::vector<ST::string> parts)
+{
+	if (parts.size() < 1) return ST::null;
+
+	ST::string path = parts[0];
+	for (size_t i = 1; i < parts.size(); i++)
+	{
+		path = joinPaths(path, parts[i]);
+	}
+	return path;
+}
+
 
 SGPFile* FileMan::getSGPFileFromFile(File* f)
 {
@@ -552,7 +564,12 @@ ST::string FileMan::fileReadText(SGPFile* file)
 /** Check file existance. */
 bool FileMan::checkFileExistance(const ST::string& folder, const ST::string& fileName)
 {
-	ST::string path = joinPaths(folder, fileName);
+	return checkPathExistance(joinPaths(folder, fileName));
+}
+
+/**  Check path existence. */
+bool FileMan::checkPathExistance(const ST::string& path)
+{
 	return Fs_exists(path.c_str());
 }
 

--- a/src/sgp/FileMan.h
+++ b/src/sgp/FileMan.h
@@ -83,6 +83,9 @@ public:
 	/** Join two path components. */
 	static ST::string joinPaths(const ST::string& first, const ST::string& second);
 
+	/** Join multiple path components. */
+	static ST::string joinPaths(const std::vector<ST::string> parts);
+
 	/** Replace extension of a file. */
 	static ST::string replaceExtension(const ST::string& path, const ST::string& newExtension);
 
@@ -109,6 +112,9 @@ public:
 
 	/** Check file existance. */
 	static bool checkFileExistance(const ST::string& folder, const ST::string& fileName);
+
+	/** Returns if the given path (dir or file) exists */
+	static bool checkPathExistance(const ST::string& path);
 
 	/** Move a file */
 	static void moveFile(const ST::string& from, const ST::string& to);

--- a/src/sgp/FileMan_unittest.cc
+++ b/src/sgp/FileMan_unittest.cc
@@ -41,6 +41,26 @@ TEST(FileManTest, joinPaths)
 }
 
 
+TEST(FileManTest, joinPathsMultiple)
+{
+	{
+		ST::string result;
+
+		result = FileMan::joinPaths({});
+		EXPECT_EQ(result, ST::null);
+
+		result = FileMan::joinPaths({ "foo" });
+		EXPECT_EQ(result, "foo");
+
+		result = FileMan::joinPaths({ "foo", "bar" });
+		EXPECT_EQ(result, "foo" PATH_SEPARATOR_STR "bar");
+
+		result = FileMan::joinPaths({ "foo", "bar", "baz" });
+		EXPECT_EQ(result, "foo" PATH_SEPARATOR_STR "bar" PATH_SEPARATOR_STR "baz");
+	}
+}
+
+
 TEST(FileManTest, FindFilesInDir)
 {
 #define PS PATH_SEPARATOR_STR

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -432,17 +432,14 @@ int main(int argc, char* argv[])
 	uint32_t n = EngineOptions_getModsLength(params.get());
 	if(n > 0)
 	{
-		std::vector<ST::string> modNames;
-		std::vector<ST::string> modResFolders;
+		std::vector<ST::string> enabledMods;
 		for (uint32_t i = 0; i < n; ++i)
 		{
 			RustPointer<char> modName(EngineOptions_getMod(params.get(), i));
-			ST::string modResFolder = FileMan::joinPaths(FileMan::joinPaths(FileMan::joinPaths(extraDataDir, "mods"), modName.get()), "data");
-			modNames.emplace_back(modName.get());
-			modResFolders.emplace_back(modResFolder);
+			enabledMods.emplace_back(modName.get());
 		}
 		cm = new ModPackContentManager(version,
-						modNames, modResFolders, configFolderPath.get(),
+						enabledMods, extraDataDir, configFolderPath.get(),
 						gameResRootPath.get(), externalizedDataPath);
 		SLOGI("------------------------------------------------------------------------------");
 		SLOGI("JA2 Home Dir:                  '%s'", configFolderPath.get());
@@ -452,12 +449,6 @@ int main(int argc, char* argv[])
 		SLOGI("Tilecache directory:           '%s'", cm->getTileDir().c_str());
 		SLOGI("Saved games directory:         '%s'", cm->getSavedGamesFolder().c_str());
 		SLOGI("------------------------------------------------------------------------------");
-		for (uint32_t i = 0; i < n; ++i)
-		{
-			SLOGI("MOD name:                      '%s'", modNames[i].c_str());
-			SLOGI("MOD resource directory:        '%s'", modResFolders[i].c_str());
-			SLOGI("------------------------------------------------------------------------------");
-		}
 	}
 	else
 	{


### PR DESCRIPTION
For #707. Building on top of the VFS introduced in #1067.

# Summary

- Adding VFS_ORDER for user home directory
    - The effective VFS order is like https://github.com/ja2-stracciatella/ja2-stracciatella/issues/707#issuecomment-509862638, except the tmp dir
- Adding mods and assets directory in user home (`~/.ja2` or `%userprofile%\documents\JA2`)
    - Mods can be loaded from one or more directories. VFS ordering determines which files to use
    - User home directory (`~/.ja2/data`) has the higher  priority than Stracciatella assets (`/usr/share/ja2`)
- Update launcher to list mods from both assets and home directories
-------

If this PR is accepted, we may need to update documentations to tell users what they can do. They may need to create `~/.ja2/data/` and copy from `/usr/share/ja2`. We do not support JSON merging, so a customized `game.json` in home directory will replace the default file.