### PR TITLE
Fix tactical screen scroll freeze

### DIFF
--- a/src/game/Tactical/Handle_UI.cc
+++ b/src/game/Tactical/Handle_UI.cc
@@ -4113,14 +4113,16 @@ void StopRubberBandedMercFromMoving( )
 }
 
 
-void EndRubberBanding( )
+void EndRubberBanding(BOOLEAN fCancel)
 {
-	if ( gRubberBandActive	)
+	if (gRubberBandActive)
 	{
 		FreeMouseCursor( );
 		gfIgnoreScrolling = FALSE;
-
-		EndMultiSoldierSelection( TRUE );
+		if (!fCancel)
+		{
+			EndMultiSoldierSelection(TRUE);
+		}
 
 		gRubberBandActive = FALSE;
 	}

--- a/src/game/Tactical/Handle_UI.h
+++ b/src/game/Tactical/Handle_UI.h
@@ -265,7 +265,7 @@ BOOLEAN UIHandleOnMerc( BOOLEAN fMovementMode );
 
 void ChangeInterfaceLevel( INT16 sLevel );
 
-void EndRubberBanding(void);
+void EndRubberBanding(BOOLEAN fCancel = false);
 void ResetMultiSelection(void);
 void EndMultiSoldierSelection( BOOLEAN fAcknowledge );
 void StopRubberBandedMercFromMoving(void);

--- a/src/game/Tactical/Interface_Control.cc
+++ b/src/game/Tactical/Interface_Control.cc
@@ -577,8 +577,8 @@ void EraseInterfaceMenus( BOOLEAN fIgnoreUIUnLock )
 	PopDownOpenDoorMenu( );
 	DeleteTalkingMenu( );
 
-	// Stop Rubberbanding every time a menu is erased/opened
-	gRubberBandActive = FALSE;
+	// Cancel Rubberbanding every time a menu is erased/opened
+	EndRubberBanding(true);
 	ResetMultiSelection();
 }
 
@@ -595,8 +595,6 @@ void ResetInterfaceAndUI( )
 	EraseInterfaceMenus( FALSE );
 
 	EraseRenderArrows( );
-
-	EndRubberBanding( );
 
 	//ResetMultiSelection( );
 


### PR DESCRIPTION
Analysis here: https://github.com/ja2-stracciatella/ja2-stracciatella/issues/1122#issuecomment-650511871

Fixes #1122. Preserves the behavior of #565.

This fix ensures scrolling is un-freezed when we enter combat mode during rubber-banding. Also re-tested #550.
