### PR TITLE
Adjusting y-position of Skill Traits title

### DIFF
--- a/src/game/Laptop/IMP_SkillTraits.cc
+++ b/src/game/Laptop/IMP_SkillTraits.cc
@@ -97,7 +97,7 @@ enum
 #define	IMP_SKILL_TRAIT__TEXT_OFFSET_Y											12
 
 #define	IMP_SKILL_TRAIT__TITLE_X														LAPTOP_SCREEN_UL_X
-#define	IMP_SKILL_TRAIT__TITLE_Y														53
+#define	IMP_SKILL_TRAIT__TITLE_Y														56
 #define	IMP_SKILL_TRAIT__TITLE_WIDTH												( LAPTOP_SCREEN_LR_X - LAPTOP_SCREEN_UL_X )
 
 #define	IMP_SKILL_TRAIT__GREY_BOX_OFFSET_X									5


### PR DESCRIPTION
For #1127. Adjusting title ("I.M.P. Specialties") by 3 pixels. Now it looks like:

![title-offset](https://user-images.githubusercontent.com/63151803/85918724-dcab2e80-b897-11ea-9707-f4c7f79fba5b.png)

UB [screenshot](https://user-images.githubusercontent.com/63151803/83973310-1a134080-a918-11ea-9304-c24eed2d1450.png) for comparison.