### PR TITLE
Run rust lint and fmt only once

### DIFF
--- a/.github/scripts/ci-build.sh
+++ b/.github/scripts/ci-build.sh
@@ -38,10 +38,12 @@ if [[ "${BUILD_TYPE}" != "Debug" ]]; then
 fi
 
 export RUN_TESTS=true
+export RUN_RUST_CHECKS=false
 export RUN_INSTALL_TEST=true
 export RUSTUP_INIT_ARGS="-y --no-modify-path --default-toolchain=$(cat ./rust-toolchain) --profile=minimal"
 if [[ "$CI_TARGET" == "linux" ]]; then
   export CONFIGURE_CMD="${CONFIGURE_CMD} -DCMAKE_INSTALL_PREFIX=/usr -DEXTRA_DATA_DIR=/usr/share/ja2 -DCPACK_GENERATOR=DEB"
+  export RUN_RUST_CHECKS=true
 
 elif [[ "$CI_TARGET" == "linux-mingw64" ]]; then
   # cross compiling
@@ -77,8 +79,10 @@ if [[ "$RUN_TESTS" == "true" ]]; then
   if [[ "$RUN_INSTALL_TEST" == "true" ]]; then
     sudo $BUILD_CMD --target install
   fi
-  $BUILD_CMD --target cargo-fmt-check
-  $BUILD_CMD --target cargo-clippy
+  if [[ "$RUN_RUST_CHECKS" == "true" ]]; then
+    $BUILD_CMD --target cargo-fmt-check
+    $BUILD_CMD --target cargo-clippy
+  fi
   $BUILD_CMD --target cargo-test
   ./ja2 -unittests
   ./ja2-launcher -help

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -109,14 +109,10 @@ install:
   - cmd: curl -sSf -o rustup-init.exe https://win.rustup.rs/
   - cmd: rustup-init.exe -y --default-toolchain %RUSTUP_TOOLCHAIN%
   - cmd: set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
-  - cmd: rustup.exe component add rustfmt
-  - cmd: rustup.exe component add clippy
 
   - cmd: echo "%RUSTUP_TOOLCHAIN%"
   - cmd: rustc -V
   - cmd: cargo -V
-  - cmd: cargo fmt -- -V
-  - cmd: cargo clippy -- -V
   - cmd: cmake --version
 
 before_build:
@@ -128,8 +124,6 @@ build_script:
   - ps: cmake --build c:\projects\ja2-stracciatella\ci-build --target ALL_BUILD --config ${env:BUILD_TYPE}
 
 test_script:
-  - cmd: cmake --build . --target cargo-fmt-check
-  - cmd: cmake --build . --target cargo-clippy
   - cmd: cmake --build . --target cargo-test
   - cmd: cd %BUILD_TYPE%
   - cmd: ja2.exe -unittests


### PR DESCRIPTION
Small improvement for #1102. This should save around 2 minutes on each AppVeyor build. 

`rustfmt` and `clippy` are both static analysis. We only need to run once per commit to rust code, and no point to run on each and every platform.

After this PR rust code checks will only run on the Linux build on GitHub CI, which is currently the fastest build. This should speed up all other builds.

