### PR TITLE
Fix some more coverity issues with format strings

### DIFF
--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -1175,7 +1175,7 @@ const ST::string* DefaultContentManager::getMusicForMode(MusicMode mode) const {
 	const uint32_t index = Random((uint32_t)m_musicMap.find(mode)->second->size());
 	const ST::string* chosen = m_musicMap.find(mode)->second->at(index);
 
-	SLOGD("Choosing music index %d of %d for: '%s'", index, m_musicMap.find(mode)->second->size(), chosen->c_str());
+	SLOGD(ST::format("Choosing music index {} of {} for: '{}'", index, m_musicMap.find(mode)->second->size(), chosen));
 	return chosen;
 }
 

--- a/src/game/Editor/EditScreen.cc
+++ b/src/game/Editor/EditScreen.cc
@@ -1410,7 +1410,7 @@ static void HandleKeyboardShortcuts(void)
 
 				case SDLK_F4:
 					MusicPlay( GCM->getMusicForMode(giMusicMode) );
-					SLOGD("Testing music %s", GCM->getMusicForMode(giMusicMode));
+					SLOGD(ST::format("Testing music {}", GCM->getMusicForMode(giMusicMode)));
 					giMusicMode = (MusicMode)(giMusicMode + 1);
 					if( giMusicMode >= MAX_MUSIC_MODES )
 						giMusicMode = MUSIC_MAIN_MENU;

--- a/src/game/Laptop/IMP_Compile_Character.cc
+++ b/src/game/Laptop/IMP_Compile_Character.cc
@@ -223,7 +223,7 @@ static void CreatePlayerSkills(void)
 		else if (iLastElementInSkillsList > 2)
 		{
 			// This should be impossible
-			SLOGA("Invalid number ({}) of skills selected", iLastElementInSkillsList);
+			SLOGA(ST::format("Invalid number ({}) of skills selected", iLastElementInSkillsList));
 		}
 	
 		return;

--- a/src/game/Strategic/Map_Screen_Interface_Map_Inventory.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map_Inventory.cc
@@ -1368,7 +1368,7 @@ static void CheckGridNoOfItemsInMapScreenMapInventory(void)
 
 	if( uiNumFlagsNotSet > 0 )
 	{
-		SLOGD("Item with invalid gridno doesnt have flag set: %d", uiNumFlagsNotSet );
+		SLOGD(ST::format("Item with invalid gridno doesnt have flag set: {}", uiNumFlagsNotSet));
 	}
 }
 

--- a/src/game/Strategic/Queen_Command.cc
+++ b/src/game/Strategic/Queen_Command.cc
@@ -648,7 +648,7 @@ void ProcessQueenCmdImplicationsOfDeath(const SOLDIERTYPE* const pSoldier)
 		}
 		if( pGroup->fPlayer )
 		{
-			SLOGW("Attempting to process player group thinking it's an enemy group in ProcessQueenCmdImplicationsOfDeath()", pSoldier->ubGroupID);
+			SLOGW(ST::format("Attempting to process player group thinking it's an enemy group (#{}) in ProcessQueenCmdImplicationsOfDeath()", pSoldier->ubGroupID));
 			return;
 		}
 		switch( pSoldier->ubSoldierClass )

--- a/src/game/Strategic/Strategic_AI.cc
+++ b/src/game/Strategic/Strategic_AI.cc
@@ -1139,15 +1139,15 @@ static BOOLEAN EvaluateGroupSituation(GROUP* pGroup)
 						else
 						{ //Add all the troops to the queen's guard.
 							pSector->ubNumElites += pGroup->ubGroupSize;
-							SLOGD("%d reinforcements have arrived to garrison queen's sector.",
-									pGroup->ubGroupSize, pGroup->ubSectorY + 'A' - 1, pGroup->ubSectorX );
+							SLOGD(ST::format("{} reinforcements have arrived to garrison queen's sector ({}{}).",
+									pGroup->ubGroupSize, pGroup->ubSectorY + 'A' - 1, pGroup->ubSectorX));
 						}
 					}
 					else
 					{ //Add all the troops to the reinforcement pool as the queen's guard is at full strength.
 						giReinforcementPool += pGroup->ubGroupSize;
-						SLOGD("%d reinforcements have arrived at queen's sector and have been added to the reinforcement pool.",
-								pGroup->ubGroupSize, pGroup->ubSectorY + 'A' - 1, pGroup->ubSectorX );
+						SLOGD(ST::format("{} reinforcements have arrived at queen's sector ({}{}) and have been added to the reinforcement pool.",
+								pGroup->ubGroupSize, pGroup->ubSectorY + 'A' - 1, pGroup->ubSectorX));
 					}
 				}
 

--- a/src/game/Tactical/LOS.cc
+++ b/src/game/Tactical/LOS.cc
@@ -2468,7 +2468,7 @@ static UINT8 CalcChanceToGetThrough(BULLET* pBullet)
 		// check a particular tile
 		// retrieve values from world for this particular tile
 		iGridNo = pBullet->iCurrTileX + pBullet->iCurrTileY * WORLD_COLS;
-		SLOGD("CTGT now at %ld", iGridNo);
+		SLOGD(ST::format("CTGT now at {}", iGridNo));
 		pMapElement = &(gpWorldLevelData[ iGridNo ] );
 		qLandHeight = INT32_TO_FIXEDPT( CONVERT_PIXELS_TO_HEIGHTUNITS( pMapElement->sHeight ) );
 		qWallHeight = gqStandardWallHeight + qLandHeight;
@@ -2710,8 +2710,8 @@ static UINT8 CalcChanceToGetThrough(BULLET* pBullet)
 				pBullet->bLOSIndexX = FIXEDPT_TO_LOS_INDEX( pBullet->qCurrX );
 				pBullet->bLOSIndexY = FIXEDPT_TO_LOS_INDEX( pBullet->qCurrY );
 
-				SLOGD("CTGT at %ld %ld after traversing empty tile",
-					pBullet->bLOSIndexX, pBullet->bLOSIndexY);
+				SLOGD(ST::format("CTGT at {} {} after traversing empty tile",
+					pBullet->bLOSIndexX, pBullet->bLOSIndexY));
 			}
 			else
 			{
@@ -2824,9 +2824,9 @@ static UINT8 CalcChanceToGetThrough(BULLET* pBullet)
 				}
 				while( (pBullet->bLOSIndexX == bOldLOSIndexX) && (pBullet->bLOSIndexY == bOldLOSIndexY) && (pBullet->iCurrCubesZ == iOldCubesZ));
 
-				SLOGD("CTGT at %ld %ld %ld after moving in nonempty tile from %ld %ld %ld",
+				SLOGD(ST::format("CTGT at {} {} {} after moving in nonempty tile from {} {} {}",
 					pBullet->bLOSIndexX, pBullet->bLOSIndexY, pBullet->iCurrCubesZ,
-					bOldLOSIndexX, bOldLOSIndexY, iOldCubesZ);
+					bOldLOSIndexX, bOldLOSIndexY, iOldCubesZ));
 				pBullet->iCurrTileX = FIXEDPT_TO_INT32( pBullet->qCurrX ) / CELL_X_SIZE;
 				pBullet->iCurrTileY = FIXEDPT_TO_INT32( pBullet->qCurrY ) / CELL_Y_SIZE;
 			}

--- a/src/game/Tactical/Soldier_Ani.cc
+++ b/src/game/Tactical/Soldier_Ani.cc
@@ -490,8 +490,8 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 					pSoldier->fInNonintAnim = FALSE;
 
 					if (pSoldier->usAnimState == STEAL_ITEM) {
-						SLOGD("Reducing attacker busy count..., CODE FROM ANIMATION %hs ( %d )",
-							gAnimControl[pSoldier->usAnimState].zAnimStr, pSoldier->usAnimState);
+						SLOGD(ST::format("Reducing attacker busy count..., CODE FROM ANIMATION {} ( {} )",
+							gAnimControl[pSoldier->usAnimState].zAnimStr, pSoldier->usAnimState));
 						ReduceAttackBusyCount(pSoldier, FALSE);
 					}
 

--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -987,8 +987,8 @@ static BOOLEAN UseGun(SOLDIERTYPE* pSoldier, INT16 sTargetGridNo)
 			{
 				// Increment attack counter...
 				gTacticalStatus.ubAttackBusyCount++;
-				SLOGD("Incrementing Attack: Exaust from LAW",
-					gTacticalStatus.ubAttackBusyCount);
+				SLOGD(ST::format("Incrementing Attack: Exhaust from LAW ({})",
+					gTacticalStatus.ubAttackBusyCount));
 				EVENT_SoldierGotHit(tgt, MINI_GRENADE, 10, 200, pSoldier->bDirection, 0, pSoldier, 0, ANIM_CROUCH, sNewGridNo);
 			}
 		}

--- a/src/game/TacticalAI/AIMain.cc
+++ b/src/game/TacticalAI/AIMain.cc
@@ -600,7 +600,7 @@ void EndAIDeadlock()
 			SLOGD("Ending turn for %d because breaking deadlock", s.ubID);
 		}
 
-		SLOGD("Number of bullets in the air is %ld", guiNumBullets);
+		SLOGD(ST::format("Number of bullets in the air is {}", guiNumBullets));
 		SLOGD("Setting attack busy count to 0 from deadlock break");
 		gTacticalStatus.ubAttackBusyCount = 0;
 
@@ -1325,13 +1325,13 @@ INT8 ExecuteAction(SOLDIERTYPE *pSoldier)
 
 	if (gfTurnBasedAI || gTacticalStatus.fAutoBandageMode)
 	{
-		SLOGD("%d does %s (a.d. %d) in %d with %d APs left",
+		SLOGD(ST::format("{} does {} (a.d. {}) in {} with {} APs left",
 			pSoldier->ubID, gzActionStr[pSoldier->bAction], pSoldier->usActionData,
-			pSoldier->sGridNo, pSoldier->bActionPoints);
+			pSoldier->sGridNo, pSoldier->bActionPoints));
 	}
 
-	SLOGD("%d does %s (a.d. %d) at time %ld", pSoldier->ubID,
-		gzActionStr[pSoldier->bAction], pSoldier->usActionData, GetJA2Clock());
+	SLOGD(ST::format("{} does {} (a.d. {}) at time {}", pSoldier->ubID,
+		gzActionStr[pSoldier->bAction], pSoldier->usActionData, GetJA2Clock()));
 
 	switch (pSoldier->bAction)
 	{

--- a/src/game/TacticalAI/FindLocations.cc
+++ b/src/game/TacticalAI/FindLocations.cc
@@ -69,9 +69,9 @@ static INT32 CalcPercentBetter(INT32 iOldValue, INT32 iNewValue, INT32 iOldScale
 		return(NOWHERE);
 	}
 	iPercentBetter = (iValueChange * 100) / iScaleSum;
-	SLOGD("CalcPercentBetter: %%Better %ld, old %ld, new %ld, change %ld\noldScale %ld, newScale %ld, scaleSum %ld",
+	SLOGD(ST::format("CalcPercentBetter: %Better {}, old {}, new {}, change {}\noldScale {}, newScale {}, scaleSum {}",
 				iPercentBetter, iOldValue, iNewValue, iValueChange, iOldScale,
-				iNewScale, iScaleSum);
+				iNewScale, iScaleSum));
 	return(iPercentBetter);
 }
 
@@ -976,8 +976,8 @@ INT16 FindBestNearbyCover(SOLDIERTYPE *pSoldier, INT32 morale, INT32 *piPercentB
 		// if best cover value found was at least 5% better than our current cover
 		if (*piPercentBetter >= MIN_PERCENT_BETTER)
 		{
-			SLOGD("Found Cover: current %ld, best %ld, %d%%Better %ld",
-				iCurrentCoverValue, iBestCoverValue, *piPercentBetter);
+			SLOGD(ST::format("Found Cover: current {}, best {}, %Better {}",
+				iCurrentCoverValue, iBestCoverValue, *piPercentBetter));
 			return((INT16)sBestCover);       // return the gridno of that cover
 		}
 	}

--- a/src/game/TacticalAI/NPC.cc
+++ b/src/game/TacticalAI/NPC.cc
@@ -1610,7 +1610,7 @@ void ConverseFull(UINT8 const ubNPC, UINT8 const ubMerc, Approach bApproach, UIN
 					break;
 				case TRIGGER_NPC:
 					// if triggering, pass in the approach data as the record to consider
-					SLOGD("Handling trigger %s/%d at %ld", gMercProfiles[ubNPC].zNickname.c_str(), approach_record, GetJA2Clock());
+					SLOGD(ST::format("Handling trigger {}/{} at {}", gMercProfiles[ubNPC].zNickname.c_str(), approach_record, GetJA2Clock()));
 					NPCConsiderTalking(ubNPC, ubMerc, bApproach, approach_record, pNPCQuoteInfoArray, &pQuotePtr, &ubRecordNum);
 					break;
 				default:

--- a/src/game/TileEngine/Physics.cc
+++ b/src/game/TileEngine/Physics.cc
@@ -476,15 +476,15 @@ static BOOLEAN PhysicsIntegrate(REAL_OBJECT* pObject, float DeltaTime)
 
 	if ( pObject->fPotentialForDebug )
 	{
-		SLOGD("Object %d: Force		%f %f %f",  REALOBJ2ID(pObject),
-			pObject->Force.x, pObject->Force.y, pObject->Force.z);
-		SLOGD("Object %d: Velocity %f %f %f",  REALOBJ2ID(pObject),
-			pObject->Velocity.x, pObject->Velocity.y, pObject->Velocity.z);
-		SLOGD("Object %d: Position %f %f %f",  REALOBJ2ID(pObject),
-			pObject->Position.x, pObject->Position.y, pObject->Position.z);
-		SLOGD("Object %d: Delta Pos %f %f %f", REALOBJ2ID(pObject),
+		SLOGD(ST::format("Object {}: Force     {} {} {}", REALOBJ2ID(pObject),
+			pObject->Force.x, pObject->Force.y, pObject->Force.z));
+		SLOGD(ST::format("Object {}: Velocity  {} {} {}", REALOBJ2ID(pObject),
+			pObject->Velocity.x, pObject->Velocity.y, pObject->Velocity.z));
+		SLOGD(ST::format("Object {}: Position  {} {} {}", REALOBJ2ID(pObject),
+			pObject->Position.x, pObject->Position.y, pObject->Position.z));
+		SLOGD(ST::format("Object {}: Delta Pos {} {} {}", REALOBJ2ID(pObject),
 			pObject->OldPosition.x - pObject->Position.x, pObject->OldPosition.y - pObject->Position.y,
-			pObject->OldPosition.z - pObject->Position.z);
+			pObject->OldPosition.z - pObject->Position.z));
 	}
 
 	if ( pObject->Obj.usItem == MORTAR_SHELL && !pObject->fTestObject && pObject->ubActionCode == THROW_ARM_ITEM )
@@ -832,7 +832,7 @@ static BOOLEAN PhysicsCheckForCollisions(REAL_OBJECT* pObject, INT32* piCollisio
 			if ( !pObject->fTestObject )
 			{
 				// Break window!
-				SLOGD("Object %d: Collision Window", REALOBJ2ID(pObject));
+				SLOGD(ST::format("Object {}: Collision Window", REALOBJ2ID(pObject)));
 
 				sGridNo = MAPROWCOLTOPOS( ( (INT16)pObject->Position.y / CELL_Y_SIZE ), ( (INT16)pObject->Position.x / CELL_X_SIZE ) );
 
@@ -1034,13 +1034,13 @@ static BOOLEAN PhysicsCheckForCollisions(REAL_OBJECT* pObject, INT32* piCollisio
 
 			if ( pObject->fPotentialForDebug )
 			{
-				SLOGD("Object %d: Collision %d", REALOBJ2ID(pObject), iCollisionCode);
-				SLOGD("Object %d: Collision Normal %f %f %f", REALOBJ2ID(pObject),
-					vTemp.x, vTemp.y, vTemp.z);
-				SLOGD("Object %d: Collision OldPos %f %f %f", REALOBJ2ID(pObject),
-					pObject->Position.x, pObject->Position.y, pObject->Position.z);
-				SLOGD("Object %d: Collision Velocity %f %f %f", REALOBJ2ID(pObject),
-					pObject->CollisionVelocity.x, pObject->CollisionVelocity.y, pObject->CollisionVelocity.z);
+				SLOGD(ST::format("Object {}: Collision {}", REALOBJ2ID(pObject), iCollisionCode));
+				SLOGD(ST::format("Object {}: Collision Normal {} {} {}", REALOBJ2ID(pObject),
+					vTemp.x, vTemp.y, vTemp.z));
+				SLOGD(ST::format("Object {}: Collision OldPos {} {} {}", REALOBJ2ID(pObject),
+					pObject->Position.x, pObject->Position.y, pObject->Position.z));
+				SLOGD(ST::format("Object {}: Collision Velocity {} {} {}", REALOBJ2ID(pObject),
+					pObject->CollisionVelocity.x, pObject->CollisionVelocity.y, pObject->CollisionVelocity.z));
 			}
 		}
 		else
@@ -1195,7 +1195,7 @@ static BOOLEAN PhysicsMoveObject(REAL_OBJECT* pObject)
 
 		if ( pObject->fPotentialForDebug )
 		{
-			SLOGD("Object %d: uiNumTilesMoved: %d", REALOBJ2ID(pObject), pObject->uiNumTilesMoved);
+			SLOGD(ST::format("Object {}d: uiNumTilesMoved: {}", REALOBJ2ID(pObject), pObject->uiNumTilesMoved));
 		}
 	}
 
@@ -1311,7 +1311,7 @@ static vector_3 FindBestForceForTrajectory(INT16 sSrcGridNo, INT16 sGridNo, INT1
 	{
 		(*pdMagForce) = dForce;
 	}
-	SLOGD("Number of integration: %d", iNumChecks );
+	SLOGD(ST::format("Number of integration: {}", iNumChecks));
 
 	return( vForce );
 }

--- a/src/game/TileEngine/TileDef.cc
+++ b/src/game/TileEngine/TileDef.cc
@@ -138,9 +138,9 @@ void CreateTileDatabase()
 	}
 
 	//Calculate mem usgae
-	SLOGD("Database Sizes: %d vs %d", gTileDatabaseSize, NUMBEROFTILES);
-	SLOGD("Database Types: %d", NUMBEROFTILETYPES);
-	SLOGD("Database Item Mem: %d", gTileDatabaseSize * sizeof(TILE_ELEMENT));
+	SLOGD(ST::format("Database Sizes: {} vs {}", gTileDatabaseSize, NUMBEROFTILES));
+	SLOGD(ST::format("Database Types: {}", NUMBEROFTILETYPES));
+	SLOGD(ST::format("Database Item Mem: {}", gTileDatabaseSize * sizeof(TILE_ELEMENT)));
 }
 
 

--- a/src/sgp/MemMan.cc
+++ b/src/sgp/MemMan.cc
@@ -37,11 +37,11 @@ void ShutdownMemoryManager(void)
 {
 	if (MemDebugCounter != 0)
 	{
-		SLOGE("Memory leak detected: \n\
-					%d memory blocks still allocated\n\
-					%d bytes memory total was allocated\n\
-					%d bytes memory total was freed",
-					MemDebugCounter, guiMemAlloced, guiMemFreed);
+		SLOGE(ST::format("Memory leak detected: \n\
+					{} memory blocks still allocated\n\
+					{} bytes memory total was allocated\n\
+					{} bytes memory total was freed",
+					MemDebugCounter, guiMemAlloced, guiMemFreed));
 	}
 	fMemManagerInit = FALSE;
 }

--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -1066,7 +1066,7 @@ static BOOLEAN SoundStopChannel(SOUNDTAG* channel)
 
 	if (channel->pSample == NULL) return FALSE;
 
-	SLOGD("stopping channel channel %u", channel - pSoundList);
+	SLOGD(ST::format("stopping channel channel {}", (channel - pSoundList)));
 	channel->State = CHANNEL_STOP;
 	return TRUE;
 }


### PR DESCRIPTION
This should supersede #899. Changes only logging.

I went through the format string issues flagged by Coverity, and replaced `printf`-style format strings with `ST::format`. I went through the ones under "API usage error", not so sure if I missed any other things.

