### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/externalized/ShippingDestinationModel.cc
+++ b/src/externalized/ShippingDestinationModel.cc
@@ -45,7 +45,7 @@ ShippingDestinationModel* ShippingDestinationModel::deserialize(JsonObjectReader
 void ShippingDestinationModel::validateData(std::vector<const ShippingDestinationModel*> destinations, std::vector<const ST::string*> destinationNames)
 {
 	int numPrimaryDestinations = 0;
-	for (int i = 0; i < destinations.size(); i++)
+	for (size_t i = 0; i < destinations.size(); i++)
 	{
 		auto dest = destinations[i];
 		if (dest->locationId != i)

--- a/src/externalized/army/ArmyCompositionModel.cc
+++ b/src/externalized/army/ArmyCompositionModel.cc
@@ -97,7 +97,7 @@ void ArmyCompositionModel::validateLoadedData(const std::vector<ARMY_COMPOSITION
 	{
 		// Warn if default compositions are altered. It might work, but no guarantee.
 		auto comp = armyCompositions[i];
-		if (comp.iReadability != i)
+		if (comp.iReadability != static_cast<int32_t>(i))
 		{
 			SLOGW(ST::format("Army Composition has incorrect ID. The save might be corrupted. Expected: {}; Actual: {}", i, comp.iReadability));
 		}

--- a/src/externalized/strategic/MineModel.h
+++ b/src/externalized/strategic/MineModel.h
@@ -17,8 +17,8 @@ public:
 	bool isAbandoned() const;
 
 	const uint8_t mineId;
-	const uint8_t associatedTownId;
 	const uint8_t entranceSector;
+	const uint8_t associatedTownId;
 	const uint8_t mineType;
 	const uint16_t minimumMineProduction;
 	const bool headMinerAssigned;

--- a/src/game/Laptop/IMP_SkillTraits.cc
+++ b/src/game/Laptop/IMP_SkillTraits.cc
@@ -618,7 +618,6 @@ void AddSelectedSkillsToSkillsList()
 
 void HandleLastSelectedTraits( INT8 bNewTrait )
 {
-	INT8	bTemp=-1;
 	//if there are none selected
 	if( gbLastSelectedTraits[ 0 ] == -1 )
 	{

--- a/src/game/Strategic/Creature_Spreading.cc
+++ b/src/game/Strategic/Creature_Spreading.cc
@@ -184,7 +184,6 @@ static bool IsMineInfestible(const MineModel* mine)
 
 void InitCreatureQuest()
 {
-	UNDERGROUND_SECTORINFO *curr;
 	INT32 i=-1;
 	UINT8 ubChosenMineId;
 	INT32 iRandom;


### PR DESCRIPTION
Fixing some recently introduced GCC warnings: `-Wunused-variable`, `-Wsign-compare` and `-Wreorder`.
 
 