### PR TITLE
Fix time consuming logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,10 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-missing-braces -Wno-unused-function")
 endif()
 
+# This is used for performant log calls from C++ to Rust that use non-absolute file name
+string(LENGTH "${CMAKE_SOURCE_DIR}/src/" SOURCE_PATH_SIZE)
+add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
+
 add_executable(${JA2_BINARY} ${JA2_SOURCES})
 target_link_libraries(${JA2_BINARY} ${SDL2_LIBRARY} ${GTEST_LIBRARIES} smacker ${STRACCIATELLA_LIBRARIES} string_theory-internal)
 add_dependencies(${JA2_BINARY} stracciatella)

--- a/rust/stracciatella/src/logger.rs
+++ b/rust/stracciatella/src/logger.rs
@@ -11,7 +11,8 @@ use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use log::{
-    logger, set_boxed_logger, set_max_level, warn, Level, LevelFilter, Log, Metadata, MetadataBuilder, Record,
+    logger, set_boxed_logger, set_max_level, warn, Level, LevelFilter, Log, Metadata,
+    MetadataBuilder, Record,
 };
 use simplelog::{
     CombinedLogger, Config, SharedLogger, SimpleLogger, TermLogger, TerminalMode, WriteLogger,

--- a/rust/stracciatella/src/logger.rs
+++ b/rust/stracciatella/src/logger.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use log::{
-    logger, set_boxed_logger, set_max_level, warn, Level, LevelFilter, Log, Metadata, Record,
+    logger, set_boxed_logger, set_max_level, warn, Level, LevelFilter, Log, Metadata, MetadataBuilder, Record,
 };
 use simplelog::{
     CombinedLogger, Config, SharedLogger, SimpleLogger, TermLogger, TerminalMode, WriteLogger,
@@ -141,13 +141,16 @@ impl Logger {
     /// Can be used e.g. in C++ or scripting
     pub fn log_with_custom_metadata(level: LogLevel, message: &str, target: &str) {
         let level = level.into();
+        let logger = logger();
+        let metadata = MetadataBuilder::new().level(level).target(target).build();
 
-        logger().log(
-            &Record::builder()
-                .level(level)
-                .target(target)
-                .args(format_args!("{}", message))
-                .build(),
-        );
+        if logger.enabled(&metadata) {
+            logger.log(
+                &Record::builder()
+                    .metadata(metadata)
+                    .args(format_args!("{}", message))
+                    .build(),
+            );
+        }
     }
 }

--- a/rust/stracciatella_c_api/src/c/logger.rs
+++ b/rust/stracciatella_c_api/src/c/logger.rs
@@ -26,5 +26,5 @@ pub extern "C" fn Logger_log(level: LogLevel, message: *const c_char, target: *c
     let message = str_from_c_str_or_panic(unsafe_c_str(message));
     let target = str_from_c_str_or_panic(unsafe_c_str(target));
 
-    Logger::log_with_custom_metadata(level, message, target);
+    Logger::log_with_custom_metadata(level, message, &target);
 }

--- a/rust/stracciatella_c_api/src/c/logger.rs
+++ b/rust/stracciatella_c_api/src/c/logger.rs
@@ -26,9 +26,5 @@ pub extern "C" fn Logger_log(level: LogLevel, message: *const c_char, target: *c
     let message = str_from_c_str_or_panic(unsafe_c_str(message));
     let target = str_from_c_str_or_panic(unsafe_c_str(target));
 
-    let mut target = target.replace("\\", "/");
-    if let Some(subpath) = target.rsplit("/src/").next() {
-        target = subpath.to_owned();
-    }
-    Logger::log_with_custom_metadata(level, message, &target);
+    Logger::log_with_custom_metadata(level, message, target);
 }

--- a/src/sgp/Logger.h
+++ b/src/sgp/Logger.h
@@ -8,19 +8,22 @@
 void LogMessage(bool isAssert, LogLevel level, const char* file, const ST::string& str);
 void LogMessage(bool isAssert, LogLevel level, const char *file, const char *format, ...);
 
+/** Get filename relative to src directory */
+#define __FILENAME__ (__FILE__ + SOURCE_PATH_SIZE)
+
 /** Print debug message macro. */
-#define SLOGD(FORMAT, ...) LogMessage(false, LogLevel::Debug, __FILE__, FORMAT, ##__VA_ARGS__)
+#define SLOGD(FORMAT, ...) LogMessage(false, LogLevel::Debug, __FILENAME__, FORMAT, ##__VA_ARGS__)
 
 /** Print info message macro. */
-#define SLOGI(FORMAT, ...) LogMessage(false, LogLevel::Info,  __FILE__, FORMAT, ##__VA_ARGS__)
+#define SLOGI(FORMAT, ...) LogMessage(false, LogLevel::Info,  __FILENAME__, FORMAT, ##__VA_ARGS__)
 
 /** Print warning message macro. */
-#define SLOGW(FORMAT, ...) LogMessage(false, LogLevel::Warn, __FILE__, FORMAT, ##__VA_ARGS__)
+#define SLOGW(FORMAT, ...) LogMessage(false, LogLevel::Warn, __FILENAME__, FORMAT, ##__VA_ARGS__)
 
 /** Print error message macro. */
-#define SLOGE(FORMAT, ...) LogMessage(false, LogLevel::Error, __FILE__, FORMAT, ##__VA_ARGS__)
+#define SLOGE(FORMAT, ...) LogMessage(false, LogLevel::Error, __FILENAME__, FORMAT, ##__VA_ARGS__)
 
 /** Print error message macro. */
-#define SLOGA(FORMAT, ...) LogMessage(true, LogLevel::Error, __FILE__, FORMAT, ##__VA_ARGS__)
+#define SLOGA(FORMAT, ...) LogMessage(true, LogLevel::Error, __FILENAME__, FORMAT, ##__VA_ARGS__)
 
 #endif//SGP_LOGGER_H_


### PR DESCRIPTION
Fixes #1136 

Should optimize logging performance in general:

- Dont build log record when it is filtered anyways
- Pass filename via Macro to Rust instead of building it from the full path in rust