### PR TITLE
Fix a crash when a Civ of faction bleeds out

### DIFF
--- a/src/game/Tactical/Soldier_Profile.cc
+++ b/src/game/Tactical/Soldier_Profile.cc
@@ -838,11 +838,13 @@ BOOLEAN UnRecruitEPC(ProfileID const pid)
 
 INT8 WhichBuddy( UINT8 ubCharNum, UINT8 ubBuddy )
 {
-	INT8								bLoop;
+	if (ubCharNum == NO_PROFILE)
+	{
+		return -1;
+	}
 
 	MERCPROFILESTRUCT const& p = GetProfile(ubCharNum);
-
-	for (bLoop = 0; bLoop < 3; bLoop++)
+	for (INT8 bLoop = 0; bLoop < 3; bLoop++)
 	{
 		if (p.bBuddy[bLoop] == ubBuddy)
 		{


### PR DESCRIPTION
## Summary

This is almost the same crash as #1068, but for a civilian in faction. (cf. #1069)

This is a crash of the same thing at a different place. If a non-hostile unnamed civ of faction dies when game is in strategic map, it crashes with uncaught exception `invalid profile id 200`. 

## Reproducing the bug

Just any way you get a unnamed civ in faction injured without turning hostile. For example:

- In San Mona, spawn a creature/monster and have it injure one of Kingpin's men. 
- Kill the monster so the civ is left at wounded, bleeding state
- Go to map screen and fast forward still he bleeds out

In Night Ops maps, I got a bloodcat ambush near San Mona. The bloodcats wounded one of civs of Kingpin faction. This should also be possible in vanilla with the Hicks.

## Stack trace
```
ja2.exe!WhichBuddy(unsigned char ubCharNum, unsigned char ubBuddy) Line 843	C++
ja2.exe!HandleSoldierDeadComments(const SOLDIERTYPE * dead) Line 55	C++
ja2.exe!HandleStrategicDeath(SOLDIERTYPE & s) Line 38	C++
ja2.exe!StrategicHandlePlayerTeamMercDeath(SOLDIERTYPE & s) Line 130	C++
ja2.exe!HandleTakeDamageDeath(SOLDIERTYPE * pSoldier, unsigned char bOldLife, unsigned char ubReason) Line 5433	C++
ja2.exe!SoldierTakeDamage(SOLDIERTYPE * pSoldier, short sLifeDeduct, short sBreathLoss, unsigned char ubReason, SOLDIERTYPE * attacker) Line 5881	C++
ja2.exe!SoldierBleed(SOLDIERTYPE * s, unsigned char fBandagedBleed) Line 8017	C++
ja2.exe!CheckBleeding(SOLDIERTYPE * pSoldier) Line 7976	C++
ja2.exe!EVENT_BeginMercTurn(SOLDIERTYPE & s) Line 4059	C++
ja2.exe!HandleTacticalEndTurn() Line 162	C++
ja2.exe!HandleStrategicTurn() Line 93	C++
ja2.exe!MapScreenHandle() Line 1656	C++
```