### PR TITLE
AnimCache should not evict in-use surface

### DIFF
--- a/src/game/Tactical/Animation_Cache.cc
+++ b/src/game/Tactical/Animation_Cache.cc
@@ -112,7 +112,7 @@ void GetCachedAnimationSurface(UINT16 const usSoldierID, AnimationSurfaceCacheTy
 
 		if (ubLowestIndex == -1)
 		{
-			SLOGW(ST::format("Anim Cache: No perferred cache slot for eviction ( Soldier {} )", usSoldierID));
+			SLOGW(ST::format("Anim Cache: No preferred cache slot for eviction ( Soldier {} )", usSoldierID));
 			ubLowestIndex = 0;
 		}
 		

--- a/src/game/Tactical/Animation_Cache.cc
+++ b/src/game/Tactical/Animation_Cache.cc
@@ -110,21 +110,21 @@ void GetCachedAnimationSurface(UINT16 const usSoldierID, AnimationSurfaceCacheTy
 			}
 		}
 
-		if (ubLowestIndex != -1)
+		if (ubLowestIndex == -1)
 		{
-			// Bump off lowest index
-			SLOGD("Anim Cache: Bumping %d ( Soldier %d )", ubLowestIndex, usSoldierID);
-			UnLoadAnimationSurface( usSoldierID, pAnimCache->usCachedSurfaces[ ubLowestIndex ] );
+			SLOGW(ST::format("Anim Cache: No perferred cache slot for eviction ( Soldier {} )", usSoldierID));
+			ubLowestIndex = 0;
+		}
+		
+		// Bump off lowest index
+		SLOGD("Anim Cache: Bumping %d ( Soldier %d )", ubLowestIndex, usSoldierID);
+		UnLoadAnimationSurface( usSoldierID, pAnimCache->usCachedSurfaces[ ubLowestIndex ] );
 
-			// Decrement
-			pAnimCache->sCacheHits[ ubLowestIndex ] = 0;
-			pAnimCache->usCachedSurfaces[ ubLowestIndex ] = EMPTY_CACHE_ENTRY;
-			pAnimCache->ubCacheSize--;
-		}
-		else
-		{
-			SLOGW("Anim Cache: No slots can be evicted");
-		}
+		// Decrement
+		pAnimCache->sCacheHits[ ubLowestIndex ] = 0;
+		pAnimCache->usCachedSurfaces[ ubLowestIndex ] = EMPTY_CACHE_ENTRY;
+		pAnimCache->ubCacheSize--;
+
 	}
 
 	// If here, Insert at an empty slot

--- a/src/game/Tactical/Animation_Cache.h
+++ b/src/game/Tactical/Animation_Cache.h
@@ -3,8 +3,7 @@
 
 #include "Types.h"
 
-#define MAX_CACHE_SIZE	20
-#define MIN_CACHE_SIZE	2
+#define DEFAULT_ANIM_CACHE_SIZE	3
 
 
 struct AnimationSurfaceCacheType


### PR DESCRIPTION
Fixes #721, which is caused by evicting an in-use animation surface from AnimCache.

Should also fix #139.

## Summary

- For cache eviction, consider also the current `pSoldier->usAnimSurface`
- We can have up to 2 "reserved" cache slots, the max cache size must be larger than 2
- `guiCacheSize` increased from 2 to 3
    - This may lead to higher memory usage, extra ~40 bytes for each soldier
    - AnimCache does not get saved, so it does not impact game saves
    - Cache size might be made configurable, some day. See also https://github.com/ja2-stracciatella/ja2-stracciatella/commit/235a49d07fb8bf5e5ce1959e7720a6bf6234eda1

## Testing

Bug described [here](https://github.com/ja2-stracciatella/ja2-stracciatella/issues/721#issuecomment-654258818) can no longer be reproduced. Now it hits the added eviction check as expected, with log `Anim Cache: REJECTING Slot 1 IN-USE ANIM SURFACE ( Soldier 0, Surface 202 )`.

## Related commits

This bug probably does not manifest in vanilla, because vanilla returns `FALSE` and pretends nothing happened. See below:

- https://github.com/ja2-stracciatella/ja2-stracciatella/commit/3aab5adc11058a1cb2ac7415234e83064f54624b
- https://github.com/ja2-stracciatella/ja2-stracciatella/commit/a8278d914b3f916d152483ef342e470a3fc0c32d
