### PR TITLE
Initialize VFS at a single place from EngineOptions

### DIFF
--- a/rust/stracciatella/Cargo.toml
+++ b/rust/stracciatella/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/stracciatella.rs"
 
 [[bin]]
 name = "ja2-resource-pack"
-path = "src/bin_resource_pack.rs"
+path = "src/bin/resource_pack.rs"
 required-features = ["bin"]
 
 [dependencies]

--- a/rust/stracciatella/src/bin/resource_pack.rs
+++ b/rust/stracciatella/src/bin/resource_pack.rs
@@ -11,10 +11,6 @@
 //! ```
 //!
 
-mod file_formats;
-mod res;
-mod unicode;
-
 use std::fmt::Debug;
 use std::fs;
 use std::path::Path;

--- a/rust/stracciatella/src/file_formats/mod.rs
+++ b/rust/stracciatella/src/file_formats/mod.rs
@@ -1,3 +1,57 @@
 //! This module contains code to read and write fileformats that are used by Jagged Alliance 2
 
+use std::io::ErrorKind::{InvalidData, InvalidInput};
+use std::io::{Error, Read, Result, Write};
+
 pub mod slf;
+
+/// Trait that adds extra functions to Read.
+pub trait StracciatellaReadExt: Read {
+    /// Reads and discards unused bytes.
+    fn read_unused(&mut self, num_bytes: usize) -> Result<()> {
+        let mut buffer = vec![0u8; num_bytes];
+        self.read_exact(&mut buffer)?;
+        Ok(())
+    }
+
+    /// Reads a nul terminated fixed size string.
+    fn read_fixed_string(&mut self, num_bytes: usize) -> Result<String> {
+        let mut buffer = vec![0u8; num_bytes];
+        self.read_exact(&mut buffer)?;
+        // must be nul terminated and valid utf8
+        match buffer.iter().position(|&byte| byte == 0) {
+            Some(position) => match ::std::str::from_utf8(&buffer[..position]) {
+                Ok(s) => Ok(s.to_string()),
+                Err(e) => Err(Error::new(InvalidData, e)),
+            },
+            None => Err(Error::new(InvalidData, "string is not nul terminated")),
+        }
+    }
+}
+
+/// Trait that adds extra functions to Write.
+pub trait StracciatellaWriteExt: Write {
+    /// Writes zeroed unused bytes.
+    fn write_unused(&mut self, num_bytes: usize) -> Result<()> {
+        let buffer = vec![0u8; num_bytes];
+        self.write_all(&buffer)
+    }
+
+    /// Write a nul terminated fixed size string, unused space is zeroed.
+    fn write_fixed_string(&mut self, num_bytes: usize, string: &str) -> Result<()> {
+        let mut buffer = vec![0u8; num_bytes];
+        let string_bytes = string.as_bytes();
+        if string_bytes.len() >= buffer.len() {
+            return Err(Error::new(InvalidInput, "string is too long"));
+        }
+        buffer[..string_bytes.len()].copy_from_slice(&string_bytes);
+        self.write_all(&buffer)?;
+        Ok(())
+    }
+}
+
+/// Everything that implements Read gets Ja2WriteExt for free.
+impl<T: Read + ?Sized> StracciatellaReadExt for T {}
+
+/// Everything that implements Write gets Ja2WriteExt for free.
+impl<T: Write + ?Sized> StracciatellaWriteExt for T {}

--- a/rust/stracciatella/src/vfs/mod.rs
+++ b/rust/stracciatella/src/vfs/mod.rs
@@ -9,18 +9,29 @@ pub mod slf;
 
 use std::fmt;
 use std::io;
-use std::io::SeekFrom;
-use std::path::Path;
+use std::io::{ErrorKind, SeekFrom};
+use std::path::{Path, PathBuf};
+
+use log::{info, warn};
 
 use crate::unicode::Nfc;
 use crate::vfs::dir::{DirFs, DirFsFile};
 use crate::vfs::slf::{SlfFs, SlfFsFile};
+use crate::EngineOptions;
+use crate::{fs, get_assets_dir};
 
 /// A virtual filesystem that mounts other filesystems.
 #[derive(Debug, Default)]
 pub struct Vfs {
     /// List of entries.
-    pub entries: Vec<VfsEntry>,
+    pub entries: Vec<VfsSource>,
+}
+
+/// A virtual filesystem that mounts other filesystems.
+#[derive(Debug)]
+pub struct VfsInitError {
+    path: PathBuf,
+    error: io::Error,
 }
 
 /// A filesystem entry.
@@ -44,6 +55,11 @@ pub enum VfsFile {
     Slf(SlfFsFile),
 }
 
+static MODS_DIR: &str = "mods";
+static DATA_DIR: &str = "data";
+static EXTERNALIZED_DIR: &str = "externalized";
+static EDITOR_SLF_NAME: &str = "editor.slf";
+
 impl Vfs {
     /// Creates a new virtual filesystem.
     pub fn new() -> Vfs {
@@ -51,27 +67,123 @@ impl Vfs {
     }
 
     /// Adds an overlay filesystem backed by a filesystem directory.
-    pub fn add_dir(&mut self, order: i32, path: &Path) -> io::Result<()> {
-        self.insert_entry(VfsEntry {
-            order,
-            source: VfsSource::Dir(DirFs::new(&path)?),
-        });
+    pub fn add_dir(&mut self, path: &Path) -> Result<(), VfsInitError> {
+        let dir_fs = DirFs::new(&path).map_err(|error| VfsInitError {
+            path: path.to_owned(),
+            error,
+        })?;
+        self.entries.push(VfsSource::Dir(dir_fs));
         Ok(())
     }
 
     /// Adds an overlay filesystem backed by a SLF file.
-    pub fn add_slf(&mut self, order: i32, path: &Path) -> io::Result<()> {
-        self.insert_entry(VfsEntry {
-            order,
-            source: VfsSource::Slf(SlfFs::new(&path)?),
+    pub fn add_slf(&mut self, path: &Path) -> Result<(), VfsInitError> {
+        let slf_fs = SlfFs::new(&path).map_err(|error| VfsInitError {
+            path: path.to_owned(),
+            error,
+        })?;
+        self.entries.push(VfsSource::Slf(slf_fs));
+        Ok(())
+    }
+
+    pub fn init_from_engine_options(
+        &mut self,
+        engine_options: &EngineOptions,
+    ) -> Result<(), VfsInitError> {
+        let vanilla_data_dir = fs::resolve_existing_components(
+            Path::new(DATA_DIR),
+            Some(&engine_options.vanilla_game_dir),
+            true,
+        );
+        let assets_dir = fs::resolve_existing_components(&get_assets_dir(), None, true);
+        let externalized_dir =
+            fs::resolve_existing_components(Path::new(EXTERNALIZED_DIR), Some(&assets_dir), true);
+        let editor_slf_path = fs::resolve_existing_components(
+            &Path::new(EDITOR_SLF_NAME),
+            Some(&externalized_dir),
+            true,
+        );
+
+        // Add mod directories
+        for mod_name in engine_options.mods.iter() {
+            // First are mod directories in home directory then mods in externalized directory (only one of them is required)
+            let mod_path =
+                Path::new(MODS_DIR).join(Path::new(&format!("{}/{}", &mod_name, DATA_DIR)));
+            let mod_in_home = fs::resolve_existing_components(
+                &mod_path,
+                Some(&engine_options.stracciatella_home),
+                true,
+            );
+            let mod_in_externalized =
+                fs::resolve_existing_components(&mod_path, Some(&assets_dir), true);
+
+            match (mod_in_home.exists(), mod_in_externalized.exists()) {
+                (false, false) => {
+                    return Err(VfsInitError {
+                        path: mod_path,
+                        error: ErrorKind::NotFound.into(),
+                    });
+                }
+                (true, false) => {
+                    self.add_dir(&mod_in_home)?;
+                }
+                (false, true) => {
+                    self.add_dir(&mod_in_externalized)?;
+                }
+                (true, true) => {
+                    self.add_dir(&mod_in_home)?;
+                    self.add_dir(&mod_in_externalized)?;
+                }
+            };
+        }
+
+        // Next is externalized data dir (required)
+        self.add_dir(&externalized_dir)?;
+
+        // Next is vanilla data dir (required)
+        self.add_dir(&vanilla_data_dir)?;
+
+        // Next are SLF files in vanilla data dir
+        let slf_paths =
+            fs::read_dir_paths(&vanilla_data_dir, false).map_err(|error| VfsInitError {
+                path: vanilla_data_dir.clone(),
+                error,
+            })?;
+        let slf_paths = slf_paths.iter().filter(|path| {
+            path.extension().map(|e| e.to_string_lossy().to_lowercase()) == Some("slf".to_string())
         });
+        for path in slf_paths {
+            self.add_slf(&path)?;
+        }
+
+        // Last is fallback editor.slf if it exists (does not need to exist)
+        if engine_options.run_editor {
+            if editor_slf_path.exists() {
+                self.add_slf(&editor_slf_path)?;
+            } else {
+                warn!(
+                    "Free editor.slf not found in {:?}, the editor might not work",
+                    assets_dir
+                );
+            }
+        }
+
+        // Print VFS order to console
+        for (index, v) in self.entries.iter().enumerate() {
+            info!(
+                "VFS item with priority {}: {}",
+                self.entries.len() - index,
+                v
+            );
+        }
+
         Ok(())
     }
 
     /// Opens a file.
     pub fn open(&self, file_path: &Nfc) -> io::Result<VfsFile> {
         for entry in self.entries.iter() {
-            let file_result = match &entry.source {
+            let file_result = match &entry {
                 VfsSource::Dir(x) => x.open(&file_path).map(VfsFile::Dir),
                 VfsSource::Slf(x) => x.open(&file_path).map(VfsFile::Slf),
             };
@@ -83,16 +195,6 @@ impl Vfs {
             return file_result;
         }
         Err(io::ErrorKind::NotFound.into())
-    }
-
-    /// Inserts an entry in the position according to the order.
-    fn insert_entry(&mut self, entry: VfsEntry) {
-        let index = self
-            .entries
-            .iter()
-            .position(|x| x.order > entry.order)
-            .unwrap_or_else(|| self.entries.len());
-        self.entries.insert(index, entry);
     }
 }
 
@@ -121,7 +223,7 @@ impl fmt::Display for Vfs {
             if f.alternate() {
                 f.write_str("\n    ")?;
             }
-            write!(f, "{}, ", entry.source)?;
+            write!(f, "{}, ", entry)?;
         }
         if f.alternate() {
             f.write_str("\n}")
@@ -137,6 +239,15 @@ impl fmt::Display for VfsSource {
             VfsSource::Dir(x) => x.fmt(f),
             VfsSource::Slf(x) => x.fmt(f),
         }
+    }
+}
+
+impl fmt::Display for VfsInitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "Error initializing VFS for {:?}: {}",
+            self.path, self.error
+        ))
     }
 }
 

--- a/rust/stracciatella/src/vfs/mod.rs
+++ b/rust/stracciatella/src/vfs/mod.rs
@@ -122,6 +122,11 @@ impl Vfs {
             true,
         );
         let assets_dir = fs::resolve_existing_components(&get_assets_dir(), None, true);
+        let home_data_dir = fs::resolve_existing_components(
+            &PathBuf::from(DATA_DIR),
+            Some(&engine_options.stracciatella_home),
+            true,
+        );
         let externalized_dir =
             fs::resolve_existing_components(Path::new(EXTERNALIZED_DIR), Some(&assets_dir), true);
         let editor_slf_path = fs::resolve_existing_components(
@@ -165,6 +170,13 @@ impl Vfs {
                     self.add_slf_files(&mod_in_externalized, false)?;
                 }
             };
+        }
+
+        // Next is home data dir (does not need to exist)
+        if home_data_dir.exists() {
+            self.add_dir(&home_data_dir)?;
+            // home data dir can include slf files
+            self.add_slf_files(&home_data_dir, false)?;
         }
 
         // Next is externalized data dir (required)

--- a/rust/stracciatella/src/vfs/mod.rs
+++ b/rust/stracciatella/src/vfs/mod.rs
@@ -34,13 +34,6 @@ pub struct VfsInitError {
     error: io::Error,
 }
 
-/// A filesystem entry.
-#[derive(Debug)]
-pub struct VfsEntry {
-    pub order: i32,
-    pub source: VfsSource,
-}
-
 /// A source filesystem.
 #[derive(Debug)]
 pub enum VfsSource {

--- a/rust/stracciatella/src/vfs/mod.rs
+++ b/rust/stracciatella/src/vfs/mod.rs
@@ -88,14 +88,17 @@ impl Vfs {
 
     /// Adds an overlay for all SLF files in dir
     pub fn add_slf_files(&mut self, path: &Path, required: bool) -> Result<(), VfsInitError> {
-        let slf_paths =
-            fs::read_dir_paths(path, false).map_err(|error| VfsInitError {
-                path: path.to_owned(),
-                error,
-            })?;
-        let slf_paths: Vec<_> = slf_paths.iter().filter(|path| {
-            path.extension().map(|e| e.to_string_lossy().to_lowercase()) == Some("slf".to_string())
-        }).collect();
+        let slf_paths = fs::read_dir_paths(path, false).map_err(|error| VfsInitError {
+            path: path.to_owned(),
+            error,
+        })?;
+        let slf_paths: Vec<_> = slf_paths
+            .iter()
+            .filter(|path| {
+                path.extension().map(|e| e.to_string_lossy().to_lowercase())
+                    == Some("slf".to_string())
+            })
+            .collect();
         if required && slf_paths.is_empty() {
             return Err(VfsInitError {
                 path: path.join(Path::new("*.slf")),

--- a/rust/stracciatella/tests/test_vfs.rs
+++ b/rust/stracciatella/tests/test_vfs.rs
@@ -8,7 +8,7 @@ mod vfs {
         create_data_slf(&dir); // data.slf
 
         let mut vfs = Vfs::new();
-        vfs.add_slf(0, &dir.join("data.slf")).unwrap();
+        vfs.add_slf(&dir.join("data.slf")).unwrap();
         let data = read_file_data(&vfs, "foo.txt");
         assert_eq!(&data, b"data.slf");
 
@@ -21,7 +21,7 @@ mod vfs {
         create_data_slf(&dir); // data.slf
 
         let mut vfs = Vfs::new();
-        vfs.add_slf(0, &dir.join("data.slf")).unwrap();
+        vfs.add_slf(&dir.join("data.slf")).unwrap();
         let mut file = vfs.open(&Nfc::caseless_path("foo.txt")).unwrap();
 
         assert_eq!(file.seek(SeekFrom::End(0)).unwrap(), 8);
@@ -40,32 +40,13 @@ mod vfs {
         create_foobar_slf(&dir); // foobar.slf
         create_foo_bar_baz_txt(&dir); // baz.txt
 
-        macro_rules! t {
-            ($a: expr, $b: expr, $c: expr, $data: expr) => {
-                let mut vfs = Vfs::new();
-                vfs.add_dir($a, &dir).expect("dir");
-                vfs.add_slf($b, &dir.join("foo.slf")).expect("foo");
-                vfs.add_slf($c, &dir.join("foobar.slf")).expect("foobar");
-                let data = read_file_data(&vfs, "foo/bar/baz.txt");
-                assert_eq!(&data, $data);
-            };
-        }
+        let mut vfs = Vfs::new();
+        vfs.add_dir(&dir).expect("dir");
+        vfs.add_slf(&dir.join("foo.slf")).expect("foo");
+        vfs.add_slf(&dir.join("foobar.slf")).expect("foobar");
 
-        // integer order
-        t!(0, 1, 2, b"baz.txt");
-        t!(0, 2, 1, b"baz.txt");
-        t!(1, 0, 2, b"foo.slf");
-        t!(1, 2, 0, b"foobar.slf");
-        t!(2, 0, 1, b"foo.slf");
-        t!(2, 1, 0, b"foobar.slf");
-        // when integer is the same, fifo order
-        t!(0, 0, 0, b"baz.txt");
-        t!(0, 0, 1, b"baz.txt");
-        t!(0, 1, 0, b"baz.txt");
-        t!(1, 0, 0, b"foo.slf");
-        t!(1, 1, 0, b"foobar.slf");
-        t!(1, 0, 1, b"foo.slf");
-        t!(1, 1, 1, b"baz.txt");
+        let data = read_file_data(&vfs, "foo/bar/baz.txt");
+        assert_eq!(&data, b"baz.txt");
 
         temp.close().expect("close temp dir");
     }
@@ -76,7 +57,7 @@ mod vfs {
         create_foo_slf(&dir); // foo.slf
 
         let mut vfs = Vfs::new();
-        vfs.add_slf(0, &dir.join("foo.slf")).unwrap();
+        vfs.add_slf(&dir.join("foo.slf")).unwrap();
         // case insensitive
         let data = read_file_data(&vfs, "FOO/bar.txt");
         assert_eq!(&data, b"foo.slf");

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -40,8 +40,7 @@ public:
 
 	/// Called after construction.
 	/// @throw runtime_error
-	virtual void init();
-	void initOptionalFreeEditorSlf(const ST::string &path);
+	virtual void init(EngineOptions* engine_options);
 
 	/** Load the game data. */
 	bool loadGameData();
@@ -275,7 +274,6 @@ protected:
 	bool loadTacticalLayerData();
 
 	std::shared_ptr<rapidjson::Document> readJsonDataFile(const char *fileName) const;
-	void AddVFSLayer(VFS_ORDER order, const ST::string path, const bool throwOnError = true);
 };
 
 class LibraryFileNotFoundException : public std::runtime_error

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -16,17 +16,6 @@
 #include <stdexcept>
 #include <vector>
 
-enum VFS_ORDER : int32_t {
-	MOD                    = 100, // assets overriden by mods
-	
-	ASSETS_USERHOME        = 200, // assets in user home directory
-	ASSETS_STRACCIATELLA   = 210, // assets shipped with stracciatella
-	ASSETS_VANILLA         = 220, // vanilla game data
-
-	FALLBACK               = 400,
-};
-
-
 class DefaultContentManager : public ContentManager, public IGameDataLoader
 {
 public:

--- a/src/externalized/DefaultContentManagerUT.cc
+++ b/src/externalized/DefaultContentManagerUT.cc
@@ -12,8 +12,7 @@ DefaultContentManagerUT::DefaultContentManagerUT(GameVersion gameVersion,
 
 void DefaultContentManagerUT::init()
 {
-	// externalized data is used in the tests
-	AddVFSLayer(VFS_ORDER::ASSETS_STRACCIATELLA, m_externalizedDataPath);
+	Vfs_addDir(m_vfs.get(), m_externalizedDataPath.c_str());
 }
 
 std::shared_ptr<rapidjson::Document> DefaultContentManagerUT::_readJsonDataFile(const char* fileName) const

--- a/src/externalized/ModPackContentManager.cc
+++ b/src/externalized/ModPackContentManager.cc
@@ -24,42 +24,6 @@ ModPackContentManager::~ModPackContentManager()
 {
 }
 
-void ModPackContentManager::loadMod(ST::string modName)
-{
-	bool isLoaded = false;
-
-	ST::string modResFolder = FileMan::joinPaths({ m_userHomeDir, "mods", modName, "data" });
-	if (FileMan::checkPathExistance(modResFolder))
-	{
-		AddVFSLayer(VFS_ORDER::MOD, modResFolder);
-		isLoaded = true;
-	}
-	
-	modResFolder = FileMan::joinPaths({m_assetsRootPath, "mods", modName, "data"});
-	if (FileMan::checkPathExistance(modResFolder))
-	{
-		AddVFSLayer(VFS_ORDER::MOD, modResFolder);
-		isLoaded = true;
-	}
-
-	if (!isLoaded)
-	{
-		SLOGE(ST::format("Unable to locate data directory of mod '{}'", modName));
-		throw std::runtime_error("Failed to load mod");
-	}
-	
-	SLOGI(ST::format("Loaded mod '{}'", modName));
-}
-
-void ModPackContentManager::init()
-{
-	for (const ST::string& modName :m_modNames)
-	{
-		loadMod(modName);
-	}
-	DefaultContentManager::init();
-}
-
 /** Get folder for saved games. */
 ST::string ModPackContentManager::getSavedGamesFolder() const
 {

--- a/src/externalized/ModPackContentManager.h
+++ b/src/externalized/ModPackContentManager.h
@@ -19,10 +19,6 @@ public:
 
 	virtual ~ModPackContentManager() override;
 
-	/// Called after construction.
-	/// @throw runtime_error
-	virtual void init() override;
-
 	/** Get folder for saved games. */
 	virtual ST::string getSavedGamesFolder() const override;
 

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -468,13 +468,7 @@ int main(int argc, char* argv[])
 		SLOGI("------------------------------------------------------------------------------");
 	}
 
-	cm->init();
-
-	if(EngineOptions_shouldRunEditor(params.get()))
-	{
-		RustPointer<char> path{Path_push(extraDataDir.get(), "editor.slf")};
-		cm->initOptionalFreeEditorSlf(path.get());
-	}
+	cm->init(params.get());
 
 	if(!cm->loadGameData())
 	{


### PR DESCRIPTION
This is a proposal to move VFS initialization to a single place: The rust vfs module. Imho this makes it easier to grasp how the VFS is initialized compared to the VFS initialization at multiple places in C++ code using the order enum.

It also allows for SLF files in the mods directories.

The first two commits are cleanup commits that are kind of unrelated.