### PR TITLE
Catch and ignore exception with bad map data

### DIFF
--- a/src/game/TileEngine/Render_Fun.cc
+++ b/src/game/TileEngine/Render_Fun.cc
@@ -106,14 +106,21 @@ void SetGridNoRevealedFlag(UINT16 const grid_no)
 			if (!(i->fFlags & STRUCTURE_OBSTACLE) || i->fFlags & (STRUCTURE_PERSON | STRUCTURE_CORPSE)) continue;
 		}
 
-		STRUCTURE* const base = FindBaseStructure(i);
-		LEVELNODE* const node = FindLevelNodeBasedOnStructure(base);
-		node->uiFlags |= LEVELNODE_SHOW_THROUGH;
-
-		if (i->fFlags & STRUCTURE_SLANTED_ROOF)
+		try
 		{
-			AddSlantRoofFOVSlot(base->sGridNo);
-			node->uiFlags |= LEVELNODE_HIDDEN;
+			STRUCTURE* const base = FindBaseStructure(i);
+			LEVELNODE* const node = FindLevelNodeBasedOnStructure(base);
+			node->uiFlags |= LEVELNODE_SHOW_THROUGH;
+
+			if (i->fFlags & STRUCTURE_SLANTED_ROOF)
+			{
+				AddSlantRoofFOVSlot(base->sGridNo);
+				node->uiFlags |= LEVELNODE_HIDDEN;
+			}
+		}
+		catch (std::logic_error e)
+		{
+			SLOGW(ST::format("Failed to find LEVELNODE for a structure at grid {}. ({})", grid_no, e.what()));
 		}
 	}
 


### PR DESCRIPTION
This is a fix for a edge-case handling in `SetGridNoRevealedFlag` (Render_Fun.cc) with possible bad map data, which does not happen with vanilla maps but with mods. 

## Motivation

The sector [I8](https://github.com/ja2-stracciatella/mod-nightops-maps/blob/master/data/Maps/I8.dat) of NightOps map pack crashes with a uncaught `std::logic_error("FindLevelNodeBasedOnStruct failed")` when grid `11937` is revealed. Tried both the debugger and map editor, I have not been able to figure out what's wrong with the map data. The crash analysis is at https://github.com/ja2-stracciatella/mod-nightops-maps/issues/2.

The map would not have crashed in vanilla (see https://github.com/ja2-stracciatella/ja2-stracciatella/commit/a0a4a5a55f8fe2d62711ba24440fa3f8688f0440). This change effectively restores that part of error "handling".


## Summary

This PR adds a catch clause to handle a `std::logic_error` thrown by `FindLevelNodeBasedOnStructure`, so the game does not crash. The behaviour of ignoring error in this edge-case is same as vanilla JA2.

Before https://github.com/ja2-stracciatella/ja2-stracciatella/commit/a0a4a5a55f8fe2d62711ba24440fa3f8688f0440, `FindLevelNodeBasedOnStructure` would return NULL. The caller `SetGridNoRevealedFlag` would ignore processing if `LEVELNODE` is not found, as `pNode` evaluated to false. The `std::logic_error` was introduced by Stracciatella, and left unhandled.

With this fix, the game will carry on as normal with the WARN log. I do not notice any anomalies in the map, the room or the rendering.

> [ WARN] game\TileEngine\Render_Fun.cc: Failed to find LEVELNODE for a structure at grid 11937. (FindLevelNodeBasedOnStruct failed)