### PR TITLE
Drassen to be consistent with other mines before depletion

### DIFF
--- a/src/game/Strategic/Strategic_Mines.cc
+++ b/src/game/Strategic/Strategic_Mines.cc
@@ -39,6 +39,7 @@
 #define MINE_PRODUCTION_NUMBER_OF_PERIODS 4						// how many times a day mine production is processed
 #define MINE_PRODUCTION_START_TIME				(9 * 60)		// hour of first daily mine production event (in minutes)
 #define MINE_PRODUCTION_PERIOD						(3 * 60)		// time seperating daily mine production events (in minutes)
+#define MINE_PRODUCTION_DAYS_AFTER_HEAD_MINER_WARNING 2.5					// how many more days the mine can still produce after head miner warns of depletion
 
 
 // this table holds mine values that change during the course of the game and must be saved
@@ -144,8 +145,8 @@ void InitializeMines( void )
 			// the mine that runs out has only enough ore for this many days of full production
 			pMineStatus->uiRemainingOreSupply = ubMinDaysBeforeDepletion * (MINE_PRODUCTION_NUMBER_OF_PERIODS * pMineStatus->uiMaxRemovalRate);
 
-			// ore starts running out when reserves drop to less than 25% of the initial supply
-			pMineStatus->uiOreRunningOutPoint = pMineStatus->uiRemainingOreSupply / 4;
+			// ore starts running out when reserves drop to less than 2.5 days worth of supply
+			pMineStatus->uiOreRunningOutPoint = (UINT32)(MINE_PRODUCTION_DAYS_AFTER_HEAD_MINER_WARNING * MINE_PRODUCTION_NUMBER_OF_PERIODS * pMineStatus->uiMaxRemovalRate);
 		}
 		else
 		if (!pMineStatus->fEmpty)


### PR DESCRIPTION
Fixes #1144. 

This is about the Drassen mine, if selected for depletion, being inconsistent with other mines. With this PR any depleting mine will always run out in ~2.5 days after head miner's warning (assuming 100% production).


### Before this PR

Drassen head miner warns on depletion at around the 15th day, then it doubles the production rate, and runs out in about 2.5 days.

If any other mines are selected for depletion, the head miner warns after ~7.5 days. Production rate stays similar, and mine runs out in about 2.5 days.

### After this PR

Drassen head miner to warn after ~17.5 days. The production rate will stay about the same, and the mine runs out in another ~2.5 days. Total ore supply is the same. This behaviour is now consistent with other mines.

Depletion behaviours of other mines are unchanged.

