### PR TITLE
Heli to land only if refuel site is available

### DIFF
--- a/src/game/Strategic/Map_Screen_Helicopter.cc
+++ b/src/game/Strategic/Map_Screen_Helicopter.cc
@@ -287,7 +287,7 @@ BOOLEAN HandleHeliEnteringSector( INT16 sX, INT16 sY )
 			StopTimeCompression();
 		}
 
-		if( IsRefuelSiteInSector( CALCULATE_STRATEGIC_INDEX(sX, sY) ) )
+		if (IsRefuelAvailableInSector(CALCULATE_STRATEGIC_INDEX(sX, sY)))
 		{
 			LandHelicopter();
 		}
@@ -606,6 +606,11 @@ bool IsRefuelSiteInSector(INT16 const sector)
 		if (i->sector == sector) return true;
 	}
 	return false;
+}
+
+bool IsRefuelAvailableInSector(INT16 const sector)
+{
+	return NearestRefuelPoint(false).sector == sector;
 }
 
 void UpdateRefuelSiteAvailability( void )
@@ -1420,7 +1425,7 @@ static void MakeHeliReturnToBase(void)
 
 	sectorID = CALCULATE_STRATEGIC_INDEX(v.sSectorX, v.sSectorY);
 	// if already at a refueling point
-	if ( IsRefuelSiteInSector( sectorID ) )
+	if (IsRefuelAvailableInSector(sectorID))
 	{
 		LandHelicopter();
 	}

--- a/src/game/Strategic/Map_Screen_Helicopter.h
+++ b/src/game/Strategic/Map_Screen_Helicopter.h
@@ -128,7 +128,10 @@ BOOLEAN IsHelicopterPilotAvailable( void );
 void TakeOffHelicopter( void );
 
 // test whether or not a sector contains a fuel site
-bool IsRefuelSiteInSector(INT16 sector);
+bool IsRefuelSiteInSector(INT16 const sector);
+
+// test whether or not the sector can refuel the heli
+bool IsRefuelAvailableInSector(INT16 const sector);
 
 // update which refueling sites are controlled by player & therefore available
 void UpdateRefuelSiteAvailability( void );


### PR DESCRIPTION
Fixes #723 , which is test case 2 below.

## Summary

Before this PR, the Heli is lands if the current sector is a Refuel Site, but without checking if it is player controlled and if refueling is available. 

This PR introduces `IsRefuelAvailableInSector`, which re-uses `NearestRefuelPoint` which considers those other factors. `IsRefuelSiteInSector` is kept and used only for updating refuel site availability.

## Test cases

| # | I6 (Estoni) | I6 has fuel? | B13 (Drassen) | Heli location | Vanilla Behaviour
|--|-- | -- | -- | -- | --
1 |Not visited | No | Player Controlled | C13 | Returns to B13
2 |Not visited | No | Player Controlled | I6 | Returns to B13
3 |Not visited | No | Player Controlled | I7 | Returns to B13
 |  |   |   |   |  
4 |Not visited | No | Enemy Controlled | C13 | Returns to B13
5 |Not visited | No | Enemy Controlled | I6 | Lands (similar to #723)
6 |Not visited | No | Enemy Controlled | I7 | Returns to I6
 | |   |   |   |  
7 | Player Controlled | No | Player Controlled | C13 | Returns to B13
8 | Player Controlled | No | Player Controlled | I6 | Returns to B13
9 | Player Controlled | No | Player Controlled | I7 | Returns to B13
|  |   |   |   |  
10 |Player Controlled | No | Enemy Controlled | C13 | Returns to B13
11 |Player Controlled | No | Enemy Controlled | I6 | Lands (bug?)
12 |Player Controlled | No | Enemy Controlled | I7 | Returns to I6 (bug?)
|  |   |   |   |  
13 |Player Controlled | Yes | Player Controlled | C13 | Returns to B13
14 |Player Controlled | Yes | Player Controlled | I6 | Lands
15 |Player Controlled | Yes | Player Controlled | I7 | Returns to I6
|  |   |   |   |  
16|Player Controlled | Yes | Enemy Controlled | C13 | Returns to I6
17|Player Controlled | Yes | Enemy Controlled | I6 | Returns to I6
18|Player Controlled | Yes | Enemy Controlled | I7 | Returns to I6
19|Player Controlled | Yes | Enemy Controlled | B13| Returns to I6
|  |   |   |   |  
20 |Enemy Present | Yes | Enemy Controlled | C13 | Returns to B13
21 |Enemy Present | Yes | Enemy Controlled | I7 | Returns to I6
22 |Enemy Present | Yes | Enemy Controlled | I6 | Lands
|  |   |   |   |  
23 |Enemy Present | Yes | Player Controlled | I6 | Returns to B13


## Vanilla bugs

This PR leaves a couple vanilla bugs unfixed:

1) If Drassen Airport is hostile, Heli can and will use Estoni as refuel site, regardless of availability or hostility.
2) A squad dropped from Heli does not take control of the sector, until the squad re-enters on foot or a battle is won

## See also
- https://github.com/ja2-stracciatella/ja2-stracciatella/pull/249
  - https://github.com/ja2-stracciatella/ja2-stracciatella/pull/249/commits/f374ac72cc1c3b8aaf6a6a05d28418bff4552a18
