### PR TITLE
Allow merging stacked item

### DIFF
--- a/src/game/Tactical/Interface_Items.cc
+++ b/src/game/Tactical/Interface_Items.cc
@@ -2033,7 +2033,7 @@ static void ItemDescAmmoCallback(GUI_BUTTON*  const btn, INT32 const reason)
 
 static void DoAttachment(void)
 {
-	if ( AttachObject( gpItemDescSoldier, gpItemDescObject, gpItemPointer ) )
+	if (AttachObject(gpItemDescSoldier, gpItemDescObject, gpItemPointer, gubItemDescStatusIndex))
 	{
 		if (gpItemPointer->usItem == NOTHING)
 		{

--- a/src/game/Tactical/Items.cc
+++ b/src/game/Tactical/Items.cc
@@ -2047,7 +2047,7 @@ static void PerformAttachmentComboMerge(OBJECTTYPE& o, ComboMergeInfoStruct cons
 }
 
 
-bool AttachObject(SOLDIERTYPE* const s, OBJECTTYPE* const pTargetObj, OBJECTTYPE* const pAttachment)
+bool AttachObject(SOLDIERTYPE* const s, OBJECTTYPE* const pTargetObj, OBJECTTYPE* const pAttachment, UINT8 const ubIndexInStack)
 {
 	OBJECTTYPE& target     = *pTargetObj;
 	OBJECTTYPE& attachment = *pAttachment;
@@ -2185,17 +2185,18 @@ bool AttachObject(SOLDIERTYPE* const s, OBJECTTYPE* const pTargetObj, OBJECTTYPE
 			// count down through # of attaching items and add to status of item in position 0
 			for (INT8 bLoop = attachment.ubNumberOfObjects - 1; bLoop >= 0; --bLoop)
 			{
-				if (target.bStatus[0] + attachment.bStatus[bLoop] <= limit)
+				INT8& targetStatus = target.bStatus[ubIndexInStack];
+				if (targetStatus + attachment.bStatus[bLoop] <= limit)
 				{ // Consume this one totally and continue
-					target.bStatus[0] += attachment.bStatus[bLoop];
+					targetStatus += attachment.bStatus[bLoop];
 					RemoveObjFrom(&attachment, bLoop);
 					// reset loop limit
 					bLoop = attachment.ubNumberOfObjects; // add 1 to counteract the -1 from the loop
 				}
 				else
 				{ // Add part of this one and then we're done
-					attachment.bStatus[bLoop] -= limit - target.bStatus[0];
-					target.bStatus[0]          = limit;
+					attachment.bStatus[bLoop] -= limit - targetStatus;
+					targetStatus               = limit;
 					break;
 				}
 			}

--- a/src/game/Tactical/Items.h
+++ b/src/game/Tactical/Items.h
@@ -40,7 +40,7 @@ extern void RemoveObjFrom( OBJECTTYPE * pObj, UINT8 ubRemoveIndex );
 extern BOOLEAN PlaceObjectAtObjectIndex( OBJECTTYPE * pSourceObj, OBJECTTYPE * pTargetObj, UINT8 ubIndex );
 extern void GetObjFrom( OBJECTTYPE * pObj, UINT8 ubGetIndex, OBJECTTYPE * pDest );
 
-bool AttachObject(SOLDIERTYPE*, OBJECTTYPE* pTargetObj, OBJECTTYPE* pAttachment);
+bool AttachObject(SOLDIERTYPE* const s, OBJECTTYPE* const pTargetObj, OBJECTTYPE* const pAttachment, UINT8 const ubIndexInStack = 0);
 extern BOOLEAN RemoveAttachment( OBJECTTYPE * pObj, INT8 bAttachPos, OBJECTTYPE * pNewObj );
 
 UINT8	CalculateObjectWeight(const OBJECTTYPE* pObject);


### PR DESCRIPTION
Fixes #690. 

This PR is about the `COMBINE_POINTS` merging of the same consumable and stackable items (ammo, first-aid kits).

The game has always allowed merging the on-hand item with the first in stack. In `AttachObject` we only considered `target.bStatus[0]` which is the first in stack, no matter which stack item is selected. 

This PR passes the currently selected item index in stack (`gubItemDescStatusIndex`) to the `AttachObject` so it can do the right thing.

---

Detailed usage (in case not obvious):

1. In inventory view, stack up ammo to be merged into (or first-aid kits)
1. Pick up another ammo to merge in
1. Right-click on the stack to see stack members
1. Right-click on stack member to bring up the merge/attachment panel
1. Left-click on an attachment slot to merge