### PR TITLE
Sync usShotsHit with usShotsFired

### DIFF
--- a/src/game/Tactical/LOS.cc
+++ b/src/game/Tactical/LOS.cc
@@ -1998,7 +1998,8 @@ static BOOLEAN BulletHitMerc(BULLET* pBullet, STRUCTURE* pStructure, BOOLEAN fIn
 		// handle hit here...
 		if( pFirer->bTeam == 0 )
 		{
-			gMercProfiles[ pFirer->ubProfile ].usShotsHit++;
+			// issue #1140 : sync usShotsFired with usShotsHit and so that merc statistic <= 100%
+			if (pFirer->target->bLife > 0) gMercProfiles[ pFirer->ubProfile ].usShotsHit++;
 		}
 
 		// intentionally shot


### PR DESCRIPTION
Fixes #1140. Commit by @wvx, tested by me.

This brings the pre-conditions of `usShotsHit++` and `usShotsFired++` in sync.

