### PR TITLE
Avoiding GetObject call on JSON object

### DIFF
--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -5,7 +5,7 @@
 
 DefaultGamePolicy::DefaultGamePolicy(rapidjson::Document *json)
 {
-	JsonObjectReader gp = JsonObjectReader(json->GetObject());
+	JsonObjectReader gp = JsonObjectReader(*json);
 	extra_hotkeys = gp.getOptionalBool("extra_hotkeys", true);
 	can_enter_turnbased = gp.getOptionalBool("can_enter_turnbased");
 	middle_mouse_look = gp.getOptionalBool("middle_mouse_look", true);


### PR DESCRIPTION
This fixes a memory access violation inside RapidJSON (`obj.HasMember`) that prevents game from launching. The error only happens with Release build (built with Visual Studio 2019 on Win 10). I am not 100% sure about what's wrong, but I suspect it is some temp variables got pre-maturely cleaned up.

Exception thrown during loadGameData:
```
Exception thrown at 0x00007FF723FE1C47 in ja2.exe: 0xC0000005: Access violation reading location 0x000000C74D78000E.
```

Call stack:
```
>	ja2.exe!rapidjson::GenericValue<rapidjson::UTF8<char>,rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>>::FindMember<rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>>(const rapidjson::GenericValue<rapidjson::UTF8<char>,rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>> & name) Line 1158	C++
 	[Inline Frame] ja2.exe!rapidjson::GenericValue<rapidjson::UTF8<char>,rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>>::FindMember(const char *) Line 1134	C++
 	[Inline Frame] ja2.exe!rapidjson::GenericValue<rapidjson::UTF8<char>,rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>>::FindMember(const char *) Line 1137	C++
 	[Inline Frame] ja2.exe!rapidjson::GenericValue<rapidjson::UTF8<char>,rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>>::HasMember(const char *) Line 1094	C++
 	[Inline Frame] ja2.exe!JsonObjectReader::getOptionalBool(const char *) Line 84	C++
 	ja2.exe!DefaultGamePolicy::DefaultGamePolicy(rapidjson::GenericDocument<rapidjson::UTF8<char>,rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>,rapidjson::CrtAllocator> * json) Line 9	C++
 	ja2.exe!DefaultContentManager::loadGameData() Line 1070	C++
 	ja2.exe!SDL_main(int argc, char * * argv) Line 476	C++
 	ja2.exe!main_getcmdline(...) Line 161	C
 	[Inline Frame] ja2.exe!invoke_main() Line 78	C++
 	ja2.exe!__scrt_common_main_seh() Line 288	C++
 	kernel32.dll!00007ff80bcb6074()	Unknown
 	ntdll.dll!00007ff80cfe42db()	Unknown
```