### PR TITLE
Fix incorrect type used for Sector ID (Bloodcat Spawn)

### DIFF
--- a/src/externalized/strategic/BloodCatPlacementsModel.cc
+++ b/src/externalized/strategic/BloodCatPlacementsModel.cc
@@ -7,7 +7,7 @@ BloodCatPlacementsModel::BloodCatPlacementsModel(uint8_t sectorId_, int8_t blood
 
 BloodCatPlacementsModel* BloodCatPlacementsModel::deserialize(JsonObjectReader & obj)
 {
-	int8_t sectorId = SECTOR_FROM_SECTOR_SHORT_STRING( obj.GetString("sector") );
+	uint8_t sectorId = SECTOR_FROM_SECTOR_SHORT_STRING(obj.GetString("sector"));
 	return new BloodCatPlacementsModel(	
 		sectorId,
 		obj.GetInt("bloodCatPlacements")

--- a/src/game/Strategic/Game_Init.cc
+++ b/src/game/Strategic/Game_Init.cc
@@ -221,12 +221,12 @@ void InitBloodCatSectors()
 	};
 	for (auto placements : GCM->getBloodCatPlacements())
 	{
-		INT8 sectorId = placements->sectorId;
+		UINT8 sectorId = placements->sectorId;
 		SectorInfo[ sectorId ].bBloodCatPlacements = placements->bloodCatPlacements;
 	}
 	for (auto spawns : GCM->getBloodCatSpawns())
 	{
-		INT8 sectorId = spawns->sectorId;
+		UINT8 sectorId = spawns->sectorId;
 		INT8 spawnsCount = spawns->getSpawnsByDifficulty(gGameOptions.ubDifficultyLevel);
 		SectorInfo[ sectorId ].bBloodCatPlacements = spawnsCount;
 		SectorInfo[ sectorId ].bBloodCats = spawnsCount;


### PR DESCRIPTION
Bloodcat Lair and Arena are without the cats as a result. All sectors in the lower half of the map has no bloodcat placements (and maybe some invalid memory access with negative index, of unknown effect)

It should have been UINT8 instead of INT8. Requires a new game if game was started with the wrong init.

I did a quick grep (`grep -Ri sectorid src/ | grep -i int8 | grep -vi uint`) and found no other occurrence of `INT8 sectorId`

