### PR TITLE
Fix creature town attack

### DIFF
--- a/src/game/Strategic/Creature_Spreading.cc
+++ b/src/game/Strategic/Creature_Spreading.cc
@@ -640,14 +640,6 @@ void DeleteCreatureDirectives()
 	giLairID = 0;
 }
 
-void ClearCreatureQuest()
-{
-	//This will remove all of the underground sector information and reinitialize it.
-	//The only part that doesn't get added are the queen's lair.
-	BuildUndergroundSectorInfoList();
-	DeleteCreatureDirectives();
-}
-
 void EndCreatureQuest()
 {
 	CREATURE_DIRECTIVE *curr;

--- a/src/game/Strategic/Creature_Spreading.cc
+++ b/src/game/Strategic/Creature_Spreading.cc
@@ -495,7 +495,7 @@ static void AddCreaturesToBattle(UINT8 n_young_males, UINT8 n_young_females, UIN
 }
 
 
-static void ChooseTownSectorToAttack(UINT8 ubSectorID, BOOLEAN fOverrideTest)
+static void ChooseTownSectorToAttack(UINT8 ubSectorID, BOOLEAN fSpecificSector)
 {
 	const CreatureAttackSector* attackDetails = NULL;
 	if (gLairModel == NULL)
@@ -505,9 +505,9 @@ static void ChooseTownSectorToAttack(UINT8 ubSectorID, BOOLEAN fOverrideTest)
 	}
 
 	// determine town sector to attack
-	attackDetails = (fOverrideTest) ?
-		gLairModel->getTownAttackDetails(ubSectorID) : // pick a sector to attack
-		gLairModel->chooseTownSectorToAttack()         // attack the given sector
+	attackDetails = (fSpecificSector) ?
+		gLairModel->getTownAttackDetails(ubSectorID) : // attack the given sector
+		gLairModel->chooseTownSectorToAttack()         // pick a sector to attack
 	;
 	if (!attackDetails)
 	{
@@ -524,7 +524,7 @@ static void ChooseTownSectorToAttack(UINT8 ubSectorID, BOOLEAN fOverrideTest)
 	}
 }
 
-void CreatureAttackTown( UINT8 ubSectorID, BOOLEAN fOverrideTest )
+void CreatureAttackTown(UINT8 ubSectorID, BOOLEAN fSpecificSector)
 { //This is the launching point of the creature attack.
 	UNDERGROUND_SECTORINFO *pSector;
 	UINT8 ubSectorX, ubSectorY;
@@ -537,22 +537,22 @@ void CreatureAttackTown( UINT8 ubSectorID, BOOLEAN fOverrideTest )
 
 	gubCreatureBattleCode = CREATURE_BATTLE_CODE_NONE;
 
-	ubSectorX = (UINT8)((ubSectorID % 16) + 1);
-	ubSectorY = (UINT8)((ubSectorID / 16) + 1);
+	ubSectorX = SECTORX(ubSectorID);
+	ubSectorY = SECTORY(ubSectorID);
 
-	if( !fOverrideTest )
+	if (!fSpecificSector)
 	{
 		//Record the number of creatures in the sector.
 		pSector = FindUnderGroundSector( ubSectorX, ubSectorY, 1 );
 		if( !pSector )
 		{
-			CreatureAttackTown( ubSectorID, TRUE );
+			CreatureAttackTown(ubSectorID, TRUE);
 			return;
 		}
 		gubNumCreaturesAttackingTown = pSector->ubNumCreatures;
 		if( !gubNumCreaturesAttackingTown )
 		{
-			CreatureAttackTown( ubSectorID, TRUE );
+			CreatureAttackTown(ubSectorID, TRUE);
 			return;
 		}
 
@@ -561,12 +561,12 @@ void CreatureAttackTown( UINT8 ubSectorID, BOOLEAN fOverrideTest )
 		//Choose one of the town sectors to attack.  Sectors closer to
 		//the mine entrance have a greater chance of being chosen.
 		ChooseTownSectorToAttack( ubSectorID, FALSE );
-		ubSectorX = (UINT8)((gubSectorIDOfCreatureAttack % 16) + 1);
-		ubSectorY = (UINT8)((gubSectorIDOfCreatureAttack / 16) + 1);
+		ubSectorX = SECTORX(gubSectorIDOfCreatureAttack);
+		ubSectorY = SECTORY(gubSectorIDOfCreatureAttack);
 	}
 	else
 	{
-		ChooseTownSectorToAttack( ubSectorID, TRUE );
+		ChooseTownSectorToAttack(ubSectorID, TRUE);
 		gubNumCreaturesAttackingTown = 5;
 	}
 

--- a/src/game/Strategic/Creature_Spreading.cc
+++ b/src/game/Strategic/Creature_Spreading.cc
@@ -516,7 +516,7 @@ static void ChooseTownSectorToAttack(UINT8 ubSectorID, BOOLEAN fSpecificSector)
 	}
 
 	// determine how the enemies enter the sector
-	gubSectorIDOfCreatureAttack = ubSectorID;
+	gubSectorIDOfCreatureAttack = attackDetails->sectorId;
 	gsCreatureInsertionCode = attackDetails->insertionCode;
 	if (gsCreatureInsertionCode == INSERTION_CODE_GRIDNO)
 	{

--- a/src/game/Strategic/Creature_Spreading.h
+++ b/src/game/Strategic/Creature_Spreading.h
@@ -7,7 +7,6 @@
 
 void InitCreatureQuest(void);
 void SpreadCreatures(void);
-void ClearCreatureQuest(void);
 void DeleteCreatureDirectives(void);
 
 void SaveCreatureDirectives(HWFILE);

--- a/src/game/Strategic/Creature_Spreading.h
+++ b/src/game/Strategic/Creature_Spreading.h
@@ -15,7 +15,7 @@ void LoadCreatureDirectives(HWFILE, UINT32 uiSavedGameVersion);
 
 BOOLEAN PrepareCreaturesForBattle(void);
 void CreatureNightPlanning(void);
-void CreatureAttackTown( UINT8 ubSectorID, BOOLEAN fOverrideTest );
+void CreatureAttackTown(UINT8 ubSectorID, BOOLEAN fSpecificSector);
 
 void CheckConditionsForTriggeringCreatureQuest( INT16 sSectorX, INT16 sSectorY, INT8 bSectorZ );
 

--- a/src/game/Strategic/Game_Init.cc
+++ b/src/game/Strategic/Game_Init.cc
@@ -423,6 +423,9 @@ void ReStartingGame()
 	//Delete all the strategic events
 	DeleteAllStrategicEvents();
 
+	//Delete creature lair, if any
+	DeleteCreatureDirectives();
+
 	//This function gets called when ur in a game a click the quit to main menu button, therefore no game is in progress
 	gTacticalStatus.fHasAGameBeenStarted = FALSE;
 


### PR DESCRIPTION
Found bugs when investigating a [bug report](http://thepit.ja-galaxy-forum.com/index.php?t=msg&goto=360622&#msg_360622 ).

 - a67c898e6f54dad93d041acfe2051882f776ed35: `gubSectorIDOfCreatureAttack` is not correctly updated, which should mean all attacks will happen at the mine entrance sector. (Bug since #1106)
- fd2b3bea9431109329d7e779105c6898e6e68be1: `giLairID` never got reset during `ReStartingGame`. This seems to be an old issue (v0.16 or earlier). Loading a game with an active lair, then starting a new campaign game cause the next game to have the wrong `giLairID`, and this wrong ID will get saved.

Needs more testing, and further investigation to see if it is related to the reported bug.

