### PR TITLE
Ignore invalid items when reading files

### DIFF
--- a/src/game/Tactical/LoadSaveObjectType.cc
+++ b/src/game/Tactical/LoadSaveObjectType.cc
@@ -4,6 +4,7 @@
 
 #include "ContentManager.h"
 #include "GameInstance.h"
+#include "ItemModel.h"
 
 
 void ExtractObject(DataReader& d, OBJECTTYPE* const o)
@@ -12,7 +13,15 @@ void ExtractObject(DataReader& d, OBJECTTYPE* const o)
 	EXTR_U16(d, o->usItem)
 	EXTR_U8(d, o->ubNumberOfObjects)
 	EXTR_SKIP(d, 1)
-	switch (GCM->getItem(o->usItem)->getItemClass())
+
+	const ItemModel* item = GCM->getItem(o->usItem);
+	if (!item)
+	{
+		SLOGW(ST::format("Item (index {}) is not defined and will be ignored. Maybe the file was saved for a different game version", o->usItem));
+		item = GCM->getItem(NONE);
+	}
+
+	switch (item->getItemClass())
 	{
 		case IC_AMMO:
 			EXTR_U8A(d, o->ubShotsLeft, lengthof(o->ubShotsLeft))


### PR DESCRIPTION
Fixes https://github.com/ja2-stracciatella/mod-nightops-maps/issues/5

Changes `ExtractObject`, which reads `OBJECTTYPE` from saves and maps. 

For example, NightOps maps H13 contains a few items not defined in JA2:S. The principle here is we should be more defensive reading files, as we now have mods. On reading an invalid item index, instead of de-referencing null pointer, the game should issue a warning and continue to load rest of the file.
