### PR TITLE
Do not restore debug uiFlags from saves

### DIFF
--- a/src/game/LoadSaveTacticalStatusType.cc
+++ b/src/game/LoadSaveTacticalStatusType.cc
@@ -2,6 +2,7 @@
 
 #include "Debug.h"
 #include "FileMan.h"
+#include "GameState.h"
 #include "LoadSaveData.h"
 #include "LoadSaveTacticalStatusType.h"
 #include "Overhead.h"
@@ -133,6 +134,12 @@ void ExtractTacticalStatusTypeFromFile(HWFILE const f, bool stracLinuxFormat)
 	EXTR_SKIP(d, 2)
 	EXTR_U32(d, s->uiCreatureTenseQuoteLastUpdate)
 	Assert(d.getConsumed() == dataSize);
+
+	if (!GameState::getInstance()->debugging())
+	{
+		// Prevent restoring of debug UI modes
+		s->uiFlags &= ~(DEBUGCLIFFS | SHOW_Z_BUFFER);
+	}
 }
 
 


### PR DESCRIPTION
To avoid confusion like #1004.

Turn off debug `uiFlags` (i.e. `DEBUGCLIFFS` | `SHOW_Z_BUFFER`) when loading a save - unless we started with `-debug` option.

