### PR TITLE
Turn off console Quick Edit mode (Windows only)

### DIFF
--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -288,6 +288,10 @@ std::vector<ST::string> InitGlobalLocale()
 	{
 		problems.emplace_back(std::move(ST::format("SetConsoleCP(CP_UTF8) failed, using input code page {}", GetConsoleCP())));
 	}
+	 
+	// Ensure quick-edit mode is off, or else it will block execution
+	HANDLE hInput = GetStdHandle(STD_INPUT_HANDLE);
+	SetConsoleMode(hInput, ENABLE_EXTENDED_FLAGS);
 #endif
 
 #ifdef WITH_CUSTOM_LOCALE


### PR DESCRIPTION
The Windows console has a feature called "quick edit mode". When activated, it freezes the STDIO and pauses program execution., when user click anywhere on the console. It might be defaulted to enabled in Windows 10, but I am not entirely sure. 

This PR will switch off Quick Edit mode whenever the game starts, in case it is already turned on at that time. User can still manually enable the quick edit mode from the menu.

A minor usability improvement. Not strictly necessary for the 0.17 release

Documentation: https://docs.microsoft.com/en-us/windows/console/setconsolemode

> To enable this mode, use ENABLE_QUICK_EDIT_MODE | ENABLE_EXTENDED_FLAGS. 
> 
> To disable this mode, use ENABLE_EXTENDED_FLAGS without this flag.