### PR TITLE
Better error messages on JSON parse errors

### DIFF
--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -1049,8 +1049,6 @@ std::shared_ptr<rapidjson::Document> DefaultContentManager::readJsonDataFile(con
 			document->GetErrorOffset(),
 			rapidjson::GetParseError_En(document->GetParseError())
 		);
-
-		SLOGE(errorMessage);
 		throw std::runtime_error(errorMessage.to_std_string());
 	}
 

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -12,6 +12,7 @@
 #include <string_theory/string>
 
 #include <map>
+#include <memory>
 #include <stdexcept>
 #include <vector>
 
@@ -262,7 +263,7 @@ protected:
 	bool loadStrategicLayerData();
 	bool loadTacticalLayerData();
 
-	rapidjson::Document* readJsonDataFile(const char *fileName) const;
+	std::shared_ptr<rapidjson::Document> readJsonDataFile(const char *fileName) const;
 	void AddVFSLayer(VFS_ORDER order, const ST::string path, const bool throwOnError = true);
 };
 

--- a/src/externalized/DefaultContentManagerUT.cc
+++ b/src/externalized/DefaultContentManagerUT.cc
@@ -16,7 +16,7 @@ void DefaultContentManagerUT::init()
 	AddVFSLayer(VFS_ORDER::ASSETS_STRACCIATELLA, m_externalizedDataPath);
 }
 
-rapidjson::Document* DefaultContentManagerUT::_readJsonDataFile(const char* fileName) const
+std::shared_ptr<rapidjson::Document> DefaultContentManagerUT::_readJsonDataFile(const char* fileName) const
 {
 	return DefaultContentManager::readJsonDataFile(fileName);
 }

--- a/src/externalized/DefaultContentManagerUT.h
+++ b/src/externalized/DefaultContentManagerUT.h
@@ -11,7 +11,7 @@ public:
 	virtual void init();
 
 	// expose this method to unit tests
-	rapidjson::Document* _readJsonDataFile(const char* fileName) const;
+	std::shared_ptr<rapidjson::Document> _readJsonDataFile(const char* fileName) const;
 
 	/** Create DefaultContentManager for usage in unit testing. */
 	static DefaultContentManagerUT* createDefaultCMForTesting();

--- a/src/externalized/DefaultContentManager_unittests.cc
+++ b/src/externalized/DefaultContentManager_unittests.cc
@@ -144,7 +144,7 @@ TEST(ExternalizedData, readEveryFile)
 	std::vector<ST::string> results = FindFilesInDir(dataPath, "json", true, false, false, true);
 	for (ST::string f : results)
 	{
-		auto json = cm->_readJsonDataFile(f.c_str());
+		auto json = cm->_readJsonDataFile(f.c_str()).get();
 		ASSERT_FALSE(json == NULL);
 	}
 }


### PR DESCRIPTION
Another usability improvement, but also involves some refactoring.

JSON errors or schema differences (e.g. using 0.16.1 JSON with 0.17) may just result in a "exited with status code <something>". At least on Windows, the exception message does not get printed.

# What's included

- Centralizes `rapidjson` parsing and error handling in one function
- Logs and throws an error message with parse error code and byte offset
- Wraps the `rapidjson` document in a `shared_ptr`; `delete` no longer required