### PR TITLE
Print unhandled exception message on Windows

### DIFF
--- a/src/externalized/ShippingDestinationModel.cc
+++ b/src/externalized/ShippingDestinationModel.cc
@@ -50,21 +50,21 @@ void ShippingDestinationModel::validateData(std::vector<const ShippingDestinatio
 		auto dest = destinations[i];
 		if (dest->locationId != i)
 		{
-			SLOGE(ST::format("Wrong locationId at position {}. Got {}.", i, dest->locationId));
-			throw std::runtime_error("");
+			ST::string err = ST::format("Wrong locationId at position {}. Got {}.", i, dest->locationId);
+			throw std::runtime_error(err.to_std_string());
 		}
 		if (dest->isPrimary) numPrimaryDestinations++;
 	}
 
 	if (numPrimaryDestinations != 1)
 	{
-		SLOGE(ST::format("There must be exactly 1 primary Shipping Destination. Got {}.", numPrimaryDestinations));
-		throw std::runtime_error("");
+		ST::string err = ST::format("There must be exactly 1 primary Shipping Destination. Got {}.", numPrimaryDestinations);
+		throw std::runtime_error(err.to_std_string());
 	}
 
 	if (destinations.size() != destinationNames.size())
 	{
-		SLOGE(ST::format("There must be {} Shipping Destinations (Must be same as the number of names in strings/shipping-destinations). Got {}.", destinationNames.size(), destinations.size()));
-		throw std::runtime_error("");
+		ST::string err = ST::format("There must be {} Shipping Destinations (Must be same as the number of names in strings/shipping-destinations). Got {}.", destinationNames.size(), destinations.size());
+		throw std::runtime_error(err.to_std_string());
 	}
 }

--- a/src/externalized/strategic/CreatureLairModel.cc
+++ b/src/externalized/strategic/CreatureLairModel.cc
@@ -22,8 +22,8 @@ uint8_t creatureHabitatFromString(std::string habitat)
 	if (habitat == "FEEDING_GROUNDS") return FEEDING_GROUNDS;
 	if (habitat == "MINE_EXIT") return MINE_EXIT;
 
-	SLOGE(ST::format("Unrecognized creature habitat: '{}'", habitat));
-	throw std::runtime_error("");
+	ST::string err = ST::format("Unrecognized creature habitat: '{}'", habitat);
+	throw std::runtime_error(err.to_std_string());
 }
 
 InsertionCode insertionCodeFromString(std::string code)
@@ -39,8 +39,8 @@ InsertionCode insertionCodeFromString(std::string code)
 	if (code == "SECONDARY_EDGEINDEX") return INSERTION_CODE_SECONDARY_EDGEINDEX;
 	if (code == "CENTER") return INSERTION_CODE_CENTER;
 
-	SLOGE(ST::format("Unrecognized insertion code: '{}'", code));
-	throw std::runtime_error("");
+	ST::string err = ST::format("Unrecognized insertion code: '{}'", code);
+	throw std::runtime_error(err.to_std_string());
 }
 
 std::vector<CreatureLairSector> readLairSectors(const rapidjson::Value& json)
@@ -65,8 +65,8 @@ std::vector<CreatureLairSector> readLairSectors(const rapidjson::Value& json)
 
 	if (sectors.size() == 0)
 	{
-		SLOGE(ST::format("Lair has no lair sectors"));
-		throw std::runtime_error("");
+		ST::string err = ST::format("Lair has no lair sectors");
+		throw std::runtime_error(err.to_std_string());
 	}
 
 	return sectors;
@@ -95,8 +95,8 @@ std::vector<CreatureAttackSector> readAttackSectors(const rapidjson::Value& json
 
 	if (attacks.size() == 0)
 	{
-		SLOGE(ST::format("Lair has no town attack sectors"));
-		throw std::runtime_error("");
+		ST::string err = ST::format("Lair has no town attack sectors");
+		throw std::runtime_error(err.to_std_string());
 	}
 
 	return attacks;
@@ -189,23 +189,23 @@ void CreatureLairModel::validateData(const std::vector<const CreatureLairModel*>
 		// checkd for valid lairId, 0 is reserved
 		if (lair->lairId < 1)
 		{
-			SLOGE(ST::format("lairID {} is invalid. Must be greater than 0"));
-			throw std::runtime_error("");
+			ST::string err = ST::format("lairID {} is invalid. Must be greater than 0");
+			throw std::runtime_error(err.to_std_string());
 		}
 
 		// make sure we do not define the same lairId more than once
 		if (distinctLairIds.find(lair->lairId) != distinctLairIds.end())
 		{
-			SLOGE(ST::format("lairID {} is already defined before"));
-			throw std::runtime_error("");
+			ST::string err = ST::format("lairID {} is already defined before");
+			throw std::runtime_error(err.to_std_string());
 		}
 		distinctLairIds.insert(lair->lairId);
 
 		// if the mineId is valid
 		if (lair->associatedMineId > numMines)
 		{
-			SLOGE(ST::format("Invalid mineId {}", lair->associatedMineId));
-			throw std::runtime_error("");
+			ST::string err = ST::format("Invalid mineId {}", lair->associatedMineId);
+			throw std::runtime_error(err.to_std_string());
 		}
 		
 		// The first lair sector in list should be QUEEN_LAIR
@@ -250,8 +250,8 @@ void CreatureLairModel::validateData(const std::vector<const CreatureLairModel*>
 			}
 			if (!isDefined)
 			{
-				SLOGE(ST::format("Underground lair sector ({},{}) is not defined as an underground sector. Make sure the data is consistent with strategic-map-underground-sectors.json.", sec.sectorId, sec.sectorLevel));
-				throw std::runtime_error("");
+				ST::string err = ST::format("Underground lair sector ({},{}) is not defined as an underground sector. Make sure the data is consistent with strategic-map-underground-sectors.json.", sec.sectorId, sec.sectorLevel);
+				throw std::runtime_error(err.to_std_string());
 			}
 		}
 	}

--- a/src/externalized/strategic/MineModel.cc
+++ b/src/externalized/strategic/MineModel.cc
@@ -23,8 +23,8 @@ uint8_t mineTypeFromString(std::string mineType)
 	if (mineType == "GOLD_MINE") return GOLD_MINE;
 	if (mineType == "SILVER_MINE") return SILVER_MINE;
 	
-	SLOGE(ST::format("Unrecognized mine type: '{}'", mineType));
-	throw std::runtime_error("");
+	ST::string err = ST::format("Unrecognized mine type: '{}'", mineType);
+	throw std::runtime_error(err.to_std_string());
 }
 
 std::vector<std::array<uint8_t, 2>> readMineSectors(const rapidjson::Value& sectorsJson)
@@ -56,8 +56,8 @@ MineModel* MineModel::deserialize(uint8_t index, const rapidjson::Value& json)
 	const char* entrance = obj.GetString("entranceSector");
 	if (!IS_VALID_SECTOR_SHORT_STRING(entrance))
 	{
-		SLOGE(ST::format("Invalid mine entrance sector: '{}'", entrance));
-		throw std::runtime_error("");
+		ST::string err = ST::format("Invalid mine entrance sector: '{}'", entrance);
+		throw std::runtime_error(err.to_std_string());
 	}
 
 	auto mineSectors = readMineSectors(json["mineSectors"]);
@@ -85,7 +85,7 @@ void MineModel::validateData(std::vector<const MineModel*> models)
 	if (models.size() < MAX_NUMBER_OF_MINES)
 	{
 		// Mine-related quests use hard-coded enums and may run into problems.
-		SLOGE(ST::format("There are fewer than {} mines defined.", MAX_NUMBER_OF_MINES));
-		throw std::runtime_error("");
+		ST::string err = ST::format("There are fewer than {} mines defined.", MAX_NUMBER_OF_MINES);
+		throw std::runtime_error(err.to_std_string());
 	}
 }

--- a/src/externalized/strategic/UndergroundSectorModel.cc
+++ b/src/externalized/strategic/UndergroundSectorModel.cc
@@ -35,8 +35,8 @@ std::array<uint8_t, NUM_DIF_LEVELS> readIntArray(const rapidjson::Value& obj, co
 	auto arr = obj[fieldName].GetArray();
 	if (arr.Size() != NUM_DIF_LEVELS)
 	{
-		SLOGE(ST::format("The number of values in {} is not same as NUM_DIF_LEVELS({})", fieldName, NUM_DIF_LEVELS));
-		throw std::runtime_error("");
+		ST::string err = ST::format("The number of values in {} is not same as NUM_DIF_LEVELS({})", fieldName, NUM_DIF_LEVELS);
+		throw std::runtime_error(err.to_std_string());
 	}
 	for (auto i = 0; i < NUM_DIF_LEVELS; i++)
 	{
@@ -51,15 +51,15 @@ UndergroundSectorModel* UndergroundSectorModel::deserialize(const rapidjson::Val
 	auto sectorString = obj["sector"].GetString();
 	if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
 	{
-		SLOGE(ST::format("'{}' is not valid sector", sectorString));
-		throw std::runtime_error("");
+		ST::string err = ST::format("'{}' is not valid sector", sectorString);
+		throw std::runtime_error(err.to_std_string());
 	}
 	uint8_t sectorId = SECTOR_FROM_SECTOR_SHORT_STRING(sectorString);
 	uint8_t sectorZ = obj["sectorLevel"].GetUint();
 	if (sectorZ == 0 || sectorZ > 3)
 	{
-		SLOGE("Sector level must be between 1 and 3");
-		throw std::runtime_error("");
+		ST::string err = "Sector level must be between 1 and 3";
+		throw std::runtime_error(err.to_std_string());
 	}
 
 	uint8_t adjacencyFlag = NO_ADJACENT_SECTOR;
@@ -71,8 +71,8 @@ UndergroundSectorModel* UndergroundSectorModel::deserialize(const rapidjson::Val
 			const char* adj = el.GetString();
 			if (strlen(adj) != 1)
 			{
-				SLOGE(ST::format("'{}' is not a valid adjacency direction.", adj));
-				throw std::runtime_error("");
+				ST::string err = ST::format("'{}' is not a valid adjacency direction.", adj);
+				throw std::runtime_error(err.to_std_string());
 			}
 			switch (adj[0])
 			{
@@ -89,8 +89,8 @@ UndergroundSectorModel* UndergroundSectorModel::deserialize(const rapidjson::Val
 				adjacencyFlag |= WEST_ADJACENT_SECTOR;
 				break;
 			default:
-				SLOGE(ST::format("{} is not a valid direction.", adj[0]));
-				throw std::runtime_error("");
+				ST::string err = ST::format("{} is not a valid direction.", adj[0]);
+				throw std::runtime_error(err.to_std_string());
 			}
 		}
 	}
@@ -119,8 +119,8 @@ void UndergroundSectorModel::validateData(const std::vector<const UndergroundSec
 		auto iter = std::find_if(ugSectors.begin(), ugSectors.end(), [sectorId, sectorZ](const UndergroundSectorModel* s) { return (s->sectorId == sectorId && s->sectorZ == sectorZ); });
 		if (iter == ugSectors.end())
 		{
-			SLOGW(ST::format("An underground sector is expected at ({},{},{}), but is not defined.", basementLoc[0], basementLoc[1], basementLoc[2]));
-			throw std::runtime_error("");
+			ST::string err = ST::format("An underground sector is expected at ({},{},{}), but is not defined.", basementLoc[0], basementLoc[1], basementLoc[2]);
+			throw std::runtime_error(err.to_std_string());
 		}
 	}
 }

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -565,7 +565,7 @@ void TerminationHandler()
 		}
 		catch (const std::exception& e) 
 		{
-			SLOGE(ST::format("Game has been terminated due to an unrecoverable: {} ({})", e.what(), typeid(e).name()));
+			SLOGE(ST::format("Game has been terminated due to an unrecoverable error: {} ({})", e.what(), typeid(e).name()));
 		}
 		catch (...)
 		{

--- a/src/sgp/SGP.h
+++ b/src/sgp/SGP.h
@@ -7,4 +7,6 @@
  * Call this function if you want to exit the game. */
 void requestGameExit();
 
+/** Handler for set_terminate */
+void TerminationHandler();
 #endif


### PR DESCRIPTION
Un-handled exceptions on Windows are not logged. It only prints something like "exited with status code X" (e.g. #1165).  

This PR adds a `std::terminate()` handler (`_WIN32` only) which prints `e.what()` and the type, and then continues with `std::abort()`. Example output:

```
2020-08-02T03:14:34 [ERROR] sgp\SGP.cc: Game has been terminated due to an unrecoverable error: Unrecognized mine type: 'SILVER_MINES' (class std::runtime_error)
2020-08-02T03:14:34 [ERROR] launcher\Launcher.cc: Command_execute "D:\\Games\\JA2Classic\\ja2.exe" []: exited with status code -1073740791
```

There are a few cases we log and then throw without a message (e.g. https://github.com/ja2-stracciatella/ja2-stracciatella/pull/1074#discussion_r426923424). All those are updated to throw an exception with message.