### PR TITLE
Disable quick edit mode when Launaher start (Windows only)

### DIFF
--- a/src/launcher/main.cc
+++ b/src/launcher/main.cc
@@ -4,8 +4,15 @@
 #include <FL/Fl.H>
 
 
-int main(int argc, char* argv[]) {
+int main(int argc, char* argv[]) 
+{
 	Logger_initialize("ja2-launcher.log");
+
+#ifdef _WIN32
+	// Ensure quick-edit mode is off, or else it will block execution
+	HANDLE hInput = GetStdHandle(STD_INPUT_HANDLE);
+	SetConsoleMode(hInput, ENABLE_EXTENDED_FLAGS);
+#endif
 
 	Launcher launcher(argc, argv);
 	launcher.loadJa2Json();


### PR DESCRIPTION
Same as #1166 but for the launcher. Quick-edit mode on Windows can also freeze the launcher.

This PR forces Quick-Edit mode to be off when launcher starts. When JA2.exe starts, it will try to disable it again. This is necessary, because they are independent executables sharing the same console window.