### PR TITLE
Allow inconsistency in minor map version

### DIFF
--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -2378,7 +2378,7 @@ try
 
 	if (dMajorMapVersion >= 4.00 && gMapInformation.ubMapVersion != ubMinorMapVersion)
 	{
-		throw new std::runtime_error("map version must match minor version");
+		SLOGW(ST::format("map version must match minor version ({} != {})", gMapInformation.ubMapVersion, ubMinorMapVersion));
 	}
 
 	if (uiFlags & MAP_FULLSOLDIER_SAVED)


### PR DESCRIPTION
This is for https://github.com/ja2-stracciatella/mod-nightops-maps/issues/7. The map crashes without this PR.

There is a check in World Def loading, that `gMapInformation.ubMapVersion` must be equal to `ubMinorMapVersion`. Both values come from the map .DAT file, but somehow they are inconsistent in certain NightOps maps. My guess is that the map author did some manual/hex editing when adapting the maps for vanilla. 

I changed the throw-exception into a `SLOGW`. With this PR, the sectors load fine and I completed the entire game.