### PR TITLE
Configurable BASETIMESLICE duration

### DIFF
--- a/assets/externalized/game.json
+++ b/assets/externalized/game.json
@@ -37,6 +37,11 @@
     //  Stracciatella standard value: 25
     "ms_per_game_cycle": 25,
 
+    //  Number of milliseconds for one game time slice.
+    //  Decreasing this value will speed up UI transitions and soldier animations.
+    //  Stracciatella standard value: 10
+    "ms_per_time_slice": 10,
+
     //  --------------------------------------------------
     //  Gameplay settings
     //  --------------------------------------------------

--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -12,6 +12,7 @@ DefaultGamePolicy::DefaultGamePolicy(rapidjson::Document *json)
 
 	f_draw_item_shadow = gp.getOptionalBool("draw_item_shadow", true);
 	ms_per_game_cycle = gp.getOptionalInt("ms_per_game_cycle", 25);
+	ms_per_time_slice = gp.getOptionalInt("ms_per_time_slice", 10);
 
 	starting_cash_easy = gp.getOptionalInt("starting_cash_easy", 45000);
 	starting_cash_medium = gp.getOptionalInt("starting_cash_medium", 35000);

--- a/src/externalized/policy/GamePolicy.h
+++ b/src/externalized/policy/GamePolicy.h
@@ -30,6 +30,7 @@ public:
 	bool f_draw_item_shadow;              /**< Draw shadows from the inventory items. */
 
 	int32_t ms_per_game_cycle;            /**< Milliseconds per game cycle. */
+	int32_t ms_per_time_slice;            /**< Milliseconds per time slice. */
 
 	int32_t starting_cash_easy;
 	int32_t starting_cash_medium;

--- a/src/game/Utils/Timer_Control.cc
+++ b/src/game/Utils/Timer_Control.cc
@@ -1,13 +1,17 @@
+#include "Timer_Control.h"
+
+#include "ContentManager.h"
+#include "Debug.h"
+#include "GameInstance.h"
+#include "GamePolicy.h"
+#include "Handle_Items.h"
+#include "MapScreen.h"
+#include "Overhead.h"
+#include "Soldier_Control.h"
+#include "WorldDef.h"
+
 #include <SDL.h>
 #include <stdexcept>
-
-#include "Debug.h"
-#include "MapScreen.h"
-#include "Soldier_Control.h"
-#include "Timer_Control.h"
-#include "Overhead.h"
-#include "Handle_Items.h"
-#include "WorldDef.h"
 
 
 INT32	giClockTimer = -1;
@@ -136,7 +140,7 @@ void InitializeJA2Clock(void)
 		giTimerCounters[i] = giTimerIntervals[i];
 	}
 
-	g_timer = SDL_AddTimer(BASETIMESLICE, TimeProc, 0);
+	g_timer = SDL_AddTimer(gamepolicy(ms_per_time_slice), TimeProc, 0);
 	if (!g_timer) throw std::runtime_error("Could not create timer callback");
 #endif
 }

--- a/src/game/Utils/Timer_Control.cc
+++ b/src/game/Utils/Timer_Control.cc
@@ -139,7 +139,12 @@ void InitializeJA2Clock(void)
 		giTimerCounters[i] = giTimerIntervals[i];
 	}
 
-	g_timer = SDL_AddTimer(gamepolicy(ms_per_time_slice), TimeProc, 0);
+	INT32 msPerTimeSlice = gamepolicy(ms_per_time_slice);
+	if (msPerTimeSlice <= 0)
+	{
+		throw std::runtime_error("ms_per_time_slice must be a positive integer");
+	}
+	g_timer = SDL_AddTimer(msPerTimeSlice, TimeProc, 0);
 	if (!g_timer) throw std::runtime_error("Could not create timer callback");
 }
 

--- a/src/game/Utils/Timer_Control.cc
+++ b/src/game/Utils/Timer_Control.cc
@@ -131,7 +131,6 @@ static UINT32 TimeProc(UINT32 const interval, void*)
 
 void InitializeJA2Clock(void)
 {
-#ifdef CALLBACKTIMER
 	SDL_InitSubSystem(SDL_INIT_TIMER);
 
 	// Init timer delays
@@ -142,15 +141,12 @@ void InitializeJA2Clock(void)
 
 	g_timer = SDL_AddTimer(gamepolicy(ms_per_time_slice), TimeProc, 0);
 	if (!g_timer) throw std::runtime_error("Could not create timer callback");
-#endif
 }
 
 
 void ShutdownJA2Clock(void)
 {
-#ifdef CALLBACKTIMER
 	SDL_RemoveTimer(g_timer);
-#endif
 }
 
 

--- a/src/game/Utils/Timer_Control.h
+++ b/src/game/Utils/Timer_Control.h
@@ -3,11 +3,6 @@
 
 #include "Types.h"
 
-
-#ifndef CALLBACKTIMER
-#define CALLBACKTIMER
-#endif
-
 typedef void (*CUSTOMIZABLE_TIMER_CALLBACK) ( void );
 
 // TIMER DEFINES
@@ -68,8 +63,6 @@ extern CUSTOMIZABLE_TIMER_CALLBACK gpCustomizableTimerCallback;
 // MACROS
 // Check if new counter < 0        | set to 0 |        Decrement
 
-#ifdef CALLBACKTIMER
-
 #define UPDATECOUNTER( c )		( ( giTimerCounters[ c ] - BASETIMESLICE ) < 0 ) ?  ( giTimerCounters[ c ] = 0 ) : ( giTimerCounters[ c ] -= BASETIMESLICE )
 #define RESETCOUNTER( c )		( giTimerCounters[ c ] = giTimerIntervals[ c ] )
 #define COUNTERDONE( c )		( giTimerCounters[ c ] == 0 ) ? TRUE : FALSE
@@ -85,19 +78,6 @@ extern CUSTOMIZABLE_TIMER_CALLBACK gpCustomizableTimerCallback;
 
 #define SYNCTIMECOUNTER()		(void)0
 #define ZEROTIMECOUNTER( c )		( c = 0 )
-
-#else
-
-#define UPDATECOUNTER( c )
-#define RESETCOUNTER( c )		( giTimerCounters[ c ] = giClockTimer )
-#define COUNTERDONE( c )		((((giClockTimer = GetJA2Clock()) - giTimerCounters[c]) >  giTimerIntervals[c]) ? TRUE : FALSE)
-
-#define UPDATETIMECOUNTER( c )
-#define RESETTIMECOUNTER( c, d )	( c = giClockTimer )
-#define TIMECOUNTERDONE(c, d)		(giClockTimer - c >  d)
-#define SYNCTIMECOUNTER( )		( giClockTimer = GetJA2Clock() )
-
-#endif
 
 // whenever guiBaseJA2Clock changes, we must reset all the timer variables that
 // use it as a reference


### PR DESCRIPTION
Vanilla JA2 has no speed control, so animations and UI transitions run as fast as the computer can handle; In JA2:S we have the `GetJA2Clock()`, which ticks by 10 for each 10ms of system time.

This PR adds a `ms_per_time_slice` (Suggestions for better names are welcome) to the game policy. The player can double the JA2Clock speed, by setting it to 5ms per time slice. It affects everything that waits on JA2Clock. From what I see, soldier animations and laptop transition are the most noticeable.

And we removed `CALLBACKTIMER`, since it's a useless define.

Resolves #148.