### PR TITLE
No strategic movements during bloodcat ambush

### DIFF
--- a/src/game/Strategic/Map_Screen_Interface.cc
+++ b/src/game/Strategic/Map_Screen_Interface.cc
@@ -3880,6 +3880,8 @@ static MoveError CanCharacterMoveInStrategic(SOLDIERTYPE& s)
 			if (gTacticalStatus.uiFlags & INCOMBAT) return ME_COMBAT;
 			// Hostile sector?
 			if (gTacticalStatus.fEnemyInSector) return ME_ENEMY;
+			// Bloodcat ambush?
+			if (gubEnemyEncounterCode == BLOODCAT_AMBUSH_CODE && HostileBloodcatsPresent()) return ME_COMBAT;
 			// Air raid in loaded sector where character is?
 			if (InAirRaid()) return ME_AIR_RAID;
 		}

--- a/src/game/Strategic/Map_Screen_Interface_Bottom.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Bottom.cc
@@ -912,6 +912,12 @@ BOOLEAN AllowedToTimeCompress( void )
 		return FALSE;
 	}
 
+	// bloodcat ambush?
+	if (gubEnemyEncounterCode == BLOODCAT_AMBUSH_CODE && HostileBloodcatsPresent())
+	{
+		return FALSE;
+	}
+
 	return( TRUE );
 }
 
@@ -1143,9 +1149,10 @@ BOOLEAN AllowedToExitFromMapscreenTo(ExitToWhere const bExitToWhere)
 	// the following tests apply to going tactical screen only
 	if ( bExitToWhere == MAP_EXIT_TO_TACTICAL )
 	{
-		// if in battle or air raid, the ONLY sector we can go tactical in is the one that's loaded
-		if ( ( ( gTacticalStatus.uiFlags & INCOMBAT ) || ( gTacticalStatus.fEnemyInSector ) /*|| InAirRaid( )*/ ) &&
-			( ( sSelMapX != gWorldSectorX ) || ( sSelMapY != gWorldSectorY ) || ( ( UINT8 )iCurrentMapSectorZ ) != gbWorldSectorZ ) )
+		// if in battle or bloodcat ambush, the ONLY sector we can go tactical in is the one that's loaded
+		BOOLEAN fBattleGoingOn = gTacticalStatus.uiFlags & INCOMBAT || gTacticalStatus.fEnemyInSector || (gubEnemyEncounterCode == BLOODCAT_AMBUSH_CODE && HostileBloodcatsPresent)/*|| InAirRaid( )*/;
+		BOOLEAN fCurrentSectorSelected = sSelMapX == gWorldSectorX && sSelMapY == gWorldSectorY && ((UINT8)iCurrentMapSectorZ) == gbWorldSectorZ;
+		if (fBattleGoingOn && !fCurrentSectorSelected)
 		{
 			return( FALSE );
 		}


### PR DESCRIPTION
Fixes #412.

This PR disallows changing sector, time compression and strategic squad movement during a bloodcat ambush, as if sector is hostile.

Before this PR, the hostile sector check only checks for :
- `INCOMBAT` in gTacticalStatus.uiFlags
- gTacticalStatus.`fEnemyInSector`
- `InAirRaid` _(to be cleaned up)_

Bloodcats in the wild are neutral before they are spotted, similar to hostile civilians. So during an ambush but before seeing a bloodcat, player could still do strategic actions, as combat (turn-based) mode is off and there are no enemies in sector.

Bloodcat ambush is checked by ` gubEnemyEncounterCode == BLOODCAT_AMBUSH_CODE && HostileBloodcatsPresent()`. The check is specific to ambushes. All other kinds of bloodcat encounters are not covered by this check.
