### PR TITLE
Auto-switch attached goggles

### DIFF
--- a/src/externalized/Soldier.cc
+++ b/src/externalized/Soldier.cc
@@ -277,17 +277,20 @@ static void showGearRemoveMessage(const SOLDIERTYPE* s, uint16_t usItem)
 const std::vector<ITEMDEFINE> HEAD_GEARS_DAY   { SUNGOGGLES };
 const std::vector<ITEMDEFINE> HEAD_GEARS_NIGHT { UVGOGGLES, NIGHTGOGGLES };
 
+#define SWITCH_TO_NIGHT_GEAR 0
+#define SWITCH_TO_DAY_GEAR   1
+
 void Soldier::putNightHeadGear()
 {
-	switchHeadGear(HEAD_GEARS_DAY, HEAD_GEARS_NIGHT);
+	switchHeadGear(SWITCH_TO_NIGHT_GEAR);
 }
 
 void Soldier::putDayHeadGear()
 {
-	switchHeadGear(HEAD_GEARS_NIGHT, HEAD_GEARS_DAY);
+	switchHeadGear(SWITCH_TO_DAY_GEAR);
 }
 
-void Soldier::switchHeadGear(std::vector<ITEMDEFINE> fromGears, std::vector<ITEMDEFINE> toGears)
+void Soldier::switchHeadGear(int switchDirection)
 {
 	if (IsWearingHeadGear(*mSoldier, GASMASK))
 	{
@@ -295,6 +298,8 @@ void Soldier::switchHeadGear(std::vector<ITEMDEFINE> fromGears, std::vector<ITEM
 		return;
 	}
 
+	const std::vector<ITEMDEFINE>& fromGears = (switchDirection == SWITCH_TO_NIGHT_GEAR) ? HEAD_GEARS_DAY : HEAD_GEARS_NIGHT;
+	const std::vector<ITEMDEFINE>& toGears   = (switchDirection == SWITCH_TO_NIGHT_GEAR) ? HEAD_GEARS_NIGHT : HEAD_GEARS_DAY;
 	OBJECTTYPE* helmet = &mSoldier->inv[HELMETPOS];
 	OBJECTTYPE  detachedGear{};
 

--- a/src/externalized/Soldier.h
+++ b/src/externalized/Soldier.h
@@ -37,7 +37,7 @@ public:
 
 protected:
 
-	void switchHeadGear(std::vector<ITEMDEFINE> from, std::vector<ITEMDEFINE> to);
+	void switchHeadGear(int switchDirection);
 
 	const char* getPofileName() const;
 

--- a/src/externalized/Soldier.h
+++ b/src/externalized/Soldier.h
@@ -37,6 +37,8 @@ public:
 
 protected:
 
+	void switchHeadGear(std::vector<ITEMDEFINE> from, std::vector<ITEMDEFINE> to);
+
 	const char* getPofileName() const;
 
 	/** Get free head slot or NO_SLOT if the both are occupied. */


### PR DESCRIPTION
Resolves #649.

Re-worked the goggle auto-switch (Ctrl-N). Now it swaps the goggles as requested, be it in an inventory slot or as a helmet attachment.

### Difference from current implementation

It does not put away the wrong goggle, if there is no appropriate gear. It does not put away the Sun Google at night or Night Goggles in daylight. There is no penalty for wearing the wrong goggles.

### Difference from @wvx implementation 

(See cd8ff3c7a3e63e7004e3351e5135e1c255315bbe, 801fdfb0a44b85607fff0bf099b8bdd715da4793) This is simpler, that it does not require IME stuff, does not consider time of day, sector level, lighting or gas.

## Pseudo-code

  - If wearing GASMASK, return
  - Find the optimal gear to wear:
     - If gear is present in inventory, pick it
     - Else, if gear is present in helmet attachment, detach
     - If not yet found, continue with the next preferred gear
  - Find the currently mounted eye gear
     - If HEADPOS1 is an eye gear, pick it
     - If HEADPOS2 is an eye gear, pick it
     - If not found, find a free head slot
  - If no currently mounted gear and no free slot, return
  - Swap the current gear with the optimal gear found
    - If no suitable gear found, try to unequip
        - If found free pocket, swap 
        - Else, if found free and valid helmet slot, attach
        - Else, do nothing
    - If we detached gear before, attach the gear being swapped out
  - showEquipMessage and DirtyMercPanelInterface



## Test cases

Listing only the meaningful combinations - but I have not run all the cases in an actual game yet:

Case # | Switch direction | Head Inv | Pocket Inv | Helmet Inv | Action
-- | -- | -- | -- | -- | --
1 | Night | NONE | NONE | NONE | Nil
2 | Night | NONE | NIGHTGOOGLE| NONE | Swap goggles (Pocket)
3 | Night | NONE | NONE | NIGHTGOOGLE | Swap goggles (Helmet)
4 | Night | SUNGOGGLE | NONE | NONE | Un-equip
5 | Night | SUNGOGGLE | NIGHTGOGGLE | NONE | Swap goggles (Pocket)
6 | Night | SUNGOGGLE | NONE | NIGHTGOGGLE | Swap goggles (Helmet)
7 | Night | SUNGOGGLE | NIGHTGOGGLE | NIGHTGOGGLE | Swap goggles (Pocket)
8 | Night | SUNGOGGLE | NIGHTGOGGLE | UVGOOGLE | Swap goggles (Helmet)
9 | Night | NIGHTGOGGLE | NONE | SUNGOGGLE | Nil
10 | Night | NIGHTGOGGLE | UVGOOGLE | NONE | Swap goggles (Pocket)
11 | Night | UVGOOGLE | NIGHTGOGGLE |  NONE | Nil
12 | Night | GASMASK | NIGHTGOGGLE | NONE | Nil
13 | Day | SUNGOGGLE | NONE | NONE | Nil
14 | Day | SUNGOGGLE | NIGHTGOGGLE | NONE | Nil
15 | Day | NIGHTGOGGLE | NONE | NONE | Un-equip
16 | Day | NIGHTGOGGLE | NONE | SUNGOGGLE | Swap goggles (Helmet)
17 | Day | NIGHTGOGGLE | SUNGOGGLE | NONE | Swap goggles (Pocket)
18 | Day | NIGHTGOGGLE | SUNGOGGLE | SUNGOGGLE | Swap goggles (Pocket)


