### PR TITLE
Adding the monster spit effect to weapons.json

### DIFF
--- a/assets/externalized/weapons.json
+++ b/assets/externalized/weapons.json
@@ -1735,7 +1735,8 @@
         "Sound": "sounds/adult spit.wav",
         "bNotBuyable": true,
         "bNotEditor": true,
-        "bDefaultUndroppable": true
+        "bDefaultUndroppable": true,
+        "usSmokeEffect": 159  // LARGE_CREATURE_GAS
     },
     {
         "itemIndex": 49,
@@ -1984,7 +1985,8 @@
         "Sound": "sounds/adult spit.wav",
         "bNotBuyable": true,
         "bNotEditor": true,
-        "bDefaultUndroppable": true
+        "bDefaultUndroppable": true,
+        "usSmokeEffect": 160  // VERY_SMALL_CREATURE_GAS
     },
     {
         "itemIndex": 58,
@@ -2010,7 +2012,8 @@
         "Sound": "sounds/adult spit.wav",
         "bNotBuyable": true,
         "bNotEditor": true,
-        "bDefaultUndroppable": true
+        "bDefaultUndroppable": true,
+        "usSmokeEffect": 160  // VERY_SMALL_CREATURE_GAS
     },
     {
         "itemIndex": 59,
@@ -2036,7 +2039,8 @@
         "Sound": "sounds/adult spit.wav",
         "bNotBuyable": true,
         "bNotEditor": true,
-        "bDefaultUndroppable": true
+        "bDefaultUndroppable": true,
+        "usSmokeEffect": 158  // SMALL_CREATURE_GAS
     },
     {
         "itemIndex": 60,

--- a/src/externalized/WeaponModels.cc
+++ b/src/externalized/WeaponModels.cc
@@ -57,6 +57,7 @@ WeaponModel::WeaponModel(uint32_t itemClass, uint8_t weaponType, uint8_t cursor,
 	ubHitVolume          = 0;
 	sReloadSound         = NO_WEAPON_SOUND;
 	sLocknLoadSound      = NO_WEAPON_SOUND;
+	usSmokeEffect        = NONE;
 }
 
 void WeaponModel::serializeTo(JsonObject &obj) const
@@ -552,22 +553,15 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 	else if(!strcmp(internalType, "MONSTSPIT"))
 	{
 		const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
-		// uint8_t  ReadyTime       = obj.GetInt("ubReadyTime");
 		uint8_t  ShotsPer4Turns  = obj.GetInt("ubShotsPer4Turns");
-		// uint8_t  ShotsPerBurst   = obj.GetInt("ubShotsPerBurst");
-		// uint8_t  BurstPenalty    = obj.GetInt("ubBurstPenalty");
-		// uint8_t  BulletSpeed     = obj.GetInt("ubBulletSpeed");
 		uint8_t  Impact          = obj.GetInt("ubImpact");
 		uint8_t  Deadliness      = obj.GetInt("ubDeadliness");
 		uint8_t  MagSize         = obj.GetInt("ubMagSize");
 		uint16_t Range           = obj.GetInt("usRange");
-		// uint16_t ReloadDelay     = obj.GetInt("usReloadDelay");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
 		uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
 		const char * Sound       = obj.GetString("Sound");
-		// const char * BurstSound  = obj.GetString("BurstSound");
-		// SoundID  ReloadSound     = (SoundID) obj.GetInt("sReloadSound");
-		// SoundID  LocknLoadSound  = (SoundID) obj.GetInt("sLocknLoadSound");
+		uint16_t smokeEffect     = obj.GetInt("usSmokeEffect");
 		wep = new MonsterSpit(itemIndex, internalName,
 					calibre,
 					Impact,
@@ -577,7 +571,8 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 					Range,
 					AttackVolume,
 					HitVolume,
-					Sound);
+					Sound,
+					smokeEffect);
 	}
 
 	if(!wep)
@@ -1352,7 +1347,8 @@ MonsterSpit::MonsterSpit(uint16_t itemIndex, const char * internalName,
 				uint16_t Range,
 				uint8_t AttackVolume,
 				uint8_t HitVolume,
-				const char * Sound)
+				const char * Sound,
+				uint16_t smokeEffect)
 	:WeaponModel(IC_GUN, NOT_GUN, TARGETCURS, itemIndex, internalName, "MONSTSPIT")
 {
 	ubWeaponClass        = MONSTERCLASS;
@@ -1368,6 +1364,7 @@ MonsterSpit::MonsterSpit(uint16_t itemIndex, const char * internalName,
 	ubAttackVolume       = AttackVolume;
 	ubHitVolume          = HitVolume;
 	this->sound          = Sound;
+	usSmokeEffect        = smokeEffect;
 }
 
 void MonsterSpit::serializeTo(JsonObject &obj) const
@@ -1382,6 +1379,7 @@ void MonsterSpit::serializeTo(JsonObject &obj) const
 	obj.AddMember("ubAttackVolume",       ubAttackVolume);
 	obj.AddMember("ubHitVolume",          ubHitVolume);
 	obj.AddMember("Sound",                sound);
+	obj.AddMember("ubSmokeEffect",        usSmokeEffect);
 	serializeAttachments(obj);
 	serializeFlags(obj);
 }

--- a/src/externalized/WeaponModels.h
+++ b/src/externalized/WeaponModels.h
@@ -81,6 +81,7 @@ struct WeaponModel : ItemModel
 	UINT8    ubHitVolume;
 	SoundID  sReloadSound;
 	SoundID  sLocknLoadSound;
+	UINT16   usSmokeEffect;    // item index of the smoke effect on ammo miss
 
 protected:
 	void serializeAttachments(JsonObject &obj) const;
@@ -362,7 +363,8 @@ struct MonsterSpit : WeaponModel
 			uint16_t Range,
 			uint8_t AttackVolume,
 			uint8_t HitVolume,
-			const char * Sound);
+			const char * Sound,
+			uint16_t smokeEffect);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };

--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -1623,16 +1623,12 @@ static BOOLEAN DoSpecialEffectAmmoMiss(SOLDIERTYPE* const attacker, const INT16 
 
 		return( TRUE );
 	}
-	else
+	else if (ubAmmoType == AMMO_MONSTER)
 	{
-		UINT16 gas;
-		switch (usItem)
+		UINT16 gas = GCM->getWeapon(usItem)->usSmokeEffect;
+		if (gas == NONE) 
 		{
-			case CREATURE_YOUNG_MALE_SPIT:
-			case CREATURE_INFANT_SPIT:     gas = VERY_SMALL_CREATURE_GAS; break;
-			case CREATURE_OLD_MALE_SPIT:   gas = SMALL_CREATURE_GAS;      break;
-			case CREATURE_QUEEN_SPIT:      gas = LARGE_CREATURE_GAS;      break;
-			default: return FALSE;
+			return FALSE;
 		}
 
 		// Increment attack busy...


### PR DESCRIPTION
Externalizing the monster-spit to gas-effect mapping, so the code do not have a dependency on the MONSTER_SPIT pseudo-weapons. Some mods (I mean Unfinished Business) re-purpose the monster spits' item ID to be actual weapons.

The new field `usSmokeEffect` is an item index, mandatory for monster "weapons". Values should be one of the CREATURE_GAS items:

https://github.com/ja2-stracciatella/ja2-stracciatella/blob/6f2ec3397094cdac5cd3e7efaeb4304831029113/src/game/Tactical/Items.cc#L96-L98