### PR TITLE
Reduce noise in logs

### DIFF
--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -198,12 +198,12 @@ void DefaultContentManager::AddVFSLayer(VFS_ORDER order, const ST::string path, 
 	ST::string error = ST::null;
 	if (Fs_isDir(path.c_str()))
 	{
-		SLOGI(ST::format("Adding directory to VFS ({}) '{}'", order, path));
+		SLOGD(ST::format("Adding directory to VFS ({}) '{}'", order, path));
 		succeeded = Vfs_addDir(m_vfs.get(), order, path.c_str());
 	}
 	else if (Fs_isFile(path.c_str()) && path.to_lower().ends_with(".slf"))
 	{
-		SLOGI(ST::format("Adding SLF archive to VFS ({}) '{}'", order, path));
+		SLOGD(ST::format("Adding SLF archive to VFS ({}) '{}'", order, path));
 		succeeded = Vfs_addSlf(m_vfs.get(), order, path.c_str());
 	}
 	else
@@ -226,7 +226,7 @@ void DefaultContentManager::AddVFSLayer(VFS_ORDER order, const ST::string path, 
 		}
 		else
 		{
-			SLOGI(ST::format("Skipped adding to VFS '{}': {}", path, error));
+			SLOGD(ST::format("Skipped adding to VFS '{}': {}", path, error));
 		}
 	}
 }

--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -6604,7 +6604,7 @@ void TellPlayerWhyHeCantCompressTime( void )
 	// if we're locked into paused time compression by some event that enforces that
 	if ( PauseStateLocked() )
 	{
-		SLOGW("Can't compress time, pause state locked (reason %d). OK unless permanent.\n\
+		SLOGD("Can't compress time, pause state locked (reason %d). OK unless permanent.\n\
 			If permanent, take screenshot now, send with *previous* save & describe what happened since.",
 			guiLockPauseStateLastReasonId);
 	}

--- a/src/game/Strategic/Scheduling.cc
+++ b/src/game/Strategic/Scheduling.cc
@@ -194,7 +194,7 @@ void ProcessTacticalSchedule( UINT8 ubScheduleID )
 	fAutoProcess = FALSE;
 	if( guiCurrentScreen != GAME_SCREEN )
 	{
-		SLOGW("Schedule callback occurred outside of tactical -- Auto processing!" );
+		SLOGD("Schedule callback occurred outside of tactical -- Auto processing!" );
 		fAutoProcess = TRUE;
 	}
 	else

--- a/src/game/Tactical/Interface_Dialogue.cc
+++ b/src/game/Tactical/Interface_Dialogue.cc
@@ -4062,7 +4062,7 @@ add_log:
 				}
 				break;
 			default:
-				SLOGW("No code support for NPC action %d", usActionCode );
+				SLOGD(ST::format("No code support for NPC action {}", usActionCode));
 				break;
 		}
 	}


### PR DESCRIPTION
Reducing the log levels of those that does not affect anything, or those that players do not need to know:

1. `Adding directory to VFS` - unless developing mods or changing VFS, I don't think players need to know about this
2. `Skipped adding to VFS` - the caller has already requested to skip errors, so loading this is totally optional
3. `Can't compress time, pause state locked (reason %d). OK unless permanent...` - this happens when you press `+` during a message popup
4. `Schedule callback occurred outside of tactical -- Auto processing!` - this is a normal case, nothing to worry (https://github.com/ja2-stracciatella/ja2-stracciatella/commit/34f35318764671a121239543b9e86554ded499aa#diff-7715cba6d43e93a9ffead03797722f0bL201-L203)
5. `No code support for NPC action` - several NPCs at San Mona work fine despite of this message. This looks like normal case to me.