### PR TITLE
Externalize sector Loading Screens

### DIFF
--- a/assets/externalized/loading-screens-mapping.json
+++ b/assets/externalized/loading-screens-mapping.json
@@ -1,0 +1,45 @@
+/**
+ * This defines the loading screen to use for specific sectors. If the sector loading screen is not defined here, the game falls back to rules to determine loading screen.
+ *
+ * Fields:
+ *   - sector:      The short name of the sector, e.g. A9, B10
+ *   - sectorLevel: The Z-level if sector is underground. Defaults to 0, meaning that the sector is on the surface
+ *   - night:       The internal name of the loading screen to use during night time (see loading-screens.json)
+ *   - day:         The internal name of the loading screen to use during day time
+ */
+[
+    {"sector": "A2",  "night": "NIGHTCHITZENA",  "day": "DAYCHITZENA"},
+    {"sector": "B2",  "night": "NIGHTCHITZENA" , "day": "DAYCHITZENA"},
+
+    {"sector": "A9",  "night": "NIGHTOMERTA",    "day": "DAYOMERTA"},
+    {"sector": "A10", "night": "NIGHTOMERTA",    "day": "DAYOMERTA"},
+
+    {"sector": "P3",  "night": "NIGHTPALACE",    "day": "DAYPALACE"},
+
+    // Military installations
+    {"sector": "H13", "night": "NIGHTMILITARY",  "day": "DAYMILITARY"},
+    {"sector": "H14", "night": "NIGHTMILITARY",  "day": "DAYMILITARY"},
+    {"sector": "I13", "night": "NIGHTMILITARY",  "day": "DAYMILITARY"},
+    {"sector": "N7",  "night": "NIGHTMILITARY",  "day": "DAYMILITARY"},
+    
+    {"sector": "K4",  "night": "NIGHTLAB",       "day": "DAYLAB"},
+    {"sector": "J9",  "night": "NIGHTPRISON",    "day": "DAYPRISON"},
+    {"sector": "F8",  "night": "NIGHTHOSPITAL",  "day": "DAYHOSPITAL"},
+    
+    {"sector": "B13", "night": "NIGHTAIRPORT",   "day": "DAYAIRPORT"},
+    {"sector": "N3",  "night": "NIGHTAIRPORT",   "day": "DAYAIRPORT"},
+    
+    {"sector": "L11", "night": "NIGHTBALIME",    "day": "DAYBALIME"},
+    {"sector": "L12", "night": "NIGHTBALIME",    "day": "DAYBALIME"},
+    
+    {"sector": "H3",  "night": "NIGHTMINE",      "day": "DAYMINE"},
+    {"sector": "H8",  "night": "NIGHTMINE",      "day": "DAYMINE"},
+    {"sector": "D4",  "night": "NIGHTMINE",      "day": "DAYMINE"},
+
+    {"sector": "A10", "sectorLevel": 1, "night": "BASEMENT", "day": "BASEMENT"}, // Miguel's basement
+    {"sector": "I13", "sectorLevel": 1, "night": "BASEMENT", "day": "BASEMENT"}, // Alma prison dungeon
+    {"sector": "J9",  "sectorLevel": 1, "night": "BASEMENT", "day": "BASEMENT"}, // Tixa prison dungeon
+    {"sector": "K4",  "sectorLevel": 1, "night": "BASEMENT", "day": "BASEMENT"}, // Orta weapons plant
+    {"sector": "O3",  "sectorLevel": 1, "night": "BASEMENT", "day": "BASEMENT"}, // Meduna
+    {"sector": "P3",  "sectorLevel": 1, "night": "BASEMENT", "day": "BASEMENT"}  // Meduna
+]

--- a/assets/externalized/loading-screens.json
+++ b/assets/externalized/loading-screens.json
@@ -1,0 +1,43 @@
+/**
+ * Adds more loading screens after the pre-defined ones. The codebase defines 27 loading screens and those have hard-coded references. The screens added here will have indices starting from 28.
+ *
+ * Note that the ordering of this list is important. The ordering generates the screen index, which is used in save games.
+ *
+ * Fields:
+ *  - internalName:    An unique name, referenced by loading-screens-mapping.json
+ *  - filename:        There must be a corresponding image file (.sti) in Data/LoadScreens
+ * 
+ * Pre-defined loading screens:
+ *    NOTHING,  (index 0)
+ *    DAYGENERIC, DAYTOWN1, DAYTOWN2,
+ *    DAYWILD, DAYTROPICAL, DAYFOREST, DAYDESERT,
+ *    DAYPALACE,
+ *    NIGHTGENERIC, NIGHTWILD,
+ *    NIGHTTOWN1, NIGHTTOWN2,
+ *    NIGHTFOREST, NIGHTTROPICAL, NIGHTDESERT, 
+ *    NIGHTPALACE,
+ *    HELI, 
+ *    BASEMENT, MINE,CAVE,
+ *    DAYPINE, NIGHTPINE,
+ *    DAYMILITARY, NIGHTMILITARY,
+ *    DAYSAM,
+ *    NIGHTSAM  (index 27)
+ */
+[
+    {"internalName": "DAYPRISON",     "filename": "/ls_dayprison.sti"     }, // index 28
+    {"internalName": "NIGHTPRISON",   "filename": "/ls_nightprison.sti"   },
+    {"internalName": "DAYHOSPITAL",   "filename": "/ls_dayhospital.sti"   },
+    {"internalName": "NIGHTHOSPITAL", "filename": "/ls_nighthospital.sti" },
+    {"internalName": "DAYAIRPORT",    "filename": "/ls_dayairport.sti"    },
+    {"internalName": "NIGHTAIRPORT",  "filename": "/ls_nightairport.sti"  },
+    {"internalName": "DAYLAB",        "filename": "/ls_daylab.sti"        },
+    {"internalName": "NIGHTLAB",      "filename": "/ls_nightlab.sti"      },
+    {"internalName": "DAYOMERTA",     "filename": "/ls_dayomerta.sti"     },
+    {"internalName": "NIGHTOMERTA",   "filename": "/ls_nightomerta.sti"   },
+    {"internalName": "DAYCHITZENA",   "filename": "/ls_daychitzena.sti"   },
+    {"internalName": "NIGHTCHITZENA", "filename": "/ls_nightchitzena.sti" },
+    {"internalName": "DAYMINE",       "filename": "/ls_daymine.sti"       },
+    {"internalName": "NIGHTMINE",     "filename": "/ls_nightmine.sti"     },
+    {"internalName": "DAYBALIME",     "filename": "/ls_daybalime.sti"     },
+    {"internalName": "NIGHTBALIME",   "filename": "/ls_nightbalime.sti"   }
+]

--- a/src/externalized/CMakeLists.txt
+++ b/src/externalized/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LOCAL_JA2_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/DefaultContentManager.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/ItemModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/JsonUtility.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/LoadingScreenModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/MagazineModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/MercProfile.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/ModPackContentManager.cc

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -24,6 +24,7 @@ class FactParamsModel;
 class GamePolicy;
 class GarrisonGroupModel;
 class IMPPolicy;
+class LoadingScreenModel;
 class MineModel;
 class MovementCostsModel;
 class NpcActionParamsModel;
@@ -35,6 +36,7 @@ class TownModel;
 class UndergroundSectorModel;
 struct AmmoTypeModel;
 struct CalibreModel;
+struct LoadingScreen;
 struct MagazineModel;
 struct SGPFile;
 struct WeaponModel;
@@ -158,6 +160,12 @@ public:
 
 	/* Params for the given NPC_ACTION if found, or return an empty instance */
 	virtual const FactParamsModel* getFactParams(Fact fact) const = 0;
+
+	/* Gets loading screen for the sector. Returns NULL if the sector does not have an associated loading screen */
+	virtual const LoadingScreen* getLoadingScreenForSector(uint8_t sectorId, uint8_t sectorLevel, bool isNight) const = 0;
+
+	/* Gets a loading screen by ID. Never returns NULL, but throws out_of_range if index is invalid */
+	virtual const LoadingScreen* getLoadingScreen(uint8_t index) const = 0;
 
 	virtual const ST::string* getNewString(size_t stringId) const = 0;
 

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -190,6 +190,7 @@ DefaultContentManager::DefaultContentManager(GameVersion gameVersion,
 	m_gamePolicy = NULL;
 
 	m_movementCosts = NULL;
+	m_loadingScreenModel = NULL;
 }
 
 

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -22,6 +22,7 @@
 #include "DealerInventory.h"
 #include "JsonObject.h"
 #include "JsonUtility.h"
+#include "LoadingScreenModel.h"
 #include "MagazineModel.h"
 #include "RustInterface.h"
 #include "ShippingDestinationModel.h"
@@ -313,6 +314,7 @@ DefaultContentManager::~DefaultContentManager()
 	delete m_bobbyRayUsedInventory;
 	delete m_impPolicy;
 	delete m_gamePolicy;
+	delete m_loadingScreenModel;
 
 	for (const ST::string *str : m_newStrings)
 	{
@@ -1025,6 +1027,11 @@ bool DefaultContentManager::loadGameData()
 	}
 	ShippingDestinationModel::validateData(m_shippingDestinations, m_shippingDestinationNames);
 
+	auto loadScreensList = readJsonDataFile("loading-screens.json");
+	auto loadScreensMapping = readJsonDataFile("loading-screens-mapping.json");
+	m_loadingScreenModel = LoadingScreenModel::deserialize(*loadScreensList, *loadScreensMapping);
+	m_loadingScreenModel->validateData(this);
+
 	loadStringRes("strings/ammo-calibre", m_calibreNames);
 	loadStringRes("strings/ammo-calibre-bobbyray", m_calibreNamesBobbyRay);
 
@@ -1385,4 +1392,14 @@ const MovementCostsModel* DefaultContentManager::getMovementCosts() const
 const NpcPlacementModel* DefaultContentManager::getNpcPlacement(uint8_t profileId) const
 {
 	return m_npcPlacements.at(profileId);
+}
+
+const LoadingScreen* DefaultContentManager::getLoadingScreenForSector(uint8_t sectorId, uint8_t sectorLevel, bool isNight) const
+{
+	return m_loadingScreenModel->getScreenForSector(sectorId, sectorLevel, isNight);
+}
+
+const LoadingScreen* DefaultContentManager::getLoadingScreen(uint8_t index) const
+{
+	return m_loadingScreenModel->getByIndex(index);
 }

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -179,6 +179,8 @@ public:
 	virtual const std::vector <const UndergroundSectorModel*>& getUndergroundSectors() const override;
 	virtual const MovementCostsModel* getMovementCosts() const override;
 	virtual const NpcPlacementModel* getNpcPlacement(uint8_t profileId) const override;
+	virtual const LoadingScreen* getLoadingScreenForSector(uint8_t sectorId, uint8_t sectorLevel, bool isNight) const override;
+	virtual const LoadingScreen* getLoadingScreen(uint8_t index) const override;
 
 protected:
 	ST::string m_dataDir;
@@ -229,6 +231,7 @@ protected:
 	const IMPPolicy *m_impPolicy;
 	const GamePolicy *m_gamePolicy;
 
+	const LoadingScreenModel* m_loadingScreenModel;
 	const MovementCostsModel* m_movementCosts;
 
 	std::vector<const BloodCatPlacementsModel*> m_bloodCatPlacements;

--- a/src/externalized/LoadingScreenModel.cc
+++ b/src/externalized/LoadingScreenModel.cc
@@ -1,0 +1,117 @@
+#include "LoadingScreenModel.h"
+
+#include "Campaign_Types.h"
+#include "Directories.h"
+#include "JsonObject.h"
+#include "Loading_Screen.h"
+
+#include <map>
+#include <stdexcept>
+
+const std::vector<LoadingScreen> PREDEFINED_SCREENS = {
+	LoadingScreen(LOADINGSCREEN_NOTHING,     "NOTHING",     "/ls_heli.sti"),
+	LoadingScreen(LOADINGSCREEN_DAYGENERIC,  "DAYGENERIC",  "/ls_daygeneric.sti"),
+	LoadingScreen(LOADINGSCREEN_DAYTOWN1,    "DAYTOWN1",    "/ls_daytown1.sti"),
+	LoadingScreen(LOADINGSCREEN_DAYTOWN2,    "DAYTOWN2",    "/ls_daytown2.sti"),
+	LoadingScreen(LOADINGSCREEN_DAYWILD,     "DAYWILD",     "/ls_daywild.sti"),
+	LoadingScreen(LOADINGSCREEN_DAYTROPICAL, "DAYTROPICAL", "/ls_daytropical.sti"),
+	LoadingScreen(LOADINGSCREEN_DAYFOREST,   "DAYFOREST",   "/ls_dayforest.sti"),
+	LoadingScreen(LOADINGSCREEN_DAYDESERT,   "DAYDESERT",   "/ls_daydesert.sti"),
+	LoadingScreen(LOADINGSCREEN_DAYPALACE,   "DAYPALACE",   "/ls_daypalace.sti"),
+
+	LoadingScreen(LOADINGSCREEN_NIGHTGENERIC,  "NIGHTGENERIC",  "/ls_nightgeneric.sti"),
+	LoadingScreen(LOADINGSCREEN_NIGHTWILD,     "NIGHTWILD",     "/ls_nightwild.sti"),
+	LoadingScreen(LOADINGSCREEN_NIGHTTOWN1,    "NIGHTTOWN1",    "/ls_nighttown1.sti"),
+	LoadingScreen(LOADINGSCREEN_NIGHTTOWN2,    "NIGHTTOWN2",    "/ls_nighttown2.sti"),
+	LoadingScreen(LOADINGSCREEN_NIGHTFOREST,   "NIGHTFOREST",   "/ls_nightforest.sti"),
+	LoadingScreen(LOADINGSCREEN_NIGHTTROPICAL, "NIGHTTROPICAL", "/ls_nighttropical.sti"),
+	LoadingScreen(LOADINGSCREEN_NIGHTDESERT,   "NIGHTDESERT",   "/ls_nightdesert.sti"),
+	LoadingScreen(LOADINGSCREEN_NIGHTPALACE,   "NIGHTPALACE",   "/ls_nightpalace.sti"),
+
+	LoadingScreen(LOADINGSCREEN_HELI,     "HELI",     "/ls_heli.sti"),
+	LoadingScreen(LOADINGSCREEN_BASEMENT, "BASEMENT", "/ls_basement.sti"),
+	LoadingScreen(LOADINGSCREEN_MINE,     "MINE",     "/ls_mine.sti"),
+	LoadingScreen(LOADINGSCREEN_CAVE,     "CAVE",     "/ls_cave.sti"),
+
+	LoadingScreen(LOADINGSCREEN_DAYPINE,       "DAYPINE",       "/ls_daypine.sti"),
+	LoadingScreen(LOADINGSCREEN_NIGHTPINE,     "NIGHTPINE",     "/ls_nightpine.sti"),
+	LoadingScreen(LOADINGSCREEN_DAYMILITARY,   "DAYMILITARY",   "/ls_daymilitary.sti"),
+	LoadingScreen(LOADINGSCREEN_NIGHTMILITARY, "NIGHTMILITARY", "/ls_nightmilitary.sti"),
+	LoadingScreen(LOADINGSCREEN_DAYSAM,        "DAYSAM",        "/ls_daysam.sti"),
+	LoadingScreen(LOADINGSCREEN_NIGHTSAM,      "NIGHTSAM",      "/ls_nightsam.sti")
+};
+
+LoadingScreenModel::LoadingScreenModel(std::vector<LoadingScreen> screensList_, std::vector<LoadingScreenMapping> screensMapping_)
+	: screensList(screensList_), screensMapping(screensMapping_) {}
+
+const LoadingScreen* LoadingScreenModel::getScreenForSector(uint8_t sectorId, uint8_t sectorLevel, bool isNight) const
+{
+	for (auto screen : screensMapping)
+	{
+		if (screen.sectorId == sectorId && screen.sectorLevel == sectorLevel)
+		{
+			uint8_t screenId = isNight ? screen.loadScreenNight : screen.loadScreenDay;
+			return getByIndex(screenId);
+		}
+	}
+	return NULL;
+}
+
+const LoadingScreen* LoadingScreenModel::getByIndex(uint8_t index) const
+{
+	return &(screensList.at(index));
+}
+
+void LoadingScreenModel::validateData(ContentManager* cm) const
+{
+	for (int i = 0; i < screensList.size(); i++)
+	{
+		if (cm->doesGameResExists(screensList[i].filename))
+		{
+			SLOGW(ST::format("Load Screen image '{}' cannot be opened", screensList[i].filename));
+		}
+		if (screensList[i].index != i)
+		{
+			ST::string err = ST::format("Load Screen with index {} does not match its position ({}) in list", screensList[i].index, i);
+			throw std::logic_error(err.to_std_string());
+		}
+	}
+}
+
+LoadingScreenModel* LoadingScreenModel::deserialize(const rapidjson::Value& screensList, const rapidjson::Value& screensMapping)
+{
+	std::vector<LoadingScreen> screens = PREDEFINED_SCREENS;
+	int index = screens.size();
+	for (auto& item : screensList.GetArray())
+	{
+		JsonObjectReader r(item);
+		screens.push_back(
+			LoadingScreen(index++, r.GetString("internalName"), r.GetString("filename"))
+		);
+	}
+
+	std::map<std::string, uint8_t> namesMapping;
+	for (index = 0; index < screens.size(); index++)
+	{
+		std::string name = screens[index].internalName.to_std_string();
+		namesMapping[name] = index;
+	}
+	
+
+	std::vector<LoadingScreenMapping> mappings;
+	for (auto& item : screensMapping.GetArray())
+	{
+		JsonObjectReader r(item);
+		uint8_t sectorId = SECTOR_FROM_SECTOR_SHORT_STRING(r.GetString("sector"));
+		mappings.push_back(LoadingScreenMapping{
+			sectorId,
+			(UINT8)r.getOptionalInt("sectorLevel", 0),
+			namesMapping.at(r.GetString("night")),
+			namesMapping.at(r.GetString("day"))
+			});
+	}
+
+	return new LoadingScreenModel(screens, mappings);
+}
+
+

--- a/src/externalized/LoadingScreenModel.cc
+++ b/src/externalized/LoadingScreenModel.cc
@@ -64,7 +64,7 @@ const LoadingScreen* LoadingScreenModel::getByIndex(uint8_t index) const
 
 void LoadingScreenModel::validateData(ContentManager* cm) const
 {
-	for (int i = 0; i < screensList.size(); i++)
+	for (size_t i = 0; i < screensList.size(); i++)
 	{
 		if (cm->doesGameResExists(screensList[i].filename))
 		{
@@ -81,7 +81,7 @@ void LoadingScreenModel::validateData(ContentManager* cm) const
 LoadingScreenModel* LoadingScreenModel::deserialize(const rapidjson::Value& screensList, const rapidjson::Value& screensMapping)
 {
 	std::vector<LoadingScreen> screens = PREDEFINED_SCREENS;
-	int index = screens.size();
+	size_t index = screens.size();
 	for (auto& item : screensList.GetArray())
 	{
 		JsonObjectReader r(item);
@@ -94,7 +94,7 @@ LoadingScreenModel* LoadingScreenModel::deserialize(const rapidjson::Value& scre
 	for (index = 0; index < screens.size(); index++)
 	{
 		std::string name = screens[index].internalName.to_std_string();
-		namesMapping[name] = index;
+		namesMapping[name] = static_cast<uint8_t>(index);
 	}
 	
 

--- a/src/externalized/LoadingScreenModel.h
+++ b/src/externalized/LoadingScreenModel.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "ContentManager.h"
+#include "JA2Types.h"
+
+#include <vector>
+#include <rapidjson/document.h>
+
+
+// Definition of a Loading Screen
+struct LoadingScreen
+{
+	LoadingScreen(uint8_t index_, ST::string internalName_, ST::string filename_)
+		: index(index_), internalName(internalName_), filename(filename_) {}
+
+	uint8_t index;
+	ST::string internalName;
+	ST::string filename;
+};
+
+// An entry in the sector to loading-screen mapping
+struct LoadingScreenMapping
+{
+	uint8_t sectorId;
+	uint8_t sectorLevel;
+	uint8_t loadScreenNight;
+	uint8_t loadScreenDay;
+};
+
+// Model class providing access to the available loading screens
+class LoadingScreenModel
+{
+public:
+	LoadingScreenModel(std::vector<LoadingScreen> screensList, std::vector<LoadingScreenMapping> screensMapping);
+
+	// returns NULL if the given sector is not mapped
+	const LoadingScreen* LoadingScreenModel::getScreenForSector(uint8_t sectorId, uint8_t sectorLevel, bool isNight) const;
+
+	// throws out_of_range if index is out of bounds
+	const LoadingScreen* getByIndex(uint8_t index) const;
+
+	void validateData(ContentManager* cm) const;
+
+	static LoadingScreenModel* deserialize(const rapidjson::Value& screensList, const rapidjson::Value& screensMapping);
+	
+protected:
+	// list of available loading screens
+	std::vector<LoadingScreen> screensList;
+
+	// mapping of sector to loading screens
+	std::vector<LoadingScreenMapping> screensMapping;
+};
+

--- a/src/externalized/LoadingScreenModel.h
+++ b/src/externalized/LoadingScreenModel.h
@@ -34,7 +34,7 @@ public:
 	LoadingScreenModel(std::vector<LoadingScreen> screensList, std::vector<LoadingScreenMapping> screensMapping);
 
 	// returns NULL if the given sector is not mapped
-	const LoadingScreen* LoadingScreenModel::getScreenForSector(uint8_t sectorId, uint8_t sectorLevel, bool isNight) const;
+	const LoadingScreen* getScreenForSector(uint8_t sectorId, uint8_t sectorLevel, bool isNight) const;
 
 	// throws out_of_range if index is out of bounds
 	const LoadingScreen* getByIndex(uint8_t index) const;

--- a/src/game/Loading_Screen.cc
+++ b/src/game/Loading_Screen.cc
@@ -1,10 +1,14 @@
+#include "Loading_Screen.h"
+
 #include "Campaign_Types.h"
+#include "ContentManager.h"
 #include "Debug.h"
 #include "Directories.h"
 #include "Font.h"
 #include "Font_Control.h"
 #include "Game_Clock.h"
-#include "Loading_Screen.h"
+#include "GameInstance.h"
+#include "LoadingScreenModel.h"
 #include "Local.h"
 #include "Random.h"
 #include "Render_Dirty.h"
@@ -17,50 +21,25 @@
 #include <string_theory/format>
 
 
-LoadingScreenID gubLastLoadingScreenID = LOADINGSCREEN_NOTHING;
+UINT8 gubLastLoadingScreenID = LOADINGSCREEN_NOTHING;
 
 
-LoadingScreenID GetLoadScreenID(INT16 const x, INT16 const y, INT8 const z)
+UINT8 GetLoadScreenID(INT16 const x, INT16 const y, INT8 const z)
 {
 	bool  const night     = NightTime();
 	UINT8 const sector_id = SECTOR(x, y);
+	
+	if (DidGameJustStart()) return LOADINGSCREEN_HELI;
+
+	const LoadingScreen* screen = GCM->getLoadingScreenForSector(sector_id, z, night);
+	if (screen != NULL)
+	{
+		return screen->index;
+	}
+
 	switch (z)
 	{
 		case 0:
-			if (DidGameJustStart()) return LOADINGSCREEN_HELI;
-			switch (sector_id)
-			{
-				case SEC_A2:
-				case SEC_B2:
-					return night ? LOADINGSCREEN_NIGHTCHITZENA : LOADINGSCREEN_DAYCHITZENA;
-				case SEC_A9:
-				case SEC_A10:
-					return night ? LOADINGSCREEN_NIGHTOMERTA : LOADINGSCREEN_DAYOMERTA;
-				case SEC_P3:
-					return night ? LOADINGSCREEN_NIGHTPALACE : LOADINGSCREEN_DAYPALACE;
-				case SEC_H13: // Military installations
-				case SEC_H14:
-				case SEC_I13:
-				case SEC_N7:
-					return night ? LOADINGSCREEN_NIGHTMILITARY : LOADINGSCREEN_DAYMILITARY;
-				case SEC_K4:
-					return night ? LOADINGSCREEN_NIGHTLAB : LOADINGSCREEN_DAYLAB;
-				case SEC_J9:
-					return night ? LOADINGSCREEN_NIGHTPRISON : LOADINGSCREEN_DAYPRISON;
-				case SEC_F8:
-					return night ? LOADINGSCREEN_NIGHTHOSPITAL : LOADINGSCREEN_DAYHOSPITAL;
-				case SEC_B13:
-				case SEC_N3:
-					return night ? LOADINGSCREEN_NIGHTAIRPORT : LOADINGSCREEN_DAYAIRPORT;
-				case SEC_L11:
-				case SEC_L12:
-					return night ? LOADINGSCREEN_NIGHTBALIME : LOADINGSCREEN_DAYBALIME;
-				case SEC_H3:
-				case SEC_H8:
-				case SEC_D4:
-					return night ? LOADINGSCREEN_NIGHTMINE : LOADINGSCREEN_DAYMINE;
-			}
-
 			if (IsThisSectorASAMSector(x, y, z))
 			{
 				return night ? LOADINGSCREEN_NIGHTSAM : LOADINGSCREEN_DAYSAM;
@@ -105,18 +84,8 @@ LoadingScreenID GetLoadScreenID(INT16 const x, INT16 const y, INT8 const z)
 			}
 
 		case 1:
-			switch (sector_id)
-			{
-				case SEC_A10: // Miguel's basement
-				case SEC_I13:	// Alma prison dungeon
-				case SEC_J9:	// Tixa prison dungeon
-				case SEC_K4:	// Orta weapons plant
-				case SEC_O3:  // Meduna
-				case SEC_P3:  // Meduna
-					return LOADINGSCREEN_BASEMENT;
-				default:			// Rest are mines
-					return LOADINGSCREEN_MINE;
-			}
+			// All sectors at this level, except mine sectors, are mapped to specific loading screens
+			return LOADINGSCREEN_MINE;
 
 		case 2:
 		case 3:
@@ -130,60 +99,14 @@ LoadingScreenID GetLoadScreenID(INT16 const x, INT16 const y, INT8 const z)
 }
 
 
-void DisplayLoadScreenWithID(LoadingScreenID const id)
+void DisplayLoadScreenWithID(UINT8 const id)
 {
-	char const* filename;
-	switch (id)
-	{
-		case LOADINGSCREEN_NOTHING:       filename = LOADSCREENSDIR "/ls_heli.sti";          break;
-		case LOADINGSCREEN_DAYGENERIC:    filename = LOADSCREENSDIR "/ls_daygeneric.sti";    break;
-		case LOADINGSCREEN_DAYTOWN1:      filename = LOADSCREENSDIR "/ls_daytown1.sti";      break;
-		case LOADINGSCREEN_DAYTOWN2:      filename = LOADSCREENSDIR "/ls_daytown2.sti";      break;
-		case LOADINGSCREEN_DAYWILD:       filename = LOADSCREENSDIR "/ls_daywild.sti";       break;
-		case LOADINGSCREEN_DAYTROPICAL:   filename = LOADSCREENSDIR "/ls_daytropical.sti";   break;
-		case LOADINGSCREEN_DAYFOREST:     filename = LOADSCREENSDIR "/ls_dayforest.sti";     break;
-		case LOADINGSCREEN_DAYDESERT:     filename = LOADSCREENSDIR "/ls_daydesert.sti";     break;
-		case LOADINGSCREEN_DAYPALACE:     filename = LOADSCREENSDIR "/ls_daypalace.sti";     break;
-		case LOADINGSCREEN_NIGHTGENERIC:  filename = LOADSCREENSDIR "/ls_nightgeneric.sti";  break;
-		case LOADINGSCREEN_NIGHTWILD:     filename = LOADSCREENSDIR "/ls_nightwild.sti";     break;
-		case LOADINGSCREEN_NIGHTTOWN1:    filename = LOADSCREENSDIR "/ls_nighttown1.sti";    break;
-		case LOADINGSCREEN_NIGHTTOWN2:    filename = LOADSCREENSDIR "/ls_nighttown2.sti";    break;
-		case LOADINGSCREEN_NIGHTFOREST:   filename = LOADSCREENSDIR "/ls_nightforest.sti";   break;
-		case LOADINGSCREEN_NIGHTTROPICAL: filename = LOADSCREENSDIR "/ls_nighttropical.sti"; break;
-		case LOADINGSCREEN_NIGHTDESERT:   filename = LOADSCREENSDIR "/ls_nightdesert.sti";   break;
-		case LOADINGSCREEN_NIGHTPALACE:   filename = LOADSCREENSDIR "/ls_nightpalace.sti";   break;
-		case LOADINGSCREEN_HELI:          filename = LOADSCREENSDIR "/ls_heli.sti";          break;
-		case LOADINGSCREEN_BASEMENT:      filename = LOADSCREENSDIR "/ls_basement.sti";      break;
-		case LOADINGSCREEN_MINE:          filename = LOADSCREENSDIR "/ls_mine.sti";          break;
-		case LOADINGSCREEN_CAVE:          filename = LOADSCREENSDIR "/ls_cave.sti";          break;
-		case LOADINGSCREEN_DAYPINE:       filename = LOADSCREENSDIR "/ls_daypine.sti";       break;
-		case LOADINGSCREEN_NIGHTPINE:     filename = LOADSCREENSDIR "/ls_nightpine.sti";     break;
-		case LOADINGSCREEN_DAYMILITARY:   filename = LOADSCREENSDIR "/ls_daymilitary.sti";   break;
-		case LOADINGSCREEN_NIGHTMILITARY: filename = LOADSCREENSDIR "/ls_nightmilitary.sti"; break;
-		case LOADINGSCREEN_DAYSAM:        filename = LOADSCREENSDIR "/ls_daysam.sti";        break;
-		case LOADINGSCREEN_NIGHTSAM:      filename = LOADSCREENSDIR "/ls_nightsam.sti";      break;
-		case LOADINGSCREEN_DAYPRISON:     filename = LOADSCREENSDIR "/ls_dayprison.sti";     break;
-		case LOADINGSCREEN_NIGHTPRISON:   filename = LOADSCREENSDIR "/ls_nightprison.sti";   break;
-		case LOADINGSCREEN_DAYHOSPITAL:   filename = LOADSCREENSDIR "/ls_dayhospital.sti";   break;
-		case LOADINGSCREEN_NIGHTHOSPITAL: filename = LOADSCREENSDIR "/ls_nighthospital.sti"; break;
-		case LOADINGSCREEN_DAYAIRPORT:    filename = LOADSCREENSDIR "/ls_dayairport.sti";    break;
-		case LOADINGSCREEN_NIGHTAIRPORT:  filename = LOADSCREENSDIR "/ls_nightairport.sti";  break;
-		case LOADINGSCREEN_DAYLAB:        filename = LOADSCREENSDIR "/ls_daylab.sti";        break;
-		case LOADINGSCREEN_NIGHTLAB:      filename = LOADSCREENSDIR "/ls_nightlab.sti";      break;
-		case LOADINGSCREEN_DAYOMERTA:     filename = LOADSCREENSDIR "/ls_dayomerta.sti";     break;
-		case LOADINGSCREEN_NIGHTOMERTA:   filename = LOADSCREENSDIR "/ls_nightomerta.sti";   break;
-		case LOADINGSCREEN_DAYCHITZENA:   filename = LOADSCREENSDIR "/ls_daychitzena.sti";   break;
-		case LOADINGSCREEN_NIGHTCHITZENA: filename = LOADSCREENSDIR "/ls_nightchitzena.sti"; break;
-		case LOADINGSCREEN_DAYMINE:       filename = LOADSCREENSDIR "/ls_daymine.sti" ;      break;
-		case LOADINGSCREEN_NIGHTMINE:     filename = LOADSCREENSDIR "/ls_nightmine.sti" ;    break;
-		case LOADINGSCREEN_DAYBALIME:     filename = LOADSCREENSDIR "/ls_daybalime.sti" ;    break;
-		case LOADINGSCREEN_NIGHTBALIME:   filename = LOADSCREENSDIR "/ls_nightbalime.sti";   break;
-		default:                          filename = LOADSCREENSDIR "/ls_heli.sti";          break;
-	}
+	const LoadingScreen* screen = GCM->getLoadingScreen(id);
+	ST::string filename = LOADSCREENSDIR + screen->filename;
 
 	try
 	{ // Blit the background image.
-		BltVideoSurfaceOnce(FRAME_BUFFER, filename, STD_SCREEN_X, STD_SCREEN_Y);
+		BltVideoSurfaceOnce(FRAME_BUFFER, filename.c_str(), STD_SCREEN_X, STD_SCREEN_Y);
 	}
 	catch (...)
 	{ // Failed to load the file, so use a black screen and print out message.

--- a/src/game/Loading_Screen.h
+++ b/src/game/Loading_Screen.h
@@ -1,6 +1,7 @@
 #ifndef LOADING_SCREEN_H
 #define LOADING_SCREEN_H
 
+#include "JA2Types.h"
 
 enum LoadingScreenID
 {
@@ -31,33 +32,19 @@ enum LoadingScreenID
 	LOADINGSCREEN_NIGHTMILITARY,
 	LOADINGSCREEN_DAYSAM,
 	LOADINGSCREEN_NIGHTSAM,
-	LOADINGSCREEN_DAYPRISON,
-	LOADINGSCREEN_NIGHTPRISON,
-	LOADINGSCREEN_DAYHOSPITAL,
-	LOADINGSCREEN_NIGHTHOSPITAL,
-	LOADINGSCREEN_DAYAIRPORT,
-	LOADINGSCREEN_NIGHTAIRPORT,
-	LOADINGSCREEN_DAYLAB,
-	LOADINGSCREEN_NIGHTLAB,
-	LOADINGSCREEN_DAYOMERTA,
-	LOADINGSCREEN_NIGHTOMERTA,
-	LOADINGSCREEN_DAYCHITZENA,
-	LOADINGSCREEN_NIGHTCHITZENA,
-	LOADINGSCREEN_DAYMINE,
-	LOADINGSCREEN_NIGHTMINE,
-	LOADINGSCREEN_DAYBALIME,
-	LOADINGSCREEN_NIGHTBALIME,
+
+	NUM_HARDCODED_LOADING_SCREENS
 };
 
 
 // For use by the game loader, before it can possibly know the situation.
-extern LoadingScreenID gubLastLoadingScreenID;
+extern UINT8 gubLastLoadingScreenID;
 
 // Return the loading screen ID for the specified sector.
-LoadingScreenID GetLoadScreenID(INT16 x, INT16 y, INT8 z);
+UINT8 GetLoadScreenID(INT16 x, INT16 y, INT8 z);
 
 /* Set up the loadscreen with specified ID, draw it to the FRAME_BUFFER, and
  * refresh the screen with it. */
-void DisplayLoadScreenWithID(LoadingScreenID);
+void DisplayLoadScreenWithID(UINT8);
 
 #endif

--- a/src/game/Strategic/StrategicMap.cc
+++ b/src/game/Strategic/StrategicMap.cc
@@ -300,7 +300,7 @@ void BeginLoadScreen( )
 	// ( which gets reloaded into gubLastLoadingScreenID )
 	if( !gfGotoSectorTransition )
 	{
-		LoadingScreenID const id = gTacticalStatus.uiFlags & LOADING_SAVED_GAME ?
+		UINT8 const id = gTacticalStatus.uiFlags & LOADING_SAVED_GAME ?
 			gubLastLoadingScreenID :
 			GetLoadScreenID(gWorldSectorX, gWorldSectorY, gbWorldSectorZ);
 		DisplayLoadScreenWithID(id);


### PR DESCRIPTION
At the high level, there are 2 ways to determine the loading screen for a sector:

1. Specific mapping from sector to loading screen (e.g. P3 => `DAYPALACE`,  A2 => `NIGHTCHITZENA`)
2. If no mapping found, there are rules for land types, SAM sites, underground caves, etc

### What's included

This PR externalizes part 1 of the loading screen logic. There are 2 kinds of data externalized:

1. Loading screen details, which has an index (`LoadingScreenID`), and points to a resource file (.STI) 
2. Mapping from `sector + night/day` to `LoadingScreenID`

With this, mods can freely add new loading screens and then maps specific sectors to them. Though it is not possible to change the rules via JSON, the mods can resort to adding a mapping for every single sector.


Part of #665.