### PR TITLE
Externalize (arms) dealer info

### DIFF
--- a/assets/externalized/dealers.json
+++ b/assets/externalized/dealers.json
@@ -1,0 +1,277 @@
+/**
+ * List of all the shopkeepers / arms dealers / traders in game.
+ *
+ * Fields:
+ *  - profileID: The shopkeeper merc's profile ID
+ *  - type: Must be one of BUYS_ONLY, SELLS_ONLY, BUYS_SELLS or REPAIRS
+ *  - buyingPrice: Mandatory if this dealer buys from the player. This is a multiplier applied on the item's value
+ *  - sellingPrice: Mandatory if this dealer sells to the player. This is a multiplier applied on the item's value
+ *  - repairSpeed: The speed to repair an item, expressed in minutes per dollar-value. With a speed of 1.0, it takes 16.6 hours to do a full 100% status repair of an $2000 item. Lower value means faster repair. Mandatory for repairmen.
+ *  - repairCost: Cost to repair items, as one of the multipliers to the item's value. Mandatory for repairmen.
+ *  - initialCash: Initial cash the dealer has. It is replenished once a day.
+ *  - flags: Flags describing the dealer. See the below section.
+ *
+ * Currently implemented flags:
+ *   - SOME_USED_ITEMS: can offer used items for sale
+ *   - ONLY_USED_ITEMS: only offers used items
+ *   - GIVES_CHANGE: the dealer gives changes to the player
+ *   - ACCEPTS_GIFTS: accepts gifts (bribes) from player
+ *   - HAS_NO_INVENTORY: no inventory; nothing to sell
+ *   - DELAYS_REPAIR: there is a chance repair jobs are delayed
+ *   - REPAIRS_ELECTRONICS: able to and only repairs electronics
+ *   - SELLS_ALCOHOL: always restocked with alcohol
+ *   - SELLS_FUEL: can sell fuel after the arrangement is made
+ *   - BUYS_EVERYTHING: these guys will buy nearly anything from the player, regardless of what they carry for sale!
+ */
+[
+	/* Tony            */
+    {
+        "profileID": 91,
+        "internalName": "TONY",
+        "type": "BUYS_SELLS",
+        "buyingPrice": 0.75,
+        "sellingPrice": 1.25, 
+        "initialCash": 15000,
+        "flags": [
+            "SOME_USED_ITEMS",
+            "GIVES_CHANGE"
+        ]
+    },
+	/* Franz Hinkle    */
+    {
+        "profileID": 124,
+        "internalName": "FRANK",
+        "type": "BUYS_SELLS",
+        "buyingPrice": 1.0,
+        "sellingPrice": 1.5,
+        "initialCash": 5000, 
+        "flags": [
+            "SOME_USED_ITEMS",
+            "GIVES_CHANGE",
+            "BUYS_EVERYTHING"
+        ]
+    },
+	/* Keith Hemps     */
+    {
+        "profileID": 147,
+        "internalName": "KEITH",
+        "type": "BUYS_SELLS",
+        "buyingPrice": 0.75,
+        "sellingPrice": 1.0,
+        "initialCash": 1500,
+        "flags": [
+            "ONLY_USED_ITEMS",
+            "GIVES_CHANGE",
+            "BUYS_EVERYTHING"
+        ]
+    },
+	/* Jake Cameron    */
+    {
+        "profileID": 113,
+        "internalName": "JAKE",
+        "type": "BUYS_SELLS",
+        "buyingPrice": 0.8,
+        "sellingPrice": 1.1,
+        "initialCash": 2500,
+        "flags": [
+            "ONLY_USED_ITEMS",
+            "GIVES_CHANGE",
+            "BUYS_EVERYTHING",
+            "SELLS_FUEL"
+        ]
+    },
+	/* Gabby Mulnick   */
+    {
+        "profileID": 104,
+        "internalName": "GABBY",
+        "type": "BUYS_SELLS",
+        "buyingPrice": 1.0,
+        "sellingPrice": 1.0,
+        "initialCash": 3000,
+        "flags": [
+            "GIVES_CHANGE"
+        ]
+    },
+	/* Devin Connell   */
+    {
+        "profileID": 61,
+        "internalName": "DEVIN",
+        "type": "SELLS_ONLY",
+        "buyingPrice": 0.75,
+        "sellingPrice": 1.25,
+        "initialCash": 5000,
+        "flags": [
+            "GIVES_CHANGE"
+        ]
+    },
+	/* Howard Filmore  */
+    {
+        "profileID": 125,
+        "internalName": "HOWARD",
+        "type": "SELLS_ONLY",
+        "buyingPrice": 1.0,
+        "sellingPrice": 1.0,
+        "initialCash": 3000,
+        "flags": [
+            "GIVES_CHANGE"
+        ]
+    },
+	/* Sam Rozen       */
+    {
+        "profileID": 126,
+        "internalName": "SAM",
+        "type": "SELLS_ONLY",
+        "buyingPrice": 1.0,
+        "sellingPrice": 1.0,
+        "initialCash": 3000, 
+        "flags": [
+            "GIVES_CHANGE"
+        ]
+    },
+	/* Frank           */
+    {
+        "profileID": 92,
+        "internalName": "FRANK",
+        "type": "SELLS_ONLY",
+        "buyingPrice": 1.0,
+        "sellingPrice": 1.0,
+        "initialCash": 500, 
+        "flags":  [
+            "ACCEPTS_GIFTS",
+            "SELLS_ALCOHOL"
+        ]
+    },
+	/* Bar Bro 1       */
+    {
+        "profileID": 151,
+        "internalName": "HERVE-SANTOS",
+        "type": "SELLS_ONLY",
+        "buyingPrice": 1.0,
+        "sellingPrice": 1.0 ,
+        "initialCash": 250, 
+        "flags": [
+            "ACCEPTS_GIFTS",
+            "SELLS_ALCOHOL"
+        ]
+    },
+	/* Bar Bro 2       */
+    {
+        "profileID": 152,
+        "internalName": "PETER-SANTOS",
+        "type": "SELLS_ONLY",
+        "buyingPrice": 1.0,
+        "sellingPrice": 1.0 ,
+        "initialCash": 250, 
+        "flags": [
+            "ACCEPTS_GIFTS",
+            "SELLS_ALCOHOL"
+        ]
+    },
+	/* Bar Bro 3       */
+	{
+        "profileID": 153,
+        "internalName": "ALBERTO-SANTOS",
+        "type": "SELLS_ONLY",
+        "buyingPrice": 1.0,
+        "sellingPrice": 1.0 ,
+        "initialCash": 250, 
+        "flags": [
+            "ACCEPTS_GIFTS",
+            "SELLS_ALCOHOL"
+        ]
+    },
+    /* Bar Bro 4       */
+    {
+        "profileID": 154,
+        "internalName": "CARLO-SANTOS",
+        "type": "SELLS_ONLY",
+        "buyingPrice": 1.0,
+        "sellingPrice": 1.0 ,
+        "initialCash": 250, 
+        "flags": [
+            "ACCEPTS_GIFTS",
+            "SELLS_ALCOHOL"
+        ]
+    },
+	/* Micky O'Brien   */
+    {
+        "profileID": 96,
+        "internalName": "MICKY",
+        "type": "BUYS_ONLY",
+        "buyingPrice": 1.0,
+        "sellingPrice": 1.4,
+        "initialCash": 10000, 
+        "flags": [
+            "HAS_NO_INVENTORY",
+            "GIVES_CHANGE"
+        ]
+    },
+	/* Arnie Brunzwell */
+    {
+        "profileID": 128,
+        "internalName": "ARNIE",
+        "type": "REPAIRS",
+        "repairSpeed": 0.1,
+        "repairCost": 0.8,
+        "initialCash": 1500,
+        "flags": [
+            "HAS_NO_INVENTORY",
+            "GIVES_CHANGE"
+        ]
+    },
+	/* Fredo           */
+    {
+        "profileID": 130,
+        "internalName": "FREDO",
+        "type": "REPAIRS",
+        "repairSpeed": 0.6,
+        "repairCost": 0.6,
+        "initialCash": 1000,
+        "flags": [
+            "HAS_NO_INVENTORY",
+            "GIVES_CHANGE",
+            "REPAIRS_ELECTRONICS",
+            "DELAYS_REPAIR"
+        ]
+    },
+	/* Perko           */
+    {
+        "profileID": 74,
+        "internalName": "PERKO",
+        "type": "REPAIRS",
+        "repairSpeed": 1.0,
+        "repairCost": 0.4,
+        "initialCash": 1000, 
+        "flags": [
+            "HAS_NO_INVENTORY",
+            "GIVES_CHANGE",
+            "DELAYS_REPAIR"
+        ]
+    },
+	/* Elgin / Druggist */
+    {
+        "profileID": 112,
+        "internalName": "ELGIN",
+        "type": "SELLS_ONLY",
+        "buyingPrice": 1.0,
+        "sellingPrice": 1.0 ,
+        "initialCash": 500, 
+        "flags": [
+            "ACCEPTS_GIFTS",
+            "SELLS_ALCOHOL"
+        ]
+    },
+	/* Manny           */
+    {
+        "profileID": 155,
+        "internalName": "MANNY",
+        "type": "SELLS_ONLY",
+        "buyingPrice": 1.0,
+        "sellingPrice": 1.0 ,
+        "initialCash": 500, 
+        "flags": [
+            "ACCEPTS_GIFTS",
+            "SELLS_ALCOHOL"
+        ]
+    }
+]

--- a/assets/externalized/dealers.json
+++ b/assets/externalized/dealers.json
@@ -3,6 +3,7 @@
  *
  * Fields:
  *  - profileID: The shopkeeper merc's profile ID
+ *  - internalName: Name with which we find the dealer's inventory data file
  *  - type: Must be one of BUYS_ONLY, SELLS_ONLY, BUYS_SELLS or REPAIRS
  *  - buyingPrice: Mandatory if this dealer buys from the player. This is a multiplier applied on the item's value
  *  - sellingPrice: Mandatory if this dealer sells to the player. This is a multiplier applied on the item's value

--- a/src/externalized/CMakeLists.txt
+++ b/src/externalized/CMakeLists.txt
@@ -10,6 +10,7 @@ file(GLOB LOCAL_JA2_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
 set(LOCAL_JA2_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/AmmoTypeModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/CalibreModel.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/DealerModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/DealerInventory.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/DefaultContentManager.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/ItemModel.cc

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -20,6 +20,7 @@ class BloodCatPlacementsModel;
 class BloodCatSpawnsModel;
 class CreatureLairModel;
 class DealerInventory;
+class DealerModel;
 class FactParamsModel;
 class GamePolicy;
 class GarrisonGroupModel;
@@ -121,6 +122,9 @@ public:
 	virtual const std::vector<GARRISON_GROUP>& getGarrisonGroups() const = 0;
 	virtual const std::vector<PATROL_GROUP>& getPatrolGroups() const = 0;
 	virtual const std::vector<ARMY_COMPOSITION>& getArmyCompositions() const = 0;
+
+	virtual const DealerModel* getDealer(uint8_t dealerID) const = 0;
+	virtual const std::vector<const DealerModel*> getDealers() const = 0;
 
 	virtual const DealerInventory* getDealerInventory(int dealerId) const = 0;
 	virtual const DealerInventory* getBobbyRayNewInventory() const = 0;

--- a/src/externalized/DealerModel.cc
+++ b/src/externalized/DealerModel.cc
@@ -1,0 +1,125 @@
+#include "DealerModel.h"
+
+#include "JsonObject.h"
+
+
+DealerModel::DealerModel(UINT8 dealerID_, UINT8 mercID_, ST::string internalName_, ArmsDealerType dealerType_, 
+	FLOAT buyingPrice_, FLOAT sellingPrice_, FLOAT repairSpeed_, FLOAT repairCost_, 
+	INT32 initialCash_, std::bitset<ArmsDealerFlag::NUM_FLAGS> flags_)
+	: dealerID(dealerID_), profileID(mercID_), internalName(internalName_), type(dealerType_), 
+		buyingPrice(buyingPrice_), sellingPrice(sellingPrice_), repairSpeed(repairSpeed_), repairCost(repairCost_),
+		initialCash(initialCash_), flags(flags_) {}
+
+ST::string DealerModel::getInventoryDataFileName() const
+{
+	return ST::format("dealer-inventory-{}.json", internalName.to_lower());
+}
+
+BOOLEAN DealerModel::hasFlag(ArmsDealerFlag flag) const
+{
+	return flags.test(flag);
+}
+
+BOOLEAN DealerModel::doesRepairs() const
+{
+	return type == ARMS_DEALER_REPAIRS;
+}
+
+ArmsDealerType parseType(const std::string str)
+{
+	if (str == "BUYS_ONLY") return ArmsDealerType::ARMS_DEALER_BUYS_ONLY;
+	if (str == "SELLS_ONLY") return ArmsDealerType::ARMS_DEALER_SELLS_ONLY;
+	if (str == "BUYS_SELLS") return ArmsDealerType::ARMS_DEALER_BUYS_SELLS;
+	if (str == "REPAIRS") return ArmsDealerType::ARMS_DEALER_REPAIRS;
+
+	ST::string err = ST::format("Unrecognized dealer type: '{}'", str);
+	throw std::runtime_error(err.to_std_string());
+}
+
+ArmsDealerFlag parseFlag(const std::string str)
+{
+	if (str == "ONLY_USED_ITEMS") return ArmsDealerFlag::ONLY_USED_ITEMS;
+	if (str == "SOME_USED_ITEMS") return ArmsDealerFlag::SOME_USED_ITEMS;
+	if (str == "GIVES_CHANGE") return ArmsDealerFlag::GIVES_CHANGE;
+	if (str == "ACCEPTS_GIFTS") return ArmsDealerFlag::ACCEPTS_GIFTS;
+	if (str == "HAS_NO_INVENTORY") return ArmsDealerFlag::HAS_NO_INVENTORY;
+	if (str == "DELAYS_REPAIR") return ArmsDealerFlag::DELAYS_REPAIR;
+	if (str == "REPAIRS_ELECTRONICS") return ArmsDealerFlag::REPAIRS_ELECTRONICS;
+	if (str == "SELLS_ALCOHOL") return ArmsDealerFlag::SELLS_ALCOHOL;
+	if (str == "SELLS_FUEL") return ArmsDealerFlag::SELLS_FUEL;
+	if (str == "BUYS_EVERYTHING") return ArmsDealerFlag::BUYS_EVERYTHING;
+	
+	ST::string err = ST::format("Unrecognized dealer flag: '{}'", str);
+	throw std::runtime_error(err.to_std_string());
+}
+
+const DealerModel* DealerModel::deserialize(rapidjson::Value& val, UINT8 dealerIndex)
+{
+	std::bitset<ArmsDealerFlag::NUM_FLAGS> flags;
+	auto flagsArray = val["flags"].GetArray();
+	for (auto& fl : flagsArray)
+	{
+		UINT8 flagIndex = static_cast<UINT8>(parseFlag(fl.GetString()));
+		flags.set(flagIndex);
+	}
+
+	JsonObjectReader obj(val);
+	return new DealerModel(
+		dealerIndex,
+		obj.GetUInt("profileID"),
+		obj.GetString("internalName"),
+		parseType(obj.GetString("type")),
+		obj.getOptionalDouble("buyingPrice"),
+		obj.getOptionalDouble("sellingPrice"),
+		obj.getOptionalDouble("repairSpeed"),
+		obj.getOptionalDouble("repairCost"),
+		obj.GetInt("initialCash"),
+		flags
+	);
+}
+
+void DealerModel::validateData(std::vector<const DealerModel*> models)
+{
+	if (models.size() < NUM_ARMS_DEALERS)
+	{
+		// because of we still have hard-coded references, and also for save compatibility with vanilla
+		ST::string err = ST::format("Number of Arms Dealers must be {}. Got {}", NUM_ARMS_DEALERS, models.size());
+		throw std::runtime_error(err.to_std_string());
+	}
+
+	int i = -1;
+	for (auto dealer: models)
+	{
+		if (dealer->dealerID != ++i)
+		{
+			ST::string err = ST::format("Inconsistent Dealer ID. Expected {} but got {}", i, dealer->dealerID);
+			throw std::runtime_error(err.to_std_string());
+		}
+
+		if (dealer->type == ArmsDealerType::ARMS_DEALER_REPAIRS 
+			&& (dealer->repairCost == 0.0 || dealer->repairSpeed == 0.0))
+		{
+			ST::string err = ST::format("Dealer #{} is a repairman, but repair cost or speed is not set", dealer->dealerID);
+			throw std::runtime_error(err.to_std_string());
+		}
+		else if (dealer->type == ArmsDealerType::ARMS_DEALER_BUYS_ONLY 
+			&& (dealer->buyingPrice == 0.0))
+		{
+			ST::string err = ST::format("Dealer is a buyer, but buying price is not set", dealer->dealerID);
+			throw std::runtime_error(err.to_std_string());
+		}
+		else if (dealer->type == ArmsDealerType::ARMS_DEALER_SELLS_ONLY 
+			&& (dealer->sellingPrice == 0.0))
+		{
+			ST::string err = ST::format("Dealer #{} is a seller, but selling price is not set", dealer->dealerID);
+			throw std::runtime_error(err.to_std_string());
+		}
+		else if (dealer->type == ArmsDealerType::ARMS_DEALER_BUYS_ONLY 
+			&& (dealer->buyingPrice == 0.0 || dealer->sellingPrice == 0.0))
+		{
+			ST::string err = ST::format("Dealer #{} is a trader, but buying price or selling price is not set", dealer->dealerID);
+			throw std::runtime_error(err.to_std_string());
+		}
+	}
+}
+

--- a/src/externalized/DealerModel.h
+++ b/src/externalized/DealerModel.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "Arms_Dealer_Init.h"
+#include "JA2Types.h"
+#include <bitset>
+#include <rapidjson/document.h>
+#include <vector>
+
+
+enum ArmsDealerFlag
+{
+	ONLY_USED_ITEMS,
+	SOME_USED_ITEMS,       //The arms dealer can have used items in his inventory
+	GIVES_CHANGE,          //The arms dealer will give the required change when doing a transaction
+	ACCEPTS_GIFTS,         //The arms dealer is the kind of person who will accept gifts
+	HAS_NO_INVENTORY,      //The arms dealer does not carry any inventory
+	DELAYS_REPAIR,
+	REPAIRS_ELECTRONICS,
+	SELLS_ALCOHOL,
+	SELLS_FUEL,
+	BUYS_EVERYTHING,       //these guys will buy nearly anything from the player, regardless of what they carry for sale!
+
+	NUM_FLAGS
+};
+
+
+class DealerModel
+{
+public:
+	DealerModel(UINT8 dealerID, UINT8 mercID, ST::string internalName, ArmsDealerType dealerType, 
+		FLOAT buyingPrice, FLOAT sellingPrice, FLOAT repairSped, FLOAT repairCost,
+		INT32 initialCash, std::bitset<ArmsDealerFlag::NUM_FLAGS> flags
+	);
+	
+	const UINT8 dealerID;
+
+	// Merc profile Id for the dealer
+	const UINT8 profileID;            
+
+	// Internal merc name of the dealer
+	const ST::string internalName;
+
+	// Whether he buys/sells, sells, buys, or repairs
+	const ArmsDealerType type;
+
+	// The price modifier used when this dealer is BUYING something.
+	const FLOAT buyingPrice;  
+
+	// The price modifier used when this dealer is SELLING something.
+	const FLOAT sellingPrice; 
+
+	// Modifier to the speed at which a repairman repairs things
+	const FLOAT repairSpeed;
+
+	// Modifier to the price a repairman charges for repairs
+	const FLOAT repairCost; 
+	
+	// How much cash dealer starts with (we now reset to this amount once / day)
+	const INT32 initialCash; 
+
+	BOOLEAN hasFlag(ArmsDealerFlag flag) const;
+
+	BOOLEAN doesRepairs() const;
+
+	// name of the data file holding the inventory data
+	ST::string getInventoryDataFileName() const;
+
+	static const DealerModel* deserialize(rapidjson::Value& val, UINT8 dealerIndex);
+
+	static void validateData(std::vector<const DealerModel*> models);
+
+protected:
+	// various flags which control the dealer's operations
+	const std::bitset<ArmsDealerFlag::NUM_FLAGS> flags;
+};
+

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -167,7 +167,6 @@ DefaultContentManager::DefaultContentManager(GameVersion gameVersion,
 	:m_gameVersion(gameVersion),
 	mNormalGunChoice(ARMY_GUN_LEVELS),
 	mExtendedGunChoice(ARMY_GUN_LEVELS),
-	m_dealersInventory(NUM_ARMS_DEALERS),
 	m_vfs(Vfs_create())
 {
 	/*
@@ -193,6 +192,7 @@ DefaultContentManager::DefaultContentManager(GameVersion gameVersion,
 
 	m_movementCosts = NULL;
 	m_loadingScreenModel = NULL;
+	m_samSitesAirControl = NULL;
 }
 
 
@@ -1090,7 +1090,8 @@ bool DefaultContentManager::loadAllDealersAndInventory()
 		m_dealers.push_back(DealerModel::deserialize(element, index++));
 	}
 	DealerModel::validateData(m_dealers);
-
+	
+	m_dealersInventory = std::vector<const DealerInventory*>(m_dealers.size());
 	for (auto dealer : m_dealers)
 	{
 		ST::string filename = dealer->getInventoryDataFileName();

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -20,6 +20,7 @@
 #include "CalibreModel.h"
 #include "ContentMusic.h"
 #include "DealerInventory.h"
+#include "DealerModel.h"
 #include "JsonObject.h"
 #include "JsonUtility.h"
 #include "LoadingScreenModel.h"
@@ -308,12 +309,12 @@ DefaultContentManager::~DefaultContentManager()
 	m_ammoTypes.clear();
 	m_ammoTypeMap.clear();
 
-	for(const DealerInventory* inv : m_dealersInventory)
-	{
-		if(inv) delete inv;
-	}
+	deleteElements(m_dealersInventory);
 	delete m_bobbyRayNewInventory;
 	delete m_bobbyRayUsedInventory;
+
+	deleteElements(m_dealers);
+
 	delete m_impPolicy;
 	delete m_gamePolicy;
 	delete m_loadingScreenModel;
@@ -358,6 +359,16 @@ const DealerInventory* DefaultContentManager::getBobbyRayNewInventory() const
 const DealerInventory* DefaultContentManager::getBobbyRayUsedInventory() const
 {
 	return m_bobbyRayUsedInventory;
+}
+
+const DealerModel* DefaultContentManager::getDealer(uint8_t dealerID) const
+{
+	return m_dealers[dealerID];
+}
+
+const std::vector<const DealerModel*> DefaultContentManager::getDealers() const
+{
+	return m_dealers;
 }
 
 const std::vector<const ShippingDestinationModel*>& DefaultContentManager::getShippingDestinations() const
@@ -1012,7 +1023,7 @@ bool DefaultContentManager::loadGameData()
 	auto replacement_json = readJsonDataFile("tactical-map-item-replacements.json");
 	m_mapItemReplacements = MapItemReplacementModel::deserialize(replacement_json.get(), this);
 
-	loadAllDealersInventory();
+	loadAllDealersAndInventory();
 
 	auto game_json = readJsonDataFile("game.json");
 	m_gamePolicy = new DefaultGamePolicy(game_json.get());
@@ -1070,27 +1081,21 @@ const DealerInventory * DefaultContentManager::loadDealerInventory(const char *f
 	return new DealerInventory(readJsonDataFile(fileName).get(), this);
 }
 
-bool DefaultContentManager::loadAllDealersInventory()
+bool DefaultContentManager::loadAllDealersAndInventory()
 {
-	m_dealersInventory[ARMS_DEALER_TONY]          = loadDealerInventory("dealer-inventory-tony.json");
-	m_dealersInventory[ARMS_DEALER_FRANK]         = loadDealerInventory("dealer-inventory-frank.json");
-	m_dealersInventory[ARMS_DEALER_MICKY]         = loadDealerInventory("dealer-inventory-micky.json");
-	m_dealersInventory[ARMS_DEALER_ARNIE]         = loadDealerInventory("dealer-inventory-arnie.json");
-	m_dealersInventory[ARMS_DEALER_PERKO]         = loadDealerInventory("dealer-inventory-perko.json");
-	m_dealersInventory[ARMS_DEALER_KEITH]         = loadDealerInventory("dealer-inventory-keith.json");
-	m_dealersInventory[ARMS_DEALER_BAR_BRO_1]     = loadDealerInventory("dealer-inventory-herve-santos.json");
-	m_dealersInventory[ARMS_DEALER_BAR_BRO_2]     = loadDealerInventory("dealer-inventory-peter-santos.json");
-	m_dealersInventory[ARMS_DEALER_BAR_BRO_3]     = loadDealerInventory("dealer-inventory-alberto-santos.json");
-	m_dealersInventory[ARMS_DEALER_BAR_BRO_4]     = loadDealerInventory("dealer-inventory-carlo-santos.json");
-	m_dealersInventory[ARMS_DEALER_JAKE]          = loadDealerInventory("dealer-inventory-jake.json");
-	m_dealersInventory[ARMS_DEALER_FRANZ]         = loadDealerInventory("dealer-inventory-franz.json");
-	m_dealersInventory[ARMS_DEALER_HOWARD]        = loadDealerInventory("dealer-inventory-howard.json");
-	m_dealersInventory[ARMS_DEALER_SAM]           = loadDealerInventory("dealer-inventory-sam.json");
-	m_dealersInventory[ARMS_DEALER_FREDO]         = loadDealerInventory("dealer-inventory-fredo.json");
-	m_dealersInventory[ARMS_DEALER_GABBY]         = loadDealerInventory("dealer-inventory-gabby.json");
-	m_dealersInventory[ARMS_DEALER_DEVIN]         = loadDealerInventory("dealer-inventory-devin.json");
-	m_dealersInventory[ARMS_DEALER_ELGIN]         = loadDealerInventory("dealer-inventory-elgin.json");
-	m_dealersInventory[ARMS_DEALER_MANNY]         = loadDealerInventory("dealer-inventory-manny.json");
+	auto json = readJsonDataFile("dealers.json");
+	int index = 0;
+	for (auto& element : json->GetArray())
+	{
+		m_dealers.push_back(DealerModel::deserialize(element, index++));
+	}
+	DealerModel::validateData(m_dealers);
+
+	for (auto dealer : m_dealers)
+	{
+		ST::string filename = dealer->getInventoryDataFileName();
+		m_dealersInventory[dealer->dealerID] = loadDealerInventory(filename.c_str());
+	}
 	m_bobbyRayNewInventory                        = loadDealerInventory("bobby-ray-inventory-new.json");
 	m_bobbyRayUsedInventory                       = loadDealerInventory("bobby-ray-inventory-used.json");
 	return true;

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -145,6 +145,10 @@ public:
 	virtual const DealerInventory* getDealerInventory(int dealerId) const override;
 	virtual const DealerInventory* getBobbyRayNewInventory() const override;
 	virtual const DealerInventory* getBobbyRayUsedInventory() const override;
+
+	virtual const DealerModel* getDealer(uint8_t dealerID) const override;
+	virtual const std::vector<const DealerModel*> getDealers() const override;
+
 	virtual const std::vector<const ShippingDestinationModel*>& getShippingDestinations() const override;
 	virtual const ShippingDestinationModel* getShippingDestination(uint8_t locationId) const override;
 	virtual const ShippingDestinationModel* getPrimaryShippingDestination() const override;
@@ -222,6 +226,8 @@ protected:
 	const DealerInventory *m_bobbyRayNewInventory;
 	const DealerInventory *m_bobbyRayUsedInventory;
 
+	std::vector<const DealerModel*> m_dealers;
+
 	std::vector<const ShippingDestinationModel*> m_shippingDestinations;
 	std::vector<const ST::string*> m_shippingDestinationNames;
 
@@ -258,7 +264,7 @@ protected:
 	bool loadMusic();
 
 	const DealerInventory * loadDealerInventory(const char *fileName);
-	bool loadAllDealersInventory();
+	bool loadAllDealersAndInventory();
 	void loadStringRes(const char *name, std::vector<const ST::string*> &strings) const;
 
 	bool readWeaponTable(

--- a/src/game/Tactical/Arms_Dealer_Init.cc
+++ b/src/game/Tactical/Arms_Dealer_Init.cc
@@ -83,6 +83,10 @@ DEALER_ITEM_HEADER gArmsDealersInventory[ NUM_ARMS_DEALERS ][ MAXITEMS ];
 static void AdjustCertainDealersInventory(void);
 static void InitializeOneArmsDealer(ArmsDealerID);
 
+const ARMS_DEALER_INFO& GetDealer(UINT8 dealerID)
+{
+	return ArmsDealerInfo[dealerID];
+}
 
 void InitAllArmsDealers()
 {
@@ -120,10 +124,10 @@ static void InitializeOneArmsDealer(ArmsDealerID const ubArmsDealer)
 
 
 	//Reset the arms dealers cash on hand to the default initial value
-	gArmsDealerStatus[ ubArmsDealer ].uiArmsDealersCash = ArmsDealerInfo[ ubArmsDealer ].iInitialCash;
+	gArmsDealerStatus[ ubArmsDealer ].uiArmsDealersCash = GetDealer(ubArmsDealer).iInitialCash;
 
 	//if the arms dealer isn't supposed to have any items (includes all repairmen)
-	if( ArmsDealerInfo[ ubArmsDealer ].uiFlags & ARMS_DEALER_HAS_NO_INVENTORY )
+	if( GetDealer(ubArmsDealer).uiFlags & ARMS_DEALER_HAS_NO_INVENTORY )
 	{
 		return;
 	}
@@ -302,7 +306,7 @@ static void SimulateArmsDealerCustomer(void)
 			continue;
 
 		//if the arms dealer isn't supposed to have any items (includes all repairmen)
-		if( ArmsDealerInfo[ ubArmsDealer ].uiFlags & ARMS_DEALER_HAS_NO_INVENTORY )
+		if( GetDealer(ubArmsDealer).uiFlags & ARMS_DEALER_HAS_NO_INVENTORY )
 			continue;
 
 		//loop through all items of the same type
@@ -366,10 +370,10 @@ static void DailyCheckOnItemQuantities(void)
 			continue;
 
 		//Reset the arms dealers cash on hand to the default initial value
-		gArmsDealerStatus[ ubArmsDealer ].uiArmsDealersCash = ArmsDealerInfo[ ubArmsDealer ].iInitialCash;
+		gArmsDealerStatus[ ubArmsDealer ].uiArmsDealersCash = GetDealer(ubArmsDealer).iInitialCash;
 
 		//if the arms dealer isn't supposed to have any items (includes all repairmen)
-		if( ArmsDealerInfo[ ubArmsDealer ].uiFlags & ARMS_DEALER_HAS_NO_INVENTORY )
+		if( GetDealer(ubArmsDealer).uiFlags & ARMS_DEALER_HAS_NO_INVENTORY )
 			continue;
 
 
@@ -886,7 +890,7 @@ BOOLEAN IsMercADealer( UINT8 ubMercID )
 	//loop through the list of arms dealers
 	for( cnt=0; cnt<NUM_ARMS_DEALERS; cnt++ )
 	{
-		if( ArmsDealerInfo[ cnt ].ubShopKeeperID == ubMercID )
+		if( GetDealer(cnt).ubShopKeeperID == ubMercID )
 			return( TRUE );
 	}
 	return( FALSE );
@@ -898,7 +902,7 @@ ArmsDealerID GetArmsDealerIDFromMercID(UINT8 const ubMercID)
 	//loop through the list of arms dealers
 	for (ArmsDealerID cnt = ARMS_DEALER_FIRST; cnt < NUM_ARMS_DEALERS; ++cnt)
 	{
-		if( ArmsDealerInfo[ cnt ].ubShopKeeperID == ubMercID )
+		if( GetDealer(cnt).ubShopKeeperID == ubMercID )
 			return( cnt );
 	}
 
@@ -909,13 +913,13 @@ ArmsDealerID GetArmsDealerIDFromMercID(UINT8 const ubMercID)
 
 UINT8 GetTypeOfArmsDealer( UINT8 ubDealerID )
 {
-	return( ArmsDealerInfo[ ubDealerID ].ubTypeOfArmsDealer );
+	return GetDealer(ubDealerID).ubTypeOfArmsDealer;
 }
 
 
 BOOLEAN	DoesDealerDoRepairs(ArmsDealerID const ubArmsDealer)
 {
-	return ArmsDealerInfo[ ubArmsDealer ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS;
+	return GetDealer(ubArmsDealer).ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS;
 }
 
 
@@ -972,7 +976,7 @@ static bool DoesItemAppearInDealerInventoryList(ArmsDealerID, UINT16 usItemIndex
 
 BOOLEAN CanDealerTransactItem(ArmsDealerID const ubArmsDealer, UINT16 const usItemIndex, BOOLEAN const fPurchaseFromPlayer)
 {
-	switch ( ArmsDealerInfo[ ubArmsDealer ].ubTypeOfArmsDealer )
+	switch ( GetDealer(ubArmsDealer).ubTypeOfArmsDealer )
 	{
 		case ARMS_DEALER_SELLS_ONLY:
 			if ( fPurchaseFromPlayer )
@@ -1016,7 +1020,7 @@ BOOLEAN CanDealerTransactItem(ArmsDealerID const ubArmsDealer, UINT16 const usIt
 			return( CanDealerRepairItem( ubArmsDealer, usItemIndex ) );
 
 		default:
-			AssertMsg( FALSE, String( "CanDealerTransactItem(), type of dealer %d.  AM 0.", ArmsDealerInfo[ ubArmsDealer ].ubTypeOfArmsDealer ) );
+			AssertMsg( FALSE, String( "CanDealerTransactItem(), type of dealer %d.  AM 0.", GetDealer(ubArmsDealer).ubTypeOfArmsDealer ) );
 			return(FALSE);
 	}
 
@@ -1144,8 +1148,8 @@ static UINT8 DetermineDealerItemCondition(ArmsDealerID const ubArmsDealer, UINT1
 	if ( ( GCM->getItem(usItemIndex)->getFlags() & ITEM_DAMAGEABLE ) && !ItemContainsLiquid( usItemIndex ) )
 	{
 		// if he ONLY has used items, or 50% of the time if he carries both used & new items
-		if ( ( ArmsDealerInfo[ ubArmsDealer ].uiFlags & ARMS_DEALER_ONLY_USED_ITEMS ) ||
-			( ( ArmsDealerInfo[ ubArmsDealer ].uiFlags & ARMS_DEALER_SOME_USED_ITEMS ) && ( Random( 100 ) < 50 ) ) )
+		if ( ( GetDealer(ubArmsDealer).uiFlags & ARMS_DEALER_ONLY_USED_ITEMS ) ||
+			( ( GetDealer(ubArmsDealer).uiFlags & ARMS_DEALER_SOME_USED_ITEMS ) && ( Random( 100 ) < 50 ) ) )
 		{
 			// make the item a used one
 			ubCondition = (UINT8)(20 + Random( 60 ));
@@ -2018,7 +2022,7 @@ static UINT32 CalculateSimpleItemRepairTime(ArmsDealerID const ubArmsDealer, UIN
 	// For a repairman, his BUY modifier controls his REPAIR SPEED (1.0 means minutes to repair = price in $)
 	// with a REPAIR SPEED of 1.0, typical gun price of $2000, and a REPAIR COST of 0.5 this works out to 16.6 hrs
 	// for a full 100% status repair...  Not bad.
-	uiTimeToRepair = (UINT32)(uiRepairCost * ArmsDealerInfo[ubArmsDealer].u.repair.speed);
+	uiTimeToRepair = (UINT32)(uiRepairCost * GetDealer(ubArmsDealer).u.repair.speed);
 
 	// repairs on electronic items take twice as long if the guy doesn't have the skill
 	// for dealers, this means anyone but Fredo the Electronics guy takes twice as long (but doesn't charge double)
@@ -2071,7 +2075,7 @@ static UINT32 CalculateSimpleItemRepairCost(ArmsDealerID const ubArmsDealer, UIN
 
 	// figure out the full value of the item, modified by this dealer's personal Sell (i.e. repair cost) modifier
 	// don't use CalcShopKeeperItemPrice - we want FULL value!!!
-	uiItemCost = (UINT32)(GCM->getItem(usItemIndex)->getPrice() * ArmsDealerInfo[ubArmsDealer].u.repair.cost);
+	uiItemCost = (UINT32)(GCM->getItem(usItemIndex)->getPrice() * GetDealer(ubArmsDealer).u.repair.cost);
 
 	// get item's repair ease, for each + point is 10% easier, each - point is 10% harder to repair
 	sRepairCostAdj = 100 - ( 10 * GCM->getItem(usItemIndex)->getRepairEase() );
@@ -2383,7 +2387,7 @@ BOOLEAN ItemIsARocketRifle(INT16 sItemIndex)
 
 static BOOLEAN GetArmsDealerShopHours(ArmsDealerID const ubArmsDealer, UINT32* const puiOpeningTime, UINT32* const puiClosingTime)
 {
-	SOLDIERTYPE* const pSoldier = FindSoldierByProfileID(ArmsDealerInfo[ubArmsDealer].ubShopKeeperID);
+	SOLDIERTYPE* const pSoldier = FindSoldierByProfileID(GetDealer(ubArmsDealer).ubShopKeeperID);
 	if ( pSoldier == NULL )
 	{
 		return( FALSE );

--- a/src/game/Tactical/Arms_Dealer_Init.h
+++ b/src/game/Tactical/Arms_Dealer_Init.h
@@ -9,9 +9,10 @@
 
 
 //the enums for the different kinds of arms dealers
-enum
+enum ArmsDealerType
 {
-	ARMS_DEALER_BUYS_SELLS,
+	NOT_VALID_DEALER = -1,
+	ARMS_DEALER_BUYS_SELLS = 0,
 	ARMS_DEALER_SELLS_ONLY,
 	ARMS_DEALER_BUYS_ONLY,
 	ARMS_DEALER_REPAIRS,
@@ -62,12 +63,6 @@ enum
 #define ARMS_DEALER_CREATURE_PARTS	0x02000000
 #define ARMS_DEALER_ROCKET_RIFLE	0x04000000
 
-#define ARMS_DEALER_ONLY_USED_ITEMS	0x08000000
-#define ARMS_DEALER_GIVES_CHANGE	0x10000000 //The arms dealer will give the required change when doing a transaction
-#define ARMS_DEALER_ACCEPTS_GIFTS	0x20000000 //The arms dealer is the kind of person who will accept gifts
-#define ARMS_DEALER_SOME_USED_ITEMS	0x40000000 //The arms dealer can have used items in his inventory
-#define ARMS_DEALER_HAS_NO_INVENTORY	0x80000000 //The arms dealer does not carry any inventory
-
 
 #define ARMS_DEALER_ALL_GUNS		ARMS_DEALER_HANDGUNCLASS | ARMS_DEALER_SMGCLASS | ARMS_DEALER_RIFLECLASS | ARMS_DEALER_MGCLASS | ARMS_DEALER_SHOTGUNCLASS
 
@@ -91,28 +86,6 @@ enum
 #define ARMS_DEALER_FLAG__FRANZ_HAS_SOLD_VIDEO_CAMERA_TO_PLAYER 0x00000001 // Franz Hinkle has sold the video camera to the player
 
 
-// THIS STRUCTURE HAS UNCHANGING INFO THAT DOESN'T GET SAVED/RESTORED/RESET
-struct ARMS_DEALER_INFO
-{
-	union
-	{
-		struct
-		{
-			FLOAT buy;  // The price modifier used when this dealer is BUYING something.
-			FLOAT sell; // The price modifier used when this dealer is SELLING something.
-		} price;
-		struct
-		{
-			FLOAT speed; // Modifier to the speed at which a repairman repairs things
-			FLOAT cost;  // Modifier to the price a repairman charges for repairs
-		} repair;
-	} u;
-
-	UINT8  ubShopKeeperID; // Merc Id for the dealer
-	UINT8  ubTypeOfArmsDealer; // Whether he buys/sells, sells, buys, or repairs
-	INT32  iInitialCash; // How much cash dealer starts with (we now reset to this amount once / day)
-	UINT32 uiFlags; // various flags which control the dealer's operations
-};
 
 
 // THIS STRUCTURE GETS SAVED/RESTORED/RESET
@@ -181,8 +154,6 @@ struct DEALER_ITEM_HEADER
 	BOOLEAN fPreviouslyEligible; // whether or not dealer has been eligible to sell this item in days prior to today
 };
 
-
-extern const ARMS_DEALER_INFO ArmsDealerInfo[NUM_ARMS_DEALERS];
 extern ARMS_DEALER_STATUS gArmsDealerStatus[ NUM_ARMS_DEALERS ];
 extern DEALER_ITEM_HEADER gArmsDealersInventory[ NUM_ARMS_DEALERS ][ MAXITEMS ];
 
@@ -211,7 +182,7 @@ void LoadArmsDealerInventoryFromSavedGameFile(HWFILE, UINT32 savegame_version);
 
 void DailyUpdateOfArmsDealersInventory(void);
 
-UINT8		GetTypeOfArmsDealer( UINT8 ubDealerID );
+ArmsDealerType GetTypeOfArmsDealer( UINT8 ubDealerID );
 
 BOOLEAN	DoesDealerDoRepairs(ArmsDealerID);
 BOOLEAN RepairmanIsFixingItemsButNoneAreDoneYet( UINT8 ubProfileID );

--- a/src/game/Tactical/ShopKeeper_Interface.cc
+++ b/src/game/Tactical/ShopKeeper_Interface.cc
@@ -1910,11 +1910,8 @@ static void DisplayArmsDealerCurrentInventoryPage(void)
 				//if the dealer repairs
 				else if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 				{
-					//if the item is damaged
-					if (gpTempDealersInventory[usCnt].uiFlags & ARMS_INV_ITEM_NOT_REPAIRED_YET)
-						fDisplayHatchOnItem = TRUE;
-					else
-						fDisplayHatchOnItem = FALSE;
+					// not displaying the hatch, because it would obscure the repair ETA
+					fDisplayHatchOnItem = FALSE;
 				}
 				else // non-repairman
 				{

--- a/src/game/Tactical/ShopKeeper_Interface.cc
+++ b/src/game/Tactical/ShopKeeper_Interface.cc
@@ -601,7 +601,7 @@ static void EnterShopKeeperInterface(void)
 	//Transaction button
 	//if the dealer repairs, use the repair fast help text for the transaction button
 	ST::string help;
-	if (ArmsDealerInfo[gbSelectedArmsDealerID].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS)
+	if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 	{
 		help = SkiMessageBoxText[SKI_REPAIR_TRANSACTION_BUTTON_HELP_TEXT];
 	}
@@ -640,7 +640,7 @@ static void EnterShopKeeperInterface(void)
 	std::fill_n(PlayersOfferArea, SKI_NUM_TRADING_INV_SLOTS, INVENTORY_IN_SLOT{});
 
 
-	if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+	if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 	{
 		HandlePossibleRepairDelays();
 	}
@@ -683,7 +683,7 @@ static void EnterShopKeeperInterface(void)
 
 		//if this is NOT a repair dealer or he is is but there is enough space in the player's offer area
 		// (you can't be out of space if it isn't a repairman, only they can fill it up with repaired items!)
-		if( ( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer != ARMS_DEALER_REPAIRS ) ||
+		if( (!DoesDealerDoRepairs(gbSelectedArmsDealerID)) ||
 			( CountNumberOfItemsInThePlayersOfferArea( ) < SKI_NUM_ARMS_DEALERS_INV_SLOTS ) )
 		{
 			// if we're supposed to store the original pocket #, but that pocket still holds more of these
@@ -977,7 +977,7 @@ static void RenderShopKeeperInterface(void)
 	DrawTextToScreen(SKI_Text[SKI_TEXT_MERCHADISE_IN_STOCK], SKI_MAIN_TITLE_X, SKI_MAIN_TITLE_Y, SKI_MAIN_TITLE_WIDTH, SKI_TITLE_FONT, SKI_TITLE_COLOR, FONT_MCOLOR_BLACK, CENTER_JUSTIFIED);
 
 	//if the dealer repairs
-	if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+	if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 	{
 		//Display the Repair cost text
 		DisplayWrappedString(SKI_TOTAL_COST_X, SKI_TOTAL_COST_Y, SKI_TOTAL_COST_WIDTH, 2, SKI_LABEL_FONT, SKI_TITLE_COLOR, SKI_Text[SKI_TEXT_REPAIR_COST], FONT_MCOLOR_BLACK, CENTER_JUSTIFIED);
@@ -1192,7 +1192,7 @@ static void CreateSkiInventorySlotMouseRegions(void)
 {
 	MSYS_DefineRegion(&g_dealer_inventory_scroll_region, 161, 27, 532, 137, MSYS_PRIORITY_HIGH, CURSOR_NORMAL, NULL, DealerInventoryScrollRegionCallback);
 
-	bool const does_repairs = ArmsDealerInfo[gbSelectedArmsDealerID].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS;
+	bool const does_repairs = DoesDealerDoRepairs(gbSelectedArmsDealerID);
 
 	// Create the mouse regions for the shopkeeper's inventory
 	for (UINT32 i = 0; i != SKI_NUM_ARMS_DEALERS_INV_SLOTS; ++i)
@@ -1257,7 +1257,7 @@ static void DestroySkiInventorySlotMouseRegions(void)
 {
 	MSYS_RemoveRegion(&g_dealer_inventory_scroll_region);
 
-	bool const does_repairs = ArmsDealerInfo[gbSelectedArmsDealerID].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS;
+	bool const does_repairs = DoesDealerDoRepairs(gbSelectedArmsDealerID);
 
 	for (UINT32 i = 0; i != SKI_NUM_ARMS_DEALERS_INV_SLOTS; ++i)
 	{
@@ -1304,7 +1304,7 @@ static void SelectDealersInventoryRegionCallBack(MOUSE_REGION* pRegion, INT32 iR
 			if( !( gpTempDealersInventory[ ubSelectedInvSlot ].uiFlags & ARMS_INV_ITEM_SELECTED ) )
 			{
 				//if the dealer repairs
-				if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+				if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 				{
 					// ignore left clicks on items under repair.  Fully repaired items are moved out to player's slots automatically
 				}
@@ -1525,7 +1525,7 @@ static void SelectDealersOfferSlotsRegionCallBack(MOUSE_REGION* pRegion, INT32 i
 		if (a->fActive)
 		{
 			//if the dealer repairs
-			if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+			if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 			{
 				// return item to player
 				RemoveRepairItemFromDealersOfferArea( ubSelectedInvSlot );
@@ -1555,13 +1555,13 @@ static void SelectDealersOfferSlotsRegionCallBack(MOUSE_REGION* pRegion, INT32 i
 		if (a->fActive)
 		{
 			//if this is a repair dealer
-			if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+			if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 			{
 				//if we don't have an item, pick one up
 				if( gMoveingItem.sItemIndex == 0 )
 				{
 					//if the dealer is a repair dealer, allow the player to pick up the item
-					if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+					if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 					{
 						BeginSkiItemPointer( ARMS_DEALER_OFFER_AREA, ubSelectedInvSlot, FALSE );
 					}
@@ -1617,7 +1617,7 @@ static void SelectDealersOfferSlotsRegionCallBack(MOUSE_REGION* pRegion, INT32 i
 			if( gMoveingItem.sItemIndex > 0 )
 			{
 				// we'd better talking to a repairman, cursor is locked out of this area while full for non-repairmen!
-				Assert( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS );
+				Assert(DoesDealerDoRepairs(gbSelectedArmsDealerID));
 
 				//Drop the item into the current slot
 				AddInventoryToSkiLocation( &gMoveingItem, ubSelectedInvSlot, ARMS_DEALER_OFFER_AREA );
@@ -1896,7 +1896,7 @@ static void DisplayArmsDealerCurrentInventoryPage(void)
 					fDisplayHatchOnItem = TRUE;
 				}
 				//if the dealer repairs
-				else if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+				else if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 				{
 					//if the item is damaged
 					if( ArmsDealerInfo[ gbSelectedArmsDealerID ].uiFlags & ARMS_INV_ITEM_NOT_REPAIRED_YET )
@@ -1926,7 +1926,7 @@ static void DisplayArmsDealerCurrentInventoryPage(void)
 					SetSkiRegionHelpText( &gpTempDealersInventory[ usCnt ], &gDealersInventoryMouseRegions[sItemCount], ARMS_DEALER_INVENTORY );
 
 					//if the dealer repairs
-					if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+					if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 					{
 						SetSkiFaceRegionHelpText( &gpTempDealersInventory[ usCnt ], &gRepairmanInventorySmallFaceMouseRegions[sItemCount], ARMS_DEALER_INVENTORY );
 					}
@@ -1955,7 +1955,7 @@ static void DisplayArmsDealerCurrentInventoryPage(void)
 			SetSkiRegionHelpText( NULL, &gDealersInventoryMouseRegions[ sItemCount ], ARMS_DEALER_INVENTORY );
 
 			//if the dealer repairs
-			if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+			if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 			{
 				SetSkiFaceRegionHelpText( NULL, &gRepairmanInventorySmallFaceMouseRegions[ sItemCount ], ARMS_DEALER_INVENTORY );
 			}
@@ -2042,7 +2042,7 @@ static UINT32 DisplayInvSlot(UINT8 const slot_num, UINT16 const item_idx, UINT16
 	else if (item_area == ARMS_DEALER_INVENTORY)
 	{
 		ARMS_DEALER_INFO const& dealer_info = ArmsDealerInfo[gbSelectedArmsDealerID];
-		if (dealer_info.ubTypeOfArmsDealer != ARMS_DEALER_REPAIRS)
+		if (!DoesDealerDoRepairs(gbSelectedArmsDealerID))
 		{
 			if (!hatched_out || item_o.ubNumberOfObjects != 0)
 			{
@@ -2063,7 +2063,7 @@ static UINT32 DisplayInvSlot(UINT8 const slot_num, UINT16 const item_idx, UINT16
 	else // Dealer's offer area
 	{
 		ARMS_DEALER_INFO const& dealer_info = ArmsDealerInfo[gbSelectedArmsDealerID];
-		if (dealer_info.ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS)
+		if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 		{
 			// The dealer repairs, there is an item here, therefore display the item's owner's face
 			owner     = ArmsDealerOfferArea[slot_num].ubIdOfMercWhoOwnsTheItem;
@@ -2226,7 +2226,7 @@ static void DetermineArmsDealersSellingInventory(void)
 					{
 						UINT8 ubOwner;
 
-						if ( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer != ARMS_DEALER_REPAIRS )
+						if (!DoesDealerDoRepairs(gbSelectedArmsDealerID))
 						{
 							// no merc is the owner
 							ubOwner = NO_PROFILE;
@@ -2248,7 +2248,7 @@ static void DetermineArmsDealersSellingInventory(void)
 	if ( guiNextFreeInvSlot > 1 )
 	{
 		// repairmen sort differently from merchants
-		if ( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+		if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 		{
 			// sort this list by object category, and by ascending price within each category
 			qsort( gpTempDealersInventory, guiNextFreeInvSlot, sizeof( INVENTORY_IN_SLOT ), RepairmanItemQsortCompare );
@@ -2926,7 +2926,7 @@ static void DisplayPlayersOfferArea(void)
 			else	// not money
 			{
 				//if non-repairman
-				if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer != ARMS_DEALER_REPAIRS )
+				if(!DoesDealerDoRepairs(gbSelectedArmsDealerID))
 				{
 					// don't evaluate anything he wouldn't buy!
 					if (!WillShopKeeperRejectObjectsFromPlayer(gbSelectedArmsDealerID, sCnt))
@@ -3035,7 +3035,7 @@ static UINT32 CalculateTotalArmsDealerCost(void)
 		if (a->fActive)
 		{
 			//if the dealer repairs
-			if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+			if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 			{
 				uiTotal += CalculateObjectItemRepairCost(gbSelectedArmsDealerID, &a->ItemObject);
 			}
@@ -3171,7 +3171,7 @@ static void PerformTransaction(UINT32 uiMoneyFromPlayersAccount)
 	else // not a bribe
 	{
 		//if the dealer is not a repairman
-		if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer != ARMS_DEALER_REPAIRS )
+		if(!DoesDealerDoRepairs(gbSelectedArmsDealerID))
 		{
 			uiAvailablePlayerOfferSlots = ( SKI_NUM_TRADING_INV_SLOTS - CountNumberOfValuelessItemsInThePlayersOfferArea( ) );
 
@@ -3234,7 +3234,7 @@ static void PerformTransaction(UINT32 uiMoneyFromPlayersAccount)
 
 
 		//if the dealer repairs
-		if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+		if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 		{
 			//Make sure there is enough money in the Player's offer area to cover the repair charge
 			if( ( uiMoneyFromPlayersAccount + uiMoneyInPlayersOfferArea ) >= uiArmsDealersItemsCost )
@@ -3711,7 +3711,7 @@ void SetSkiCursor( UINT16 usCursor )
 			gDealersOfferSlotsMouseRegions[ubCnt].ChangeCursor(usCursor);
 
 			//if the dealer repairs
-			if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+			if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 			{
 				gDealersOfferSlotsSmallFaceMouseRegions[ubCnt].ChangeCursor(usCursor);
 			}
@@ -3750,7 +3750,7 @@ void SetSkiCursor( UINT16 usCursor )
 			gDealersOfferSlotsMouseRegions[ubCnt].ChangeCursor(usCursor);
 
 			//if the dealer repairs
-			if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+			if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 			{
 				gDealersOfferSlotsSmallFaceMouseRegions[ubCnt].ChangeCursor(usCursor);
 			}
@@ -3998,7 +3998,7 @@ static void HandleShopKeeperDialog(UINT8 ubInit)
 				// first check if one of the situation warrants one of the more precise quotes
 
 				//if the dealer repairs
-				if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+				if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 				{
 					// if there are items in the arms dealer's offer area (must be awaiting repairs)
 					if ( CountNumberOfItemsInTheArmsDealersOfferArea() > 0)
@@ -4319,7 +4319,7 @@ static void EnableDisableEvaluateAndTransactionButtons(void)
 				{
 					fItemEvaluated = TRUE;
 				}
-				else if (ArmsDealerInfo[gbSelectedArmsDealerID].ubTypeOfArmsDealer != ARMS_DEALER_REPAIRS && GCM->getItem(o->sItemIndex)->getItemClass() == IC_MONEY)
+				else if (!DoesDealerDoRepairs(gbSelectedArmsDealerID) && GCM->getItem(o->sItemIndex)->getItemClass() == IC_MONEY)
 				{
 					//else if it is not a repair dealer, and the item is money
 					fItemEvaluated = TRUE;
@@ -4328,7 +4328,7 @@ static void EnableDisableEvaluateAndTransactionButtons(void)
 		}
 
 		//if the dealer is a repair dealer
-		if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+		if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 		{
 			//if there is an item here, the item has to have been evaluated
 			if( ArmsDealerOfferArea[ ubCnt ].fActive )
@@ -4353,7 +4353,7 @@ static void EnableDisableEvaluateAndTransactionButtons(void)
 			DisableButton( guiSKI_TransactionButton );*/
 
 		//If its a repair dealer, and there is no items in the Dealer Offer area,
-		if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS &&
+		if(DoesDealerDoRepairs(gbSelectedArmsDealerID)&&
 				CountNumberOfItemsInTheArmsDealersOfferArea( ) == 0 &&
 				uiPlayersOfferAreaTotalMoney < uiArmsDealerTotalCost
 			)
@@ -4570,7 +4570,7 @@ static void ClearArmsDealerOfferSlot(INT32 ubSlotToClear)
 	gDealersOfferSlotsMouseRegions[ubSlotToClear].SetFastHelpText(ST::null);
 
 	//if the dealer repairs
-	if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+	if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 	{
 		gDealersOfferSlotsSmallFaceMouseRegions[ubSlotToClear].SetFastHelpText(ST::null);
 	}
@@ -4627,7 +4627,7 @@ static void EvaluateItemAddedToPlayersOfferArea(INT8 bSlotID, BOOLEAN fFirstOne)
 	if (!WillShopKeeperRejectObjectsFromPlayer(gbSelectedArmsDealerID, bSlotID))
 	{
 		//if the dealer repairs
-		if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+		if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 		{
 			UINT32 uiNumberOfItemsInForRepairs = CountTotalItemsRepairDealerHasInForRepairs( gbSelectedArmsDealerID );
 			UINT32 uiNumberOfItemsAlreadyEvaluated = CountNumberOfItemsInTheArmsDealersOfferArea();
@@ -4711,7 +4711,7 @@ static void EvaluateItemAddedToPlayersOfferArea(INT8 bSlotID, BOOLEAN fFirstOne)
 	}
 	else // dealer doesn't handle this type of object
 	{
-		if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+		if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 		{
 			// only otherwise repairable items count as actual rejections
 			if (GCM->getItem(o->sItemIndex)->getFlags() & ITEM_REPAIRABLE)
@@ -5188,7 +5188,7 @@ static BOOLEAN OfferObjectToDealer(OBJECTTYPE* pComplexObject, UINT8 ubOwnerProf
 	BOOLEAN fSuccess = FALSE;
 
 
-	if ( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer != ARMS_DEALER_REPAIRS )
+	if (!DoesDealerDoRepairs(gbSelectedArmsDealerID))
 	{
 		// if not actually doing repairs, there's no need to split objects up at all
 		if ( !AddObjectForEvaluation( pComplexObject, ubOwnerProfileId, bOwnerSlotId, TRUE ) )
@@ -5751,7 +5751,7 @@ static void ExitSKIRequested(void)
 			fPlayerOwnedStuffOnTable = TRUE;
 		}
 
-		if( ( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS ) &&
+		if( (DoesDealerDoRepairs(gbSelectedArmsDealerID)) &&
 				AreThereItemsInTheArmsDealersOfferArea( ) )
 		{
 			fPlayerOwnedStuffOnTable = TRUE;
@@ -5845,7 +5845,7 @@ static void DealWithItemsStillOnTheTable(void)
 
 
 	//if the dealer repairs
-	if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+	if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 	{
 		//loop through the arms dealers' offer area and return any items there to the player
 		for( ubCnt = 0; ubCnt < SKI_NUM_TRADING_INV_SLOTS; ubCnt++)
@@ -6331,7 +6331,7 @@ static ST::string BuildItemHelpTextString(const INVENTORY_IN_SLOT* pInv, UINT8 u
 
 		// add repair time for items in a repairman's offer area
 		if ( ( ubScreenArea == ARMS_DEALER_OFFER_AREA ) &&
-			( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS ) )
+			(DoesDealerDoRepairs(gbSelectedArmsDealerID)) )
 		{
 			zRepairTime = BuildRepairTimeString(CalculateObjectItemRepairTime( gbSelectedArmsDealerID, &( pInv->ItemObject ) ));
 			return ST::format("{}\n({}: {})", zHelpText, gzLateLocalizedString[STR_LATE_44], zRepairTime);
@@ -6357,7 +6357,7 @@ static void DisableAllDealersInventorySlots(void)
 		gDealersInventoryMouseRegions[iCnt].Disable();
 
 		//if the dealer repairs
-		if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+		if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 		{
 			gRepairmanInventorySmallFaceMouseRegions[iCnt].Disable();
 		}
@@ -6374,7 +6374,7 @@ static void EnableAllDealersInventorySlots(void)
 		gDealersInventoryMouseRegions[iCnt].Enable();
 
 		//if the dealer repairs
-		if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+		if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 		{
 			gRepairmanInventorySmallFaceMouseRegions[iCnt].Enable();
 		}
@@ -6391,7 +6391,7 @@ static void DisableAllDealersOfferSlots(void)
 		gDealersOfferSlotsMouseRegions[iCnt].Disable();
 
 		//if the dealer repairs
-		if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+		if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 		{
 			gDealersOfferSlotsSmallFaceMouseRegions[iCnt].Disable();
 		}
@@ -6408,7 +6408,7 @@ static void EnableAllDealersOfferSlots(void)
 		gDealersOfferSlotsMouseRegions[iCnt].Enable();
 
 		//if the dealer repairs
-		if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_REPAIRS )
+		if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 		{
 			gDealersOfferSlotsSmallFaceMouseRegions[iCnt].Enable();
 		}

--- a/src/game/Tactical/ShopKeeper_Interface.cc
+++ b/src/game/Tactical/ShopKeeper_Interface.cc
@@ -407,6 +407,11 @@ static void HandleShopKeeperInterface(void);
 static void RenderShopKeeperInterface(void);
 
 
+ARMS_DEALER_INFO const& SelectedArmsDealer()
+{
+	return ArmsDealerInfo[gbSelectedArmsDealerID];
+}
+
 ScreenID ShopKeeperScreenHandle()
 {
 	if( gfSKIScreenEntry )
@@ -654,7 +659,7 @@ static void EnterShopKeeperInterface(void)
 	std::fill(std::begin(gfCommonQuoteUsedThisSession), std::end(gfCommonQuoteUsedThisSession), FALSE);
 
 	//Init the shopkeepers face
-	InitShopKeepersFace( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubShopKeeperID );
+	InitShopKeepersFace( SelectedArmsDealer().ubShopKeeperID );
 
 	gfDoneBusinessThisSession = FALSE;
 
@@ -741,7 +746,7 @@ static void EnterShopKeeperInterface(void)
 
 static BOOLEAN InitShopKeepersFace(UINT8 ubMercID)
 {
-	SOLDIERTYPE* const pSoldier = FindSoldierByProfileID(ArmsDealerInfo[gbSelectedArmsDealerID].ubShopKeeperID);
+	SOLDIERTYPE* const pSoldier = FindSoldierByProfileID(SelectedArmsDealer().ubShopKeeperID);
 	FACETYPE& f = InitFace(ubMercID, pSoldier, FACE_BIGFACE);
 	giShopKeeperFaceIndex = &f;
 
@@ -1899,7 +1904,7 @@ static void DisplayArmsDealerCurrentInventoryPage(void)
 				else if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 				{
 					//if the item is damaged
-					if( ArmsDealerInfo[ gbSelectedArmsDealerID ].uiFlags & ARMS_INV_ITEM_NOT_REPAIRED_YET )
+					if( SelectedArmsDealer().uiFlags & ARMS_INV_ITEM_NOT_REPAIRED_YET )
 						fDisplayHatchOnItem = TRUE;
 					else
 						fDisplayHatchOnItem = FALSE;
@@ -2041,7 +2046,7 @@ static UINT32 DisplayInvSlot(UINT8 const slot_num, UINT16 const item_idx, UINT16
 	}
 	else if (item_area == ARMS_DEALER_INVENTORY)
 	{
-		ARMS_DEALER_INFO const& dealer_info = ArmsDealerInfo[gbSelectedArmsDealerID];
+		ARMS_DEALER_INFO const& dealer_info = SelectedArmsDealer();
 		if (!DoesDealerDoRepairs(gbSelectedArmsDealerID))
 		{
 			if (!hatched_out || item_o.ubNumberOfObjects != 0)
@@ -2062,7 +2067,7 @@ static UINT32 DisplayInvSlot(UINT8 const slot_num, UINT16 const item_idx, UINT16
 	}
 	else // Dealer's offer area
 	{
-		ARMS_DEALER_INFO const& dealer_info = ArmsDealerInfo[gbSelectedArmsDealerID];
+		ARMS_DEALER_INFO const& dealer_info = SelectedArmsDealer();
 		if (DoesDealerDoRepairs(gbSelectedArmsDealerID))
 		{
 			// The dealer repairs, there is an item here, therefore display the item's owner's face
@@ -3041,7 +3046,7 @@ static UINT32 CalculateTotalArmsDealerCost(void)
 			}
 			else
 			{
-				uiTotal += CalcShopKeeperItemPrice(DEALER_SELLING, FALSE, a->sItemIndex, ArmsDealerInfo[gbSelectedArmsDealerID].u.price.sell, &a->ItemObject);
+				uiTotal += CalcShopKeeperItemPrice(DEALER_SELLING, FALSE, a->sItemIndex, SelectedArmsDealer().u.price.sell, &a->ItemObject);
 			}
 		}
 	}
@@ -3160,12 +3165,12 @@ static void PerformTransaction(UINT32 uiMoneyFromPlayersAccount)
 		StartShopKeeperTalking( SK_QUOTES_DEALER_OFFERED_MONEY_AS_A_GIFT );
 
 		// if the arms dealer is the kind of person who accepts gifts
-		if( ArmsDealerInfo[ gbSelectedArmsDealerID ].uiFlags & ARMS_DEALER_ACCEPTS_GIFTS )
+		if( SelectedArmsDealer().uiFlags & ARMS_DEALER_ACCEPTS_GIFTS )
 		{
 			//Move all the players evaluated items to the dealer (also adds it to dealer's cash)
 			MovePlayerOfferedItemsOfValueToArmsDealersInventory();
 
-			DealerGetsBribed( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubShopKeeperID, uiMoneyInPlayersOfferArea );
+			DealerGetsBribed( SelectedArmsDealer().ubShopKeeperID, uiMoneyInPlayersOfferArea );
 		}
 	}
 	else // not a bribe
@@ -3243,7 +3248,7 @@ static void PerformTransaction(UINT32 uiMoneyFromPlayersAccount)
 				MovePlayerOfferedItemsOfValueToArmsDealersInventory();
 
 				//if the arms dealer is the type of person to give change
-				if( ArmsDealerInfo[ gbSelectedArmsDealerID ].uiFlags & ARMS_DEALER_GIVES_CHANGE )
+				if( SelectedArmsDealer().uiFlags & ARMS_DEALER_GIVES_CHANGE )
 				{
 					//determine the amount of change to give
 					iChangeToGiveToPlayer = ( uiMoneyFromPlayersAccount + uiMoneyInPlayersOfferArea ) - uiArmsDealersItemsCost;
@@ -3281,8 +3286,8 @@ static void PerformTransaction(UINT32 uiMoneyFromPlayersAccount)
 
 
 			//if the arms dealer buys stuff
-			if( ( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_BUYS_ONLY ) ||
-				( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_BUYS_SELLS ) )
+			if( ( SelectedArmsDealer().ubTypeOfArmsDealer == ARMS_DEALER_BUYS_ONLY ) ||
+				( SelectedArmsDealer().ubTypeOfArmsDealer == ARMS_DEALER_BUYS_SELLS ) )
 			{
 				// but the dealer can't afford this transaction
 				if( iChangeToGiveToPlayer > ( INT32 ) gArmsDealerStatus[ gbSelectedArmsDealerID ].uiArmsDealersCash )
@@ -3308,7 +3313,7 @@ static void PerformTransaction(UINT32 uiMoneyFromPlayersAccount)
 
 
 			//if the arms dealer is the type of person to give change
-			if( ArmsDealerInfo[ gbSelectedArmsDealerID ].uiFlags & ARMS_DEALER_GIVES_CHANGE )
+			if( SelectedArmsDealer().uiFlags & ARMS_DEALER_GIVES_CHANGE )
 			{
 				if( iChangeToGiveToPlayer > 0 )
 				{
@@ -3453,7 +3458,7 @@ static void MovePlayerOfferedItemsOfValueToArmsDealersInventory(void)
 				else
 				{
 					//if the dealer doesn't strictly buy items from the player, give the item to the dealer
-					if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer != ARMS_DEALER_BUYS_ONLY )
+					if( SelectedArmsDealer().ubTypeOfArmsDealer != ARMS_DEALER_BUYS_ONLY )
 					{
 						// item cease to be merc-owned during this operation
 						AddObjectToArmsDealerInventory(gbSelectedArmsDealerID, &o->ItemObject);
@@ -4079,7 +4084,7 @@ static BOOLEAN StartShopKeeperTalking(UINT16 usQuoteNum)
 	DialogueEvent::Add(new DialogueEventShopkeeperSetQuote(usQuoteNum));
 
 	// post quote dialogue
-	CharacterDialogue(ArmsDealerInfo[gbSelectedArmsDealerID].ubShopKeeperID, usQuoteNum, giShopKeeperFaceIndex, DIALOGUE_SHOPKEEPER_UI, FALSE);
+	CharacterDialogue(SelectedArmsDealer().ubShopKeeperID, usQuoteNum, giShopKeeperFaceIndex, DIALOGUE_SHOPKEEPER_UI, FALSE);
 
 	// post event to mark shopkeeper dialogue as ended
 	DialogueEvent::Add(new DialogueEventShopkeeperSetQuote(-1));
@@ -4395,7 +4400,7 @@ static void EnableDisableEvaluateAndTransactionButtons(void)
 
 	//ARM: Always permit trying bribes, even if they don't work on a given dealer!
 	// if the arms dealer is the kind of person who accepts gifts, and there is stuff to take
-	//if( ArmsDealerInfo[ gbSelectedArmsDealerID ].uiFlags & ARMS_DEALER_ACCEPTS_GIFTS )
+	//if( SelectedArmsDealer().uiFlags & ARMS_DEALER_ACCEPTS_GIFTS )
 	{
 		//if the player is giving the dealer money, without buying anything
 		if( IsMoneyTheOnlyItemInThePlayersOfferArea( ) && CountNumberOfItemsInTheArmsDealersOfferArea( ) == 0 )
@@ -4744,7 +4749,7 @@ static void EvaluateItemAddedToPlayersOfferArea(INT8 bSlotID, BOOLEAN fFirstOne)
 		switch ( uiEvalResult )
 		{
 			case EVAL_RESULT_DONT_HANDLE:
-				if( ArmsDealerInfo[ gbSelectedArmsDealerID ].ubTypeOfArmsDealer == ARMS_DEALER_SELLS_ONLY )
+				if( SelectedArmsDealer().ubTypeOfArmsDealer == ARMS_DEALER_SELLS_ONLY )
 				{
 					// then he doesn't have quotes 17, 19, or 20, always use 4.  Devin doesn't have 18 either,
 					// while the text of 18 seems wrong for Sam & Howard if offered something they should consider valuable.
@@ -4867,7 +4872,7 @@ void ConfirmToDeductMoneyFromPlayersAccountMessageBoxCallBack(MessageBoxReturnVa
 		//Perform the transaction with the extra money from the players account
 		PerformTransaction( iMoneyToDeduct );
 
-		AddTransactionToPlayersBook( PURCHASED_ITEM_FROM_DEALER, ArmsDealerInfo[ gbSelectedArmsDealerID ].ubShopKeeperID, GetWorldTotalMin(), -iMoneyToDeduct );
+		AddTransactionToPlayersBook( PURCHASED_ITEM_FROM_DEALER, SelectedArmsDealer().ubShopKeeperID, GetWorldTotalMin(), -iMoneyToDeduct );
 	}
 
 	// done, re-enable calls to PerformTransaction()
@@ -5702,7 +5707,7 @@ BOOLEAN CanMercInteractWithSelectedShopkeeper(const SOLDIERTYPE* pSoldier)
 	Assert( pSoldier!= NULL );
 	Assert( gbSelectedArmsDealerID != -1 );
 
-	const SOLDIERTYPE* const pShopkeeper = FindSoldierByProfileID(ArmsDealerInfo[gbSelectedArmsDealerID].ubShopKeeperID);
+	const SOLDIERTYPE* const pShopkeeper = FindSoldierByProfileID(SelectedArmsDealer().ubShopKeeperID);
 	Assert( pShopkeeper != NULL );
 	Assert( pShopkeeper->bInSector );
 
@@ -6175,21 +6180,21 @@ static UINT32 EvaluateInvSlot(INVENTORY_IN_SLOT* pInvSlot)
 	//if the dealer is Micky
 	if( gbSelectedArmsDealerID == ARMS_DEALER_MICKY )
 	{
-		const SOLDIERTYPE* const s = FindSoldierByProfileIDOnPlayerTeam(ArmsDealerInfo[gbSelectedArmsDealerID].ubShopKeeperID);
+		const SOLDIERTYPE* const s = FindSoldierByProfileIDOnPlayerTeam(SelectedArmsDealer().ubShopKeeperID);
 		if (s != NULL && GetDrunkLevel(s) == DRUNK)
 		{
 			//Micky is DRUNK, pays more!
-			dPriceModifier = ArmsDealerInfo[gbSelectedArmsDealerID].u.price.sell;
+			dPriceModifier = SelectedArmsDealer().u.price.sell;
 		}
 		else
 		{
 			// Micky isn't drunk, charge regular price
-			dPriceModifier = ArmsDealerInfo[gbSelectedArmsDealerID].u.price.buy;
+			dPriceModifier = SelectedArmsDealer().u.price.buy;
 		}
 	}
 	else
 	{
-		dPriceModifier = ArmsDealerInfo[gbSelectedArmsDealerID].u.price.buy;
+		dPriceModifier = SelectedArmsDealer().u.price.buy;
 	}
 
 


### PR DESCRIPTION
Externalizes (#665) `ARMS_DEALER_INFO`, which is the info for all bartenders/traders/repairmen in game. Dealer inventory are already externalized, and this PR externalizes the dealers themselves.



## Summary 

The first few commits are method extraction that should not change any functionalities.

The next commits are adding the JSON data, adding model classes, and replacing `ARMS_DEALER_INFO&` with `const DealerModel*`. New dealer flags are added but not yet used in this PR.


## What's next

This PR avoids any non-essential changes, as it already has many lines changed. I intend to make further PRs to generalize some hardcode logic (e.g. repairmen check, electronics repairer (Fredo) check, and so on), and maybe to relax the limit on number of dealers.

I will do a full round of testing after the follow-up PRs.