### PR TITLE
Fix warp exit from mine

### DIFF
--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -192,6 +192,7 @@ DefaultContentManager::DefaultContentManager(GameVersion gameVersion,
 
 	m_movementCosts = NULL;
 	m_loadingScreenModel = NULL;
+	m_samSitesAirControl = NULL;
 }
 
 

--- a/src/game/Strategic/Creature_Spreading.cc
+++ b/src/game/Strategic/Creature_Spreading.cc
@@ -1095,16 +1095,20 @@ bool GetWarpOutOfMineCodes(INT16* const sector_x, INT16* const sector_y, INT8* c
 	if (!gfWorldLoaded)      return false;
 	if (gbWorldSectorZ == 0) return false;
 
-	INT32 lair_id = giLairID;
-	if (lair_id == -1) lair_id = giDestroyedLairID;
-
-	//:Now make sure the mercs are in the previously infested mine
-	if (gLairModel != NULL && gLairModel->isSectorInLair(gWorldSectorX, gWorldSectorY, gbWorldSectorZ))
+	auto lair = gLairModel;
+	if (lair == NULL && giLairID == -1)
 	{
-		*sector_x = SECTORX(gLairModel->warpExitSector);
-		*sector_y = SECTORY(gLairModel->warpExitSector);
+		// Quest is finished
+		lair = GCM->getCreatureLair(giDestroyedLairID);
+	}
+
+	// Now make sure the mercs are in the previously infested mine
+	if (lair != NULL && lair->isSectorInLair(gWorldSectorX, gWorldSectorY, gbWorldSectorZ))
+	{
+		*sector_x = SECTORX(lair->warpExitSector);
+		*sector_y = SECTORY(lair->warpExitSector);
 		*sector_z = 0;
-		*insertion_grid_no = gLairModel->warpExitGridNo;
+		*insertion_grid_no = lair->warpExitGridNo;
 
 		return true;
 	}


### PR DESCRIPTION
Warp exit is not working in some cases (since 0.17.0). After finishing the quest, but before leaving the lair, save and load the game. It no longer prompts for "Travel to surface"

When the creature quest is finished, `giLairID` becomes -1. On the next game load, `gLairModel` becomes NULL, and we must rely on `giDestroyedLairID` instead.