### PR TITLE
Generalizing hard-coded dealer logic

### DIFF
--- a/src/externalized/DealerModel.h
+++ b/src/externalized/DealerModel.h
@@ -1,28 +1,10 @@
 #pragma once
 
-#include "Arms_Dealer_Init.h"
+#include "Arms_Dealer.h"
 #include "JA2Types.h"
 #include <bitset>
 #include <rapidjson/document.h>
 #include <vector>
-
-
-enum ArmsDealerFlag
-{
-	ONLY_USED_ITEMS,
-	SOME_USED_ITEMS,       //The arms dealer can have used items in his inventory
-	GIVES_CHANGE,          //The arms dealer will give the required change when doing a transaction
-	ACCEPTS_GIFTS,         //The arms dealer is the kind of person who will accept gifts
-	HAS_NO_INVENTORY,      //The arms dealer does not carry any inventory
-	DELAYS_REPAIR,
-	REPAIRS_ELECTRONICS,
-	SELLS_ALCOHOL,
-	SELLS_FUEL,
-	BUYS_EVERYTHING,       //these guys will buy nearly anything from the player, regardless of what they carry for sale!
-
-	NUM_FLAGS
-};
-
 
 class DealerModel
 {

--- a/src/game/Tactical/Arms_Dealer.h
+++ b/src/game/Tactical/Arms_Dealer.h
@@ -1,6 +1,32 @@
 #ifndef ARMS_DEALER_H
 #define ARMS_DEALER_H
 
+//the enums for the different kinds of arms dealers
+enum ArmsDealerType
+{
+	NOT_VALID_DEALER = -1,
+	ARMS_DEALER_BUYS_SELLS = 0,
+	ARMS_DEALER_SELLS_ONLY,
+	ARMS_DEALER_BUYS_ONLY,
+	ARMS_DEALER_REPAIRS,
+};
+
+// various flags which control the dealer's operations
+enum ArmsDealerFlag
+{
+	ONLY_USED_ITEMS,
+	SOME_USED_ITEMS,       //The arms dealer can have used items in his inventory
+	GIVES_CHANGE,          //The arms dealer will give the required change when doing a transaction
+	ACCEPTS_GIFTS,         //The arms dealer is the kind of person who will accept gifts
+	HAS_NO_INVENTORY,      //The arms dealer does not carry any inventory
+	DELAYS_REPAIR,
+	REPAIRS_ELECTRONICS,
+	SELLS_ALCOHOL,
+	SELLS_FUEL,
+	BUYS_EVERYTHING,       //these guys will buy nearly anything from the player, regardless of what they carry for sale!
+
+	NUM_FLAGS
+};
 
 //enums for the various arms dealers
 enum ArmsDealerID

--- a/src/game/Tactical/Arms_Dealer_Init.cc
+++ b/src/game/Tactical/Arms_Dealer_Init.cc
@@ -1020,15 +1020,15 @@ BOOLEAN CanDealerRepairItem(ArmsDealerID const ubArmsDealer, UINT16 const usItem
 	auto dealer = GetDealer(ubArmsDealer);
 	if (dealer->type == ArmsDealerType::ARMS_DEALER_REPAIRS)
 	{
-		if (!dealer->hasFlag(ArmsDealerFlag::REPAIRS_ELECTRONICS))
-		{
-			// repairs ANYTHING non-electronic
-			return !(uiFlags & ITEM_ELECTRONIC);
-		}
-		else
+		if (dealer->hasFlag(ArmsDealerFlag::REPAIRS_ELECTRONICS))
 		{
 			// repairs ONLY electronics
 			return (uiFlags & ITEM_ELECTRONIC);
+		}
+		else
+		{
+			// repairs ANYTHING non-electronic
+			return !(uiFlags & ITEM_ELECTRONIC);
 		}
 	}
 	else

--- a/src/game/Tactical/Arms_Dealer_Init.cc
+++ b/src/game/Tactical/Arms_Dealer_Init.cc
@@ -452,6 +452,8 @@ static void LimitArmsDealersInventory(ArmsDealerID, UINT32 uiDealerItemType, UIN
 
 static void AdjustCertainDealersInventory(void)
 {
+	auto dealers = GCM->getDealers();
+
 	//Adjust Tony's items (this restocks *instantly* 1/day, doesn't use the reorder system)
 	GuaranteeAtLeastOneItemOfType( ARMS_DEALER_TONY, ARMS_DEALER_BIG_GUNS );
 	LimitArmsDealersInventory( ARMS_DEALER_TONY, ARMS_DEALER_BIG_GUNS, 2 );
@@ -459,13 +461,13 @@ static void AdjustCertainDealersInventory(void)
 	LimitArmsDealersInventory( ARMS_DEALER_TONY, ARMS_DEALER_AMMO, 8 );
 
 	//Adjust all bartenders' alcohol levels to a minimum
-	GuaranteeMinimumAlcohol( ARMS_DEALER_FRANK );
-	GuaranteeMinimumAlcohol( ARMS_DEALER_BAR_BRO_1 );
-	GuaranteeMinimumAlcohol( ARMS_DEALER_BAR_BRO_2 );
-	GuaranteeMinimumAlcohol( ARMS_DEALER_BAR_BRO_3 );
-	GuaranteeMinimumAlcohol( ARMS_DEALER_BAR_BRO_4 );
-	GuaranteeMinimumAlcohol( ARMS_DEALER_ELGIN );
-	GuaranteeMinimumAlcohol( ARMS_DEALER_MANNY );
+	for (auto dealer : dealers)
+	{
+		if (dealer->hasFlag(ArmsDealerFlag::SELLS_ALCOHOL))
+		{
+			GuaranteeMinimumAlcohol((ArmsDealerID)dealer->dealerID);
+		}
+	}
 
 	//make sure Sam (hardware guy) has at least one empty jar
 	GuaranteeAtLeastXItemsOfIndex( ARMS_DEALER_SAM, JAR, 1 );
@@ -473,7 +475,13 @@ static void AdjustCertainDealersInventory(void)
 	if ( CheckFact( FACT_ESTONI_REFUELLING_POSSIBLE, 0 ) )
 	{
 		// gas is restocked regularly, unlike most items
-		GuaranteeAtLeastXItemsOfIndex( ARMS_DEALER_JAKE, GAS_CAN, ( UINT8 ) ( 4 + Random( 3 ) ) );
+		for (auto dealer : dealers)
+		{
+			if (dealer->hasFlag(ArmsDealerFlag::SELLS_FUEL))
+			{
+				GuaranteeAtLeastXItemsOfIndex((ArmsDealerID)dealer->dealerID, GAS_CAN, (UINT8)(4 + Random(3)));
+			}
+		}
 	}
 
 	//If the player hasn't bought a video camera from Franz yet, make sure Franz has one to sell
@@ -970,23 +978,17 @@ BOOLEAN CanDealerTransactItem(ArmsDealerID const ubArmsDealer, UINT16 const usIt
 			break;
 
 		case ARMS_DEALER_BUYS_SELLS:
-			switch ( ubArmsDealer )
+			if (GetDealer(ubArmsDealer)->hasFlag(ArmsDealerFlag::BUYS_EVERYTHING))
 			{
-				case ARMS_DEALER_JAKE:
-				case ARMS_DEALER_KEITH:
-				case ARMS_DEALER_FRANZ:
-					if ( fPurchaseFromPlayer )
-					{
-						// these guys will buy nearly anything from the player, regardless of what they carry for sale!
-						return( CalcValueOfItemToDealer( ubArmsDealer, usItemIndex, FALSE ) > 0 );
-					}
-					//else selling inventory uses their inventory list
-					break;
-
-				default:
-					// the others go by their inventory list
-					break;
+				if ( fPurchaseFromPlayer )
+				{
+					// these guys will buy nearly anything from the player, regardless of what they carry for sale!
+					return( CalcValueOfItemToDealer( ubArmsDealer, usItemIndex, FALSE ) > 0 );
+				}
+				//else selling inventory uses their inventory list
+				break;
 			}
+			// the others go by their inventory list
 			break;
 
 		case ARMS_DEALER_REPAIRS:
@@ -1015,27 +1017,23 @@ BOOLEAN CanDealerRepairItem(ArmsDealerID const ubArmsDealer, UINT16 const usItem
 		return(FALSE);
 	}
 
-	switch ( ubArmsDealer )
+	auto dealer = GetDealer(ubArmsDealer);
+	if (dealer->type == ArmsDealerType::ARMS_DEALER_REPAIRS)
 	{
-		case ARMS_DEALER_ARNIE:
-		case ARMS_DEALER_PERKO:
+		if (!dealer->hasFlag(ArmsDealerFlag::REPAIRS_ELECTRONICS))
+		{
 			// repairs ANYTHING non-electronic
-			if ( !( uiFlags & ITEM_ELECTRONIC ) )
-			{
-				return(TRUE);
-			}
-			break;
-
-		case ARMS_DEALER_FREDO:
+			return !(uiFlags & ITEM_ELECTRONIC);
+		}
+		else
+		{
 			// repairs ONLY electronics
-			if ( uiFlags & ITEM_ELECTRONIC )
-			{
-				return(TRUE);
-			}
-			break;
-
-		default:
-			AssertMsg(FALSE, String("CanDealerRepairItem(), Arms Dealer %d is not a recognized repairman!.  AM 1.", ubArmsDealer));
+			return (uiFlags & ITEM_ELECTRONIC);
+		}
+	}
+	else
+	{
+		AssertMsg(FALSE, String("CanDealerRepairItem(), Arms Dealer %d is not a recognized repairman!.  AM 1.", ubArmsDealer));
 	}
 
 	// can't repair this...

--- a/src/game/Tactical/Arms_Dealer_Init.h
+++ b/src/game/Tactical/Arms_Dealer_Init.h
@@ -87,6 +87,7 @@ enum ArmsDealerType
 
 
 
+class DealerModel;
 
 // THIS STRUCTURE GETS SAVED/RESTORED/RESET
 struct ARMS_DEALER_STATUS
@@ -182,6 +183,7 @@ void LoadArmsDealerInventoryFromSavedGameFile(HWFILE, UINT32 savegame_version);
 
 void DailyUpdateOfArmsDealersInventory(void);
 
+const DealerModel* GetDealer(UINT8);
 ArmsDealerType GetTypeOfArmsDealer( UINT8 ubDealerID );
 
 BOOLEAN	DoesDealerDoRepairs(ArmsDealerID);

--- a/src/game/Tactical/Arms_Dealer_Init.h
+++ b/src/game/Tactical/Arms_Dealer_Init.h
@@ -8,17 +8,6 @@
 #include <vector>
 
 
-//the enums for the different kinds of arms dealers
-enum ArmsDealerType
-{
-	NOT_VALID_DEALER = -1,
-	ARMS_DEALER_BUYS_SELLS = 0,
-	ARMS_DEALER_SELLS_ONLY,
-	ARMS_DEALER_BUYS_ONLY,
-	ARMS_DEALER_REPAIRS,
-};
-
-
 //The following defines indicate what items can be sold by the arms dealer
 #define ARMS_DEALER_HANDGUNCLASS	0x00000001
 #define ARMS_DEALER_SMGCLASS		0x00000002

--- a/src/game/Tactical/ShopKeeper_Interface.cc
+++ b/src/game/Tactical/ShopKeeper_Interface.cc
@@ -2389,10 +2389,10 @@ static BOOLEAN RepairIsDone(UINT16 usItemIndex, UINT8 ubElement)
 		}
 	}
 
-	// if the item is imprinted (by anyone, even player's mercs), and it's Fredo repairing it
+	// if the item is imprinted (by anyone, even player's mercs), and it's the elctronics guy repairing it
 	if (
 		/*( gArmsDealersInventory[ gbSelectedArmsDealerID ][ usItemIndex ].SpecialItem[ ubElement ].Info.ubImprintID == (NO_PROFILE + 1) ) && */
-		gbSelectedArmsDealerID == ARMS_DEALER_FREDO)
+		GetDealer(gbSelectedArmsDealerID)->hasFlag(ArmsDealerFlag::REPAIRS_ELECTRONICS))
 	{
 		// then reset the imprinting!
 		RepairItem.ItemObject.ubImprintID = NO_PROFILE;
@@ -4691,8 +4691,8 @@ static void EvaluateItemAddedToPlayersOfferArea(INT8 bSlotID, BOOLEAN fFirstOne)
 						uiEvalResult = EVAL_RESULT_OK_BUT_REALLY_DAMAGED;
 					}
 
-					// check if it's the first time a rocket rifle is being submitted to Fredo
-					if( fRocketRifleWasEvaluated && ( gbSelectedArmsDealerID == ARMS_DEALER_FREDO ) )
+					// check if it's the first time a rocket rifle is being submitted to the electronics guy
+					if (fRocketRifleWasEvaluated && GetDealer(gbSelectedArmsDealerID)->hasFlag(ArmsDealerFlag::REPAIRS_ELECTRONICS))
 					{
 						//if he hasn't yet said his quote
 						if( !( gArmsDealerStatus[ gbSelectedArmsDealerID ].ubSpecificDealerFlags & ARMS_DEALER_FLAG__FREDO_HAS_SAID_ROCKET_RIFLE_QUOTE ) )
@@ -5953,7 +5953,7 @@ static void HandlePossibleRepairDelays(void)
 	// assume there won't be a delay
 	gfStartWithRepairsDelayedQuote = FALSE;
 
-	if (gbSelectedArmsDealerID != ARMS_DEALER_FREDO && gbSelectedArmsDealerID != ARMS_DEALER_PERKO) return;
+	if (!GetDealer(gbSelectedArmsDealerID)->hasFlag(ArmsDealerFlag::DELAYS_REPAIR)) return;
 
 	ARMS_DEALER_STATUS& status = gArmsDealerStatus[gbSelectedArmsDealerID];
 	// because the quotes are so specific, we'll only use them once per game per repairman


### PR DESCRIPTION
This PR generalizes some hard-coded dealer logic with dealer flags. The ultimate goal should be removing all `ArmsDealerID` enum references in code, but this PR only covers the obvious ones. 

The other references couple with quests and facts. We can generalize or externalize those when mods require, or when we have some kind of scripting.

### Changes included

- `REPAIRS_ELECTRONICS`: replaces checks for `FREDO`
- `DELAYS_REPAIR`: only `PERKO` and `FREDO` can delay repair jobs
- `BUYS_EVERYTHING`: `JAKE`, `KEITH` and `FRANZ` buys things not in their inventory list
- `SELLS_FUEL` : replaces checks for `JAKE`
- `SELLS_ALCOHOL`: replaces the hard-coded bartender list 