### PR TITLE
Unused items slots should be IC_NONE

### DIFF
--- a/src/externalized/MagazineModel.cc
+++ b/src/externalized/MagazineModel.cc
@@ -6,12 +6,13 @@
 
 MagazineModel::MagazineModel(uint16_t itemIndex_,
 				const char* internalName_,
+				uint32_t itemClass_,
 				const CalibreModel *calibre_,
 				uint16_t capacity_,
 				const AmmoTypeModel *ammoType_,
 				bool dontUseAsDefaultMagazine_
 )
-	:ItemModel(itemIndex_, internalName_, IC_AMMO, 0, INVALIDCURS),
+	:ItemModel(itemIndex_, internalName_, itemClass_, 0, INVALIDCURS),
 	calibre(calibre_), capacity(capacity_), ammoType(ammoType_),
 	dontUseAsDefaultMagazine(dontUseAsDefaultMagazine_)
 {
@@ -57,10 +58,11 @@ MagazineModel* MagazineModel::deserialize(
 	int itemIndex                 = obj.GetInt("itemIndex");
 	const char *internalName      = obj.GetString("internalName");
 	const CalibreModel *calibre   = getCalibre(obj.GetString("calibre"), calibreMap);
+	uint32_t itemClass            = (calibre->index != NOAMMO) ? IC_AMMO : IC_NONE;
 	uint16_t capacity             = obj.GetInt("capacity");
 	const AmmoTypeModel *ammoType = getAmmoType(obj.GetString("ammoType"), ammoTypeMap);
 	bool dontUseAsDefaultMagazine = obj.getOptionalBool("dontUseAsDefaultMagazine");
-	MagazineModel *mag = new MagazineModel(itemIndex, internalName, calibre, capacity, ammoType,
+	MagazineModel *mag = new MagazineModel(itemIndex, internalName, itemClass, calibre, capacity, ammoType,
 						dontUseAsDefaultMagazine);
 
 	mag->fFlags = mag->deserializeFlags(obj);

--- a/src/externalized/MagazineModel.h
+++ b/src/externalized/MagazineModel.h
@@ -16,6 +16,7 @@ struct MagazineModel : ItemModel
 {
 	MagazineModel(uint16_t itemIndex,
 			const char* internalName,
+			uint32_t  itemClass,
 			const CalibreModel *calibre,
 			uint16_t capacity,
 			const AmmoTypeModel *ammoType,

--- a/src/externalized/WeaponModels.cc
+++ b/src/externalized/WeaponModels.cc
@@ -672,7 +672,7 @@ int WeaponModel::getRateOfFire() const
 ////////////////////////////////////////////////////////////
 
 NoWeapon::NoWeapon(uint16_t itemIndex, const char * internalName, uint16_t Range)
-	:WeaponModel(IC_PUNCH, NOT_GUN, PUNCHCURS, itemIndex, internalName, "NOWEAPON")
+	:WeaponModel(IC_NONE, NOT_GUN, PUNCHCURS, itemIndex, internalName, "NOWEAPON")
 {
 }
 


### PR DESCRIPTION
The editor displays the "unused", "NOWEAPON", "CLIP_NOTHING" at the end of the item display.  Those are item slots reserved for weapons or magazines, but not used. 

In Vanilla they are of class `IC_NONE` and hence ignored by the editor. In Stracc, it was changed during the externalization and they are currently of class `IC_PUNCH` and `IC_AMMO` (see https://github.com/ja2-stracciatella/ja2-stracciatella/commit/1aa7ef5e6ae2d40ed88e87910555f225fabf9d23).

This PR changes those "items" back to `IC_NONE`, so they will be ignored by the editor.