### PR TITLE
Fix punching and throwing rocks

### DIFF
--- a/assets/externalized/weapons.json
+++ b/assets/externalized/weapons.json
@@ -2,7 +2,7 @@
     {
         "itemIndex": 0,
         "internalName": "Nothing",
-        "internalType": "NOWEAPON",
+        "internalType": "PUNCH",
         "ubGraphicType": 0,
         "ubGraphicNum": 0,
         "ubWeight": 0,
@@ -1505,10 +1505,9 @@
         "bShowStatus": true
     },
     {
-        "thrown": true,
         "itemIndex": 39,
         "internalName": "ROCK",
-        "internalType": "NOWEAPON",
+        "internalType": "THROWN",
         "ubGraphicType": 1,
         "ubGraphicNum": 57,
         "ubWeight": 5,
@@ -1580,10 +1579,9 @@
         "bTwoHanded": true
     },
     {
-        "thrown": true,
         "itemIndex": 42,
         "internalName": "ROCK2",
-        "internalType": "NOWEAPON",
+        "internalType": "THROWN",
         "ubGraphicType": 1,
         "ubGraphicNum": 60,
         "ubWeight": 4,

--- a/src/externalized/WeaponModels.cc
+++ b/src/externalized/WeaponModels.cc
@@ -62,11 +62,6 @@ WeaponModel::WeaponModel(uint32_t itemClass, uint8_t weaponType, uint8_t cursor,
 
 void WeaponModel::serializeTo(JsonObject &obj) const
 {
-	if(usItemClass & IC_THROWN)
-	{
-		obj.AddMember("thrown", true);
-	}
-
 	obj.AddMember("itemIndex",            itemIndex);
 	obj.AddMember("internalName",         internalName);
 	obj.AddMember("internalType",         internalType);
@@ -107,10 +102,17 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 	const char *internalName = obj.GetString("internalName");
 	const char *internalType = obj.GetString("internalType");
 
-	if(!strcmp(internalType, "NOWEAPON"))
+	if (!strcmp(internalType, WEAPON_TYPE_NOWEAPON))
 	{
-		uint16_t Range           = obj.GetInt("usRange");
-		wep = new NoWeapon(itemIndex, internalName, Range);
+		wep = new NoWeapon(itemIndex, internalName);
+	}
+	else if (!strcmp(internalType, WEAPON_TYPE_PUNCH))
+	{
+		wep = new NoWeapon(itemIndex, internalName, IC_PUNCH, PUNCHCURS);
+	}
+	else if (!strcmp(internalType, WEAPON_TYPE_THROWN))
+	{
+		wep = new NoWeapon(itemIndex, internalName, IC_THROWN, TOSSCURS);
 	}
 	else if(!strcmp(internalType, "PISTOL"))
 	{
@@ -600,11 +602,6 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 	wep->attachSpringAndBoltUpgrade   = obj.getOptionalBool("attachment_SpringAndBoltUpgrade");
 	wep->attachGunBarrelExtender      = obj.getOptionalBool("attachment_GunBarrelExtender");
 
-	if(obj.getOptionalBool("thrown"))
-	{
-		wep->usItemClass = IC_THROWN;
-	}
-
 	wep->fFlags |= wep->deserializeFlags(obj);
 
 	const char *replacement = obj.getOptionalString("standardReplacement");
@@ -671,8 +668,13 @@ int WeaponModel::getRateOfFire() const
 //
 ////////////////////////////////////////////////////////////
 
-NoWeapon::NoWeapon(uint16_t itemIndex, const char * internalName, uint16_t Range)
-	:WeaponModel(IC_NONE, NOT_GUN, PUNCHCURS, itemIndex, internalName, "NOWEAPON")
+NoWeapon::NoWeapon(uint16_t itemIndex, const char * internalName)
+	:NoWeapon(itemIndex, internalName, IC_NONE, INVALIDCURS)
+{
+}
+
+NoWeapon::NoWeapon(uint16_t itemIndex, const char* internalName, uint32_t itemClass, uint8_t cursor)
+	: WeaponModel(itemClass, NOT_GUN, cursor, itemIndex, internalName, WEAPON_TYPE_NOWEAPON)
 {
 }
 

--- a/src/externalized/WeaponModels.h
+++ b/src/externalized/WeaponModels.h
@@ -19,6 +19,10 @@ struct MagazineModel;
 #define NO_WEAPON_SOUND ((SoundID)-1)
 #define NO_WEAPON_SOUND_STR ("")
 
+#define WEAPON_TYPE_NOWEAPON ("NOWEAPON")
+#define WEAPON_TYPE_PUNCH ("PUNCH")
+#define WEAPON_TYPE_THROWN ("THROWN")
+
 struct WeaponModel : ItemModel
 {
 	WeaponModel(uint32_t itemClass,
@@ -89,7 +93,9 @@ protected:
 
 struct NoWeapon : WeaponModel
 {
-	NoWeapon(uint16_t indexIndex, const char * internalName, uint16_t Range);
+	NoWeapon(uint16_t indexIndex, const char * internalName);
+
+	NoWeapon(uint16_t itemIndex, const char* internalName, uint32_t itemClass, uint8_t cursor);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };


### PR DESCRIPTION
Resolves #1192. 

There were some minor data errors in the weapons data. 
  - Punch is done with the "Nothing" item, which should have class `IC_PUNCH` with `PUNCHCURS` cursor
  - Rocks (for throwing) should have class `IC_THROWN` with `TOSSCURS` cursor
  - Unused items should  be of class `IC_NONE` with `INVALIDCURS` (the question mark cursor).

Commit for reference: https://github.com/ja2-stracciatella/ja2-stracciatella/commit/1aa7ef5e6ae2d40ed88e87910555f225fabf9d23

##  Summary

- Added new internalTypes for the "punch" and rocks.
- `ROCK` and `ROCK2` now uses internalType of `THROWN`, and removed the flag `thrown`
- The internalType `NOWEAPON` now indicates only unused item slots. 