### PR TITLE
Correcting dealers.json data error

### DIFF
--- a/assets/externalized/dealers.json
+++ b/assets/externalized/dealers.json
@@ -41,7 +41,7 @@
 	/* Franz Hinkle    */
     {
         "profileID": 124,
-        "internalName": "FRANK",
+        "internalName": "FRANZ",
         "type": "BUYS_SELLS",
         "buyingPrice": 1.0,
         "sellingPrice": 1.5,


### PR DESCRIPTION
`FRANZ` was mistyped as `FRANK`.

The `internalName` field is used to link up dealers with their inventory list.