### PR TITLE
Small bug-fixes from Unfinished Business

### DIFF
--- a/src/game/Tactical/Handle_Items.cc
+++ b/src/game/Tactical/Handle_Items.cc
@@ -2939,13 +2939,12 @@ static void BoobyTrapMessageBoxCallBack(MessageBoxReturnValue const ubExitValue)
 			else
 			{
 				// make sure the item in the world is untrapped
-				OBJECTTYPE& o = wi.o;
-				o.bTrap   = 0;
-				o.fFlags &= ~OBJECT_KNOWN_TO_BE_TRAPPED;
+				// ATE: Copy object into world items
+				wi.o = Object;
 
 				// ATE; If we failed to add to inventory, put failed one in our cursor...
 				gfDontChargeAPsToPickup = TRUE;
-				HandleAutoPlaceFail(gpBoobyTrapSoldier, &o, gsBoobyTrapGridNo);
+				HandleAutoPlaceFail(gpBoobyTrapSoldier, &(wi.o), gsBoobyTrapGridNo);
 				RemoveItemFromPool(wi);
 			}
 		}

--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -122,6 +122,7 @@ enum
 	EX_DIRECTION_IRRELEVANT
 };
 
+static void SetSoldierPersonalLightLevel(SOLDIERTYPE*);
 
 static UINT8 Dir2ExtDir(const UINT8 dir)
 {
@@ -2025,6 +2026,11 @@ static void SetSoldierGridNo(SOLDIERTYPE& s, GridNo new_grid_no, BOOLEAN const f
 			n->ubSumLights         = other.ubSumLights;
 			n->ubMaxLights         = other.ubMaxLights;
 			n->ubNaturalShadeLevel = other.ubNaturalShadeLevel;
+		}
+		else    //The player DOESNT want the mercs to cast the fake lights
+		{
+			//Only light the soldier
+			SetSoldierPersonalLightLevel(&s);
 		}
 
 		HandleAnimationProfile(s, s.usAnimState, FALSE);
@@ -9049,9 +9055,6 @@ void HandlePlayerTogglingLightEffects( BOOLEAN fToggleValue )
 
 	SetRenderFlags(RENDER_FLAG_FULL);
 }
-
-
-static void SetSoldierPersonalLightLevel(SOLDIERTYPE*);
 
 
 static void EnableDisableSoldierLightEffects(BOOLEAN const enable_lights)

--- a/src/game/TileEngine/Physics.cc
+++ b/src/game/TileEngine/Physics.cc
@@ -2217,8 +2217,17 @@ static void HandleArmedObjectImpact(REAL_OBJECT* pObject)
 	{
 		if ( pObject->Obj.usItem == BREAK_LIGHT )
 		{
-			// Add a light effect...
-			NewLightEffect( pObject->sGridNo, LIGHT_FLARE_MARK_1 );
+			//if the light object will be created OFF the ground
+			if (pObject->Position.z > 0)
+			{
+				//we cannot create the light source above the ground, or on a roof.  The system doesnt support it.
+				AddItemToPool(pObject->sGridNo, &(pObject->Obj), VISIBLE, 1, 0, -1);
+			}
+			else
+			{
+				// Add a light effect...
+				NewLightEffect(pObject->sGridNo, LIGHT_FLARE_MARK_1);
+			}
 		}
 		else if ( GCM->getItem(pObject->Obj.usItem)->isGrenade()  )
 		{


### PR DESCRIPTION
This PR ports 3 of the most straight-forward patches from Unfinished Business (#1198). They fix bugs present in vanilla.

- PATCH200: Light up soldier body if fake light is off
- PATCH208: Disarming trap when inventory is full
- PATCH029: Disallow breaklights on rooftop