### PR TITLE
Correcting unsigned int comparison in NPC.cc

### DIFF
--- a/src/game/TacticalAI/NPC.cc
+++ b/src/game/TacticalAI/NPC.cc
@@ -1150,14 +1150,14 @@ static UINT8 NPCConsiderQuote(UINT8 const ubNPC, UINT8 const ubMerc, Approach co
 	// if the quote is quest-specific, is the player on that quest?
 	if (pNPCQuoteInfo->ubQuest != NO_QUEST)
 	{
-		if ((pNPCQuoteInfo->ubQuest - QUEST_DONE_NUM) < MAX_QUESTS)
+		if (pNPCQuoteInfo->ubQuest > QUEST_DONE_NUM && (pNPCQuoteInfo->ubQuest - QUEST_DONE_NUM) < MAX_QUESTS)
 		{
 			if (gubQuest[pNPCQuoteInfo->ubQuest - QUEST_DONE_NUM] != QUESTDONE)
 			{
 				return( FALSE );
 			}
 		}
-		else if ((pNPCQuoteInfo->ubQuest - QUEST_NOT_STARTED_NUM) < MAX_QUESTS)
+		else if (pNPCQuoteInfo->ubQuest > QUEST_NOT_STARTED_NUM && (pNPCQuoteInfo->ubQuest - QUEST_NOT_STARTED_NUM) < MAX_QUESTS)
 		{
 			if (gubQuest[pNPCQuoteInfo->ubQuest - QUEST_NOT_STARTED_NUM] != QUESTNOTSTARTED)
 			{


### PR DESCRIPTION
The previous commit was wrong due to unsigned int underflow (https://github.com/ja2-stracciatella/ja2-stracciatella/commit/8f82d7c8863a32d7b819030783071eb58e8dbe5f#diff-d7b592fe9648bce54f92b4be00bf2c48L1163-L1177). Fatima won't talk or accept the letter as a result of this bug.

This commit first checks if the subtraction is valid for the unsigned int, before comparing.