### PR TITLE
Support Unfinished Business ("JA 2.5") tilesets

### DIFF
--- a/src/game/Editor/PopupMenu.cc
+++ b/src/game/Editor/PopupMenu.cc
@@ -157,7 +157,7 @@ void InitPopupMenu(GUIButtonRef const button, PopupMenuID const ubPopupMenuID, U
 	switch( ubPopupMenuID )
 	{
 		case CHANGETSET_POPUP:	//change tileset
-			gPopup.ubNumEntries = NUM_TILESETS;
+			gPopup.ubNumEntries = gubNumTilesets;
 			break;
 		case OWNERSHIPGROUP_POPUP:
 		case CHANGECIVGROUP_POPUP:

--- a/src/game/TileEngine/Overhead_Map.cc
+++ b/src/game/TileEngine/Overhead_Map.cc
@@ -105,7 +105,7 @@ void InitNewOverheadDB(TileSetID const ubTilesetID)
 		catch (...)
 		{
 			// Load one we know about
-			vo = AddVideoObjectFromFile(GCM->getTilesetResourceName(0, ST::string("t/") + "grass.sti").c_str());
+			vo = AddVideoObjectFromFile(GCM->getTilesetResourceName(res.tilesetID, ST::string("t/") + "grass.sti").c_str());
 		}
 
 		gSmTileSurf[i].vo = vo;

--- a/src/game/TileEngine/WorldDat.cc
+++ b/src/game/TileEngine/WorldDat.cc
@@ -14,7 +14,8 @@
 
 // THIS FILE CONTAINS DEFINITIONS FOR TILESET FILES
 
-TILESET gTilesets[NUM_TILESETS];
+UINT8 gubNumTilesets;
+TILESET gTilesets[MAX_NUM_TILESETS];
 
 
 static void SetTilesetFourTerrainValues(void);
@@ -28,10 +29,16 @@ try
 	AutoSGPFile f(GCM->openGameResForReading(GCM->getTilesetDBResName()));
 
 	// READ # TILESETS and compare
-	UINT8 ubNumSets;
-	FileRead(f, &ubNumSets, sizeof(ubNumSets));
-	if (ubNumSets != NUM_TILESETS)
+	FileRead(f, &gubNumTilesets, sizeof(gubNumTilesets));
+	switch (gubNumTilesets)
 	{
+	case VANILLA_NUM_TILESETS:
+		SLOGD("Loading vanilla tilesets");
+		break;
+	case JA25_NUM_TILESETS:
+		SLOGI("Loading tilesets for Unfinished Business");
+		break;
+	default:
 		SET_ERROR("Number of tilesets in code does not match data file");
 		return;
 	}
@@ -46,19 +53,20 @@ try
 	}
 
 	// Loop through each tileset, load name then files
-	FOR_EACH(TILESET, ts, gTilesets)
+	for (UINT8 i = 0; i < gubNumTilesets; i++)
 	{
+		TILESET& ts = gTilesets[i];
 		//Read name
-		ts->zName = FileReadString(f, TILESET_NAME_LENGTH);
+		ts.zName = FileReadString(f, TILESET_NAME_LENGTH);
 
 		// Read ambience value
-		FileRead(f, &ts->ubAmbientID, sizeof(UINT8));
+		FileRead(f, &(ts.ubAmbientID), sizeof(UINT8));
 
 		// Loop for files
 		for (UINT32 cnt2 = 0; cnt2 < uiNumFiles; ++cnt2)
 		{
 			// Read file name
-			ts->zTileSurfaceFilenames[cnt2] = FileReadString(f, TILE_SURFACE_FILENAME_LENGTH);
+			ts.zTileSurfaceFilenames[cnt2] = FileReadString(f, TILE_SURFACE_FILENAME_LENGTH);
 		}
 	}
 

--- a/src/game/TileEngine/WorldDat.h
+++ b/src/game/TileEngine/WorldDat.h
@@ -23,7 +23,8 @@ struct TILESET
 
 
 
-extern TILESET gTilesets[NUM_TILESETS];
+extern UINT8 gubNumTilesets;
+extern TILESET gTilesets[MAX_NUM_TILESETS];
 
 
 void InitEngineTilesets(void);

--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -208,14 +208,17 @@ static void AddTileSurface(const ST::string filename, UINT32 const tileType);
 
 TILE_SURFACE_RESOURCE GetAdjustedTilesetResource(TileSetID tilesetID, UINT32 uiTileType, const ST::string filePrefix)
 {
-	if (tilesetID >= NUM_TILESETS) throw std::logic_error("invavlid tilesetID");
+	if (tilesetID >= gubNumTilesets) throw std::logic_error("invavlid tilesetID");
 
 	ST::string  filename = gTilesets[tilesetID].zTileSurfaceFilenames[uiTileType];
 	if (filename.empty())
 	{
 		// Try loading from default tileset
-		filename = gTilesets[GENERIC_1].zTileSurfaceFilenames[uiTileType];
-		tilesetID = GENERIC_1;
+		tilesetID = (uiTileType >= DEFAULT_JA25_TILESET || (gubNumTilesets == JA25_NUM_TILESETS && uiTileType == SPECIALTILES))
+			? DEFAULT_JA25_TILESET     //If the map uses JA25 tilesets ( 50 - 69 ) or it is SPECIALTILES (and JA25 tilesets available), use DEFAULT_JA25_TILESET
+			: GENERIC_1                //If the map uses tilesets from Ja2 ( 0 - 49 ), use t0 as the default
+		;
+		filename = gTilesets[tilesetID].zTileSurfaceFilenames[uiTileType];
 	}
 
 	TILE_SURFACE_RESOURCE res;
@@ -2633,7 +2636,7 @@ static void TrashMapTile(const INT16 MapTile)
 
 void LoadMapTileset(TileSetID const id)
 {
-	if (id >= NUM_TILESETS)
+	if (id >= gubNumTilesets)
 	{
 		throw std::logic_error("Tried to load tileset with invalid ID");
 	}

--- a/src/game/TileEngine/WorldDef.h
+++ b/src/game/TileEngine/WorldDef.h
@@ -237,7 +237,7 @@ struct TILE_SURFACE_RESOURCE
 	// whether or not the default tileset is being used
 	BOOLEAN isDefaultTileset()
 	{
-		return tilesetID == GENERIC_1;
+		return (tilesetID == GENERIC_1 || tilesetID == DEFAULT_JA25_TILESET);
 	}
 };
 

--- a/src/game/TileEngine/World_Tileset_Enums.h
+++ b/src/game/TileEngine/World_Tileset_Enums.h
@@ -5,6 +5,7 @@ enum TileSetID
 {
 	TILESET_INVALID = -1,
 
+	// Vanilla tilesets
 	GENERIC_1,
 	CAVES_1,
 	DESERT_1,
@@ -59,8 +60,33 @@ enum TileSetID
 	TEMP_28,
 	TEMP_29,
 	TEMP_30,
+	VANILLA_NUM_TILESETS = 50,
 
-	NUM_TILESETS
+	// Unfinished Business ("JA 2.5") tilesets
+	DEFAULT_JA25_TILESET = 50,
+	TEMP_32,
+	TEMP_33,
+	TEMP_34,
+	TEMP_35,
+	TEMP_36,
+	TEMP_37,
+	TEMP_38,
+	TEMP_39,
+	TEMP_40,
+
+	TEMP_41,
+	TEMP_42,
+	TEMP_43,
+	TEMP_44,
+	TEMP_45,
+	TEMP_46,
+	TEMP_47,
+	TEMP_48,
+	TEMP_49,
+	TEMP_50,
+
+	JA25_NUM_TILESETS = 70,
+	MAX_NUM_TILESETS = 70
 };
 
 


### PR DESCRIPTION
This PR allows us to load both JA2 Vanilla and JA2.5 Unfinished Business maps.

# Background

Vanilla has 50 tilesets. Unfinished Business adds another 20, a total of 70. I believe there are no dispute that tilesets 50~69 are for UB.

# Summary of changes

- `gTilesets` is now 70 elements long
- This is fully compatible with vanilla data; With vanilla data, we only load first the 50 tilesets and the maps only reference those.
- `NUM_TILESETS` is now a variable `ubNumTilesets` read from Tileset DB; it must be either 50 or 70.
- There is a "default tileset" (`GENERIC_1` in vanilla) which has the special tiles such as doors; JA2.5 tilesets (index > 50) uses a different "default"

# Reference

This is ported from UB source code: 

- [PATCH020](https://github.com/ja2-derek/ja2-ub-comparison/commit/c41920c5)
- [PATCH119](https://github.com/ja2-derek/ja2-ub-comparison/commit/a9d2a98a)
- [PATCH120](https://github.com/ja2-derek/ja2-ub-comparison/commit/e3baf3c7)
