### PR TITLE
Use fixed Windows SDK version on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,7 +67,7 @@ init:
         }
         true;
 
-  - ps: $env:BUILD_SWITCHES = "-DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVERSION_TAG=%VERSION_TAG% -DCPACK_GENERATOR=ZIP;NSIS -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain-msvc.cmake"
+  - ps: $env:BUILD_SWITCHES = "-DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVERSION_TAG=%VERSION_TAG% -DCPACK_GENERATOR=ZIP;NSIS -DCMAKE_SYSTEM_VERSION=10.0 -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain-msvc.cmake"
   - ps: >
         if ("$env:BUILD_TYPE" -eq "Release") {
           $env:BUILD_SWITCHES = "${env:BUILD_SWITCHES} -DWITH_EDITOR_SLF=ON";

--- a/dependencies/lib-fltk/CMakeLists.txt
+++ b/dependencies/lib-fltk/CMakeLists.txt
@@ -17,7 +17,7 @@ configure_file(
 )
 
 # execute builder
-execute_process(COMMAND ${CMAKE_COMMAND} . "-G${CMAKE_GENERATOR}" WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/builder")
+execute_process(COMMAND ${CMAKE_COMMAND} . "-G${CMAKE_GENERATOR}" "-DCMAKE_SYSTEM_VERSION=${CMAKE_SYSTEM_VERSION}" WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/builder")
 execute_process(COMMAND ${CMAKE_COMMAND} --build "${CMAKE_CURRENT_BINARY_DIR}/builder")
 
 # interface library

--- a/dependencies/lib-fltk/builder/CMakeLists.txt.in
+++ b/dependencies/lib-fltk/builder/CMakeLists.txt.in
@@ -18,6 +18,7 @@ externalproject_add(fltk
         "-G@CMAKE_GENERATOR@"
         "-C@CACHE_FILE@"
         "-DCMAKE_INSTALL_PREFIX=@INSTALL_PREFIX@"
+        "-DCMAKE_SYSTEM_VERSION=${CMAKE_SYSTEM_VERSION}"
         -DCMAKE_BUILD_TYPE=RelWithDebInfo
         -DOPTION_USE_GL=OFF
         -DOPTION_USE_SYSTEM_ZLIB=OFF

--- a/dependencies/lib-gtest/CMakeLists.txt
+++ b/dependencies/lib-gtest/CMakeLists.txt
@@ -12,7 +12,7 @@ configure_file(
 )
 
 # execute getter
-execute_process(COMMAND ${CMAKE_COMMAND} . "-G${CMAKE_GENERATOR}" WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/getter")
+execute_process(COMMAND ${CMAKE_COMMAND} . "-G${CMAKE_GENERATOR}" "-DCMAKE_SYSTEM_VERSION=${CMAKE_SYSTEM_VERSION}" WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/getter")
 execute_process(COMMAND ${CMAKE_COMMAND} --build "${CMAKE_CURRENT_BINARY_DIR}/getter")
 
 # library

--- a/dependencies/lib-string_theory/CMakeLists.txt
+++ b/dependencies/lib-string_theory/CMakeLists.txt
@@ -36,7 +36,7 @@ configure_file(
 )
 
 # execute builder
-execute_process(COMMAND ${CMAKE_COMMAND} . "-G${CMAKE_GENERATOR}" WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/builder")
+execute_process(COMMAND ${CMAKE_COMMAND} . "-G${CMAKE_GENERATOR}""-DCMAKE_SYSTEM_VERSION=${CMAKE_SYSTEM_VERSION}" WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/builder")
 execute_process(COMMAND ${CMAKE_COMMAND} --build "${CMAKE_CURRENT_BINARY_DIR}/builder")
 
 # interface library

--- a/dependencies/lib-string_theory/builder/CMakeLists.txt.in
+++ b/dependencies/lib-string_theory/builder/CMakeLists.txt.in
@@ -18,6 +18,7 @@ externalproject_add(string_theory
         "-G@CMAKE_GENERATOR@"
         "-C@CACHE_FILE@"
         "-DCMAKE_INSTALL_PREFIX=@INSTALL_PREFIX@"
+        "-DCMAKE_SYSTEM_VERSION=${CMAKE_SYSTEM_VERSION}"
         -DCMAKE_BUILD_TYPE=RelWithDebInfo
         -DST_ENABLE_STL_FILESYSTEM:BOOL=OFF
         -DST_BUILD_TESTS:BOOL=OFF


### PR DESCRIPTION
Currently all builds on appveyor fail because fltk cannot be compiled. There are a bunch of errors of the following kind, within `winbase.h`.

```
C:\Program Files (x86)\Windows Kits\8.1\Include\um\winbase.h(9036,31): error C2065: '_InterlockedOr64': undeclared identifier [C:\projects\ja2-stracciatella\ci-build\dependencies\lib-fltk\builder\fltk-prefix\src\fltk-build\src\fltk.vcxproj] [C:\projects\ja2-stracciatella\ci-build\dependencies\lib-fltk\builder\fltk.vcxproj]
```

Since we didn't change anything about fltk or how it is built, my guess this is due to external changes.

According to https://developercommunity.visualstudio.com/content/problem/1139955/c-builds-with-windows-sdk-81-fail-after-upgrade-to.html there is an issue with windows sdk in version 8.1 and Visual Studio 16.7. Since those are the versions currently in use on appveyor (see https://www.appveyor.com/docs/windows-images-software/), my hope is that this does not happen with windows sdk 10.0, as written in the linked issue. But it is still a shot in the dark...