### PR TITLE
Better lua debugging functionality

### DIFF
--- a/src/externalized/scripting/ScriptingExtensionsLua.cc
+++ b/src/externalized/scripting/ScriptingExtensionsLua.cc
@@ -48,7 +48,7 @@ void JA2Require(std::string scriptFileName)
 	std::string scriptbody = FileMan::fileReadText(
 		AutoSGPFile(GCM->openGameResForReading(SCRIPTS_DIR "/" + scriptFileName))
 	).to_std_string();
-	lua.script(scriptbody);
+	lua.script(scriptbody, ST::format("@{}", scriptFileName).to_std_string());
 }
 
 void InitScriptingEngine()

--- a/src/externalized/scripting/ScriptingExtensionsLua.cc
+++ b/src/externalized/scripting/ScriptingExtensionsLua.cc
@@ -82,7 +82,7 @@ void InitScriptingEngine()
 
 		isLuaInitialized = true;
 	} 
-	catch (std::exception ex)
+	catch (const std::exception &ex)
 	{
 		SLOGE(ST::format("Lua script engine has failed to initialize:\n {}", ex.what()));
 		ST::string err = "The game cannot be started due to an error in the mod scripts. Check the logs for more details.";


### PR DESCRIPTION
- Errors in lua scripts now include the filename where the error happened
- Log messages from lua now print the lua filename where they are triggered from (unfortunately not the exact location as it only prints the vfs filename right now, e.g. `main.lua` instead of `mods/mod_name/scripts/main.lua`).

References: #1205 