### PR TITLE
Build AppImage for linux

### DIFF
--- a/.ci/ci-publish.sh
+++ b/.ci/ci-publish.sh
@@ -43,8 +43,9 @@ cd ci-build
 echo "## publish ##"
 for file in ja2-stracciatella_*; do
   echo "$file"
-  if [[ "$file" == *".deb" ]]; then
-    dpkg -c "$file"
+  if [[ "$file" == *".AppImage" ]]; then
+    export PATH=$PATH:$HOME/linuxdeploy
+    appimagelint $file
   elif [[ "$file" == *".zip" ]]; then
     unzip -l "$file"
   elif [[ "$file" == *".dmg" ]]; then

--- a/.github/scripts/ci-setup.sh
+++ b/.github/scripts/ci-setup.sh
@@ -18,8 +18,19 @@ if [[ "$CI_TARGET" == "linux" ]]; then
     sudo apt-get -yq update
     sudo apt-get -yq install build-essential libsdl2-dev libfltk1.3-dev ccache
 
+    # Google Cloud SDK for Artifact Upload
     curl https://sdk.cloud.google.com | bash
     source $HOME/google-cloud-sdk/path.bash.inc
+
+    # linuxdeploy for appimage build on linux
+    mkdir $HOME/linuxdeploy
+    curl https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -L -o $HOME/linuxdeploy/linuxdeploy
+    chmod +x $HOME/linuxdeploy/linuxdeploy
+    curl https://github.com/TheAssassin/appimagelint/releases/download/continuous/appimagelint-x86_64.AppImage -L -o $HOME/linuxdeploy/appimagelint
+    chmod +x $HOME/linuxdeploy/appimagelint
+    export PATH=$PATH:$HOME/linuxdeploy
+    linuxdeploy --version
+    appimagelint --version
 elif [[ "$CI_TARGET" == "linux-mingw64" ]]; then
     # cross compiling
     sudo apt-get -yq update

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,16 +80,13 @@ before_install:
 
   - export BUILD_SWITCHES="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DVERSION_TAG=$VERSION_TAG"
   - if [ "$PUBLISH_BINARY" == "true" ] && [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$TRAVIS_MINGW" != "true" ]; then
-      export BUILD_SWITCHES="$BUILD_SWITCHES -DCMAKE_INSTALL_PREFIX=/usr -DEXTRA_DATA_DIR=/usr/share/ja2";
+      export BUILD_SWITCHES="$BUILD_SWITCHES -DCMAKE_INSTALL_PREFIX=AppDir/usr -DEXTRA_DATA_DIR=../share/ja2";
     fi
   - if [ "$PUBLISH_BINARY" == "true" ] && [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$TRAVIS_MINGW" == "true" ]; then
       export BUILD_SWITCHES="$BUILD_SWITCHES -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain-mingw.cmake -DCPACK_GENERATOR=ZIP";
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       export BUILD_SWITCHES="$BUILD_SWITCHES -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain-macos.cmake -DCPACK_GENERATOR=Bundle";
-    fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [ "$TRAVIS_MINGW" != "true" ]; then
-      export BUILD_SWITCHES="$BUILD_SWITCHES -DCPACK_GENERATOR=DEB";
     fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [ "$TRAVIS_MINGW" == "true" ]; then
       export BUILD_SWITCHES="$BUILD_SWITCHES -DCMAKE_TOOLCHAIN_FILE=./cmake/toolchain-mingw.cmake -DCPACK_GENERATOR=ZIP";
@@ -113,6 +110,18 @@ before_install:
   - export CLOUDSDK_CORE_DISABLE_PROMPTS=1
   - curl https://sdk.cloud.google.com | bash
   - source $HOME/google-cloud-sdk/path.bash.inc
+
+  # linuxdeploy for appimage build on linux
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [ "$TRAVIS_MINGW" != "true" ]; then
+      mkdir $HOME/linuxdeploy;
+      curl https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -L -o $HOME/linuxdeploy/linuxdeploy;
+      chmod +x $HOME/linuxdeploy/linuxdeploy;
+      curl https://github.com/TheAssassin/appimagelint/releases/download/continuous/appimagelint-x86_64.AppImage -L -o $HOME/linuxdeploy/appimagelint;
+      chmod +x $HOME/linuxdeploy/appimagelint;
+      export PATH=$PATH:$HOME/linuxdeploy;
+      linuxdeploy --version;
+      appimagelint --version;
+    fi
 
   - cargo -V
   - rustc -V
@@ -139,13 +148,19 @@ script:
       make cargo-test;
     fi
   - if [ "$TRAVIS_MINGW" != "true" ]; then
-      ./ja2 -unittests && ./ja2-launcher -help;
+      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        ./AppDir/usr/bin/ja2 -unittests && ./AppDir/usr/bin/ja2-launcher -help;
+      else
+        ./ja2 -unittests && ./ja2-launcher -help;
+      fi
+    fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [ "$TRAVIS_MINGW" != "true" ]; then
+      make package-appimage;
+    else
+      make package;
     fi
   - if [ "$PUBLISH_BINARY" == "true" ] && [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$TRAVIS_MINGW" != "true" ]; then
       sudo make uninstall;
-    fi
-  - if [ "$PUBLISH_BINARY" == "true" ]; then
-      make package;
     fi
 
 after_success:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,9 +122,6 @@ set(BUILD_SHARED_LIBS OFF CACHE BOOL "")
 
 set(GAME_VERSION "v${ja2-stracciatella_VERSION}")
 
-message(STATUS "Setting extra data dir to: ${EXTRA_DATA_DIR}")
-add_definitions(-DEXTRA_DATA_DIR="${EXTRA_DATA_DIR}")
-
 message(STATUS "Setting directory for libraries to: ${INSTALL_LIB_DIR}")
 add_definitions(-DINSTALL_LIB_DIR="${INSTALL_LIB_DIR}")
 
@@ -347,7 +344,7 @@ set(CPACK_NSIS_URL_INFO_ABOUT "https://ja2-stracciatella.github.io/")
 
 if(UNIX AND NOT MINGW AND NOT APPLE)
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-        set(PACKAGE_ARCH "amd64")
+        set(PACKAGE_ARCH "x86_64")
     else()
         set(PACKAGE_ARCH "i386")
     endif()
@@ -439,6 +436,16 @@ if(APPLE)
     install(FILES ${APPLE_DIST_FILES} DESTINATION .)
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/lib-SDL2-2.0.8-macos/SDL2.framework DESTINATION .)
 endif()
+
+## Build AppImage
+
+add_custom_target(package-appimage
+    COMMAND rm -rf *.AppImage
+    COMMAND linuxdeploy --appdir AppDir --output appimage
+    COMMAND mv *.AppImage ${PROJECT_NAME}_${CPACK_PACKAGE_VERSION}_${PACKAGE_ARCH}.AppImage
+    WORKING_DIRECTORY "$<TARGET_FILE_DIR:${JA2_BINARY}>"
+    DEPENDS "${JA2_BINARY}"
+)
 
 ## Uninstall
 

--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -145,7 +145,7 @@ cmake. The supported options are:
 
 | Switch        | Description           | Default  |
 | ------------- |-------------| -----|
-| `EXTRA_DATA_DIR` | Directory to read externalized data from. Useful for creating installable packages that have a fixed data path. | `` |
+| `EXTRA_DATA_DIR` | Directory to read externalized data from relative to binary location. Useful for creating installable packages that have a fixed data path. | `` |
 | `LOCAL_SDL_LIB` | Use SDL library from this directory. | `` |
 | `WITH_UNITTESTS` | Build with unittests | `ON` |
 | `WITH_FIXMES` | Build with fixme messages | `OFF` |

--- a/rust/stracciatella_c_api/src/c/misc.rs
+++ b/rust/stracciatella_c_api/src/c/misc.rs
@@ -185,6 +185,13 @@ pub extern "C" fn Command_execute(program: *const c_char, args: *mut VecCString)
     no_rust_error()
 }
 
+/// Gets the path to the assets dir.
+/// Can be set via EXTRA_DATA_DIR env variable at compilation time
+#[no_mangle]
+pub extern "C" fn Env_assetsDir() -> *mut c_char {
+    c_string_from_path_or_panic(&get_assets_dir()).into_raw()
+}
+
 /// Gets the path to the current directory.
 /// On error it returns null.
 /// Sets the rust error.

--- a/src/externalized/TestUtils.cc
+++ b/src/externalized/TestUtils.cc
@@ -11,10 +11,6 @@ SGPFile* OpenTestResourceForReading(const char *filePath)
 
 ST::string GetExtraDataDir()
 {
-	ST::string extraDataDir = EXTRA_DATA_DIR;
-	if(extraDataDir.empty())
-	{
-		extraDataDir = ".";
-	}
-	return extraDataDir;
+	RustPointer<char> extraDataDir(Env_assetsDir());
+	return ST::string(extraDataDir.get());
 }

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -425,14 +425,8 @@ int main(int argc, char* argv[])
 	RustPointer<char> configFolderPath(EngineOptions_getStracciatellaHome(params.get()));
 	RustPointer<char> gameResRootPath(EngineOptions_getVanillaGameDir(params.get()));
 
-	ST::string extraDataDir = EXTRA_DATA_DIR;
-	if(extraDataDir.empty())
-	{
-		// use location of the exe file
-		extraDataDir = exeFolder;
-	}
-
-	ST::string externalizedDataPath = FileMan::joinPaths(extraDataDir, "externalized");
+	RustPointer<char> extraDataDir(Env_assetsDir());
+	ST::string externalizedDataPath = FileMan::joinPaths(extraDataDir.get(), "externalized");
 
 	FileMan::switchTmpFolder(configFolderPath.get());
 
@@ -448,12 +442,12 @@ int main(int argc, char* argv[])
 			enabledMods.emplace_back(modName.get());
 		}
 		cm = new ModPackContentManager(version,
-						enabledMods, extraDataDir, configFolderPath.get(),
+						enabledMods, extraDataDir.get(), configFolderPath.get(),
 						gameResRootPath.get(), externalizedDataPath);
 		SLOGI("------------------------------------------------------------------------------");
 		SLOGI("JA2 Home Dir:                  '%s'", configFolderPath.get());
 		SLOGI("Root game resources directory: '%s'", gameResRootPath.get());
-		SLOGI("Extra data directory:          '%s'", extraDataDir.c_str());
+		SLOGI("Extra data directory:          '%s'", extraDataDir.get());
 		SLOGI("Data directory:                '%s'", cm->getDataDir().c_str());
 		SLOGI("Tilecache directory:           '%s'", cm->getTileDir().c_str());
 		SLOGI("Saved games directory:         '%s'", cm->getSavedGamesFolder().c_str());
@@ -467,7 +461,7 @@ int main(int argc, char* argv[])
 		SLOGI("------------------------------------------------------------------------------");
 		SLOGI("JA2 Home Dir:                  '%s'", configFolderPath.get());
 		SLOGI("Root game resources directory: '%s'", gameResRootPath.get());
-		SLOGI("Extra data directory:          '%s'", extraDataDir.c_str());
+		SLOGI("Extra data directory:          '%s'", extraDataDir.get());
 		SLOGI("Data directory:                '%s'", cm->getDataDir().c_str());
 		SLOGI("Tilecache directory:           '%s'", cm->getTileDir().c_str());
 		SLOGI("Saved games directory:         '%s'", cm->getSavedGamesFolder().c_str());
@@ -478,7 +472,7 @@ int main(int argc, char* argv[])
 
 	if(EngineOptions_shouldRunEditor(params.get()))
 	{
-		RustPointer<char> path{Path_push(extraDataDir.c_str(), "editor.slf")};
+		RustPointer<char> path{Path_push(extraDataDir.get(), "editor.slf")};
 		cm->initOptionalFreeEditorSlf(path.get());
 	}
 


### PR DESCRIPTION
Some changes to currrent logic were necessary:

- Always search EXTRA_DATA_DIR relative to binary (makes binary relocatable)
- Install linuxdeploy in CI, to build the AppImage
- Add cmake task `package-appimage` that is executed instead of `package` for linux

Closes #1213. Closes #138.

I will wait for build and test the resulting AppImage on multiple distros before merging.