### PR TITLE
Dependency inversion with Observable and notify

### DIFF
--- a/src/game/Strategic/StrategicMap.h
+++ b/src/game/Strategic/StrategicMap.h
@@ -98,6 +98,8 @@ bool IsThisSectorASAMSector(INT16 x, INT16 y, INT8 z);
 
 void InitializeSAMSites();
 
+bool DoesSAMExistHere(INT16 const x, INT16 const y, INT16 const z, GridNo const gridno);
+
 // Number of sectors this town takes up
 UINT8 GetTownSectorSize(INT8 town_id);
 

--- a/src/game/TileEngine/Explosion_Control.cc
+++ b/src/game/TileEngine/Explosion_Control.cc
@@ -101,6 +101,7 @@ static SOLDIERTYPE* gPersonToSetOffExplosions           = 0;
 #define NUM_EXPLOSION_SLOTS 100
 static EXPLOSIONTYPE gExplosionData[NUM_EXPLOSION_SLOTS];
 
+Observable<INT16, INT16, INT16, INT16, UINT8> OnStructureDamaged = {};
 
 static EXPLOSIONTYPE* GetFreeExplosion(void)
 {
@@ -2605,52 +2606,6 @@ void LoadExplosionTableFromSavedGameFile(HWFILE const hFile)
 		GenerateExplosionFromExplosionPointer(e);
 	}
 }
-
-
-bool DoesSAMExistHere(INT16 const x, INT16 const y, INT16 const z, GridNo const gridno)
-{
-	// ATE: If we are below, return right away
-	if (z != 0) return false;
-
-	for (auto s : GCM->getSamSites())
-	{
-		if (s->doesSamExistHere(x, y, gridno))
-		{
-			return true;
-		}
-	}
-	return false;
-}
-
-
-void UpdateAndDamageSAMIfFound( INT16 sSectorX, INT16 sSectorY, INT16 sSectorZ, INT16 sGridNo, UINT8 ubDamage )
-{
-	INT16 sSectorNo;
-
-	// OK, First check if SAM exists, and if not, return
-	if ( !DoesSAMExistHere( sSectorX, sSectorY, sSectorZ, sGridNo ) )
-	{
-		return;
-	}
-
-	// Damage.....
-	sSectorNo = CALCULATE_STRATEGIC_INDEX( sSectorX, sSectorY );
-	SLOGD(ST::format("SAM site at sector #{} is damaged by {} points", sSectorNo, ubDamage));
-	if ( StrategicMap[ sSectorNo ].bSAMCondition >= ubDamage )
-	{
-		StrategicMap[ sSectorNo ].bSAMCondition -= ubDamage;
-	}
-	else
-	{
-		StrategicMap[ sSectorNo ].bSAMCondition = 0;
-	}
-
-	// SAM site may have been put out of commission...
-	UpdateAirspaceControl( );
-
-	// ATE: GRAPHICS UPDATE WILL GET DONE VIA NORMAL EXPLOSION CODE.....
-}
-
 
 void UpdateSAMDoneRepair(INT16 const x, INT16 const y, INT16 const z)
 {

--- a/src/game/TileEngine/Explosion_Control.h
+++ b/src/game/TileEngine/Explosion_Control.h
@@ -3,6 +3,7 @@
 
 #include "JA2Types.h"
 #include "Weapons.h"
+#include "Observable.h"
 
 #define MAX_DISTANCE_EXPLOSIVE_CAN_DESTROY_STRUCTURES 2
 
@@ -57,6 +58,16 @@ struct ExplosionQueueElement
 extern UINT8 gubElementsOnExplosionQueue;
 extern BOOLEAN gfExplosionQueueActive;
 
+/**
+ * Callback after a strurture has just been damaged by explosives
+ * @param INT16 sSectorX
+ * @param INT16 sSectorY
+ * @param INT16 sSectorZ
+ * @param INT16 sGridNo
+ * @param UINT8 ubDamage
+ */
+extern Observable<INT16, INT16, INT16, INT16, UINT8> OnStructureDamaged;
+
 void IgniteExplosion(SOLDIERTYPE* owner, INT16 z, INT16 sGridNo, UINT16 item, INT8 level);
 void IgniteExplosionXY(SOLDIERTYPE* owner, INT16 sX, INT16 sY, INT16 sZ, INT16 sGridNo, UINT16 usItem, INT8 bLevel);
 void InternalIgniteExplosion(SOLDIERTYPE* owner, INT16 sX, INT16 sY, INT16 sZ, INT16 sGridNo, UINT16 usItem, BOOLEAN fLocate, INT8 bLevel);
@@ -74,7 +85,6 @@ void SetOffPanicBombs(SOLDIERTYPE* s, INT8 bPanicTrigger);
 void UpdateExplosionFrame(EXPLOSIONTYPE* e, INT16 sCurrentFrame);
 void RemoveExplosionData(EXPLOSIONTYPE* e);
 
-void UpdateAndDamageSAMIfFound( INT16 sSectorX, INT16 sSectorY, INT16 sSectorZ, INT16 sGridNo, UINT8 ubDamage );
 void UpdateSAMDoneRepair(INT16 x, INT16 y, INT16 z);
 
 
@@ -89,7 +99,5 @@ void RemoveAllActiveTimedBombs( void );
 BOOLEAN DishOutGasDamage(SOLDIERTYPE* pSoldier, EXPLOSIVETYPE const* pExplosive, INT16 sSubsequent, BOOLEAN fRecompileMovementCosts, INT16 sWoundAmt, INT16 sBreathAmt, SOLDIERTYPE* owner);
 
 void HandleExplosionQueue();
-
-bool DoesSAMExistHere(INT16 x, INT16 y, INT16 z, GridNo);
 
 #endif

--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -1258,8 +1258,7 @@ BOOLEAN DamageStructure(STRUCTURE* const s, UINT8 damage, StructureDamageReason 
 		damage = 0;
 	}
 
-	// Look for a SAM site, update
-	UpdateAndDamageSAMIfFound(gWorldSectorX, gWorldSectorY, gbWorldSectorZ, grid_no, damage);
+	OnStructureDamaged(gWorldSectorX, gWorldSectorY, gbWorldSectorZ, grid_no, damage);
 
 	// Find the base so we can reduce the hit points!
 	STRUCTURE* const base = FindBaseStructure(s);

--- a/src/game/Utils/CMakeLists.txt
+++ b/src/game/Utils/CMakeLists.txt
@@ -13,6 +13,7 @@ set(JA2_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/MercTextBox.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/Message.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/Music_Control.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/Observable.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/PopUpBox.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/Quantize.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/STIConvert.cc

--- a/src/game/Utils/Observable.cc
+++ b/src/game/Utils/Observable.cc
@@ -1,0 +1,12 @@
+#include "Observable.h"
+
+/**
+ * @brief Specialized addListener() override for no-args callbacks. This can only be used with 'Observable<>'
+ * @param callback a Callable taking no arguments
+ * @return the current instance for method chaining
+*/
+template<>
+Observable<_observable::Nil> Observable<_observable::Nil>::addListener(const ST::string key, const std::function<void()> f)
+{
+	return addListener(key, [f](_observable::Nil) { f(); });
+}

--- a/src/game/Utils/Observable.h
+++ b/src/game/Utils/Observable.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <functional>
+#include <list>
+#include <vector>
+
+template<typename ...A>
+class Observable
+{
+public:
+	void listen(std::function<void(A...)> callback)
+	{
+		observers.push_back(callback);
+	}
+
+	void notify(A... args) const
+	{
+		for (auto f : observers)
+		{
+			f(args...);
+		}
+	}
+	void clear()
+	{
+		observers.clear();
+	}
+
+private:
+	std::list<std::function<void(A...)>> observers;
+};

--- a/src/game/Utils/Observable.h
+++ b/src/game/Utils/Observable.h
@@ -1,30 +1,86 @@
 #pragma once
 
 #include <functional>
-#include <list>
 #include <vector>
 
-template<typename ...A>
+namespace _observable
+{
+	// placeholder struct for a no-args callback function to satisfy class template 
+	struct Nil {};
+}
+
+/**
+ * @brief Implements the Observer design pattern, for dependency inversion and allow registering callbacks at runtime.
+ * @tparam ARG1 the first argument the callback function takes
+ * @tparam ...ARGS arguments that the callback function takes
+*/
+template<typename ARG1 = _observable::Nil, typename ...ARGS>
 class Observable
 {
 public:
-	void listen(std::function<void(A...)> callback)
+	/**
+	 * @brief Register a function to be called when callback is invoked
+	 * @param callback a Callable taking the expected args
+	 */
+	Observable<ARG1, ARGS...> listen(std::function<void(ARG1, ARGS...)> callback)
 	{
 		observers.push_back(callback);
+		return *this;
 	}
 
-	void notify(A... args) const
+	/**
+	 * @brief This override is only available with 'Observable<>'
+	 * @throw logic_error
+	 */
+	Observable<ARG1, ARGS...> listen(std::function<void()> callback)
+	{
+		throw new std::logic_error("no-args callback only allowed with 'Observable<>'");
+	}
+
+	/**
+	 * @brief Notifies all the registered callbacks, in the same order as registration
+	 * @tparam ARG1 first argument to the callback; uses default value if skipped
+	 * @tparam ...ARGS the remaining arguments to pass to the callback 
+	 */
+	void notify(ARG1 arg1 = ARG1(), ARGS... args) const
 	{
 		for (auto f : observers)
 		{
-			f(args...);
+			f(arg1, args...);
 		}
 	}
-	void clear()
+
+	/**
+	 * @brief Alias to notify(), to make the object callable.
+	 * @tparam ARG1 first argument to the callback; uses default value if skipped
+	 * @tparam ...ARGS the remaining arguments to pass to the callback
+	*/
+	void operator()(ARG1 arg1 = ARG1(), ARGS... args) const
+	{
+		notify(arg1, args...);
+	}
+
+	/**
+	 * @brief Clears the list of registered callbacks
+	 * @return the current instance for method chaining
+	 */
+	Observable<ARG1, ARGS...>& reset()
 	{
 		observers.clear();
+		return *this;
 	}
 
 private:
-	std::list<std::function<void(A...)>> observers;
+	std::vector<std::function<void(ARG1, ARGS...)>> observers;
 };
+
+/**
+ * @brief Specialized listen() override for no-args callbacks. This can only be used with 'Observable<>'
+ * @param callback a Callable taking no arguments
+ * @return the current instance for method chaining
+*/
+template<>
+Observable<_observable::Nil> Observable<_observable::Nil>::listen(std::function<void()> f)
+{
+	return listen([f](_observable::Nil) { f(); });
+}


### PR DESCRIPTION
Further to the discussion at https://github.com/ja2-stracciatella/ja2-stracciatella/issues/1205#issuecomment-689418616. This is a proposal to implement the "Observer" pattern, for 1) dependency inversion, and 2) allow registering callback at runtime.

## Overview

This is conceptually similar to event/delegate of C#. The subject ("observable") allows registering of typed callback functions, and the subject need no knowledge of what's inside the callbacks. Typically it is the core engine calling back a campaign or sector specific logic.

### Limitations

In contrast to the Strategic_Event_Handler implementation, the Observable class is strong-typed. But that means each callback must be registered explicitly, you cannot have a single handler function switching on event type. This could mean quite a lot of boilerplate code in the scripting extension.

Currently it only support void-functions. Return values could be complicated, because at runtime there might be multiple callbacks. One way is to pass a pointer argument (e.g. `int*`), which can be read and modified by every callback function.

Also there is no clear point of callback registration (ReStartingGame? GameInit?). We need to be careful to register exactly once, at the correct place.

### Drawbacks

Tracing of code is harder because of the added indirection.

## Example implementation

An example is that TileEngine has logic about SAM site but it shouldn't. Using the observer pattern we can move the logic back to Strategic layer.

This is just a proposal to illustrate my idea. I have only briefly tested.