### PR TITLE
Build caching on AppVeyor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,13 @@ endmacro()
 
 ## Project Setup
 
+# compiler caching
 find_program(CCACHE_PROGRAM "ccache")
-if(CCACHE_PROGRAM)
+find_program(SCCACHE_PROGRAM "sccache")
+if(SCCACHE_PROGRAM)
+    message(STATUS "sccache found at ${SCCACHE_PROGRAM}")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${SCCACHE_PROGRAM}")
+elseif(CCACHE_PROGRAM)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
 endif()
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,17 @@ matrix:
 clone_folder: c:\projects\ja2-stracciatella
 clone_depth: 1
 
+cache:
+  # rust and cargo
+  - '%USERPROFILE%\.cargo\bin\ -> rust\Cargo.lock, rust\Cargo.toml'
+  - '%USERPROFILE%\.cargo\registry\index\ -> rust\Cargo.lock, rust\Cargo.toml'
+  - '%USERPROFILE%\.cargo\registry\cache\ -> rust\Cargo.lock, rust\Cargo.toml'
+  - '%USERPROFILE%\.cargo\git\db\ -> rust\Cargo.lock, rust\Cargo.toml'
+  - '%USERPROFILE%\.rustup\ -> rust-toolchain'
+  # lib-fltk
+  - 'C:\projects\ja2-stracciatella\ci-build\lib-fltk\ -> dependencies\lib-fltk\CMakeLists.txt, dependencies\lib-fltk\builder\CMakeLists.txt.in'
+  - 'C:\projects\ja2-stracciatella\ci-build\dependencies\lib-fltk\ -> dependencies\lib-fltk\CMakeLists.txt, dependencies\lib-fltk\builder\CMakeLists.txt.in'
+
 skip_commits:
   # appveyor only searches for tags in the first line by default
   message: /\[ci skip\]/
@@ -101,6 +112,7 @@ install:
   - cmd: gcloud version
 
 before_build:
+  - cmd: setlocal enableextensions
   - cmd: mkdir ci-build
   - cmd: cd ci-build
   - cmd: cmake %BUILD_SWITCHES% ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,6 +42,8 @@ cache:
   # lib-fltk
   - 'C:\projects\ja2-stracciatella\ci-build\lib-fltk\ -> dependencies\lib-fltk\CMakeLists.txt, dependencies\lib-fltk\builder\CMakeLists.txt.in'
   - 'C:\projects\ja2-stracciatella\ci-build\dependencies\lib-fltk\ -> dependencies\lib-fltk\CMakeLists.txt, dependencies\lib-fltk\builder\CMakeLists.txt.in'
+  # sccache
+  - '%LOCALAPPDATA%\Mozilla\sccache'
 
 skip_commits:
   # appveyor only searches for tags in the first line by default
@@ -94,6 +96,9 @@ init:
   - cmd: echo "%BUILD_SWITCHES%"
 
 install:
+  - cmd: choco install sccache
+  - cmd: set SCCACHE_CACHE_SIZE=500M
+
   - ps: $rustVersion = Get-Content .\rust-toolchain -Raw
   - ps: $env:RUSTUP_TOOLCHAIN = "${rustVersion}-${env:RUST_TARGET}";
 
@@ -109,16 +114,18 @@ install:
   - cmd: rustc -V
   - cmd: cargo -V
   - cmd: cmake --version
+  - cmd: sccache -V
   - cmd: gcloud version
 
 before_build:
-  - cmd: setlocal enableextensions
-  - cmd: mkdir ci-build
+  - cmd: if not exist ci-build md ci-build
   - cmd: cd ci-build
   - cmd: cmake %BUILD_SWITCHES% ..
 
 build_script:
+  - cmd: set RUSTC_WRAPPER=sccache
   - ps: cmake --build c:\projects\ja2-stracciatella\ci-build --target ALL_BUILD --config ${env:BUILD_TYPE}
+  - cmd: sccache -s
 
 test_script:
   - cmd: cmake --build . --target cargo-test


### PR DESCRIPTION
Enabling build cache on AppVeyor so we can re-run stuff between builds (#1102). It should save up to 3 minutes per build 

- Caching the [cargo home directory](https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci)
- Caching rustup install (`~/.rustup`)
- Caching and re-using the lib-fltk working directories
- Use [sccache](https://github.com/mozilla/sccache) to speed up rustc ~and VC++~ compilations