### PR TITLE
Use sccache on GitHub CI builds

### DIFF
--- a/.github/scripts/ci-build.sh
+++ b/.github/scripts/ci-build.sh
@@ -42,6 +42,7 @@ fi
 
 export RUN_TESTS=true
 export RUN_RUST_CHECKS=false
+export RUSTC_WRAPPER=sccache
 export RUSTUP_INIT_ARGS="-y --no-modify-path --default-toolchain=$(cat ./rust-toolchain) --profile=minimal"
 if [[ "$CI_TARGET" == "linux" ]]; then
   export CONFIGURE_CMD="${CONFIGURE_CMD} -DCMAKE_INSTALL_PREFIX=AppDir/usr -DEXTRA_DATA_DIR=../share/ja2"
@@ -99,8 +100,8 @@ if [[ "$CI_TARGET" == "linux" ]]; then
 
 # print ccache cache statistics
 echo "## print statistics"
-command -v ccache &&
-  ccache -s ||
-  echo "ccache not installed"
+command -v sccache &&
+  sccache -s ||
+  echo "sccache not installed"
 
 echo "## done ##"

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -42,16 +42,17 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Cache C++ build output
+    - name: Compiler cache (sccache)
       uses: actions/cache@v2
       with:
         path: |
-          ~/.ccache
-        key: ${{ matrix.cfg.target }}-ccache-v1-${{ github.ref }}-${{ github.sha }}
+          ~/.cache/sccache
+          ~/Library/Caches/Mozilla.sccache
+        key: ${{ matrix.cfg.target }}-sccache-v1-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ${{ matrix.cfg.target }}-ccache-v1-${{ github.ref }}-
-          ${{ matrix.cfg.target }}-ccache-v1-refs/heads/master-
-          ${{ matrix.cfg.target }}-ccache-v1-
+          ${{ matrix.cfg.target }}-sccache-v1-${{ github.ref }}-
+          ${{ matrix.cfg.target }}-sccache-v1-refs/heads/master-
+          ${{ matrix.cfg.target }}-sccache-v1-
 
     - name: Cache Rust deps and build output
       uses: actions/cache@v2


### PR DESCRIPTION
#1226 disabled caching of lib-stracciatella output, and so we need to do `rustc` build every run. That slowed down the build by ~3 minutes.

Replaces `ccache` with `sccache` ([link](https://github.com/mozilla/sccache)). `sccache` is able to cache both Rust and C++ builds, and as a bonus this makes the Linux/Mac build more consistent with AppVeyor one (since #1227)

This should also fix #1101. 

