### PR TITLE
More TileEngine refactoring

### DIFF
--- a/src/game/Strategic/SAM_Sites.cc
+++ b/src/game/Strategic/SAM_Sites.cc
@@ -23,7 +23,7 @@ BOOLEAN fSamSiteFound[NUMBER_OF_SAMS] = {
 
 Observable<> OnAirspaceControlUpdated = {};
 
-static void UpdateAndDamageSAMIfFound(INT16 sSectorX, INT16 sSectorY, INT16 sSectorZ, INT16 sGridNo, UINT8 ubDamage);
+static void UpdateAndDamageSAMIfFound(INT16 sSectorX, INT16 sSectorY, INT16 sSectorZ, INT16 sGridNo, void*, UINT8 ubDamage, BOOLEAN fIsDestroyed);
 
 void InitializeSAMSites()
 {
@@ -131,8 +131,6 @@ bool IsThisSectorASAMSector(INT16 const x, INT16 const y, INT8 const z)
 // a -1 will be returned upon failure
 INT8 GetSAMIdFromSector(INT16 sSectorX, INT16 sSectorY, INT8 bSectorZ)
 {
-	INT16 sSectorValue = 0;
-
 	// check if valid sector
 	if (bSectorZ != 0)
 	{
@@ -140,7 +138,7 @@ INT8 GetSAMIdFromSector(INT16 sSectorX, INT16 sSectorY, INT8 bSectorZ)
 	}
 
 	// get the sector value
-	sSectorValue = SECTOR(sSectorX, sSectorY);
+	INT16 sSectorValue = SECTOR(sSectorX, sSectorY);
 	return GCM->findSamIDBySector(sSectorValue);
 }
 
@@ -160,10 +158,8 @@ bool DoesSAMExistHere(INT16 const x, INT16 const y, INT16 const z, GridNo const 
 }
 
 // Look for a SAM site, update
-static void UpdateAndDamageSAMIfFound(INT16 sSectorX, INT16 sSectorY, INT16 sSectorZ, INT16 sGridNo, UINT8 ubDamage)
+static void UpdateAndDamageSAMIfFound(INT16 sSectorX, INT16 sSectorY, INT16 sSectorZ, INT16 sGridNo, void*, UINT8 ubDamage, BOOLEAN fIsDestroyed)
 {
-	INT16 sSectorNo;
-
 	// OK, First check if SAM exists, and if not, return
 	if (!DoesSAMExistHere(sSectorX, sSectorY, sSectorZ, sGridNo))
 	{
@@ -171,7 +167,7 @@ static void UpdateAndDamageSAMIfFound(INT16 sSectorX, INT16 sSectorY, INT16 sSec
 	}
 
 	// Damage.....
-	sSectorNo = CALCULATE_STRATEGIC_INDEX(sSectorX, sSectorY);
+	INT16 sSectorNo = CALCULATE_STRATEGIC_INDEX(sSectorX, sSectorY);
 	SLOGD(ST::format("SAM site at sector #{} is damaged by {} points", sSectorNo, ubDamage));
 	if (StrategicMap[sSectorNo].bSAMCondition >= ubDamage)
 	{

--- a/src/game/Tactical/End_Game.cc
+++ b/src/game/Tactical/End_Game.cc
@@ -48,7 +48,7 @@ INT8 gbLevel;
 
 
 // This function checks if our statue exists in the current sector at given gridno
-BOOLEAN DoesO3SectorStatueExistHere( INT16 sGridNo )
+static BOOLEAN DoesO3SectorStatueExistHere( INT16 sGridNo )
 {
 	INT32 cnt;
 	EXITGRID ExitGrid;
@@ -122,6 +122,17 @@ void ChangeO3SectorStatue( BOOLEAN fFromExplosion )
 	RecompileLocalMovementCostsFromRadius( 13830, 5 );
 }
 
+void HandleStatueDamaged(INT16 sectorX, INT16 sectorY, INT8 sectorZ, INT16 sGridNo, STRUCTURE *s, UINT32 uiDist, BOOLEAN *skipDamage)
+{
+	/* ATE: Check for O3 statue for special damage
+	 * Note, we do this check every time explosion goes off in game, but it's an
+	 * efficient check */
+	if (DoesO3SectorStatueExistHere(sGridNo) && uiDist <= 1)
+	{
+		ChangeO3SectorStatue(TRUE);
+		*skipDamage = true;
+	}
+}
 
 static void HandleDeidrannaDeath(SOLDIERTYPE* pKillerSoldier, INT16 sGridNo, INT8 bLevel);
 

--- a/src/game/Tactical/End_Game.h
+++ b/src/game/Tactical/End_Game.h
@@ -1,8 +1,7 @@
 #ifndef __ENDGAME_H
 #define __ENDGAME_H
 
-
-BOOLEAN DoesO3SectorStatueExistHere( INT16 sGridNo );
+void HandleStatueDamaged(INT16 sectorX, INT16 sectorY, INT8 sectorZ, INT16 sGridNo, STRUCTURE *s, UINT32 uiDist, BOOLEAN *skipDamage);
 void ChangeO3SectorStatue( BOOLEAN fFromExplosion );
 
 void BeginHandleDeidrannaDeath( SOLDIERTYPE *pKillerSoldier, INT16 sGridNo, INT8 bLevel );

--- a/src/game/TileEngine/Explosion_Control.cc
+++ b/src/game/TileEngine/Explosion_Control.cc
@@ -101,7 +101,7 @@ static SOLDIERTYPE* gPersonToSetOffExplosions           = 0;
 #define NUM_EXPLOSION_SLOTS 100
 static EXPLOSIONTYPE gExplosionData[NUM_EXPLOSION_SLOTS];
 
-Observable<INT16, INT16, INT16, INT16, UINT8> OnStructureDamaged = {};
+Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT8, BOOLEAN> OnStructureDamaged = {};
 
 static EXPLOSIONTYPE* GetFreeExplosion(void)
 {
@@ -388,6 +388,9 @@ static bool ExplosiveDamageStructureAtGridNo(STRUCTURE* const pCurrent, STRUCTUR
 		INT16 const sY = CenterY(grid_no);
 		INT8 bDamageReturnVal = DamageStructure(pCurrent, wound_amt, STRUCTURE_DAMAGE_EXPLOSION, grid_no, sX, sY, NULL);
 		if (bDamageReturnVal == STRUCTURE_NOT_DAMAGED) return true;
+
+		BOOLEAN fDestroyed = (bDamageReturnVal == STRUCTURE_DESTROYED);
+		OnStructureDamaged(gWorldSectorX, gWorldSectorY, gbWorldSectorZ, grid_no, pCurrent, wound_amt, fDestroyed);
 
 		STRUCTURE* const base         = FindBaseStructure(pCurrent);
 		GridNo     const base_grid_no = base->sGridNo;

--- a/src/game/TileEngine/Explosion_Control.cc
+++ b/src/game/TileEngine/Explosion_Control.cc
@@ -387,7 +387,7 @@ static bool ExplosiveDamageStructureAtGridNo(STRUCTURE* const pCurrent, STRUCTUR
 		INT16 const sX = CenterX(grid_no);
 		INT16 const sY = CenterY(grid_no);
 		INT8 bDamageReturnVal = DamageStructure(pCurrent, wound_amt, STRUCTURE_DAMAGE_EXPLOSION, grid_no, sX, sY, NULL);
-		if (bDamageReturnVal == 0) return true;
+		if (bDamageReturnVal == STRUCTURE_NOT_DAMAGED) return true;
 
 		STRUCTURE* const base         = FindBaseStructure(pCurrent);
 		GridNo     const base_grid_no = base->sGridNo;
@@ -408,19 +408,19 @@ static bool ExplosiveDamageStructureAtGridNo(STRUCTURE* const pCurrent, STRUCTUR
 		 * should have a in-between explosion partner, make damage code 2 - which
 		 * means only damaged - the normal explosion spreading will cause it do use
 		 * the proper pieces */
-		if (bDamageReturnVal == 1 && orig_destruction_partner < 0)
+		if (bDamageReturnVal == STRUCTURE_DESTROYED && orig_destruction_partner < 0)
 		{
-			bDamageReturnVal = 2;
+			bDamageReturnVal = STRUCTURE_DAMAGED;
 		}
 
 		INT8    destruction_partner = -1;
 		BOOLEAN fContinue           = FALSE;
-		if (bDamageReturnVal == 1)
+		if (bDamageReturnVal == STRUCTURE_DESTROYED)
 		{
 			fContinue = TRUE;
 		}
 		// Check for a damaged looking graphic
-		else if (bDamageReturnVal == 2)
+		else if (bDamageReturnVal == STRUCTURE_DAMAGED)
 		{
 			if (orig_destruction_partner < 0)
 			{

--- a/src/game/TileEngine/Explosion_Control.h
+++ b/src/game/TileEngine/Explosion_Control.h
@@ -59,7 +59,19 @@ extern UINT8 gubElementsOnExplosionQueue;
 extern BOOLEAN gfExplosionQueueActive;
 
 /**
- * Callback after a strurture has just been damaged by explosives
+ * Callback right before the structure damange is inflicted.
+ * @oaram INT16 sSectorX
+ * @param INT16 sSectorY
+ * @param INT8 bSectorZ
+ * @param INT16 sGridNo location on map affected by the exploson
+ * @param STRUCTURE* s pointer to the structure to be damaged
+ * @param UINT32 uiDistance (no of grids) from the source of explosion
+ * @param BOOLEAN* fSkipDamage damage processing will be skipped if it is set to TRUE
+ */
+extern Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT32, BOOLEAN*> BeforeStructureDamaged;
+
+/**
+ * Callback just after a structure has just been damaged by explosives
  * @param INT16 sSectorX
  * @param INT16 sSectorY
  * @param INT8 bSectorZ

--- a/src/game/TileEngine/Explosion_Control.h
+++ b/src/game/TileEngine/Explosion_Control.h
@@ -62,11 +62,13 @@ extern BOOLEAN gfExplosionQueueActive;
  * Callback after a strurture has just been damaged by explosives
  * @param INT16 sSectorX
  * @param INT16 sSectorY
- * @param INT16 sSectorZ
- * @param INT16 sGridNo
- * @param UINT8 ubDamage
+ * @param INT8 bSectorZ
+ * @param INT16 sGridNo location on map affected by the exploson
+ * @param STRUCTURE* s pointer to the structure being damaged by explosion
+ * @param UINT8 ubDamage damage amount just dealt
+ * @param BOOLEAN fIsDestroyed whether or not the structure has been destroyed
  */
-extern Observable<INT16, INT16, INT16, INT16, UINT8> OnStructureDamaged;
+extern Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT8, BOOLEAN> OnStructureDamaged;
 
 void IgniteExplosion(SOLDIERTYPE* owner, INT16 z, INT16 sGridNo, UINT16 item, INT8 level);
 void IgniteExplosionXY(SOLDIERTYPE* owner, INT16 sX, INT16 sY, INT16 sZ, INT16 sGridNo, UINT16 usItem, INT8 bLevel);

--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -1261,8 +1261,6 @@ StructureDamageResult DamageStructure(STRUCTURE* const s, UINT8 damage, Structur
 		damage = 0;
 	}
 
-	OnStructureDamaged(gWorldSectorX, gWorldSectorY, gbWorldSectorZ, grid_no, damage);
-
 	// Find the base so we can reduce the hit points!
 	STRUCTURE* const base = FindBaseStructure(s);
 	if (!base) return STRUCTURE_NOT_DAMAGED;

--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -1205,26 +1205,29 @@ BOOLEAN StructureDensity( STRUCTURE * pStructure, UINT8 * pubLevel0, UINT8 * pub
 	return( TRUE );
 }
 
-
-BOOLEAN DamageStructure(STRUCTURE* const s, UINT8 damage, StructureDamageReason const reason, GridNo const grid_no, INT16 const x, INT16 const y, SOLDIERTYPE* const owner)
+StructureDamageResult DamageStructure(STRUCTURE* const s, UINT8 damage, StructureDamageReason const reason, GridNo const grid_no, INT16 const x, INT16 const y, SOLDIERTYPE* const owner)
 {	// Do damage to a structure; returns TRUE if the structure should be removed
-	CHECKF(s);
+	if (!s)
+	{
+		SLOGW("Structure is not defined");
+		return STRUCTURE_NOT_DAMAGED;
+	}
 
 	if (s->fFlags & (STRUCTURE_PERSON | STRUCTURE_CORPSE))
 	{ // Don't hurt this structure, it's used for hit detection only
-		return FALSE;
+		return STRUCTURE_NOT_DAMAGED;
 	}
 
 	UINT8 const armour_kind = s->pDBStructureRef->pDBStructure->ubArmour;
-	if (armour_kind == MATERIAL_INDESTRUCTABLE_METAL) return FALSE;
-	if (armour_kind == MATERIAL_INDESTRUCTABLE_STONE) return FALSE;
+	if (armour_kind == MATERIAL_INDESTRUCTABLE_METAL) return STRUCTURE_NOT_DAMAGED;
+	if (armour_kind == MATERIAL_INDESTRUCTABLE_STONE) return STRUCTURE_NOT_DAMAGED;
 
 	if (reason == STRUCTURE_DAMAGE_EXPLOSION)
 	{
 		// Account for armour!
 		UINT8 const base_armour = gubMaterialArmour[armour_kind];
 		UINT8 const armour      = s->fFlags & STRUCTURE_EXPLOSIVE ? base_armour / 3 : base_armour / 2;
-		if (damage < armour) return FALSE; // Didn't even scratch the paint
+		if (damage < armour) return STRUCTURE_NOT_DAMAGED; // Didn't even scratch the paint
 		// Did some damage to the structure
 		damage -= armour;
 	}
@@ -1240,8 +1243,8 @@ BOOLEAN DamageStructure(STRUCTURE* const s, UINT8 damage, StructureDamageReason 
 
 			IgniteExplosionXY(owner, x, y, 0, grid_no, STRUCTURE_IGNITE, 0);
 
-			// ATE: Return false here, as we are dealing with deleting the graphic here
-			return FALSE;
+			// ATE: Return negative here, as we are dealing with deleting the graphic here
+			return STRUCTURE_NOT_DAMAGED;
 		}
 
 		// Make hit sound
@@ -1251,7 +1254,7 @@ BOOLEAN DamageStructure(STRUCTURE* const s, UINT8 damage, StructureDamageReason 
 		if (snd != NO_SOUND) PlayLocationJA2Sample(grid_no, snd, HIGHVOLUME, 1);
 
 		// Don't update damage HPs
-		return TRUE;
+		return STRUCTURE_DESTROYED;
 	}
 	else
 	{
@@ -1262,9 +1265,9 @@ BOOLEAN DamageStructure(STRUCTURE* const s, UINT8 damage, StructureDamageReason 
 
 	// Find the base so we can reduce the hit points!
 	STRUCTURE* const base = FindBaseStructure(s);
-	CHECKF(base);
+	if (!base) return STRUCTURE_NOT_DAMAGED;
 
-	if (base->ubHitPoints <= damage) return TRUE; // boom! structure destroyed!
+	if (base->ubHitPoints <= damage) return STRUCTURE_DESTROYED; // boom! structure destroyed!
 	base->ubHitPoints -= damage;
 
 	/* Since the structure is being damaged, set the map element that a structure
@@ -1272,7 +1275,7 @@ BOOLEAN DamageStructure(STRUCTURE* const s, UINT8 damage, StructureDamageReason 
 	gpWorldLevelData[grid_no].uiFlags |= MAPELEMENT_STRUCTURE_DAMAGED;
 
 	// We are a little damaged
-	return 2;
+	return STRUCTURE_DAMAGED;
 }
 
 

--- a/src/game/TileEngine/Structure.h
+++ b/src/game/TileEngine/Structure.h
@@ -18,6 +18,12 @@
 #define BLOCKING_TOPLEFT_OPEN_WINDOW		90
 #define BLOCKING_TOPRIGHT_OPEN_WINDOW		100
 
+enum StructureDamageResult
+{
+    STRUCTURE_NOT_DAMAGED, // structure not damaged
+    STRUCTURE_DESTROYED,   // structure to be deleted
+    STRUCTURE_DAMAGED      // structure to be replaced with damaged graphics
+};
 
 // ATE: Increased to allow corpses to not collide with soldiers
 // 100 == MAX_CORPSES
@@ -88,7 +94,7 @@ void AddZStripInfoToVObject(HVOBJECT, STRUCTURE_FILE_REF const*, BOOLEAN fFromAn
 // FUNCTIONS FOR DETERMINING STUFF THAT BLOCKS VIEW FOR TILE_bASED LOS
 INT8 GetBlockingStructureInfo( INT16 sGridNo, INT8 bDir, INT8 bNextDir, INT8 bLevel, INT8 *pStructHeight, STRUCTURE ** ppTallestStructure, BOOLEAN fWallsBlock );
 
-BOOLEAN DamageStructure(STRUCTURE*, UINT8 damage, StructureDamageReason, GridNo, INT16 x, INT16 y, SOLDIERTYPE* owner);
+StructureDamageResult DamageStructure(STRUCTURE*, UINT8 damage, StructureDamageReason, GridNo, INT16 x, INT16 y, SOLDIERTYPE* owner);
 
 // Material armour type enumeration
 enum


### PR DESCRIPTION
Follow up after our discussion in [#1223](https://github.com/ja2-stracciatella/ja2-stracciatella/pull/1223#issuecomment-694161770). Further cleaning up TileEngine by removing sector-specific code.

## Summary

- TileEngine to do callback just before and right after a structure being damaged
    - Added `STRUCTURE*` and `fIsDestroyed` to `OnStructureDamaged` callback
- Moved away SAM sites, brothel and statue logic from TileEngine
- Replaced an abused BOOLEAN return value with enum
