### PR TITLE
Externalization and generalization of M.E.R.C.

### DIFF
--- a/assets/externalized/mercs-MERC-listings.json
+++ b/assets/externalized/mercs-MERC-listings.json
@@ -1,0 +1,128 @@
+/**
+ * This file defines the profile listings on the M.E.R.C. website, and also some of the things Speck says.
+ *
+ * This only controls how the profiles show up on M.E.R.C. and not the soldier profiles themselves.
+ *
+ * Fields:
+ *  - profileID:        The profile ID of the merc
+ *  - minTotalSpending: The player must spend this amount before this merc is available for hire; Defaults to 0
+ *  - minDays:          The day (in-game days) after which this merc may be available; Defaults to 0
+ *  - quotes:           A list of quotes that Speck make regarding this merc
+ *     - quoteID:       ID of the quote. See Speck_Quotes.h
+ *     - profileID:     ID of the other merc. Only used in CROSS_SELL quotes
+ *     - type:          Type of quote:
+ *                         - "ADVERTISE" quotes are said randomly to sell the merc when the UI is idle
+ *                         - "MERC_DEAD" quotes are said as the opening tag when the merc is dead
+ *                         - "CROSS_SELL" quotes are said when the merc is just hired, and if that other merc is also available for hire. The first available quote is used if there are multiple.
+ *
+ * Notes on mercs' availability:
+ *  - If both minDays and minTotalSpending are 0, the merc is available as soon as the M.E.R.C. site is up
+ *  - New merc checks happens at random intervals, so it will not happen exactly at minDays
+ *  - Merc availability is tracked by index to the latest available merc, so the ordering here is important. Also, it means that if one merc is made available, every other earlier mercs in the list are also available.
+ * 
+ * There are some special logic in the code for LARRY_NORMAL(46) and FLO(44).
+ */
+[
+    // BIFF
+    {
+        "profileID": 40,
+        "quotes": [
+             { "type": "ADVERTISE",  "quoteID": 47 }                                     // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_BIFF
+            ,{ "type": "MERC_DEAD",  "quoteID": 28 }                                     // SPECK_QUOTE_ALTERNATE_OPENING_TAG_BIFF_IS_DEAD
+            ,{ "type": "CROSS_SELL", "quoteID": 63, "profileID": 46 /* LARRY_NORMAL */}  // SPECK_QUOTE_PLAYERS_HIRES_BIFF_SPECK_PLUGS_LARRY
+            ,{ "type": "CROSS_SELL", "quoteID": 63, "profileID": 47 /* LARRY_DRUNK  */}  // SPECK_QUOTE_PLAYERS_HIRES_BIFF_SPECK_PLUGS_LARRY
+            ,{ "type": "CROSS_SELL", "quoteID": 64, "profileID": 44 /* FLO */         }  // SPECK_QUOTE_PLAYERS_HIRES_BIFF_SPECK_PLUGS_FLO
+        ]
+    },
+    // HAYWIRE
+    {
+        "profileID": 41,
+        "quotes": [
+             { "type": "ADVERTISE",  "quoteID": 48 }                              // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_HAYWIRE
+            ,{ "type": "MERC_DEAD",  "quoteID": 29 }                              // SPECK_QUOTE_ALTERNATE_OPENING_TAG_HAYWIRE_IS_DEAD
+            ,{ "type": "CROSS_SELL", "quoteID": 65, "profileID": 43 /* RAZOR */ } // SPECK_QUOTE_PLAYERS_HIRES_HAYWIRE_SPECK_PLUGS_RAZOR
+        ]
+    },
+    // GASKET
+    {
+        "profileID": 42,
+        "quotes": [
+             { "type": "ADVERTISE", "quoteID": 49 }        // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_GASKET
+            ,{ "type": "MERC_DEAD", "quoteID": 30 }        // SPECK_QUOTE_ALTERNATE_OPENING_TAG_GASKET_IS_DEAD
+        ]
+    },
+    // RAZOR
+    {
+        "profileID": 43,
+        "quotes": [
+             { "type": "ADVERTISE",  "quoteID": 50 }                                // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_RAZOR
+            ,{ "type": "MERC_DEAD",  "quoteID": 31 }                                // SPECK_QUOTE_ALTERNATE_OPENING_TAG_RAZOR_IS_DEAD
+            ,{ "type": "CROSS_SELL", "quoteID": 66, "profileID": 41 /* HAYWIRE */ } // SPECK_QUOTE_PLAYERS_HIRES_RAZOR_SPECK_PLUGS_HAYWIRE
+        ]
+    },
+    // FLO
+    {
+        "profileID": 44,
+        "quotes": [
+             { "type": "ADVERTISE",  "quoteID": 51 }                             // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_FLO
+            ,{ "type": "CROSS_SELL", "quoteID": 67, "profileID": 40 /* BIFF */ } // SPECK_QUOTE_PLAYERS_HIRES_FLO_SPECK_PLUGS_BIFF
+             /*
+              * FLO has situational MERC_DEAD quotes, which depends on and may have an
+              * effect on BIFF, and that is handled as a special case in code
+              */
+        ]
+    },
+    // GUMPY
+    {
+        "profileID": 45,
+        "quotes" : [
+             { "type": "ADVERTISE", "quoteID": 52 }             // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_GUMPY},
+            ,{ "type": "MERC_DEAD", "quoteID": 35 }             // SPECK_QUOTE_ALTERNATE_OPENING_TAG_GUMPY_IS_DEAD
+        ]
+    },
+    // BUBBA
+    {
+        "profileID": 50,
+        "minTotalSpending": 5000,
+        "minDays": 8,
+        "quotes" : [
+             { "type": "ADVERTISE", "quoteID": 56 }             // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_BUBBA
+            ,{ "type": "MERC_DEAD", "quoteID": 40 }             // SPECK_QUOTE_ALTERNATE_OPENING_TAG_BUBBA_IS_DEAD
+        ]
+    },
+    // LARRY_NORMAL
+    {
+        /*
+         * By default Larry is sober (LARRY_NORMAL).
+         * We will handle his relapse in the code, and we will replace the profileID with LARRY_DRUNK (47)
+         */
+        "profileID": 46,
+        "minTotalSpending": 10000,
+        "minDays": 15,
+        "quotes" : [
+             { "type": "ADVERTISE",  "quoteID": 53 }                              // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_LARRY
+            ,{ "type": "MERC_DEAD",  "quoteID": 36 }                              // SPECK_QUOTE_ALTERNATE_OPENING_TAG_LARRY_IS_DEAD
+            ,{ "type": "CROSS_SELL", "quoteID": 63, "profileID": 40 /* BIFF */ }  // SPECK_QUOTE_PLAYERS_HIRES_BIFF_SPECK_PLUGS_LARRY
+        ]
+    },
+    // NUMB
+    {
+        "profileID": 49,
+        "minTotalSpending": 15000,
+        "minDays": 20,
+        "quotes" : [
+               { "type": "ADVERTISE", "quoteID": 55 }                 // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_NUMB
+              ,{ "type": "MERC_DEAD", "quoteID": 39 }                 // SPECK_QUOTE_ALTERNATE_OPENING_TAG_NUMB_IS_DEAD
+        ]
+    },
+    // COUGAR
+    {
+        "profileID": 48,
+        "minTotalSpending": 20000,
+        "minDays": 25,
+        "quotes" : [
+               { "type": "ADVERTISE",  "quoteID": 54 }                // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_COUGER
+              ,{ "type": "MERC_DEAD",  "quoteID": 38 }                // SPECK_QUOTE_ALTERNATE_OPENING_TAG_COUGER_IS_DEAD
+        ]
+    }
+]

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -25,6 +25,7 @@ class GamePolicy;
 class GarrisonGroupModel;
 class IMPPolicy;
 class LoadingScreenModel;
+class MERCListingModel;
 class MineModel;
 class MovementCostsModel;
 class NpcActionParamsModel;
@@ -172,7 +173,10 @@ public:
 
 	/* Params for the given NPC_ACTION if found, or return an empty instance */
 	virtual const FactParamsModel* getFactParams(Fact fact) const = 0;
-	
+
+	/* Returns the full list of profile listings on M.E.R.C. */
+	virtual const std::vector<const MERCListingModel*>& getMERCListings() const = 0;
+
 	/* Gets eyes and mouths offsets for the RPC small portraits. Returns null if none defined. */
 	virtual const RPCSmallFaceModel* getRPCSmallFaceOffsets(uint8_t profileID) const = 0;
 

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -31,6 +31,7 @@
 #include "army/ArmyCompositionModel.h"
 #include "army/GarrisonGroupModel.h"
 #include "army/PatrolGroupModel.h"
+#include "mercs/MERCListingModel.h"
 #include "mercs/RPCSmallFaceModel.h"
 #include "policy/DefaultGamePolicy.h"
 #include "policy/DefaultIMPPolicy.h"
@@ -296,6 +297,7 @@ DefaultContentManager::~DefaultContentManager()
 	deleteElements(m_townNameLocatives);
 	deleteElements(m_undergroundSectors);
 	deleteElements(m_rpcSmallFaces);
+	deleteElements(m_MERCListings);
 
 	delete m_movementCosts;
 	delete m_samSitesAirControl;
@@ -1225,6 +1227,14 @@ bool DefaultContentManager::loadMercsData()
 		m_rpcSmallFaces[face->ubProfileID] = face;
 	}
 
+	json = readJsonDataFile("mercs-MERC-listings.json");
+	int i = 0;
+	for (auto& element : json->GetArray())
+	{
+		auto item = MERCListingModel::deserialize(i++, element);
+		m_MERCListings.push_back(item);
+	}
+	MERCListingModel::validateData(m_MERCListings);
 	return true;
 }
 
@@ -1383,6 +1393,11 @@ const RPCSmallFaceModel* DefaultContentManager::getRPCSmallFaceOffsets(uint8_t p
 		return NULL;
 	}
 	return m_rpcSmallFaces.at(profileID);
+}
+
+const std::vector<const MERCListingModel*>& DefaultContentManager::getMERCListings() const
+{
+	return m_MERCListings;
 }
 
 const LoadingScreen* DefaultContentManager::getLoadingScreenForSector(uint8_t sectorId, uint8_t sectorLevel, bool isNight) const

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -173,6 +173,7 @@ public:
 	virtual const MovementCostsModel* getMovementCosts() const override;
 	virtual const NpcPlacementModel* getNpcPlacement(uint8_t profileId) const override;
 	virtual const RPCSmallFaceModel* getRPCSmallFaceOffsets(uint8_t profileID) const override;
+	virtual const std::vector<const MERCListingModel*>& getMERCListings() const;
 	virtual const LoadingScreen* getLoadingScreenForSector(uint8_t sectorId, uint8_t sectorLevel, bool isNight) const override;
 	virtual const LoadingScreen* getLoadingScreen(uint8_t index) const override;
 
@@ -242,6 +243,7 @@ protected:
 	std::vector<const UndergroundSectorModel*> m_undergroundSectors;
 
 	std::map<uint8_t, const RPCSmallFaceModel*> m_rpcSmallFaces;
+	std::vector<const MERCListingModel*> m_MERCListings;
 
 	RustPointer<Vfs> m_vfs;
 

--- a/src/externalized/mercs/CMakeLists.txt
+++ b/src/externalized/mercs/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB LOCAL_JA2_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
 set(LOCAL_JA2_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/MercProfile.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/MERCListingModel.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/RPCSmallFaceModel.cc
         )
 

--- a/src/externalized/mercs/MERCListingModel.cc
+++ b/src/externalized/mercs/MERCListingModel.cc
@@ -1,0 +1,95 @@
+#include "MERCListingModel.h"
+#include "JsonObject.h"
+#include "Soldier_Control.h"
+#include <set>
+#include <string_theory/format>
+
+MERCListingModel::MERCListingModel(uint8_t index_, uint8_t profileID_, 
+	uint32_t minTotalSpending_, uint32_t minDays_, 
+	std::vector<SpeckQuote> quotes_
+	) : index(index_), profileID(profileID_),
+	    minTotalSpending(minTotalSpending_), minDays(minDays_),
+	    quotes(quotes_) {}
+
+bool MERCListingModel::isAvailableAtStart() const
+{
+	return this->minDays == 0 && this->minTotalSpending == 0;
+}
+
+const std::vector<SpeckQuote> MERCListingModel::getQuotesByType(SpeckQuoteType type) const
+{
+	std::vector<SpeckQuote> filtered;
+	for (auto q : quotes)
+	{
+		if (q->type == type) filtered.push_back(q);
+	}
+	return filtered;
+}
+
+static SpeckQuoteType SpeckQuoteTypefromString(std::string s)
+{
+	if (s == "ADVERTISE") return SpeckQuoteType::ADVERTISE;
+	if (s == "MERC_DEAD") return SpeckQuoteType::MERC_DEAD;
+	if (s == "CROSS_SELL") return SpeckQuoteType::CROSS_SELL;
+
+	throw std::runtime_error("unsupported quote type: " + s);
+}
+
+MERCListingModel* MERCListingModel::deserialize(uint8_t index, const rapidjson::Value& json)
+{
+	std::vector<SpeckQuote> quotes;
+	for (auto& elem : json["quotes"].GetArray())
+	{
+		JsonObjectReader r(elem);
+		auto quote = std::make_shared<MERCSpeckQuote>(
+			r.GetUInt("quoteID"),
+			SpeckQuoteTypefromString(r.GetString("type")),
+			static_cast<uint8_t>(r.getOptionalInt("profileID"))
+		);
+		quotes.push_back(quote);
+	}
+
+	JsonObjectReader r(json);
+	return new MERCListingModel(
+		index,
+		r.GetUInt("profileID"),
+		r.getOptionalInt("minTotalSpending"), 
+		r.getOptionalInt("minDays"),
+		quotes
+	);
+
+}
+
+void MERCListingModel::validateData(std::vector<const MERCListingModel*> models)
+{
+	std::set<uint8_t> uniqueProfileIDs;
+	for (auto m : models)
+	{
+		if (m->profileID == 0 || m->profileID >= NO_PROFILE)
+		{
+			ST::string err = ST::format("Invalid profileID '{}'", m->profileID);
+			throw std::runtime_error(err.to_std_string());
+		}
+
+		// Check if we have duplicates
+		if (uniqueProfileIDs.find(m->profileID) != uniqueProfileIDs.end())
+		{
+			ST::string err = ST::format("profileID {} has been listed more than once", m->profileID);
+			throw std::runtime_error(err.to_std_string());
+		}
+		uniqueProfileIDs.insert(m->profileID);
+	}
+
+	for (auto m : models)
+	{
+		for (auto quote : m->getQuotesByType(SpeckQuoteType::CROSS_SELL))
+		{
+			// Check if related merc is set
+			if (!quote->relatedMercID)
+			{
+				ST::string err = ST::format("No related merc ID set for a CROSS_SELL quote ({})", m->profileID);
+				throw std::runtime_error(err.to_std_string());
+			}
+		}
+	}
+}

--- a/src/externalized/mercs/MERCListingModel.h
+++ b/src/externalized/mercs/MERCListingModel.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "MercProfile.h"
+#include "MERCSpeckQuote.h"
+#include <memory>
+#include <rapidjson/document.h>
+#include <vector>
+
+typedef std::shared_ptr<MERCSpeckQuote> SpeckQuote;
+
+class MERCListingModel
+{
+public:
+	MERCListingModel(uint8_t index_, uint8_t profileID_, uint32_t minTotalSpending_, uint32_t mindays, std::vector<SpeckQuote> quotes_);
+	const uint8_t index;
+
+	// If we are coming from M.E.R.C., we should always use the GetProfileIDFromMERCListing 
+	// instead, due to the hard-coded LARRY logic
+	const uint8_t profileID;
+
+	const uint32_t minTotalSpending;
+	const uint32_t minDays;
+
+	bool isAvailableAtStart() const;
+	const std::vector<SpeckQuote> MERCListingModel::getQuotesByType(SpeckQuoteType type) const;
+
+	static MERCListingModel* deserialize(uint8_t index, const rapidjson::Value& json);
+	static void MERCListingModel::validateData(std::vector<const MERCListingModel*>);
+private:
+	std::vector<SpeckQuote> quotes;
+};

--- a/src/externalized/mercs/MERCListingModel.h
+++ b/src/externalized/mercs/MERCListingModel.h
@@ -21,10 +21,10 @@ public:
 	const uint32_t minDays;
 
 	bool isAvailableAtStart() const;
-	const std::vector<SpeckQuote> MERCListingModel::getQuotesByType(SpeckQuoteType type) const;
+	const std::vector<SpeckQuote> getQuotesByType(SpeckQuoteType type) const;
 
 	static MERCListingModel* deserialize(uint8_t index, const rapidjson::Value& json);
-	static void MERCListingModel::validateData(std::vector<const MERCListingModel*>);
+	static void validateData(std::vector<const MERCListingModel*>);
 private:
 	std::vector<SpeckQuote> quotes;
 };

--- a/src/externalized/mercs/MERCSpeckQuote.h
+++ b/src/externalized/mercs/MERCSpeckQuote.h
@@ -1,0 +1,17 @@
+#pragma once
+
+enum class SpeckQuoteType
+{
+	ADVERTISE,
+	MERC_DEAD,
+	CROSS_SELL
+};
+
+struct MERCSpeckQuote
+{
+	MERCSpeckQuote(uint8_t q, SpeckQuoteType t, uint8_t r) : quoteID(q), type(t), relatedMercID(r) {}
+
+	const uint8_t quoteID;
+	const SpeckQuoteType type;
+	const uint8_t relatedMercID;
+};

--- a/src/game/Laptop/Laptop.cc
+++ b/src/game/Laptop/Laptop.cc
@@ -3449,6 +3449,9 @@ void LoadLaptopInfoFromSavedGame(HWFILE const f)
 	EXTR_SKIP( d, 87)
 	Assert(d.getConsumed() == lengthof(data));
 
+	// Handle old saves in M.E.R.C. module
+	SyncLastMercFromSaveGame();
+
 	if (l.usNumberOfBobbyRayOrderUsed != 0)
 	{ // There is anything in the Bobby Ray Orders on Delivery
 		l.BobbyRayOrdersOnDeliveryArray.resize(BobbyRayOrdersOnDeliveryArraySize);

--- a/src/game/Laptop/LaptopSave.h
+++ b/src/game/Laptop/LaptopSave.h
@@ -88,7 +88,7 @@ struct LaptopSaveInfoStruct
 	// MERC site info
 	UINT8  gubPlayersMercAccountStatus;
 	UINT32 guiPlayersMercAccountNumber;
-	UINT8  gubLastMercIndex;
+	UINT8  gubLastMercIndex; //  the index of the last hirable merc profile in M.E.R.C.
 
 
 	// Aim Site
@@ -140,7 +140,7 @@ struct LaptopSaveInfoStruct
 
 	UINT32  uiTotalMoneyPaidToSpeck;
 
-	UINT8   ubLastMercAvailableId;
+	UINT8   ubLastMercAvailableId; // deprecated
 };
 
 

--- a/src/game/Laptop/Mercs.cc
+++ b/src/game/Laptop/Mercs.cc
@@ -278,12 +278,6 @@ void GameInitMercs()
 	gfMercVideoIsBeingDisplayed = FALSE;
 
 	gusMercVideoSpeckSpeech = 0;
-
-	/*
-	for( i=0; i<MERC_NUMBER_OF_RANDOM_QUOTES; i++ )
-	{
-		gNumberOfTimesQuoteSaid[i] = 0;
-	}*/
 }
 
 
@@ -663,10 +657,6 @@ void DailyUpdateOfMercSite( UINT16 usDate)
 
 		//Set the fact the site has gone down
 		LaptopSaveInfo.fMercSiteHasGoneDownYet = TRUE;
-
-		//No lnger removing the bookmark, leave it up, and the user will go to the broken link page
-		//Remove the book mark
-		//RemoveBookMark( MERC_BOOKMARK );
 
 		//Get the site up the next day at 6:00 pm
 		uiTimeInMinutes = GetMidnightOfFutureDayInMinutes( 1 ) + 18 * 60;

--- a/src/game/Laptop/Mercs.cc
+++ b/src/game/Laptop/Mercs.cc
@@ -32,7 +32,7 @@
 #include "GameInstance.h"
 #include "ContentManager.h"
 #include "MERCListingModel.h"
-
+#include <climits>
 #include <string_theory/format>
 #include <string_theory/string>
 
@@ -970,9 +970,7 @@ static BOOLEAN IsSpeckTryingToRecruit()
 	}
 
 	auto nextAvailable = listings[LaptopSaveInfo.gubLastMercIndex + 1];
-	return nextAvailable->minTotalSpending <= LaptopSaveInfo.uiTotalMoneyPaidToSpeck
-		&& CanMercBeAvailableYet(nextAvailable)
-	;
+	return CanMercBeAvailableYet(nextAvailable);
 }
 
 static BOOLEAN GetSpeckConditionalOpening(BOOLEAN fJustEnteredScreen)
@@ -1311,7 +1309,7 @@ static void RemoveSpeckPopupTextBox(void)
 static BOOLEAN IsMercMercAvailable(UINT8 ubMercID);
 
 
-static void HandlePlayerHiringMerc(const MERCListingModel* hired) //UINT8 ubHiredMercI)
+static void HandlePlayerHiringMerc(const MERCListingModel* hired)
 {
 	gusMercVideoSpeckSpeech = MERC_VIDEO_SPECK_SPEECH_NOT_TALKING;
 

--- a/src/game/Laptop/Mercs.h
+++ b/src/game/Laptop/Mercs.h
@@ -3,13 +3,11 @@
 
 #include <string_theory/string>
 
+class  MERCListingModel;
 
 #define MERC_BUTTON_UP_COLOR			FONT_MCOLOR_WHITE
 #define MERC_BUTTON_DOWN_COLOR			FONT_MCOLOR_DKWHITE
 
-#define NUMBER_OF_MERCS				11
-#define LAST_MERC_ID				10
-#define NUMBER_OF_BAD_MERCS			5
 
 #define MERC_NUM_DAYS_TILL_FIRST_WARNING	7
 #define MERC_NUM_DAYS_TILL_ACCOUNT_SUSPENDED	9
@@ -60,7 +58,8 @@ void InitMercBackGround(void);
 void DrawMecBackGround(void);
 void RemoveMercBackGround(void);
 void DailyUpdateOfMercSite( UINT16 usDate);
-UINT8 GetMercIDFromMERCArray(UINT8 ubMercID);
+ProfileID GetProfileIDFromMERCListingIndex(UINT8 ubMercIndex);
+ProfileID GetProfileIDFromMERCListing(const MERCListingModel* listing);
 void DisplayTextForSpeckVideoPopUp(const ST::string& str);
 
 void EnterInitMercSite(void);
@@ -73,7 +72,6 @@ extern UINT16 gusMercVideoSpeckSpeech;
 
 extern UINT8 gubArrivedFromMercSubSite;
 
-extern UINT8 gubMercArray[ NUMBER_OF_MERCS ];
 extern UINT8 gubCurMercIndex;
 
 extern BOOLEAN gfJustHiredAMercMerc;
@@ -82,4 +80,5 @@ void NewMercsAvailableAtMercSiteCallBack(void);
 
 void CalcAproximateAmountPaidToSpeck(void);
 
+void SyncLastMercFromSaveGame();
 #endif

--- a/src/game/Laptop/Mercs_Files.cc
+++ b/src/game/Laptop/Mercs_Files.cc
@@ -192,7 +192,7 @@ void RenderMercsFiles()
 	BltVideoObject(FRAME_BUFFER, guiStatsBox,    0, MERC_FILES_STATS_BOX_X,    MERC_FILES_STATS_BOX_Y);
 	BltVideoObject(FRAME_BUFFER, guiBioBox,      0, MERC_FILES_BIO_BOX_X + 1,  MERC_FILES_BIO_BOX_Y);
 
-	ProfileID         const  pid = GetMercIDFromMERCArray(gubCurMercIndex);
+	ProfileID         const  pid = GetProfileIDFromMERCListingIndex(gubCurMercIndex);
 	MERCPROFILESTRUCT const& p   = GetProfile(pid);
 
 	//Display the mercs face
@@ -230,8 +230,6 @@ static void BtnMercPrevButtonCallback(GUI_BUTTON *btn, INT32 reason)
 	if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
 		if (gubCurMercIndex > 0) gubCurMercIndex--;
-		//Since there are 2 larry roachburns
-		if (gubCurMercIndex == MERC_LARRY_ROACHBURN) gubCurMercIndex--;
 		fReDrawScreenFlag = TRUE;
 		EnableDisableMercFilesNextPreviousButton();
 	}
@@ -243,8 +241,6 @@ static void BtnMercNextButtonCallback(GUI_BUTTON *btn, INT32 reason)
 	if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
 		if (gubCurMercIndex <= LaptopSaveInfo.gubLastMercIndex - 1) gubCurMercIndex++;
-		//Since there are 2 larry roachburns
-		if (gubCurMercIndex == MERC_LARRY_ROACHBURN) gubCurMercIndex++;
 		fReDrawScreenFlag = TRUE;
 		EnableDisableMercFilesNextPreviousButton( );
 	}
@@ -265,7 +261,7 @@ static void BtnMercHireButtonCallback(GUI_BUTTON *btn, INT32 reason)
 			gusMercVideoSpeckSpeech = SPECK_QUOTE_ALTERNATE_OPENING_5_PLAYER_OWES_SPECK_ACCOUNT_SUSPENDED;
 			gubArrivedFromMercSubSite = MERC_CAME_FROM_HIRE_PAGE;
 		}
-		else if (MercFilesHireMerc(GetMercIDFromMERCArray(gubCurMercIndex)))
+		else if (MercFilesHireMerc(GetProfileIDFromMERCListingIndex(gubCurMercIndex)))
 		{
 			// else try to hire the merc
 			guiCurrentLaptopMode = LAPTOP_MODE_MERC;

--- a/src/game/Laptop/Mercs_Files.cc
+++ b/src/game/Laptop/Mercs_Files.cc
@@ -271,9 +271,6 @@ static void BtnMercHireButtonCallback(GUI_BUTTON *btn, INT32 reason)
 			guiCurrentLaptopMode = LAPTOP_MODE_MERC;
 			gubArrivedFromMercSubSite = MERC_CAME_FROM_HIRE_PAGE;
 
-			//start the merc talking
-			//HandlePlayerHiringMerc(GetMercIDFromMERCArray(gubCurMercIndex));
-
 			gfJustHiredAMercMerc = TRUE;
 			DisplayPopUpBoxExplainingMercArrivalLocationAndTime();
 		}


### PR DESCRIPTION
This PR externalizes (#665) and generalizes the merc profile handling in M.E.R.C. The goal is to allow mods to add new mercs in M.E.R.C., and let them change the availabilities (e.g. make everybody available right from the start). Quite a few parts of the M.E.R.C. code was re-written.

## What's changed

- Soldiers' availability on M.E.R.C. (`CONTITION_FOR_MERC_AVAILABLE`, not my typo) are fully controlled from JSON data
- Speck's merc-specific quotes are also controlled from JSON data
- The save game data field `ubLastMercAvailableId` is no longer used

## Larry handling

Larry (`LARRY_NORMAL` and `LARRY_DRUNK`) handling has been quite ugly. The old code has 2 Larry profiles in the MERC array, and will use only of them depending on whether Larry has relapse or not. In some places (e.g. Mercs_Files page), `LARRY_DRUNK` is always skipped.

This PR changes Larry handling to keep the special logic away from the data. Now the MERC data array only have a single entry pointing at `LARRY_NORMAL`, but the code will check for Larry's relapse, and return `LARRY_DRUNK` if we are asking for Larry and he has relapsed.

However, this also means the saved index will be off by one. The later M.E.R.C. hires, `NUMB` and `COUGAR` had indices 9 and 10 in old code. After this PR, their indices will become 8 and 9. This PR also included a load game handler to address this off-by-one difference. However, it cannot handle loading of new saves from old versions. In that case, the old version game will not crash, but the later mercs might become unavailable and but should be available again in a few days again.

## Testing 

This is going to take me some time to test all the M.E.R.C. functions. I am drafting this PR first while I am still testing. Let me know if you object to this, or spot some stopper issues.