### PR TITLE
Adding game policy options to customize when M.E.R.C. goes online

### DIFF
--- a/assets/externalized/game.json
+++ b/assets/externalized/game.json
@@ -130,6 +130,13 @@
         "load_saved_merc_by_nickname": false,
         "load_keep_inventory": false
     },
+    
+    // When a new game starts, it picks randomly in the range of min and max (both inclusive) 
+    // on which day M.E.R.C. goes online and Speck sends the player an email. If 0 is picked, 
+    // then M.E.R.C. will be available right from the start.
+    // vanilla setting: 1, 2
+    "merc_online_min_days": 1,
+    "merc_online_max_days": 2,
 
     "progress": {
         //  Progress weight of parameter on campaign progress

--- a/src/externalized/JsonObject.h
+++ b/src/externalized/JsonObject.h
@@ -115,6 +115,18 @@ public:
 		}
 	}
 
+	unsigned int getOptionalUInt(const char* name, unsigned int defaultValue = 0) const
+	{
+		if (m_value.HasMember(name))
+		{
+			return m_value[name].GetUint();
+		}
+		else
+		{
+			return defaultValue;
+		}
+	}
+
 	const char * getOptionalString(const char *name) const
 	{
 		if(m_value.HasMember(name))

--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -52,6 +52,9 @@ DefaultGamePolicy::DefaultGamePolicy(rapidjson::Document *json)
 	imp_attribute_bonus = imp.getOptionalInt("bonus_attribute_points", 40);
 	imp_pick_skills_directly = imp.getOptionalBool("pick_skills_directly");
 
+	merc_online_min_days = gp.getOptionalUInt("merc_online_min_days", 1);
+	merc_online_max_days = gp.getOptionalUInt("merc_online_max_days", 2);
+
 	JsonObjectReader progress = JsonObjectReader(gp.GetValue("progress"));
 	progress_event_madlab_min = progress.getOptionalInt("event_madlab_min", 35);
 	progress_event_mike_min = progress.getOptionalInt("event_mike_min", 50);

--- a/src/externalized/policy/GamePolicy.h
+++ b/src/externalized/policy/GamePolicy.h
@@ -73,6 +73,10 @@ public:
 	int32_t imp_attribute_zero_bonus;     // IMP character attribute points given instead of imp_attribute_min, vanilla 15
 	bool imp_pick_skills_directly;        // Use the IMP_SkillTrait selection screen from JA2.5, skipping the personality quiz, vanilla falase
 
+	/* M.E.R.C. */
+	uint8_t merc_online_min_days;         // The earliest day on or after which M.E.R.C. goes online
+	uint8_t merc_online_max_days;         // The latest day on or before which M.E.R.C. goes online
+
 	// Difficulty / Campaign Progress
 	float progress_weight_kills;         // Weight of kill count on campaign progress
 	float progress_weight_control;       // Weight of area control on campaign progress

--- a/src/game/Strategic/Game_Init.cc
+++ b/src/game/Strategic/Game_Init.cc
@@ -340,9 +340,20 @@ void InitNewGame()
 		}
 		AddTransactionToPlayersBook(ANONYMOUS_DEPOSIT, 0, now, starting_cash);
 
-		// Schedule email for message from Speck at 7am 1 to 2 days in the future
-		UINT32 const days_time_merc_site_available = Random(2) + 1;
-		AddFutureDayStrategicEvent(EVENT_DAY3_ADD_EMAIL_FROM_SPECK, 60 * 7, 0, days_time_merc_site_available);
+		// random day between min and max days, inclusive
+		UINT8 ubMin = gamepolicy(merc_online_min_days);
+		UINT8 ubMax = gamepolicy(merc_online_max_days);
+		UINT32 const days_time_merc_site_available = Random(ubMax - ubMin + 1) + ubMin;
+		if (days_time_merc_site_available == 0)
+		{
+			// M.E.R.C. is already online
+			AddEmail(MERC_INTRO, MERC_INTRO_LENGTH, SPECK_FROM_MERC, GetWorldTotalMin());
+		}
+		else
+		{
+			// Schedule email for message from Speck at 7am on a random day in the future
+			AddFutureDayStrategicEvent(EVENT_DAY3_ADD_EMAIL_FROM_SPECK, 60 * 7, 0, days_time_merc_site_available);
+		}
 
 		SetLaptopExitScreen(INIT_SCREEN);
 		SetPendingNewScreen(LAPTOP_SCREEN);


### PR DESCRIPTION
Externalizes (#665) the day when M.E.R.C. goes online.

When set to [0, 0], we can hire M.E.R.C. people in the starting squad. Use #1244 if you want the better ones at the start.