### PR TITLE
Cleaning up some C++ code

### DIFF
--- a/dependencies/lib-lua/CMakeLists.txt
+++ b/dependencies/lib-lua/CMakeLists.txt
@@ -2,6 +2,10 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 
 PROJECT(lua)
 
+if(UNIX AND NOT MINGW)
+    add_compile_definitions("LUA_USE_POSIX")
+endif()
+
 FILE(GLOB LUA_SRC "${CMAKE_CURRENT_SOURCE_DIR}/lua/src/*.c")
 LIST(REMOVE_ITEM LUA_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/lua/src/lua.c"

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -1010,12 +1010,12 @@ bool DefaultContentManager::loadGameData()
 	return result;
 }
 
-std::shared_ptr<rapidjson::Document> DefaultContentManager::readJsonDataFile(const char *fileName) const
+std::unique_ptr<rapidjson::Document> DefaultContentManager::readJsonDataFile(const char *fileName) const
 {
 	AutoSGPFile f(openGameResForReading(fileName));
 	ST::string jsonData = FileMan::fileReadText(f);
 
-	auto document = std::make_shared<rapidjson::Document>();
+	auto document = std::make_unique<rapidjson::Document>();
 	if (document->Parse<rapidjson::kParseCommentsFlag>(jsonData.c_str()).HasParseError())
 	{
 		ST::string errorMessage = ST::format("Failed to parse {} (at location {}) {} ",

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -267,7 +267,7 @@ protected:
 	bool loadTacticalLayerData();
 	bool loadMercsData();
 
-	std::shared_ptr<rapidjson::Document> readJsonDataFile(const char *fileName) const;
+	std::unique_ptr<rapidjson::Document> readJsonDataFile(const char *fileName) const;
 };
 
 class LibraryFileNotFoundException : public std::runtime_error

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -173,7 +173,7 @@ public:
 	virtual const MovementCostsModel* getMovementCosts() const override;
 	virtual const NpcPlacementModel* getNpcPlacement(uint8_t profileId) const override;
 	virtual const RPCSmallFaceModel* getRPCSmallFaceOffsets(uint8_t profileID) const override;
-	virtual const std::vector<const MERCListingModel*>& getMERCListings() const;
+	virtual const std::vector<const MERCListingModel*>& getMERCListings() const override;
 	virtual const LoadingScreen* getLoadingScreenForSector(uint8_t sectorId, uint8_t sectorLevel, bool isNight) const override;
 	virtual const LoadingScreen* getLoadingScreen(uint8_t index) const override;
 

--- a/src/externalized/DefaultContentManagerUT.cc
+++ b/src/externalized/DefaultContentManagerUT.cc
@@ -15,7 +15,7 @@ void DefaultContentManagerUT::init()
 	Vfs_addDir(m_vfs.get(), m_externalizedDataPath.c_str());
 }
 
-std::shared_ptr<rapidjson::Document> DefaultContentManagerUT::_readJsonDataFile(const char* fileName) const
+std::unique_ptr<rapidjson::Document> DefaultContentManagerUT::_readJsonDataFile(const char* fileName) const
 {
 	return DefaultContentManager::readJsonDataFile(fileName);
 }

--- a/src/externalized/DefaultContentManagerUT.h
+++ b/src/externalized/DefaultContentManagerUT.h
@@ -11,7 +11,7 @@ public:
 	virtual void init();
 
 	// expose this method to unit tests
-	std::shared_ptr<rapidjson::Document> _readJsonDataFile(const char* fileName) const;
+	std::unique_ptr<rapidjson::Document> _readJsonDataFile(const char* fileName) const;
 
 	/** Create DefaultContentManager for usage in unit testing. */
 	static DefaultContentManagerUT* createDefaultCMForTesting();

--- a/src/game/Tactical/Animation_Cache.cc
+++ b/src/game/Tactical/Animation_Cache.cc
@@ -57,7 +57,7 @@ void DeleteAnimationCache( UINT16 usSoldierID, AnimationSurfaceCacheType *pAnimC
 void GetCachedAnimationSurface(UINT16 const usSoldierID, AnimationSurfaceCacheType* const pAnimCache, UINT16 const usSurfaceIndex, UINT16 const usCurrentAnimation)
 {
 	UINT8  cnt;
-	UINT8  ubLowestIndex = -1;
+	UINT8  ubLowestIndex = UINT8_MAX;
 	INT16  sMostHits = INT16_MAX;
 	UINT16 usCurrentAnimSurface;
 
@@ -110,7 +110,7 @@ void GetCachedAnimationSurface(UINT16 const usSoldierID, AnimationSurfaceCacheTy
 			}
 		}
 
-		if (ubLowestIndex == -1)
+		if (ubLowestIndex == UINT8_MAX)
 		{
 			SLOGW(ST::format("Anim Cache: No preferred cache slot for eviction ( Soldier {} )", usSoldierID));
 			ubLowestIndex = 0;

--- a/src/game/Tactical/Dialogue_Control.cc
+++ b/src/game/Tactical/Dialogue_Control.cc
@@ -199,7 +199,7 @@ void PreloadExternalNPCFaces()
 
 	fExternFacesLoaded = TRUE;
 
-	for (int i = 0; i < lengthof(preloadedExternalNPCFaces); i++)
+	for (size_t i = 0; i < lengthof(preloadedExternalNPCFaces); i++)
 	{
 		LoadExternalNPCFace(preloadedExternalNPCFaces[i]);
 	}

--- a/src/game/TileEngine/Ambient_Control.cc
+++ b/src/game/TileEngine/Ambient_Control.cc
@@ -11,6 +11,8 @@
 #include "ContentManager.h"
 #include "GameInstance.h"
 #include "Logger.h"
+#include <string_theory/format>
+#include <string_theory/string>
 
 AMBIENTDATA_STRUCT		gAmbData[ MAX_AMBIENT_SOUNDS ];
 INT16									gsNumAmbData = 0;
@@ -19,9 +21,7 @@ INT16									gsNumAmbData = 0;
 static BOOLEAN LoadAmbientControlFile(UINT8 ubAmbientID)
 try
 {
-	SGPFILENAME zFilename;
-	sprintf(zFilename, AMBIENTDIR "/%d.bad", ubAmbientID);
-
+	ST::string zFilename = ST::format("{}/{}.bad", AMBIENTDIR, ubAmbientID);
 	AutoSGPFile hFile(GCM->openGameResForReading(zFilename));
 
 	// READ #
@@ -32,8 +32,9 @@ try
 	{
 		FileRead(hFile, &gAmbData[cnt], sizeof(AMBIENTDATA_STRUCT));
 
-		sprintf(zFilename, AMBIENTDIR "/%s", gAmbData[cnt].zFilename);
-		strcpy(gAmbData[cnt].zFilename, zFilename);
+		zFilename = ST::format("{}/{}", AMBIENTDIR, gAmbData[cnt].zFilename);
+		if (zFilename.size() > SGPFILENAME_LEN) throw std::runtime_error("ambient file name too long");
+		strcpy(gAmbData[cnt].zFilename, zFilename.c_str());
 	}
 
 	return TRUE;

--- a/src/game/TileEngine/Render_Fun.cc
+++ b/src/game/TileEngine/Render_Fun.cc
@@ -118,7 +118,7 @@ void SetGridNoRevealedFlag(UINT16 const grid_no)
 				node->uiFlags |= LEVELNODE_HIDDEN;
 			}
 		}
-		catch (std::logic_error e)
+		catch (const std::logic_error& e)
 		{
 			SLOGW(ST::format("Failed to find LEVELNODE for a structure at grid {}. ({})", grid_no, e.what()));
 		}

--- a/src/sgp/Logger.h
+++ b/src/sgp/Logger.h
@@ -10,7 +10,7 @@ void LogMessage(bool isAssert, LogLevel level, const char* file, const ST::strin
 void LogMessage(bool isAssert, LogLevel level, const char *file, const char *format, ...);
 
 /** Get filename relative to src directory */
-#define __FILENAME__ (__FILE__ + SOURCE_PATH_SIZE)
+#define __FILENAME__ (&__FILE__[SOURCE_PATH_SIZE])
 
 /** Print debug message macro. */
 #define SLOGD(FORMAT, ...) LogMessage(false, LogLevel::Debug, __FILENAME__, FORMAT, ##__VA_ARGS__)


### PR DESCRIPTION
Fixes several compiler warnings, and apply the correct practices.

## Highlights

- Fixes the compiler warnings in Mac builds (https://github.com/ja2-stracciatella/ja2-stracciatella/pull/1137#discussion_r453317787)
- Replaces `std::shared_ptr` with `std::unique_ptr` whenever applicable. `std::unique_ptr` should be used if pointer is to be owned by one. It also have much less overhead
- Fixes a number of compiler warnings