### PR TITLE
Externalizing M.E.R.C. profile bio index

### DIFF
--- a/assets/externalized/mercs-MERC-listings.json
+++ b/assets/externalized/mercs-MERC-listings.json
@@ -5,6 +5,7 @@
  *
  * Fields:
  *  - profileID:        The profile ID of the merc
+ *  - bioIndex:         The start location offset to the merc's bio in the mercbios.edt
  *  - minTotalSpending: The player must spend this amount before this merc is available for hire; Defaults to 0
  *  - minDays:          The day (in-game days) after which this merc may be available; Defaults to 0
  *  - quotes:           A list of quotes that Speck make regarding this merc
@@ -26,6 +27,7 @@
     // BIFF
     {
         "profileID": 40,
+        "bioIndex": 0,
         "quotes": [
              { "type": "ADVERTISE",  "quoteID": 47 }                                     // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_BIFF
             ,{ "type": "MERC_DEAD",  "quoteID": 28 }                                     // SPECK_QUOTE_ALTERNATE_OPENING_TAG_BIFF_IS_DEAD
@@ -37,6 +39,7 @@
     // HAYWIRE
     {
         "profileID": 41,
+        "bioIndex": 1,
         "quotes": [
              { "type": "ADVERTISE",  "quoteID": 48 }                              // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_HAYWIRE
             ,{ "type": "MERC_DEAD",  "quoteID": 29 }                              // SPECK_QUOTE_ALTERNATE_OPENING_TAG_HAYWIRE_IS_DEAD
@@ -46,6 +49,7 @@
     // GASKET
     {
         "profileID": 42,
+        "bioIndex": 2,
         "quotes": [
              { "type": "ADVERTISE", "quoteID": 49 }        // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_GASKET
             ,{ "type": "MERC_DEAD", "quoteID": 30 }        // SPECK_QUOTE_ALTERNATE_OPENING_TAG_GASKET_IS_DEAD
@@ -54,6 +58,7 @@
     // RAZOR
     {
         "profileID": 43,
+        "bioIndex": 3,
         "quotes": [
              { "type": "ADVERTISE",  "quoteID": 50 }                                // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_RAZOR
             ,{ "type": "MERC_DEAD",  "quoteID": 31 }                                // SPECK_QUOTE_ALTERNATE_OPENING_TAG_RAZOR_IS_DEAD
@@ -63,6 +68,7 @@
     // FLO
     {
         "profileID": 44,
+        "bioIndex": 4,
         "quotes": [
              { "type": "ADVERTISE",  "quoteID": 51 }                             // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_FLO
             ,{ "type": "CROSS_SELL", "quoteID": 67, "profileID": 40 /* BIFF */ } // SPECK_QUOTE_PLAYERS_HIRES_FLO_SPECK_PLUGS_BIFF
@@ -75,6 +81,7 @@
     // GUMPY
     {
         "profileID": 45,
+        "bioIndex": 5,
         "quotes" : [
              { "type": "ADVERTISE", "quoteID": 52 }             // SPECK_QUOTE_PLAYER_NOT_DOING_ANYTHING_SPECK_SELLS_GUMPY},
             ,{ "type": "MERC_DEAD", "quoteID": 35 }             // SPECK_QUOTE_ALTERNATE_OPENING_TAG_GUMPY_IS_DEAD
@@ -83,6 +90,7 @@
     // BUBBA
     {
         "profileID": 50,
+        "bioIndex": 10,
         "minTotalSpending": 5000,
         "minDays": 8,
         "quotes" : [
@@ -97,6 +105,7 @@
          * We will handle his relapse in the code, and we will replace the profileID with LARRY_DRUNK (47)
          */
         "profileID": 46,
+        "bioIndex": 6,
         "minTotalSpending": 10000,
         "minDays": 15,
         "quotes" : [
@@ -108,6 +117,7 @@
     // NUMB
     {
         "profileID": 49,
+        "bioIndex": 9,
         "minTotalSpending": 15000,
         "minDays": 20,
         "quotes" : [
@@ -118,6 +128,7 @@
     // COUGAR
     {
         "profileID": 48,
+        "bioIndex": 8,
         "minTotalSpending": 20000,
         "minDays": 25,
         "quotes" : [

--- a/src/externalized/mercs/MERCListingModel.cc
+++ b/src/externalized/mercs/MERCListingModel.cc
@@ -3,20 +3,21 @@
 #include "Soldier_Control.h"
 #include <set>
 #include <string_theory/format>
+#include <utility>
 
 MERCListingModel::MERCListingModel(uint8_t index_, uint8_t profileID_, uint8_t bioIndex_,
 	uint32_t minTotalSpending_, uint32_t minDays_, 
 	std::vector<SpeckQuote> quotes_
 	) : index(index_), profileID(profileID_), bioIndex(bioIndex_),
 	    minTotalSpending(minTotalSpending_), minDays(minDays_),
-	    quotes(quotes_) {}
+	    quotes(std::move(quotes_)) {}
 
 bool MERCListingModel::isAvailableAtStart() const
 {
 	return this->minDays == 0 && this->minTotalSpending == 0;
 }
 
-const std::vector<SpeckQuote> MERCListingModel::getQuotesByType(SpeckQuoteType type) const
+std::vector<SpeckQuote> MERCListingModel::getQuotesByType(SpeckQuoteType type) const
 {
 	std::vector<SpeckQuote> filtered;
 	for (auto q : quotes)
@@ -61,7 +62,7 @@ MERCListingModel* MERCListingModel::deserialize(uint8_t index, const rapidjson::
 
 }
 
-void MERCListingModel::validateData(std::vector<const MERCListingModel*> models)
+void MERCListingModel::validateData(const std::vector<const MERCListingModel*>& models)
 {
 	std::set<uint8_t> uniqueProfileIDs;
 	for (auto m : models)
@@ -83,7 +84,7 @@ void MERCListingModel::validateData(std::vector<const MERCListingModel*> models)
 
 	for (auto m : models)
 	{
-		for (auto quote : m->getQuotesByType(SpeckQuoteType::CROSS_SELL))
+		for (const auto& quote : m->getQuotesByType(SpeckQuoteType::CROSS_SELL))
 		{
 			// Check if related merc is set
 			if (!quote->relatedMercID)

--- a/src/externalized/mercs/MERCListingModel.cc
+++ b/src/externalized/mercs/MERCListingModel.cc
@@ -4,10 +4,10 @@
 #include <set>
 #include <string_theory/format>
 
-MERCListingModel::MERCListingModel(uint8_t index_, uint8_t profileID_, 
+MERCListingModel::MERCListingModel(uint8_t index_, uint8_t profileID_, uint8_t bioIndex_,
 	uint32_t minTotalSpending_, uint32_t minDays_, 
 	std::vector<SpeckQuote> quotes_
-	) : index(index_), profileID(profileID_),
+	) : index(index_), profileID(profileID_), bioIndex(bioIndex_),
 	    minTotalSpending(minTotalSpending_), minDays(minDays_),
 	    quotes(quotes_) {}
 
@@ -53,6 +53,7 @@ MERCListingModel* MERCListingModel::deserialize(uint8_t index, const rapidjson::
 	return new MERCListingModel(
 		index,
 		r.GetUInt("profileID"),
+		r.GetUInt("bioIndex"),
 		r.getOptionalInt("minTotalSpending"), 
 		r.getOptionalInt("minDays"),
 		quotes

--- a/src/externalized/mercs/MERCListingModel.h
+++ b/src/externalized/mercs/MERCListingModel.h
@@ -10,12 +10,13 @@ typedef std::shared_ptr<MERCSpeckQuote> SpeckQuote;
 class MERCListingModel
 {
 public:
-	MERCListingModel(uint8_t index_, uint8_t profileID_, uint32_t minTotalSpending_, uint32_t mindays, std::vector<SpeckQuote> quotes_);
+	MERCListingModel(uint8_t index_, uint8_t profileID_, uint8_t bioIndex_, uint32_t minTotalSpending_, uint32_t mindays, std::vector<SpeckQuote> quotes_);
 	const uint8_t index;
 
 	// If we are coming from M.E.R.C., we should always use the GetProfileIDFromMERCListing 
 	// instead, due to the hard-coded LARRY logic
 	const uint8_t profileID;
+	const uint8_t bioIndex;
 
 	const uint32_t minTotalSpending;
 	const uint32_t minDays;

--- a/src/externalized/mercs/MERCListingModel.h
+++ b/src/externalized/mercs/MERCListingModel.h
@@ -22,10 +22,10 @@ public:
 	const uint32_t minDays;
 
 	bool isAvailableAtStart() const;
-	const std::vector<SpeckQuote> getQuotesByType(SpeckQuoteType type) const;
+	std::vector<SpeckQuote> getQuotesByType(SpeckQuoteType type) const;
 
 	static MERCListingModel* deserialize(uint8_t index, const rapidjson::Value& json);
-	static void validateData(std::vector<const MERCListingModel*>);
+	static void validateData(const std::vector<const MERCListingModel*>&);
 private:
-	std::vector<SpeckQuote> quotes;
+	const std::vector<SpeckQuote> quotes;
 };

--- a/src/game/Laptop/Mercs.cc
+++ b/src/game/Laptop/Mercs.cc
@@ -632,7 +632,7 @@ ProfileID GetProfileIDFromMERCListing(const MERCListingModel* listing)
 ProfileID GetProfileIDFromMERCListingIndex(UINT8 ubMercIndex)
 {
 	auto mercsListing = GCM->getMERCListings();
-	return GetProfileIDFromMERCListing(mercsListing[ubMercIndex]);
+	return GetProfileIDFromMERCListing(mercsListing.at(ubMercIndex));
 }
 
 static void InitMercVideoFace(void)

--- a/src/game/Laptop/Mercs_Files.cc
+++ b/src/game/Laptop/Mercs_Files.cc
@@ -197,7 +197,7 @@ void RenderMercsFiles()
 	BltVideoObject(FRAME_BUFFER, guiStatsBox,    0, MERC_FILES_STATS_BOX_X,    MERC_FILES_STATS_BOX_Y);
 	BltVideoObject(FRAME_BUFFER, guiBioBox,      0, MERC_FILES_BIO_BOX_X + 1,  MERC_FILES_BIO_BOX_Y);
 
-	const MERCListingModel*  l   = GCM->getMERCListings()[gubCurMercIndex];
+	const MERCListingModel*  l   = GCM->getMERCListings().at(gubCurMercIndex);
 	ProfileID         const  pid = GetProfileIDFromMERCListing(l);
 	MERCPROFILESTRUCT const& p   = GetProfile(pid);
 

--- a/src/game/Laptop/Mercs_Files.cc
+++ b/src/game/Laptop/Mercs_Files.cc
@@ -18,6 +18,8 @@
 #include "JA2Types.h"
 #include "Laptop.h"
 #include "LaptopSave.h"
+#include "MERCListingModel.h"
+#include "MercPortrait.h"
 #include "Merc_Hiring.h"
 #include "MercPortrait.h"
 #include "Mercs.h"
@@ -195,7 +197,8 @@ void RenderMercsFiles()
 	BltVideoObject(FRAME_BUFFER, guiStatsBox,    0, MERC_FILES_STATS_BOX_X,    MERC_FILES_STATS_BOX_Y);
 	BltVideoObject(FRAME_BUFFER, guiBioBox,      0, MERC_FILES_BIO_BOX_X + 1,  MERC_FILES_BIO_BOX_Y);
 
-	ProfileID         const  pid = GetProfileIDFromMERCListingIndex(gubCurMercIndex);
+	const MERCListingModel*  l   = GCM->getMERCListings()[gubCurMercIndex];
+	ProfileID         const  pid = GetProfileIDFromMERCListing(l);
 	MERCPROFILESTRUCT const& p   = GetProfile(pid);
 
 	//Display the mercs face
@@ -205,7 +208,7 @@ void RenderMercsFiles()
 	DrawTextToScreen(p.zName, MERC_NAME_X, MERC_NAME_Y, 0, MERC_NAME_FONT, MERC_NAME_COLOR, FONT_MCOLOR_BLACK, LEFT_JUSTIFIED);
 
 	//Load and display the mercs bio
-	LoadAndDisplayMercBio((UINT8)(pid - BIFF));
+	LoadAndDisplayMercBio(l->bioIndex);
 
 	//Display the mercs statistic
 	DisplayMercsStats(p);


### PR DESCRIPTION
The index/offset of M.E.R.C. profile text in `mercbios.edt` was determined by `profileID - BIFF`. It assumes the mercs are in a continuous range after `BIFF`. 

This PR externalizes the bio offset in JSON.