### PR TITLE
Android asset manager rehault - Part 1

### DIFF
--- a/android/app/src/main/java/io/github/ja2stracciatella/LauncherActivity.kt
+++ b/android/app/src/main/java/io/github/ja2stracciatella/LauncherActivity.kt
@@ -28,7 +28,7 @@ class LauncherActivity : AppCompatActivity() {
     private val jsonFormat = Json {
         prettyPrint = true
     }
-    private val ja2JsonFilename = "ja2.json"
+    private val ja2JsonFilename = ".ja2/ja2.json"
     private val gameDirKey = "game_dir"
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -740,6 +740,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "json_comments 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.77 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "md-5 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rust/stracciatella/Cargo.toml
+++ b/rust/stracciatella/Cargo.toml
@@ -40,7 +40,8 @@ features = ["std", "fileapi"]
 
 [target.'cfg(target_os = "android")'.dependencies.android_logger]
 version = "0.9"
-
+[target.'cfg(target_os = "android")'.dependencies.lazy_static]
+version = "1.4"
 [target.'cfg(target_os = "android")'.dependencies.jni]
 version = "0.14"
 [target.'cfg(target_os = "android")'.dependencies.ndk]

--- a/rust/stracciatella/src/android.rs
+++ b/rust/stracciatella/src/android.rs
@@ -1,9 +1,49 @@
-use jni::{errors::Result, objects::JObject, JNIEnv};
+use std::sync::RwLock;
+use std::path::PathBuf;
+
+use jni::{errors::{Result, ErrorKind}, objects::JObject, JNIEnv};
+use lazy_static::lazy_static;
 use ndk::asset::AssetManager;
 
+struct GlobalJNIEnv(pub *mut jni::sys::JNIEnv);
+
+unsafe impl Sync for GlobalJNIEnv {}
+
+unsafe impl Send for GlobalJNIEnv {}
+
+lazy_static! {
+    /// This is the global jni env
+    /// When the engine is powered up, we expect this to be set once by calling set_global_jni_env.
+    ///
+    /// We expect the passed pointer to be valid for all subsequent calls that use jni.
+    static ref GLOBAL_JNI_ENV: RwLock<GlobalJNIEnv> = {
+        RwLock::new(GlobalJNIEnv(std::ptr::null_mut()))
+    };
+}
+
+/// Set the global jni env for the stracciatella lib.
+///
+/// This should be called with the SDL JNI env
+pub fn set_global_jni_env(jni_env: *mut jni::sys::JNIEnv) -> Result<()> {
+    if jni_env.is_null() {
+        return Err(ErrorKind::NullPtr("jni_env").into());
+    }
+    let mut global_jni_env = GLOBAL_JNI_ENV.try_write().map_err(|_| ErrorKind::TryLock)?;
+    global_jni_env.0 = jni_env;
+    Ok(())
+}
+
+/// Gets the rust version of the current global jni env
+pub fn get_global_jni_env() -> Result<jni::JNIEnv<'static>> {
+    let global_jni_env = GLOBAL_JNI_ENV.try_read().map_err(|_| ErrorKind::TryLock)?;
+    unsafe {
+        JNIEnv::from_raw(global_jni_env.0)
+    }
+}
+
 /// Get current application context form JNI env
-#[cfg(target_os = "android")]
-pub fn get_application_context(jni_env: JNIEnv<'_>) -> Result<JObject> {
+pub fn get_application_context() -> Result<JObject<'static>> {
+    let jni_env = get_global_jni_env()?;
     let current_activity_thread = jni_env
         .call_static_method(
             "android/app/ActivityThread",
@@ -30,10 +70,28 @@ pub fn get_application_context(jni_env: JNIEnv<'_>) -> Result<JObject> {
         .l()
 }
 
+/// Find ja2 stracciatella configuration directory for android
+pub fn get_android_app_dir() -> Result<PathBuf> {
+    let jni_env = crate::android::get_global_jni_env()?;
+    let context = crate::android::get_application_context()?;
+    let files_dir = jni_env
+        .call_method(context, "getFilesDir", "()Ljava/io/File;", &[])?
+        .l()?;
+    let path = jni_env.get_string(
+        jni_env
+            .call_method(files_dir, "getAbsolutePath", "()Ljava/lang/String;", &[])?
+            .l()?
+            .into(),
+    )?;
+    let path_string: String = path.into();
+
+    Ok(PathBuf::from(&path_string))
+}
+
 /// Get asset manager from JNI env
-#[cfg(target_os = "android")]
-pub fn get_asset_manager(jni_env: JNIEnv<'_>) -> Result<AssetManager> {
-    let context = get_application_context(jni_env.clone())?;
+pub fn get_asset_manager() -> Result<AssetManager> {
+    let jni_env = get_global_jni_env()?;
+    let context = get_application_context()?;
     let asset_manager = jni_env
         .call_method(
             context,

--- a/rust/stracciatella/src/config/stracciatella_home.rs
+++ b/rust/stracciatella/src/config/stracciatella_home.rs
@@ -1,7 +1,5 @@
 use std::path::PathBuf;
 
-use log::error;
-
 /// Find ja2 stracciatella configuration directory inside the user's home directory
 pub fn find_stracciatella_home() -> Result<PathBuf, String> {
     use crate::fs::resolve_existing_components;
@@ -12,7 +10,7 @@ pub fn find_stracciatella_home() -> Result<PathBuf, String> {
     let base = match crate::android::get_android_app_dir() {
         Ok(v) => Some(v),
         Err(e) => {
-            error!("JNI Error: {}", e);
+            log::error!("JNI Error: {}", e);
             None
         }
     };

--- a/rust/stracciatella/src/vfs/android.rs
+++ b/rust/stracciatella/src/vfs/android.rs
@@ -7,7 +7,6 @@ use std::io;
 use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 
-use jni::JNIEnv;
 use ndk::asset::{Asset, AssetManager};
 
 use crate::android::get_asset_manager;
@@ -35,8 +34,8 @@ pub struct AssetManagerFsFile {
 
 impl AssetManagerFs {
     /// Creates a new virtual filesystem.
-    pub fn new(base_path: &Path, jni_env: JNIEnv) -> io::Result<AssetManagerFs> {
-        let asset_manager = get_asset_manager(jni_env.clone()).map_err(|err| {
+    pub fn new(base_path: &Path) -> io::Result<AssetManagerFs> {
+        let asset_manager = get_asset_manager().map_err(|err| {
             io::Error::new(
                 io::ErrorKind::Other,
                 format!(

--- a/rust/stracciatella/src/vfs/android.rs
+++ b/rust/stracciatella/src/vfs/android.rs
@@ -60,19 +60,62 @@ impl AssetManagerFs {
     /// Opens a file in the filesystem.
     /// This is currently very basic and not case insensitive
     pub fn open(&self, file_path: &Nfc) -> io::Result<AssetManagerFsFile> {
-        let asset_path = Self::path_to_cstring(&self.base_path.join(file_path.as_str()))?;
-        let asset = self.asset_manager.open(&asset_path).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                format!("AssetManagerFs: Asset not found: `{:?}`", asset_path),
-            )
-        })?;
+        let mut candidates = vec![self.base_path.to_owned()];
 
-        Ok(AssetManagerFsFile {
-            file_path: file_path.clone(),
-            base_path: self.base_path.clone(),
-            file: asset,
-        })
+        for want in file_path.split('/') {
+            let mut next = Vec::new();
+            if want == "." || want == ".." {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "special path components are not supported",
+                ));
+            }
+            for candidate in candidates {
+                let candidate_cstring = Self::path_to_cstring(&candidate)?;
+                let dir_contents = crate::android::list_asset_dir(&candidate).map_err(|e| {
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        format!("AssetManagerFs: JNI Error: `{:?}`", e),
+                    )
+                })?;
+                if self.asset_manager.open_dir(&candidate_cstring).is_some() {
+                    for entry in dir_contents {
+                        let is_match = entry
+                            .file_name()
+                            .and_then(|x| x.to_str())
+                            .map(|x| want == Nfc::caseless(x).as_str())
+                            .unwrap_or(false);
+                        if is_match {
+                            next.push(candidate.join(&entry));
+                        }
+                    }
+                }
+            }
+            candidates = next;
+            if candidates.is_empty() {
+                break;
+            }
+        }
+        candidates.sort();
+
+        for candidate in candidates {
+            let candidate_cstring = Self::path_to_cstring(&candidate)?;
+            if let Some(file) = self.asset_manager.open(&candidate_cstring) {
+                return Ok(AssetManagerFsFile {
+                    file_path: file_path.clone(),
+                    base_path: self.base_path.clone(),
+                    file,
+                });
+            }
+        }
+
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "AssetManagerFs: Asset not found: `{:?}`",
+                self.base_path.join(&file_path.as_str())
+            ),
+        ))
     }
 
     /// Maps a path to CString for asset manager

--- a/rust/stracciatella/src/vfs/mod.rs
+++ b/rust/stracciatella/src/vfs/mod.rs
@@ -14,8 +14,6 @@ use std::io;
 use std::io::{ErrorKind, SeekFrom};
 use std::path::{Path, PathBuf};
 
-#[cfg(target_os = "android")]
-use jni::JNIEnv;
 use log::{info, warn};
 
 use crate::unicode::Nfc;
@@ -89,9 +87,9 @@ impl Vfs {
 
     /// Adds an overlay filesystem backed by android assets
     #[cfg(target_os = "android")]
-    pub fn add_android_assets(&mut self, path: &Path, jni_env: JNIEnv) -> Result<(), VfsInitError> {
+    pub fn add_android_assets(&mut self, path: &Path) -> Result<(), VfsInitError> {
         let asset_manager_fs =
-            android::AssetManagerFs::new(&path, jni_env).map_err(|error| VfsInitError {
+            android::AssetManagerFs::new(&path).map_err(|error| VfsInitError {
                 path: path.to_owned(),
                 error,
             })?;
@@ -129,7 +127,6 @@ impl Vfs {
     pub fn init_from_engine_options(
         &mut self,
         engine_options: &EngineOptions,
-        #[cfg(target_os = "android")] jni_env: JNIEnv<'_>,
     ) -> Result<(), VfsInitError> {
         let vanilla_game_dir = engine_options.vanilla_game_dir.clone();
         let vanilla_data_dir =
@@ -197,7 +194,7 @@ impl Vfs {
         self.add_dir(&externalized_dir)?;
         // On android the externalized dir comes from APK assets
         #[cfg(target_os = "android")]
-        self.add_android_assets(&Path::new(EXTERNALIZED_DIR), jni_env.clone())?;
+        self.add_android_assets(&Path::new(EXTERNALIZED_DIR))?;
 
         // Next is vanilla data dir (required)
         self.add_dir(&vanilla_data_dir)?;

--- a/rust/stracciatella_c_api/src/c/config.rs
+++ b/rust/stracciatella_c_api/src/c/config.rs
@@ -2,8 +2,6 @@
 //!
 //! [`stracciatella::config`]: ../../stracciatella/config/index.html
 
-#[cfg(target_os = "android")]
-use jni;
 use std::ptr;
 
 use stracciatella::config::{
@@ -61,36 +59,8 @@ pub extern "C" fn EngineOptions_destroy(ptr: *mut EngineOptions) {
 /// Gets the `EngineOptions.stracciatella_home` path.
 /// The caller is responsible for the returned memory.
 #[no_mangle]
-#[cfg(not(target_os = "android"))]
 pub extern "C" fn EngineOptions_getStracciatellaHome() -> *mut c_char {
     let stracciatella_home = find_stracciatella_home();
-
-    forget_rust_error();
-    match stracciatella_home {
-        Ok(stracciatella_home) => {
-            let stracciatella_home = c_string_from_path_or_panic(&stracciatella_home);
-            stracciatella_home.into_raw()
-        }
-        Err(e) => {
-            remember_rust_error(format!("EngineOptions_getStracciatellaHome: {:?}", e));
-            std::ptr::null_mut()
-        }
-    }
-}
-
-/// Gets the `EngineOptions.stracciatella_home` path.
-/// The caller is responsible for the returned memory.
-/// This is the android version that reads stracciatella home via JNI
-///
-/// # Safety
-///
-/// This function does not do any safety chacks for the passed pointers
-#[no_mangle]
-#[cfg(target_os = "android")]
-pub unsafe extern "C" fn EngineOptions_getStracciatellaHome(
-    ptr: *mut jni::sys::JNIEnv,
-) -> *mut c_char {
-    let stracciatella_home = jni::JNIEnv::from_raw(ptr).and_then(find_stracciatella_home);
 
     forget_rust_error();
     match stracciatella_home {

--- a/rust/stracciatella_c_api/src/c/misc.rs
+++ b/rust/stracciatella_c_api/src/c/misc.rs
@@ -15,6 +15,17 @@ use stracciatella::guess::guess_vanilla_version;
 use crate::c::common::*;
 use crate::c::vec::VecCString;
 
+/// Sets the global JNI env for Android
+#[no_mangle]
+#[cfg(target_os = "android")]
+pub extern "C" fn setGlobalJniEnv(jni_env: *mut jni::sys::JNIEnv) -> bool {
+    forget_rust_error();
+    if let Err(e) = stracciatella::android::set_global_jni_env(jni_env) {
+        remember_rust_error(format!("setGlobalJniEnv: {}", e))
+    }
+    no_rust_error()
+}
+
 /// Deletes a CString.
 /// The caller is no longer responsible for the memory.
 #[no_mangle]
@@ -69,7 +80,6 @@ pub extern "C" fn findPathFromAssetsDir(
 /// If test_exists is true, it makes sure the path exists.
 /// The caller is responsible for the returned memory.
 #[no_mangle]
-#[cfg(not(target_os = "android"))]
 pub extern "C" fn findPathFromStracciatellaHome(
     engine_options: *mut EngineOptions,
     path: *const c_char,

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -197,17 +197,9 @@ DefaultContentManager::DefaultContentManager(GameVersion gameVersion,
 	m_samSitesAirControl = NULL;
 }
 
-#ifdef __ANDROID__
-void DefaultContentManager::init(EngineOptions* engine_options, JNIEnv* jniEnv)
-#else
 void DefaultContentManager::init(EngineOptions* engine_options)
-#endif
 {
-	#ifdef __ANDROID__
-	auto succeeded = Vfs_init_from_engine_options(m_vfs.get(), engine_options, jniEnv);
-	#else
 	auto succeeded = Vfs_init_from_engine_options(m_vfs.get(), engine_options);
-	#endif
 	if (!succeeded) {
 		RustPointer<char> err{ getRustError() };
 		auto error = ST::format("Failed to build virtual file system (VFS): {}", err.get());

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -29,11 +29,7 @@ public:
 
 	/// Called after construction.
 	/// @throw runtime_error
-	#ifdef __ANDROID__
-	virtual void init(EngineOptions* engine_options, JNIEnv* jniEnv);
-	#else
 	virtual void init(EngineOptions* engine_options);
-	#endif
 
 	/** Load the game data. */
 	bool loadGameData();

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -349,13 +349,12 @@ int main(int argc, char* argv[])
 
 		#ifdef __ANDROID__
 		JNIEnv* jniEnv = (JNIEnv*)SDL_AndroidGetJNIEnv();
-		if (jniEnv == NULL) {
-			SLOGE("Failed to get jni env");
+		
+		if (setGlobalJniEnv(jniEnv) == FALSE) {
+			SLOGE("Failed to set global jni env");
 		}
-		RustPointer<char> configFolderPath(EngineOptions_getStracciatellaHome(jniEnv));
-		#else
-		RustPointer<char> configFolderPath(EngineOptions_getStracciatellaHome());
 		#endif
+		RustPointer<char> configFolderPath(EngineOptions_getStracciatellaHome());
 		if (configFolderPath.get() == NULL) {
 			auto rustError = getRustError();
 			if (rustError != NULL) {
@@ -487,11 +486,7 @@ int main(int argc, char* argv[])
 			SLOGI("------------------------------------------------------------------------------");
 		}
 
-		#ifdef __ANDROID__
-		cm->init(params.get(), jniEnv);
-		#else
 		cm->init(params.get());
-		#endif
 
 		if(!cm->loadGameData())
 		{

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -351,7 +351,11 @@ int main(int argc, char* argv[])
 		JNIEnv* jniEnv = (JNIEnv*)SDL_AndroidGetJNIEnv();
 		
 		if (setGlobalJniEnv(jniEnv) == FALSE) {
-			SLOGE("Failed to set global jni env");
+			auto rustError = getRustError();
+			if (rustError != NULL) {
+				SLOGE("Failed to set global JNI env for Android: %s", rustError);
+			}
+			return EXIT_FAILURE;
 		}
 		#endif
 		RustPointer<char> configFolderPath(EngineOptions_getStracciatellaHome());
@@ -360,6 +364,7 @@ int main(int argc, char* argv[])
 			if (rustError != NULL) {
 				SLOGE("Failed to find home directory: %s", rustError);
 			}
+			return EXIT_FAILURE;
 		}
 
 		ST::string exeFolder = FileMan::getParentPath(argv[0], true);


### PR DESCRIPTION
This fixes 2 out of 4 issues in #1248.

- Makes Android Asset VFS case insensitive
- Stores pointer to JNI globally in Rust

One thing to note is thatI needed to implement case insensitive matching via JNI, as it is not possible to list asset directories through the NDK asset manager. It can only list files in directories not directories.

Supporting mods from assets is gonna be a little trickier, as mods may also contain SLF files, so we have an SLF VFS within another VFS.