### PR TITLE
Externalizing I.M.P. initial level

### DIFF
--- a/assets/externalized/imp.json
+++ b/assets/externalized/imp.json
@@ -1,6 +1,14 @@
 {
+    // Experience level of a new I.M.P. merc
+    // vanilla setting: 1
+    "starting_level": 1,
+
+    // Basic inventory items of any new I.M.P merc
     "inventory": ["CANTEEN", "FLAK_JACKET"],
 
+    // Additional inventory items of a good shooter (marksmanship >= 80)
     "if_good_shooter": ["MP5K", "CLIP9_30", "CLIP9_30"],
+
+    // Additional inventory items of a normal shooter (marksmanship < 80)
     "if_normal_shooter": ["BERETTA_93R", "CLIP9_15", "CLIP9_15", "CLIP9_15"]
 }

--- a/src/externalized/policy/DefaultIMPPolicy.cc
+++ b/src/externalized/policy/DefaultIMPPolicy.cc
@@ -1,6 +1,7 @@
 #include "DefaultIMPPolicy.h"
 
 #include "ItemSystem.h"
+#include "JsonObject.h"
 #include "JsonUtility.h"
 
 #include <string_theory/string>
@@ -19,10 +20,18 @@ static void readListOfItems(rapidjson::Value &value, std::vector<const ItemModel
 
 DefaultIMPPolicy::DefaultIMPPolicy(rapidjson::Document *json, const ItemSystem *itemSystem)
 {
+	JsonObjectReader r(*json);
+	m_startingLevel = r.getOptionalUInt("starting_level", 1);
+
 	readListOfItems((*json)["inventory"], m_inventory, itemSystem);
 
 	readListOfItems((*json)["if_good_shooter"], m_goodShooterItems, itemSystem);
 	readListOfItems((*json)["if_normal_shooter"], m_normalShooterItems, itemSystem);
+}
+
+uint8_t DefaultIMPPolicy::getStartingLevel() const
+{
+	return m_startingLevel;
 }
 
 const std::vector<const ItemModel *> & DefaultIMPPolicy::getInventory() const

--- a/src/externalized/policy/DefaultIMPPolicy.h
+++ b/src/externalized/policy/DefaultIMPPolicy.h
@@ -12,11 +12,13 @@ class DefaultIMPPolicy : public IMPPolicy
 public:
 	DefaultIMPPolicy(rapidjson::Document *json, const ItemSystem *itemSystem);
 
+	virtual uint8_t getStartingLevel() const;
 	virtual const std::vector<const ItemModel *> & getInventory() const;
 	virtual const std::vector<const ItemModel *> & getGoodShooterItems() const;
 	virtual const std::vector<const ItemModel *> & getNormalShooterItems() const;
 
 protected:
+	uint8_t m_startingLevel;
 	std::vector<const ItemModel *> m_inventory;
 	std::vector<const ItemModel *> m_goodShooterItems;
 	std::vector<const ItemModel *> m_normalShooterItems;

--- a/src/externalized/policy/IMPPolicy.h
+++ b/src/externalized/policy/IMPPolicy.h
@@ -9,6 +9,7 @@ class ItemSystem;
 class IMPPolicy
 {
 public:
+	virtual uint8_t getStartingLevel() const = 0;
 	virtual const std::vector<const ItemModel *> & getInventory() const = 0;
 	virtual const std::vector<const ItemModel *> & getGoodShooterItems() const = 0;
 	virtual const std::vector<const ItemModel *> & getNormalShooterItems() const = 0;

--- a/src/game/Laptop/IMP_Compile_Character.cc
+++ b/src/game/Laptop/IMP_Compile_Character.cc
@@ -4,6 +4,7 @@
 #include "Debug.h"
 #include "GameInstance.h"
 #include "GamePolicy.h"
+#include "IMPPolicy.h"
 #include "ContentManager.h"
 #include "Render_Dirty.h"
 #include "IMP_Portraits.h"
@@ -57,7 +58,7 @@ void CreateACharacterFromPlayerEnteredStats(void)
 
 	p.bAttitude = iAttitude;
 
-	p.bExpLevel = 1;
+	p.bExpLevel = GCM->getIMPPolicy()->getStartingLevel();
 
 	// set time away
 	p.bMercStatus = 0;


### PR DESCRIPTION
For #665. 

Allows I.M.P. mercs to start at higher levels, by changing the settings at `imp.json`. 

Added a field `initial_level` which has default of 1. 