### PR TITLE
Implement primitive value boxing for Lua listeners

### DIFF
--- a/src/externalized/scripting/FunctionsLibrary.h
+++ b/src/externalized/scripting/FunctionsLibrary.h
@@ -51,7 +51,7 @@ extern Observable<> BeforePrepareSector;
  * @param fSkipDamage damage processing will be skipped if it is set to TRUE
  * @ingroup observables
  */
-extern Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT32, BOOLEAN*> BeforeStructureDamaged;
+extern Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT32, BOOLEAN_S*> BeforeStructureDamaged;
 
 /**
   * Callback just after a structure has just been damaged by explosives

--- a/src/externalized/scripting/ScriptingExtensionsLua.cc
+++ b/src/externalized/scripting/ScriptingExtensionsLua.cc
@@ -198,6 +198,13 @@ static void RegisterUserTypes()
 
 		"ubBattleSoundID", &SOLDIERTYPE::ubBattleSoundID
 		);
+
+	lua.new_usertype<BOOLEAN_S>("BOOLEAN_S",
+		"val", &BOOLEAN_S::val
+		);
+	lua.new_usertype<UINT8_S>("UINT8_S",
+		"val", &UINT8_S::val
+		);
 }
 
 static void RegisterGlobals()
@@ -292,7 +299,7 @@ static void _RegisterListener(std::string observable, std::string luaFunc, ST::s
 	}
 
 	if      (observable == "OnStructureDamaged")         OnStructureDamaged.addListener(key, wrap<INT16, INT16, INT8, INT16, STRUCTURE*, UINT8, BOOLEAN>(luaFunc));
-	else if (observable == "BeforeStructureDamaged")     BeforeStructureDamaged.addListener(key, wrap<INT16, INT16, INT8, INT16, STRUCTURE*, UINT32, BOOLEAN*>(luaFunc));
+	else if (observable == "BeforeStructureDamaged")     BeforeStructureDamaged.addListener(key, wrap<INT16, INT16, INT8, INT16, STRUCTURE*, UINT32, BOOLEAN_S*>(luaFunc));
 	else if (observable == "OnAirspaceControlUpdated")   OnAirspaceControlUpdated.addListener(key, wrap<>(luaFunc));
 	else if (observable == "BeforePrepareSector")        BeforePrepareSector.addListener(key, wrap<>(luaFunc));
 	else if (observable == "OnSoldierCreated")           OnSoldierCreated.addListener(key, wrap<SOLDIERTYPE*>(luaFunc));

--- a/src/game/Tactical/End_Game.cc
+++ b/src/game/Tactical/End_Game.cc
@@ -122,7 +122,7 @@ void ChangeO3SectorStatue( BOOLEAN fFromExplosion )
 	RecompileLocalMovementCostsFromRadius( 13830, 5 );
 }
 
-void HandleStatueDamaged(INT16 sectorX, INT16 sectorY, INT8 sectorZ, INT16 sGridNo, STRUCTURE *s, UINT32 uiDist, BOOLEAN *skipDamage)
+void HandleStatueDamaged(INT16 sectorX, INT16 sectorY, INT8 sectorZ, INT16 sGridNo, STRUCTURE *s, UINT32 uiDist, BOOLEAN_S *skipDamage)
 {
 	/* ATE: Check for O3 statue for special damage
 	 * Note, we do this check every time explosion goes off in game, but it's an

--- a/src/game/Tactical/End_Game.h
+++ b/src/game/Tactical/End_Game.h
@@ -1,7 +1,7 @@
 #ifndef __ENDGAME_H
 #define __ENDGAME_H
 
-void HandleStatueDamaged(INT16 sectorX, INT16 sectorY, INT8 sectorZ, INT16 sGridNo, STRUCTURE *s, UINT32 uiDist, BOOLEAN *skipDamage);
+void HandleStatueDamaged(INT16 sectorX, INT16 sectorY, INT8 sectorZ, INT16 sGridNo, STRUCTURE *s, UINT32 uiDist, BOOLEAN_S *skipDamage);
 void ChangeO3SectorStatue( BOOLEAN fFromExplosion );
 
 void BeginHandleDeidrannaDeath( SOLDIERTYPE *pKillerSoldier, INT16 sGridNo, INT8 bLevel );

--- a/src/game/TileEngine/Explosion_Control.cc
+++ b/src/game/TileEngine/Explosion_Control.cc
@@ -101,7 +101,7 @@ static SOLDIERTYPE* gPersonToSetOffExplosions           = 0;
 #define NUM_EXPLOSION_SLOTS 100
 static EXPLOSIONTYPE gExplosionData[NUM_EXPLOSION_SLOTS];
 
-Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT32, BOOLEAN*> BeforeStructureDamaged = {};
+Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT32, BOOLEAN_S*> BeforeStructureDamaged = {};
 Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT8, BOOLEAN> OnStructureDamaged = {};
 
 static EXPLOSIONTYPE* GetFreeExplosion(void)
@@ -359,7 +359,7 @@ static STRUCTURE* RemoveOnWall(GridNo const grid_no, StructureFlags const flags,
 
 static bool ExplosiveDamageStructureAtGridNo(STRUCTURE* const pCurrent, STRUCTURE** const ppNextCurrent, INT16 const grid_no, INT16 const wound_amt, UINT32 const uiDist, BOOLEAN* const pfRecompileMovementCosts, BOOLEAN const only_walls, SOLDIERTYPE* const owner, INT8 const level)
 {
-	BOOLEAN skipDamage = false;
+	BOOLEAN_S skipDamage = false;
 	BeforeStructureDamaged(gWorldSectorX, gWorldSectorY, gbWorldSectorZ, grid_no, pCurrent, uiDist, &skipDamage);
 	if (skipDamage)
 	{

--- a/src/game/TileEngine/Explosion_Control.h
+++ b/src/game/TileEngine/Explosion_Control.h
@@ -59,7 +59,7 @@ extern UINT8 gubElementsOnExplosionQueue;
 extern BOOLEAN gfExplosionQueueActive;
 
 
-extern Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT32, BOOLEAN*> BeforeStructureDamaged;
+extern Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT32, BOOLEAN_S*> BeforeStructureDamaged;
 extern Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT8, BOOLEAN> OnStructureDamaged;
 
 void IgniteExplosion(SOLDIERTYPE* owner, INT16 z, INT16 sGridNo, UINT16 item, INT8 level);

--- a/src/sgp/Types.h
+++ b/src/sgp/Types.h
@@ -163,4 +163,25 @@ typedef SGPFile* HWFILE;
 #	define ENUM_BITSET(type)
 #endif
 
+namespace _Types
+{
+	// Object wrapper of a single primitive value.
+	// This is used to implement "pass by reference" of Lua function arguments.
+	// Usage:
+	// - In C++ it can be used as the underlying type
+	// - In Lua, the value is to be read or written with the `.val` member.
+	template<typename T>
+	struct BoxedValue
+	{
+		BoxedValue<T>(T v) : val(v) {};
+
+		operator T() const { return val; }
+
+		T val;
+	};
+}
+
+typedef _Types::BoxedValue<BOOLEAN> BOOLEAN_S;
+typedef _Types::BoxedValue<UINT8>   UINT8_S;
+
 #endif


### PR DESCRIPTION
# Motivation

The observable [BeforeStructureDamaged](https://github.com/ja2-stracciatella/ja2-stracciatella/blob/63eb7a5b1a066db795dcb314ae72184539043f0b/src/game/TileEngine/Explosion_Control.cc#L363) is an example of sharing a variable with all listeners via a pass-by-pointer argument.

But such a simple pointer to primitive does not work as intended with Lua. In Lua, all primitives arguments (including pointers to primitive types) are always passed by value and all complex types are passed by reference. To implement pass-by-reference, I have created a simple struct to wrap around the primitive type. You can think of it like the variable boxing in [Java](https://docs.oracle.com/javase/tutorial/java/data/autoboxing.html) or [C#](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/types/boxing-and-unboxing).

# Usage

The wrapper struct (e.g. `BOOLEAN_S` wraps a `BOOLEAN`) is implicitly convertible to and from the underlying data type. So it can used just like the original type. e.g.

```c++
BOOLEAN_S fSomeBoolFlag = true;
if (fSomeBoolFlag) DoSomething();
```

In Lua, it is passed as an user object, and it must be accessed via the `.val` member field.

```lua
function (bool_s_arg)            -- listener to Observable<BOOLEAN_S*> 
    if bool_s_arg.val == 1 then  -- cannot use true/false, since BOOLEAN is uint8_t / unsigned char
        do_something()
    end
    bool_s_arg.val = 0           -- set the value to FALSE and pass back to C++
end
```
