### PR TITLE
Externalizing strategic map secrets

### DIFF
--- a/assets/externalized/strategic-map-movement-costs.json
+++ b/assets/externalized/strategic-map-movement-costs.json
@@ -84,32 +84,5 @@
 	/* N */ [  0,  0, 80, 80, 80, 40, 20, 10,  5,  5,  0,  0,  0,  0,  0,  0 ],
 	/* O */ [  0,  0, 90, 90,  0,  0,  0,  5,  5,  0,  0,  0,  0,  0,  0,  0 ],
 	/* P */ [  0,  0,100,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0 ]
-	],
-	// Maps the traversability rating "short names" into codebase enums. You probably don't need to alter this.
-	"mapping": {
-		"A":  3,   // SAND	
-		"AR": 23,  // SAND_ROAD
-		"C":  20,  // COASTAL
-		"CR": 22,  // COASTAL_ROAD
-		"D":  5,   // DENSE
-		"DR": 19,  // DENSE_ROAD
-		"E":  12,  // EDGEOFWORLD
-		"F":  14,  // FARMLAND
-		"FR": 17,  // FARMLAND_ROAD
-		"G":  9,   // GROUNDBARRIER
-		"H":  8,   // HILLS
-		"HR": 21,  // HILLS_ROAD
-		"N":  10,  // NS_RIVER
-		"P":  2,   // PLAINS
-		"PR": 15,  // PLAINS_ROAD
-		"R":  1,   // ROAD
-		"S":  4,   // SPARSE
-		"SR": 16,  // SPARSE_ROAD
-		"T":  13,  // TROPICS
-		"TR": 18,  // TROPICS_ROAD
-		"W":  6,   // SWAMP
-		"WR": 24,  // SWAMP_ROAD
-		"WT": 7,   // WATER
-		"X":  0   // TOWN
-	}
+	]
 }

--- a/assets/externalized/strategic-map-secrets.json
+++ b/assets/externalized/strategic-map-secrets.json
@@ -1,0 +1,60 @@
+/**
+ * Some sectors contain secret facilities or town that are not known at game start. Once they are found, an indicator
+ * icon is displayed on the strategic map. Secrets can be found by a quest event, or by visiting the sector.
+ *
+ * The sector short description (or the "land type string") is changed and a map icon is added when the secret is found.
+ *
+ * Note that only the first 2 non-SAM secrets are persisted in saves to maintain vanilla save compatability. The base
+ * vanilla game has TIXA as the first and ORTA as the second map secret, followed by 4 secret SAM sites.
+ *
+ * The number of elements and the ordering is important. Changing these may make previous saved games unusable.
+ *
+ * Fields:
+ *   - sector:         The sector where the facility is located. This is used as a key, so one sector can only have at most one secret, so this must be unique within the list
+ *   - isSAMSite:      SAM site has different handling on the strategic map, around airspace display modes. Default is false.
+ *   - secretMapIcon:  The path to the icon to display on the strategic map, after the secret is found. Not used for SAM sites, as they are handled differently.
+ *   - secretLandType: The land type shown in strategic map before the secret is found. See strategic-map-traversibility-ratings for the available types.
+ *   - foundLandType:  Land type after the secret is found.
+ */
+[
+    {
+        "sector": "J9",  // TIXA
+        "secretMapIcon": "interface/prison.sti",
+        "secretLandType": "A",
+        "foundLandType": "X"
+    },
+    {
+        "sector": "K4",  // ORTA
+        "secretMapIcon": "interface/map_item.sti",
+        "secretLandType": "W",
+        "foundLandType": "X"
+    },
+    {
+        "sector": "D2",  // SAM site (Chitzena)
+        "isSAMSite": true,
+        "secretMapIcon": "interface/sam.sti",
+        "secretLandType": "T",
+        "foundLandType": "TROPICS_SAM_SITE"
+    },
+    {
+        "sector": "D15", // SAM site (Drassen)
+        "isSAMSite": true,
+        "secretMapIcon": "interface/sam.sti",
+        "secretLandType": "S",
+        "foundLandType": "SPARSE_SAM_SITE"
+    },
+    {
+        "sector": "I8",  // SAM site (Cambria)
+        "isSAMSite": true,
+        "secretMapIcon": "interface/sam.sti",
+        "secretLandType": "A",
+        "foundLandType": "SAND_SAM_SITE"
+    },
+    {
+        "sector": "N4",  // SAM site (Meduna)
+        "isSAMSite": true,
+        "secretMapIcon": "interface/sam.sti",
+        "secretLandType": "X",
+        "foundLandType": "MEDUNA_SAM_SITE"
+    }
+]

--- a/assets/externalized/strategic-map-secrets.json
+++ b/assets/externalized/strategic-map-secrets.json
@@ -12,7 +12,7 @@
  * Fields:
  *   - sector:         The sector where the facility is located. This is used as a key, so one sector can only have at most one secret, so this must be unique within the list
  *   - isSAMSite:      SAM site has different handling on the strategic map, around airspace display modes. Default is false.
- *   - secretMapIcon:  The path to the icon to display on the strategic map, after the secret is found. Not used for SAM sites, as they are handled differently.
+ *   - secretMapIcon:  The path to the icon to display on the strategic map, after the secret is found. If skipped, there will be no icon on the map. Not used for SAM sites, as they are handled differently.
  *   - secretLandType: The land type shown in strategic map before the secret is found. See strategic-map-traversibility-ratings for the available types.
  *   - foundLandType:  Land type after the secret is found.
  */

--- a/assets/externalized/strategic-map-traversibility-ratings.json
+++ b/assets/externalized/strategic-map-traversibility-ratings.json
@@ -1,0 +1,37 @@
+/*
+ * Maps the traversability rating string names into codebase enums.
+ *
+ * This is not directly used in the codebase, but referenced by other JSON mappings.
+ */
+{
+    /* Short names used in movement costs table */
+    "A":  3,   // SAND
+    "AR": 23,  // SAND_ROAD
+    "C":  20,  // COASTAL
+    "CR": 22,  // COASTAL_ROAD
+    "D":  5,   // DENSE
+    "DR": 19,  // DENSE_ROAD
+    "E":  12,  // EDGEOFWORLD
+    "F":  14,  // FARMLAND
+    "FR": 17,  // FARMLAND_ROAD
+    "G":  9,   // GROUNDBARRIER
+    "H":  8,   // HILLS
+    "HR": 21,  // HILLS_ROAD
+    "N":  10,  // NS_RIVER
+    "P":  2,   // PLAINS
+    "PR": 15,  // PLAINS_ROAD
+    "R":  1,   // ROAD
+    "S":  4,   // SPARSE
+    "SR": 16,  // SPARSE_ROAD
+    "T":  13,  // TROPICS
+    "TR": 18,  // TROPICS_ROAD
+    "W":  6,   // SWAMP
+    "WR": 24,  // SWAMP_ROAD
+    "WT": 7,   // WATER
+    "X":  0,   // TOWN
+    /* Below are used for text display only */
+    "SPARSE_SAM_SITE":  25,
+    "SAND_SAM_SITE":    26,
+    "TROPICS_SAM_SITE": 27,
+    "MEDUNA_SAM_SITE":  28
+}

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -36,6 +36,7 @@ class PatrolGroupModel;
 class SamSiteModel;
 class SamSiteAirControlModel;
 class ShippingDestinationModel;
+class StrategicMapSecretModel;
 class TownModel;
 class UndergroundSectorModel;
 struct AmmoTypeModel;
@@ -155,6 +156,7 @@ public:
 	virtual const std::vector<const SamSiteModel*>& getSamSites() const = 0;
 	virtual const int8_t findSamIDBySector(uint8_t sectorId) const = 0;
 	virtual const SamSiteModel* findSamSiteBySector(uint8_t sectorId) const = 0;
+	virtual const std::vector<const StrategicMapSecretModel*>& getMapSecrets() const = 0;
 
 	/* returns the index of the controlling SAM site , or -1 if sector is not covered */
 	virtual const int8_t getControllingSamSite(uint8_t sectorId) const = 0;

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -43,6 +43,7 @@
 #include "strategic/SamSiteModel.h"
 #include "strategic/SamSiteAirControlModel.h"
 #include "strategic/TownModel.h"
+#include "strategic/TraversibilityMapping.h"
 #include "strategic/MovementCostsModel.h"
 #include "strategic/NpcPlacementModel.h"
 #include "strategic/UndergroundSectorModel.h"
@@ -1184,8 +1185,11 @@ bool DefaultContentManager::loadStrategicLayerData()
 	}
 	UndergroundSectorModel::validateData(m_undergroundSectors);
 
+	json = readJsonDataFile("strategic-map-traversibility-ratings.json");
+	auto travRatingMap = TraversibilityMapping::deserialize(*json);
+
 	json = readJsonDataFile("strategic-map-movement-costs.json");
-	m_movementCosts = MovementCostsModel::deserialize(*json);
+	m_movementCosts = MovementCostsModel::deserialize(*json, travRatingMap);
 
 	json = readJsonDataFile("strategic-map-npc-placements.json");
 	for (auto& element : json->GetArray())

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -2,7 +2,6 @@
 
 #include "game/Directories.h"
 #include "game/Strategic/Strategic_Status.h"
-#include "game/Tactical/Arms_Dealer.h"
 #include "game/Tactical/Items.h"
 #include "game/Tactical/Weapons.h"
 
@@ -42,6 +41,7 @@
 #include "strategic/MineModel.h"
 #include "strategic/SamSiteModel.h"
 #include "strategic/SamSiteAirControlModel.h"
+#include "strategic/StrategicMapSecretModel.h"
 #include "strategic/TownModel.h"
 #include "strategic/TraversibilityMapping.h"
 #include "strategic/MovementCostsModel.h"
@@ -294,6 +294,7 @@ DefaultContentManager::~DefaultContentManager()
 	deleteElements(m_npcActionParams);
 	deleteElements(m_npcPlacements);
 	deleteElements(m_samSites);
+	deleteElements(m_mapSecrets);
 	deleteElements(m_shippingDestinations);
 	deleteElements(m_shippingDestinationNames);
 	deleteElements(m_towns);
@@ -1191,6 +1192,14 @@ bool DefaultContentManager::loadStrategicLayerData()
 	json = readJsonDataFile("strategic-map-movement-costs.json");
 	m_movementCosts = MovementCostsModel::deserialize(*json, travRatingMap);
 
+	json = readJsonDataFile("strategic-map-secrets.json");
+	for (auto& element : json->GetArray())
+	{
+		auto secret = StrategicMapSecretModel::deserialize(element, travRatingMap);
+		m_mapSecrets.push_back(secret);
+	}
+	StrategicMapSecretModel::validateData(m_mapSecrets, m_samSites);
+
 	json = readJsonDataFile("strategic-map-npc-placements.json");
 	for (auto& element : json->GetArray())
 	{
@@ -1387,6 +1396,11 @@ const std::vector<const UndergroundSectorModel*>& DefaultContentManager::getUnde
 const MovementCostsModel* DefaultContentManager::getMovementCosts() const
 {
 	return m_movementCosts;
+}
+
+const std::vector<const StrategicMapSecretModel*>& DefaultContentManager::getMapSecrets() const
+{
+	return m_mapSecrets;
 }
 
 const NpcPlacementModel* DefaultContentManager::getNpcPlacement(uint8_t profileId) const

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -169,6 +169,7 @@ public:
 	virtual const ST::string getTownLocative(uint8_t townId) const override;
 	virtual const std::vector <const UndergroundSectorModel*>& getUndergroundSectors() const override;
 	virtual const MovementCostsModel* getMovementCosts() const override;
+	virtual const std::vector<const StrategicMapSecretModel*>& getMapSecrets() const override;
 	virtual const NpcPlacementModel* getNpcPlacement(uint8_t profileId) const override;
 	virtual const RPCSmallFaceModel* getRPCSmallFaceOffsets(uint8_t profileID) const override;
 	virtual const std::vector<const MERCListingModel*>& getMERCListings() const override;
@@ -236,6 +237,7 @@ protected:
 	std::vector<const MineModel*> m_mines;
 	std::vector<const SamSiteModel*> m_samSites;
 	const SamSiteAirControlModel* m_samSitesAirControl;
+	std::vector<const StrategicMapSecretModel*> m_mapSecrets;
 	std::map<int8_t, const TownModel*> m_towns;
 	std::vector<const ST::string*> m_townNames;
 	std::vector<const ST::string*> m_townNameLocatives;

--- a/src/externalized/strategic/CMakeLists.txt
+++ b/src/externalized/strategic/CMakeLists.txt
@@ -11,6 +11,7 @@ set(JA2_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/NpcPlacementModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/SamSiteModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/SamSiteAirControlModel.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/StrategicMapSecretModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/TownModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/TraversibilityMapping.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/UndergroundSectorModel.cc

--- a/src/externalized/strategic/CMakeLists.txt
+++ b/src/externalized/strategic/CMakeLists.txt
@@ -12,6 +12,7 @@ set(JA2_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/SamSiteModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/SamSiteAirControlModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/TownModel.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/TraversibilityMapping.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/UndergroundSectorModel.cc
     PARENT_SCOPE
 )

--- a/src/externalized/strategic/MovementCostsModel.cc
+++ b/src/externalized/strategic/MovementCostsModel.cc
@@ -8,7 +8,7 @@
 
 
 // helper functions
-void readTraversibiltyIntoVector(const rapidjson::Value& jsonArray, IntIntVector& vec, std::map<ST::string, uint8_t>& mapping, size_t expectedRows, size_t expectedCols);
+void readTraversibiltyIntoVector(const rapidjson::Value& jsonArray, IntIntVector& vec, const TraversibilityMap& mapping, size_t expectedRows, size_t expectedCols);
 void readIntIntoVector(const rapidjson::Value& jsonArray, IntIntVector& vec, size_t expectedRows, size_t expectedCols);
 
 
@@ -39,15 +39,8 @@ const uint8_t MovementCostsModel::getTravelRating(uint8_t x, uint8_t y) const
 	return travelRatings[y][x];
 }
 
-MovementCostsModel* MovementCostsModel::deserialize(const rapidjson::Document& root)
+MovementCostsModel* MovementCostsModel::deserialize(const rapidjson::Document& root, const TraversibilityMap& mapToEnum)
 {
-	Assert(root.HasMember("mapping") && root["mapping"].IsObject());
-	std::map<ST::string, uint8_t> mapToEnum; // maps from traversibility short name to enum
-	for (auto& iter : root["mapping"].GetObject())
-	{
-		mapToEnum.insert(std::make_pair(ST::string(iter.name.GetString()), iter.value.GetInt()));
-	}
-
 	Assert(root.HasMember("traverseWE") && root["traverseWE"].IsArray());
 	IntIntVector traverseWE_;
 	readTraversibiltyIntoVector(root["traverseWE"], traverseWE_, mapToEnum, 16, 17);
@@ -72,7 +65,7 @@ MovementCostsModel* MovementCostsModel::deserialize(const rapidjson::Document& r
 	);
 }
 
-void readTraversibiltyIntoVector(const rapidjson::Value& jsonArray, IntIntVector& vec, std::map<ST::string, uint8_t>& mapping, size_t expectedRows, size_t expectedCols)
+void readTraversibiltyIntoVector(const rapidjson::Value& jsonArray, IntIntVector& vec, const TraversibilityMap& mapping, size_t expectedRows, size_t expectedCols)
 {
 	for (auto& r : jsonArray.GetArray())
 	{

--- a/src/externalized/strategic/MovementCostsModel.h
+++ b/src/externalized/strategic/MovementCostsModel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "JsonObject.h"
+#include "TraversibilityMapping.h"
 #include <vector>
 
 typedef std::vector<std::vector<uint8_t>> IntIntVector;
@@ -14,7 +15,7 @@ public:
 	const uint8_t getTraversibilityNorthSouth(uint8_t x, uint8_t y) const;
 	const uint8_t getTraversibilityThrough(uint8_t x, uint8_t y) const;
 	const uint8_t getTravelRating(uint8_t x, uint8_t y) const;
-	static MovementCostsModel* deserialize(const rapidjson::Document& root);
+	static MovementCostsModel* deserialize(const rapidjson::Document& root, const TraversibilityMap& mapping);
 
 protected:
 	IntIntVector traverseWE;

--- a/src/externalized/strategic/StrategicMapSecretModel.cc
+++ b/src/externalized/strategic/StrategicMapSecretModel.cc
@@ -1,0 +1,85 @@
+#include "StrategicMapSecretModel.h"
+#include "Campaign_Types.h"
+#include "JsonObject.h"
+#include "SamSiteModel.h"
+#include <set>
+#include <stdexcept>
+#include <utility>
+
+StrategicMapSecretModel::StrategicMapSecretModel(
+	uint8_t sectorID_, bool isSAMSite_, ST::string secretMapIcon_, uint8_t secretLandType_, uint8_t foundLandType_
+	) : sectorID(sectorID_), isSAMSite(isSAMSite_),
+		secretMapIcon(std::move(secretMapIcon_)),
+		secretLandType(secretLandType_ ), foundLandType(foundLandType_) {}
+
+StrategicMapSecretModel* StrategicMapSecretModel::deserialize(const rapidjson::Value& json, const TraversibilityMap &mapping)
+{
+	JsonObjectReader r(json);
+	auto sector = r.GetString("sector");
+	if (!IS_VALID_SECTOR_SHORT_STRING(sector))
+	{
+		throw std::runtime_error("not a valid sector");
+	}
+
+	auto landTypeString = r.GetString("secretLandType");
+	auto secretLandType = mapping.at(landTypeString);
+
+	landTypeString = r.GetString("foundLandType");
+	auto foundLandType = mapping.at(landTypeString);
+
+	return new StrategicMapSecretModel(
+		SECTOR_FROM_SECTOR_SHORT_STRING(sector),
+		r.getOptionalBool("isSAMSite"),
+		r.GetString("secretMapIcon"),
+		secretLandType,
+		foundLandType
+	);
+}
+
+void StrategicMapSecretModel::validateData(const std::vector<const StrategicMapSecretModel *>& models, const std::vector<const SamSiteModel*>& samModels)
+{
+	std::set<uint8_t> samSiteLocations;
+	for (auto s : samModels)
+	{
+		samSiteLocations.insert(s->sectorId);
+	}
+
+	int countNonSAMSites = 0;
+	std::set<uint8_t> uniqueSectors;
+	for (auto m : models)
+	{
+		// if it's a SAM site secret, ensure we have the corresponding SAM site
+		if (m->isSAMSite)
+		{
+			if (samSiteLocations.find(m->sectorID) == samSiteLocations.end())
+			{
+				ST::string err = ST::format("No SAM site at sector {}", m->sectorID);
+				throw std::runtime_error(err.to_std_string());
+			}
+		}
+		else
+		{
+			countNonSAMSites++;
+		}
+
+		// must not have duplicated keys
+		if (uniqueSectors.find(m->sectorID) != uniqueSectors.end())
+		{
+			ST::string err = ST::format("Sector {} has more than one secret", m->sectorID);
+			throw std::runtime_error(err.to_std_string());
+		}
+		uniqueSectors.insert(m->sectorID);
+	}
+
+	if (countNonSAMSites > 2)
+	{
+		// Limitation for now, to maintain vanilla game compatibility.
+		// If there is a need, we can use something like a bitset to provide more map secret slots in saves.
+		SLOGW("There are more than 2 map secrets that are not SAM sites. Only the first 2 will be persisted in saves");
+	}
+}
+
+uint8_t StrategicMapSecretModel::getLandType(bool isSecretFound) const
+{
+	return isSecretFound ? foundLandType : secretLandType;
+}

--- a/src/externalized/strategic/StrategicMapSecretModel.cc
+++ b/src/externalized/strategic/StrategicMapSecretModel.cc
@@ -30,7 +30,7 @@ StrategicMapSecretModel* StrategicMapSecretModel::deserialize(const rapidjson::V
 	return new StrategicMapSecretModel(
 		SECTOR_FROM_SECTOR_SHORT_STRING(sector),
 		r.getOptionalBool("isSAMSite"),
-		r.GetString("secretMapIcon"),
+		r.getOptionalString("secretMapIcon") ,
 		secretLandType,
 		foundLandType
 	);

--- a/src/externalized/strategic/StrategicMapSecretModel.h
+++ b/src/externalized/strategic/StrategicMapSecretModel.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "JsonObject.h"
+#include "TraversibilityMapping.h"
+#include <vector>
+class SamSiteModel;
+
+class StrategicMapSecretModel
+{
+public:
+	StrategicMapSecretModel(uint8_t sectorID_, bool isSAMSite_, ST::string secretMapIcon_, uint8_t secretLandType_, uint8_t foundLandType_);
+	static StrategicMapSecretModel* deserialize(const rapidjson::Value& json, const TraversibilityMap& mapping);
+	static void validateData(const std::vector<const StrategicMapSecretModel*>& models, const std::vector<const SamSiteModel*>& samModels);
+
+	uint8_t getLandType(bool isSecretFound) const;
+
+	const uint8_t sectorID;
+	const bool isSAMSite;
+	const ST::string secretMapIcon;
+
+protected:
+	const uint8_t secretLandType;
+	const uint8_t foundLandType;
+};

--- a/src/externalized/strategic/TraversibilityMapping.cc
+++ b/src/externalized/strategic/TraversibilityMapping.cc
@@ -1,0 +1,12 @@
+#include "TraversibilityMapping.h"
+
+// mapping from traversibility string name to enum
+TraversibilityMap TraversibilityMapping::deserialize(const rapidjson::Document& root)
+{
+	TraversibilityMap mapToEnum;
+	for (auto& iter : root.GetObject())
+	{
+		mapToEnum.insert(std::make_pair(iter.name.GetString(), iter.value.GetInt()));
+	}
+	return mapToEnum;
+}

--- a/src/externalized/strategic/TraversibilityMapping.h
+++ b/src/externalized/strategic/TraversibilityMapping.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <map>
+#include <rapidjson/document.h>
+#include <string_theory/string>
+
+typedef std::map<ST::string, uint8_t> TraversibilityMap;
+
+namespace TraversibilityMapping
+{
+	TraversibilityMap deserialize(const rapidjson::Document& root);
+}

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -98,6 +98,7 @@
 #include "Strategic_Town_Loyalty.h"
 #include "Strategic_Pathing.h"
 #include "StrategicMap.h"
+#include "StrategicMap_Secrets.h"
 #include "Tactical_Placement_GUI.h"
 #include "Tactical_Save.h"
 #include "TeamTurns.h"
@@ -1794,7 +1795,7 @@ static void SaveGeneralInfo(HWFILE const f)
 	INJ_BOOL( d, fHelicopterDestroyed)
 	INJ_SKIP( d, 1)
 	INJ_I32(  d, giSortStateForMapScreenList)
-	INJ_BOOL( d, fFoundTixa)
+	InjectMapSecretStateToSave(d, 0); // fFoundTixa
 	INJ_SKIP( d, 3)
 	INJ_U32(  d, guiTimeOfLastSkyriderMonologue)
 	INJ_BOOL( d, fShowCambriaHospitalHighLight)
@@ -1822,7 +1823,7 @@ static void SaveGeneralInfo(HWFILE const f)
 	INJ_BOOL( d, fNewFilesInFileViewer)
 	INJ_BOOL( d, gfLastBoxingMatchWonByPlayer)
 	INJ_SKIP( d, 7)
-	INJ_BOOLA(d, fSamSiteFound, lengthof(fSamSiteFound))
+	InjectSAMSitesFoundToSavedFile(d);
 	INJ_U8(   d, gubNumTerrorists)
 	INJ_U8(   d, gubCambriaMedicalObjects)
 	INJ_BOOL( d, gfDisableTacticalPanelButtons)
@@ -1940,7 +1941,7 @@ static void LoadGeneralInfo(HWFILE const f, UINT32 const savegame_version)
 	EXTR_BOOL( d, fHelicopterDestroyed)
 	EXTR_SKIP( d, 1)
 	EXTR_I32(  d, giSortStateForMapScreenList)
-	EXTR_BOOL( d, fFoundTixa)
+	ExtractMapSecretStateFromSave(d, 0);  // fFoundTixa
 	EXTR_SKIP( d, 3)
 	EXTR_U32(  d, guiTimeOfLastSkyriderMonologue)
 	EXTR_BOOL( d, fShowCambriaHospitalHighLight)
@@ -1974,7 +1975,7 @@ static void LoadGeneralInfo(HWFILE const f, UINT32 const savegame_version)
 	EXTR_BOOL( d, fNewFilesInFileViewer)
 	EXTR_BOOL( d, gfLastBoxingMatchWonByPlayer)
 	EXTR_SKIP( d, 7)
-	EXTR_BOOLA(d, fSamSiteFound, lengthof(fSamSiteFound))
+	ExtractSAMSitesFoundFromSavedFile(d);
 	EXTR_U8(   d, gubNumTerrorists)
 	EXTR_U8(   d, gubCambriaMedicalObjects)
 	EXTR_BOOL( d, gfDisableTacticalPanelButtons)

--- a/src/game/Strategic/CMakeLists.txt
+++ b/src/game/Strategic/CMakeLists.txt
@@ -34,6 +34,7 @@ set(JA2_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/Scheduling.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/Strategic.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/StrategicMap.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/StrategicMap_Secrets.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/Strategic_AI.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/Strategic_Event_Handler.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/Strategic_Merc_Handler.cc

--- a/src/game/Strategic/Game_Init.cc
+++ b/src/game/Strategic/Game_Init.cc
@@ -16,6 +16,7 @@
 #include "Game_Clock.h"
 #include "Soldier_Profile.h"
 #include "StrategicMap.h"
+#include "StrategicMap_Secrets.h"
 #include "Game_Init.h"
 #include "Animation_Data.h"
 #include "Finances.h"

--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -58,6 +58,7 @@
 #include "SaveLoadScreen.h"
 #include "Soldier_Macros.h"
 #include "Squads.h"
+#include "StrategicMap_Secrets.h"
 #include "Strategic_Movement_Costs.h"
 #include "Strategic_Pathing.h"
 #include "Strategic_Town_Loyalty.h"
@@ -1298,6 +1299,10 @@ static void DisplayCharacterList(void)
 	MarkAllBoxesAsAltered();
 }
 
+static void RefreshMapScreen()
+{
+	fMapPanelDirty = TRUE;
+}
 
 // THIS IS STUFF THAT RUNS *ONCE* DURING APPLICATION EXECUTION, AT INITIAL STARTUP
 void MapScreenInit(void)
@@ -1311,6 +1316,8 @@ void MapScreenInit(void)
 	InitLeaveList( );
 
 	guiUpdatePanelTactical = AddVideoObjectFromFile(INTERFACEDIR "/group_confirm_tactical.sti");
+
+	OnMapSecretFound.addListener("default:MapScreen", [](UINT8) { RefreshMapScreen(); });
 }
 
 
@@ -7675,7 +7682,6 @@ static void DestinationPlottingCompleted(void)
 
 static void HandleMilitiaRedistributionClick(void)
 {
-	BOOLEAN fTownStillHidden;
 	ST::string sString;
 
 
@@ -7683,7 +7689,7 @@ static void HandleMilitiaRedistributionClick(void)
 	if ( iCurrentMapSectorZ == 0 )
 	{
 		INT8 const bTownId = GetTownIdForSector(SECTOR(sSelMapX, sSelMapY));
-		fTownStillHidden = ( ( bTownId == TIXA ) && !fFoundTixa ) || ( ( bTownId == ORTA ) && !fFoundOrta );
+		BOOLEAN fTownStillHidden = !IsTownFound(bTownId);
 
 		if( ( bTownId != BLANK_SECTOR ) && !fTownStillHidden )
 		{
@@ -7714,7 +7720,7 @@ static void HandleMilitiaRedistributionClick(void)
 		else
 		{
 			INT8 const sam_id = GetSAMIdFromSector(sSelMapX, sSelMapY, 0);
-			if (sam_id != -1 && fSamSiteFound[sam_id])
+			if (sam_id != -1 && IsSecretFoundAt(SECTOR(sSelMapX, sSelMapY)))
 			{ // Cannot move militia around sam sites.
 				DoScreenIndependantMessageBox(pMapErrorString[30], MSG_BOX_FLAG_OK, NULL);
 			}

--- a/src/game/Strategic/Map_Screen_Helicopter.cc
+++ b/src/game/Strategic/Map_Screen_Helicopter.cc
@@ -33,6 +33,7 @@
 #include "Sound_Control.h"
 #include "Squads.h"
 #include "StrategicMap.h"
+#include "StrategicMap_Secrets.h"
 #include "Strategic_Event_Handler.h"
 #include "Strategic_Movement.h"
 #include "Strategic_Pathing.h"

--- a/src/game/Strategic/Map_Screen_Interface.cc
+++ b/src/game/Strategic/Map_Screen_Interface.cc
@@ -35,11 +35,13 @@
 #include "Render_Dirty.h"
 #include "Render_Fun.h"
 #include "RenderWorld.h"
+#include "SamSiteModel.h"
 #include "ShippingDestinationModel.h"
 #include "Soldier_Macros.h"
 #include "SoundMan.h"
 #include "Squads.h"
 #include "Strategic.h"
+#include "StrategicMap_Secrets.h"
 #include "Strategic_Mines.h"
 #include "Strategic_Pathing.h"
 #include "SysUtil.h"
@@ -3608,29 +3610,6 @@ void EndUpdateBox( BOOLEAN fContinueTimeCompression )
 		StopTimeCompression();
 	}
 }
-
-
-void SetTixaAsFound( void )
-{
-	// set the town of Tixa as found by the player
-	fFoundTixa = TRUE;
-	fMapPanelDirty = TRUE;
-}
-
-void SetOrtaAsFound( void )
-{
-	// set the town of Orta as found by the player
-	fFoundOrta = TRUE;
-	fMapPanelDirty = TRUE;
-}
-
-void SetSAMSiteAsFound( UINT8 uiSamIndex )
-{
-	// set this SAM site as being found by the player
-	fSamSiteFound[ uiSamIndex ] = TRUE;
-	fMapPanelDirty = TRUE;
-}
-
 
 void InitTimersForMoveMenuMouseRegions()
 {

--- a/src/game/Strategic/Map_Screen_Interface.h
+++ b/src/game/Strategic/Map_Screen_Interface.h
@@ -404,15 +404,6 @@ void CreateDestroyTheUpdateBox( void );
 void DisplaySoldierUpdateBox(void);
 
 
-/// set the town of Tixa as found by the player
-void SetTixaAsFound( void );
-
-// set the town of Orta as found by the player
-void SetOrtaAsFound( void );
-
-// set this SAM site as being found by the player
-void SetSAMSiteAsFound( UINT8 uiSamIndex );
-
 // Set up the timers for the move menu in mapscreen for double click detection.
 void InitTimersForMoveMenuMouseRegions();
 

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -2839,7 +2839,11 @@ void LoadMapScreenInterfaceMapGraphics()
 
 	for (auto s : GCM->getMapSecrets())
 	{
-		gSecretSiteIcons[s->secretMapIcon] = AddVideoObjectFromFile(s->secretMapIcon.c_str());
+		const ST::string& path = s->secretMapIcon;
+		if (!path.empty() && gSecretSiteIcons.find(path) == gSecretSiteIcons.end())
+		{
+			gSecretSiteIcons[path] = AddVideoObjectFromFile(path.c_str());
+		}
 	}
 }
 
@@ -3939,17 +3943,13 @@ static void DrawMapBoxIcon(HVOBJECT const vo, UINT16 const icon, INT16 const sec
 
 void DrawSecretSite(const StrategicMapSecretModel* secret)
 {
-	if (secret->secretMapIcon.empty())
+	if (!secret->secretMapIcon.empty())
 	{
-		ST::string err = ST::format("Secret site at sector {} has no icon", secret->sectorID);
-		SLOGW(err);
-		return;
+		const SGPVObject *const icon = gSecretSiteIcons.at(secret->secretMapIcon);
+		const INT16 x = SECTORX(secret->sectorID);
+		const INT16 y = SECTORY(secret->sectorID);
+		DrawSite(x, y, icon);
 	}
-
-	const SGPVObject* const icon = gSecretSiteIcons.at(secret->secretMapIcon);
-	const INT16 x = SECTORX(secret->sectorID);
-	const INT16 y = SECTORY(secret->sectorID);
-	DrawSite(x, y, icon);
 }
 
 

--- a/src/game/Strategic/Map_Screen_Interface_Map.h
+++ b/src/game/Strategic/Map_Screen_Interface_Map.h
@@ -108,8 +108,6 @@ UINT32 WhatPlayerKnowsAboutEnemiesInSector( INT16 sSectorX, INT16 sSectorY );
 //flag.
 void ClearAnySectorsFlashingNumberOfEnemies(void);
 
-void InitMapSecrets();
-
 
 enum {
 	ABORT_PLOTTING = 0,
@@ -145,10 +143,7 @@ enum {
 #define DMAP_GRID_Y		( MAP_GRID_Y + 1 )
 
 
-// Orta position on the map
-#define ORTA_SECTOR_X		4
-#define ORTA_SECTOR_Y		11
-
+// Tixa position on the map
 #define TIXA_SECTOR_X		9
 #define TIXA_SECTOR_Y		10
 
@@ -191,8 +186,6 @@ extern INT16 sSelectedMilitiaTown;
 extern UINT16	sSelMapX;
 extern UINT16	sSelMapY;
 
-
-extern BOOLEAN fFoundTixa;
 
 void    CreateDestroyMilitiaSectorButtons(void);
 BOOLEAN CanRedistributeMilitiaInSector(INT16 sClickedSectorX, INT16 sClickedSectorY, INT8 bClickedTownId);

--- a/src/game/Strategic/SAM_Sites.cc
+++ b/src/game/Strategic/SAM_Sites.cc
@@ -4,7 +4,6 @@
 #include "Explosion_Control.h"
 #include "GameInstance.h"
 #include "Logger.h"
-#include "MapScreen.h"
 #include "SamSiteModel.h"
 #include "SaveLoadMap.h"
 #include "StrategicMap.h"
@@ -13,13 +12,6 @@
 #include "WorldMan.h"
 #include <string_theory/format>
 
-// have any of the sam sites been found
-BOOLEAN fSamSiteFound[NUMBER_OF_SAMS] = {
-	FALSE,
-	FALSE,
-	FALSE,
-	FALSE,
-};
 
 Observable<> OnAirspaceControlUpdated = {};
 

--- a/src/game/Strategic/SAM_Sites.h
+++ b/src/game/Strategic/SAM_Sites.h
@@ -8,8 +8,6 @@
 // min condition for sam site to be functional
 #define MIN_CONDITION_FOR_SAM_SITE_TO_WORK 80
 
-extern BOOLEAN fSamSiteFound[NUMBER_OF_SAMS];
-
 extern Observable<> OnAirspaceControlUpdated;
 
 void InitializeSAMSites();

--- a/src/game/Strategic/StrategicMap.h
+++ b/src/game/Strategic/StrategicMap.h
@@ -42,8 +42,6 @@ static inline void SetWorldSectorInvalid()
 	gbWorldSectorZ = -1;
 }
 
-extern BOOLEAN fFoundOrta;
-
 extern	BOOLEAN		gfUseAlternateMap;
 
 // This is called after loading map and before setting it up (e.g. placing soldiers)
@@ -79,6 +77,9 @@ ST::string GetShortSectorString(INT16 sMapX, INT16 sMapY);
 
 // Return a string like 'A9: Omerta'
 ST::string GetSectorIDString(INT16 x, INT16 y, INT8 z, BOOLEAN detailed);
+
+// Returns a sector description string based on the sector land type
+ST::string GetSectorLandTypeString(UINT8 ubSectorID, UINT8 ubSectorZ, bool fDetailed);
 
 void GetMapFileName(INT16 x, INT16 y, INT8 z, char* buf, BOOLEAN add_alternate_map_letter);
 

--- a/src/game/Strategic/StrategicMap_Secrets.cc
+++ b/src/game/Strategic/StrategicMap_Secrets.cc
@@ -1,0 +1,168 @@
+#include "StrategicMap_Secrets.h"
+#include "Buffer.h"
+#include "ContentManager.h"
+#include "GameInstance.h"
+#include "LoadSaveData.h"
+#include "SamSiteModel.h"
+#include "StrategicMapSecretModel.h"
+#include "TownModel.h"
+
+std::map<uint8_t, BOOLEAN> isSecretFound;
+Observable<UINT8> OnMapSecretFound;
+
+void InitMapSecrets()
+{
+	isSecretFound.clear();
+	for (auto s : GCM->getMapSecrets())
+	{
+		isSecretFound[s->sectorID] = FALSE;
+	}
+}
+
+// only considers the town's base sector
+BOOLEAN IsTownFound(INT8 const bTownID)
+{
+	auto town = GCM->getTown(bTownID);
+	if (!town)
+	{
+		SLOGW(ST::format("Town #{} not found", bTownID));
+		return FALSE;
+	}
+
+	if (isSecretFound.find(town->getBaseSector()) == isSecretFound.end())
+	{
+		// town is always known to the player
+		return TRUE;
+	}
+
+	return IsSecretFoundAt(town->getBaseSector());
+}
+
+BOOLEAN IsSecretFoundAt(UINT8 const sectorID)
+{
+	if (isSecretFound.find(sectorID) == isSecretFound.end())
+	{
+		// The game always try to find secrets at J9 and K4, but they
+		// may not be present in a modded set up. So we will just
+		// return TRUE and continue.
+		SLOGW(ST::format("No secret defined at sector {}", sectorID));
+		return TRUE;
+	}
+	return isSecretFound[sectorID];
+}
+
+void SetTownAsFound(INT8 const bTownID, BOOLEAN const fFound)
+{
+	auto town = GCM->getTown(bTownID);
+	if (!town)
+	{
+		// The game has hard-coded references to TIXA and
+		// ORTA, but they may not be present in a modded
+		// set up.
+		SLOGW(ST::format("Town #{} is not defined", bTownID));
+		return;
+	}
+
+	SetSectorSecretAsFound(town->getBaseSector(), fFound);
+}
+
+void SetSAMSiteAsFound( UINT8 uiSamIndex )
+{
+	// set this SAM site as being found by the player
+	const SamSiteModel* samSite = GCM->getSamSites()[uiSamIndex];
+	SetSectorSecretAsFound(samSite->sectorId);
+}
+
+void SetSectorSecretAsFound(UINT8 const ubSectorID, BOOLEAN const fFound)
+{
+	isSecretFound[ubSectorID] = fFound;
+	if (fFound)
+	{
+		OnMapSecretFound(ubSectorID);
+	}
+}
+
+const StrategicMapSecretModel* GetMapSecretBySectorID(UINT8 const ubSectorID)
+{
+	for (auto s : GCM->getMapSecrets())
+	{
+		if (s->sectorID == ubSectorID) return s;
+	}
+	return NULL;
+}
+
+
+void InjectSAMSitesFoundToSavedFile(DataWriter& d)
+{
+	std::vector<BOOLEAN> fSAMFound;
+	for (auto s : GCM->getMapSecrets())
+	{
+		if (s->isSAMSite)
+		{
+			BOOLEAN fFound = IsSecretFoundAt(s->sectorID);
+			fSAMFound.push_back(fFound);
+		}
+	}
+	INJ_BOOLA(d, fSAMFound.data(), fSAMFound.size());
+}
+
+void ExtractSAMSitesFoundFromSavedFile(DataReader& d)
+{
+	std::vector<const StrategicMapSecretModel*> secretSAMSites;
+	for (auto s : GCM->getMapSecrets())
+	{
+		if (s->isSAMSite) secretSAMSites.push_back(s);
+	}
+
+	auto len = secretSAMSites.size();
+	SGP::Buffer<BOOLEAN> fSAMFound(len);
+	EXTR_BOOLA(d, fSAMFound, len)
+
+	int i = 0;
+	for (auto s : secretSAMSites)
+	{
+		SetSectorSecretAsFound(s->sectorID, fSAMFound[i++]);
+	}
+}
+
+void InjectMapSecretStateToSave(DataWriter& d, unsigned int const index)
+{
+	INJ_BOOL(d, GetMapSecretStateForSave(index))
+}
+
+BOOLEAN GetMapSecretStateForSave(unsigned int const index)
+{
+	unsigned int i = 0;
+	for (auto s : GCM->getMapSecrets())
+	{
+		if (s->isSAMSite) continue;
+		if (index == i++)
+		{        // we have found the secret to save
+			return IsSecretFoundAt(s->sectorID);
+		}
+	}
+	SLOGW(ST::format("There is no secret at slot #{}", index));
+	return FALSE;  // write something to maintain save compatibility
+}
+
+void ExtractMapSecretStateFromSave(DataReader & d, unsigned int const index)
+{
+	BOOLEAN fFound;
+	EXTR_BOOL(d, fFound)
+	SetMapSecretStateFromSave(index, fFound);
+}
+
+void SetMapSecretStateFromSave(unsigned int const index, BOOLEAN const fFound)
+{
+	unsigned int i = 0;
+	for (auto s : GCM->getMapSecrets())
+	{
+		if (s->isSAMSite) continue;
+		if (index == i++)
+		{	// we have found the secret to load
+			SetSectorSecretAsFound(s->sectorID, fFound);
+			return;
+		}
+	}
+	SLOGW(ST::format("There is no secret at slot #{}", index));
+}

--- a/src/game/Strategic/StrategicMap_Secrets.h
+++ b/src/game/Strategic/StrategicMap_Secrets.h
@@ -1,0 +1,46 @@
+#pragma once
+#include "Observable.h"
+#include "Types.h"
+class DataReader;
+class DataWriter;
+class StrategicMapSecretModel;
+
+extern Observable<UINT8> OnMapSecretFound;
+
+// Reset the state of all map secrets
+void InitMapSecrets();
+
+// Whether the town was found by the player. Returns TRUE if the town is not hidden (i.e. not defined in map secrets)
+BOOLEAN IsTownFound(INT8 bTownID);
+
+// Whether the map secret was known to the player. Returns TRUE with a warning, if there is no secret at the sector ID.
+BOOLEAN IsSecretFoundAt(UINT8 sectorID);
+
+// Marks the town's base sector as a found secret
+void SetTownAsFound(INT8 bTownID, BOOLEAN fFound = TRUE);
+
+// set this SAM site as being found by the player
+void SetSAMSiteAsFound(UINT8 uiSamIndex);
+
+// Marks a sector's secret as found
+void SetSectorSecretAsFound(UINT8 ubSectorID, BOOLEAN fFound = TRUE);
+
+const StrategicMapSecretModel* GetMapSecretBySectorID(UINT8 ubSectorID);
+
+// writes the map secret states of all SAM sites
+void InjectSAMSitesFoundToSavedFile(DataWriter& d);
+
+// reads the map secret states for all SAM sites
+void ExtractSAMSitesFoundFromSavedFile(DataReader& d);
+
+// write the state of a non-SAM-site map secret at the given index
+void InjectMapSecretStateToSave(DataWriter& d, unsigned int index);
+
+// Gets a non-SAM-site map secret state by index
+BOOLEAN GetMapSecretStateForSave(unsigned int index);
+
+// reads a non-SAM-site map secret state from save
+void ExtractMapSecretStateFromSave(DataReader & d, unsigned int index);
+
+// Sets a non-SAM-site map secret state by index
+void SetMapSecretStateFromSave(unsigned int index, BOOLEAN fFound);

--- a/src/game/Strategic/Strategic_Movement.cc
+++ b/src/game/Strategic/Strategic_Movement.cc
@@ -34,6 +34,7 @@
 #include "Soldier_Macros.h"
 #include "Squads.h"
 #include "Strategic.h"
+#include "StrategicMap_Secrets.h"
 #include "Strategic_AI.h"
 #include "Strategic_Pathing.h"
 #include "Tactical_Save.h"
@@ -1214,15 +1215,9 @@ void GroupArrivedAtSector(GROUP& g, BOOLEAN const check_for_battle, BOOLEAN cons
 		if (z == 0)
 		{
 			// check for discovering secret locations
-			switch (GetTownIdForSector(SECTOR(x, y)))
+			if (GetMapSecretBySectorID(SECTOR(x, y)))
 			{
-				case ORTA: SetOrtaAsFound(); break;
-				case TIXA: SetTixaAsFound(); break;
-
-				default:
-					INT8 const sam_id = GetSAMIdFromSector(x, y, 0);
-					if (sam_id != -1) SetSAMSiteAsFound(sam_id);
-					break;
+				SetSectorSecretAsFound(SECTOR(x, y));
 			}
 		}
 

--- a/src/game/Tactical/Interface_Dialogue.cc
+++ b/src/game/Tactical/Interface_Dialogue.cc
@@ -74,6 +74,7 @@
 #include "Squads.h"
 #include "Strategic.h"
 #include "StrategicMap.h"
+#include "StrategicMap_Secrets.h"
 #include "Strategic_AI.h"
 #include "Strategic_Mines.h"
 #include "Strategic_Movement.h"
@@ -2986,11 +2987,11 @@ void HandleNPCDoAction( UINT8 ubTargetNPC, UINT16 usActionCode, UINT8 ubQuoteNum
 			}
 
 			case NPC_ACTION_SHOW_TIXA:
-				SetTixaAsFound();
+				SetTownAsFound(TIXA);
 				AddHistoryToPlayersLog( HISTORY_DISCOVERED_TIXA, 0, GetWorldTotalMin(), gWorldSectorX, gWorldSectorY );
 				break;
 			case NPC_ACTION_SHOW_ORTA:
-				SetOrtaAsFound();
+				SetTownAsFound(ORTA);
 				AddHistoryToPlayersLog( HISTORY_DISCOVERED_ORTA, 0, GetWorldTotalMin(), gWorldSectorX, gWorldSectorY );
 				break;
 


### PR DESCRIPTION
This PR externalizes (#665) map secrets to JSON data files. Map secrets in base game are: Tixa, Orta and the 4 SAM sites. They are hidden at the start of game, and revealed to the player by NPCs or when arriving at the sectors.

# Summary

- Moving the traversibility mapping (from string name to enum ID) to its own file 
- Extracting map secrets information from code:
    - Sector (as primary key); Map icon; Terrain land type string
- Refactoring the sector description function (e.g. "Cambria Hospital", "Tixa Dungeon", "Farm, road")
    - Using the newly externalized data to determine land type for secret sectors
- Generalizing map secrets and save games:
    - `fFoundTixa` is generalized as "1st non-SAM site secret"
    - `fFoundOrta` is generalized as "2nd non-SAM site secret"
    - SAM site secrets are now dynamically defined by JSON, so that a mod can have any number of hidden SAM sites
    - NPC actions and quests still have direct references to TIXA and ORTA

## Limitations and assumptions

- The "is secret found?" state of only the first 2 secrets and SAM sites are saved - to fit `fFoundTixa` and `fFoundOrta`. A mod can define more but state persistence will not handled by the base game.
    - Some possibilities are: changing field from BOOLEAN to bitset, or allowing Lua scripts to write extra data to saves.
- There is at most one secret per sector
- A secret town can only have 1 town sector

# Possible use-cases 

_These should be feasible, but not tested. Testing was done with vanilla data_

- Replacing map secrets with other secret facilities on the map, and with new icons
- SAM sites that are known on game start (SAM sites without corresponding secret)
- Hide Estoni, until some NPC tells you about it
- Make the random weapon cache a map secret - that can be revealed by quests or NPCs
- Enabling [PATCH106](https://github.com/ja2-derek/ja2-ub-comparison/commit/84c0858f) 

# Testing

- Save/load of secret revealed states (Tixa, Orta and SAM sites)
- Revealing of secrets by NPC
- Revealing of secrets by visiting
- Sector string in bottom-right, saves and strategic map pop-up
