### PR TITLE
Android VFS Rework Part 2

### DIFF
--- a/rust/stracciatella/src/vfs/android.rs
+++ b/rust/stracciatella/src/vfs/android.rs
@@ -1,13 +1,13 @@
 //! This module contains a virtual filesystem backed by a SLF file.
 #![allow(dead_code)]
 
+use std::collections::HashSet;
 use std::ffi::CString;
 use std::fmt;
 use std::io;
 use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
-use std::collections::HashSet;
 
 use ndk::asset::{Asset, AssetManager};
 
@@ -174,13 +174,14 @@ impl VfsLayer for AssetManagerFs {
             })?;
 
             for file_name in dir_contents {
-                let file_name_nfc =
-                    Nfc::caseless_path(&file_name.into_os_string().into_string().map_err(|err| {
+                let file_name_nfc = Nfc::caseless_path(
+                    &file_name.into_os_string().into_string().map_err(|err| {
                         io::Error::new(
                             io::ErrorKind::InvalidInput,
                             format!("Could not convert path to NFC for AssetManager: {:?}", err),
                         )
-                    })?);
+                    })?,
+                );
                 result.insert(file_name_nfc);
             }
         }

--- a/rust/stracciatella/src/vfs/dir.rs
+++ b/rust/stracciatella/src/vfs/dir.rs
@@ -10,8 +10,8 @@ use crate::fs;
 use crate::fs::File;
 use crate::unicode::Nfc;
 use crate::vfs::{VfsFile, VfsLayer};
-use std::rc::Rc;
 use std::collections::HashSet;
+use std::rc::Rc;
 
 /// A case-insensitive virtual filesystem backed by a filesystem directory.
 #[derive(Debug)]
@@ -109,8 +109,8 @@ impl VfsLayer for DirFs {
 
             for entry in dir_contents {
                 let entry = entry?;
-                let file_name_nfc =
-                    Nfc::caseless_path(&entry.file_name().to_owned().into_string().map_err(|err| {
+                let file_name_nfc = Nfc::caseless_path(
+                    &entry.file_name().to_owned().into_string().map_err(|err| {
                         io::Error::new(
                             io::ErrorKind::InvalidInput,
                             format!(
@@ -119,7 +119,8 @@ impl VfsLayer for DirFs {
                                 err
                             ),
                         )
-                    })?);
+                    })?,
+                );
                 result.insert(file_name_nfc);
             }
         }

--- a/rust/stracciatella/src/vfs/mod.rs
+++ b/rust/stracciatella/src/vfs/mod.rs
@@ -18,11 +18,11 @@ use std::rc::Rc;
 
 use log::{info, warn};
 
+use crate::fs;
 use crate::unicode::Nfc;
 use crate::vfs::dir::DirFs;
 use crate::vfs::slf::SlfFs;
 use crate::EngineOptions;
-use crate::fs;
 
 pub trait VfsFile: io::Read + io::Seek + io::Write + fmt::Debug + fmt::Display {
     /// Returns the length of the file

--- a/rust/stracciatella/src/vfs/slf.rs
+++ b/rust/stracciatella/src/vfs/slf.rs
@@ -158,8 +158,8 @@ impl VfsFile for SlfFsFile {
 
 impl fmt::Display for SlfFs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("SlfFs { ")?;
-        write!(f, "{:?}", self.slf_path)?;
+        f.write_str("SlfFs { source: ")?;
+        write!(f, "{}", self.slf_path)?;
         f.write_str(" }")
     }
 }

--- a/rust/stracciatella/tests/test_vfs.rs
+++ b/rust/stracciatella/tests/test_vfs.rs
@@ -90,7 +90,7 @@ mod vfs {
     use stracciatella::fs;
     use stracciatella::fs::{OpenOptions, TempDir};
     use stracciatella::unicode::Nfc;
-    use stracciatella::vfs::Vfs;
+    use stracciatella::vfs::{Vfs, VfsLayer};
 
     fn read_file_data(vfs: &Vfs, path: &str) -> Vec<u8> {
         let mut file = vfs.open(&Nfc::caseless_path(path)).expect("VfsFile");

--- a/rust/stracciatella/tests/test_vfs.rs
+++ b/rust/stracciatella/tests/test_vfs.rs
@@ -38,7 +38,7 @@ mod vfs {
         let (temp, dir) = create_temp_dir();
         create_foo_slf(&dir); // foo.slf
         create_foobar_slf(&dir); // foobar.slf
-        create_foo_bar_baz_txt(&dir); // baz.txt
+        create_file(&dir.join("foo/bar/baz.txt")); // baz.txt
 
         let mut vfs = Vfs::new();
         vfs.add_dir(&dir).expect("dir");
@@ -80,11 +80,63 @@ mod vfs {
         temp.close().expect("close temp dir");
     }
 
+    #[test]
+    fn read_dir() {
+        let (temp, dir) = create_temp_dir();
+        create_foo_slf(&dir); // foo.slf
+        create_foobar_slf(&dir); // foobar.slf
+        create_file(&dir.join("foo/foo1.txt"));
+        create_file(&dir.join("foo/foo2.txt"));
+        create_file(&dir.join("foo/foo3.txt"));
+
+        let mut vfs = Vfs::new();
+        vfs.add_dir(&dir).expect("dir");
+        vfs.add_slf(&dir.join("foo.slf")).expect("foo");
+        vfs.add_slf(&dir.join("foobar.slf")).expect("foobar");
+
+        let root_paths = ["foo", "foo.slf", "foobar.slf"];
+        let foo_paths = ["foo3.txt", "foo2.txt", "foo1.txt", "bar.txt", "bar"];
+        let foo_bar_paths = ["baz.txt"];
+        // case insensitive
+        assert_vfs_read_dir(&vfs, "foo", &foo_paths);
+        assert_vfs_read_dir(&vfs, "FOO", &foo_paths);
+        assert_vfs_read_dir(&vfs, "foo/bar", &foo_bar_paths);
+        assert_vfs_read_dir(&vfs, "FOO/Bar", &foo_bar_paths);
+
+        // trailing path separators should not matter
+        assert_vfs_read_dir(&vfs, "foo/", &foo_paths);
+        assert_vfs_read_dir(&vfs, "FOO/", &foo_paths);
+        assert_vfs_read_dir(&vfs, "foo/bar/", &foo_bar_paths);
+        assert_vfs_read_dir(&vfs, "FOO/Bar/", &foo_bar_paths);
+
+        // the kind of path separator should not matter
+        assert_vfs_read_dir(&vfs, "foo\\bar", &foo_bar_paths);
+        assert_vfs_read_dir(&vfs, "FOO\\Bar", &foo_bar_paths);
+        assert_vfs_read_dir(&vfs, "foo/bar\\", &foo_bar_paths);
+        assert_vfs_read_dir(&vfs, "FOO/Bar\\", &foo_bar_paths);
+
+        // it should be possible to list root paths
+        assert_vfs_read_dir(&vfs, "", &root_paths);
+        assert_vfs_read_dir(&vfs, "/", &root_paths);
+
+        // it should be possible to list root paths in slfs only
+        let mut vfs = Vfs::new();
+        vfs.add_slf(&dir.join("foo.slf")).expect("foo");
+
+        let root_paths = ["foo"];
+        assert_vfs_read_dir(&vfs, "", &root_paths);
+        assert_vfs_read_dir(&vfs, "/", &root_paths);
+
+        temp.close().expect("close temp dir");
+    }
+
     // end of vfs tests
     //------------------
 
     use std::io::{Read, Seek, SeekFrom, Write};
     use std::path::{Path, PathBuf};
+    use std::collections::HashSet;
+    use std::iter::FromIterator;
 
     use stracciatella::file_formats::slf::{SlfEntry, SlfEntryState, SlfHeader};
     use stracciatella::fs;
@@ -93,10 +145,16 @@ mod vfs {
     use stracciatella::vfs::{Vfs, VfsLayer};
 
     fn read_file_data(vfs: &Vfs, path: &str) -> Vec<u8> {
-        let mut file = vfs.open(&Nfc::caseless_path(path)).expect("VfsFile");
+        let mut file = vfs.open(&Nfc::caseless_path(path)).expect("open");
         let mut data = Vec::new();
         file.read_to_end(&mut data).expect("Vec<u8>");
         data
+    }
+
+    fn assert_vfs_read_dir(vfs: &Vfs, path: &str, expected: &[&str]) {
+        let result = vfs.read_dir(&Nfc::caseless_path(path)).expect("read_dir");
+        let expected = HashSet::from_iter(expected.into_iter().map(|s| Nfc::caseless_path(s)));
+        assert_eq!(result, expected);
     }
 
     /// The inner file data is the name.
@@ -140,11 +198,13 @@ mod vfs {
         path
     }
 
-    /// The file data is "baz.txt".
-    fn create_foo_bar_baz_txt(dir: &Path) {
-        let dir = dir.join("foo/bar");
-        let name = "baz.txt";
-        fs::create_dir_all(&dir).expect("create_dir_all");
+    /// The file data is the same as the filename.
+    fn create_file(path: &Path) {
+        let dir = path.parent().expect("parent path");
+        let name = path.file_name().expect("file name").to_str().expect("file name string");
+        if !dir.exists() {
+            fs::create_dir_all(&dir).expect("create_dir_all");
+        }
         fs::write(&dir.join(&name), name.as_bytes()).expect("write");
     }
 

--- a/rust/stracciatella_c_api/src/c/vfs.rs
+++ b/rust/stracciatella_c_api/src/c/vfs.rs
@@ -6,9 +6,12 @@ use std::io::{Read, Seek, SeekFrom, Write};
 
 use stracciatella::config::EngineOptions;
 use stracciatella::unicode::Nfc;
-use stracciatella::vfs::{Vfs, VfsFile};
+use stracciatella::vfs::{Vfs, VfsFile as RVfsFile, VfsLayer};
 
 use crate::c::common::*;
+
+/// Concrete Type for a VFS file as we cannot return Box<dyn xxx> in the C API
+pub struct VfsFile(Box<dyn RVfsFile>);
 
 /// Creates a virtual filesystem.
 /// coverity[+alloc]
@@ -72,7 +75,7 @@ pub extern "C" fn VfsFile_open(vfs: *mut Vfs, path: *const c_char) -> *mut VfsFi
             remember_rust_error(format!("VfsFile_open {:?}: {}", path, err));
             std::ptr::null_mut()
         }
-        Ok(file) => into_ptr(file),
+        Ok(file) => into_ptr(VfsFile(file)),
     }
 }
 
@@ -89,7 +92,7 @@ pub extern "C" fn VfsFile_close(file: *mut VfsFile) {
 #[no_mangle]
 pub extern "C" fn VfsFile_len(file: *mut VfsFile, len: *mut u64) -> bool {
     forget_rust_error();
-    let file = unsafe_mut(file);
+    let file = &mut unsafe_mut(file).0;
     let len = unsafe_mut(len);
     match file.len() {
         Err(err) => {
@@ -107,7 +110,7 @@ pub extern "C" fn VfsFile_len(file: *mut VfsFile, len: *mut u64) -> bool {
 #[no_mangle]
 pub extern "C" fn VfsFile_readExact(file: *mut VfsFile, buffer: *mut u8, length: usize) -> bool {
     forget_rust_error();
-    let file = unsafe_mut(file);
+    let file = &mut unsafe_mut(file).0;
     let buffer = unsafe_slice_mut(buffer, length);
     if let Err(err) = file.read_exact(buffer) {
         remember_rust_error(format!("VfsFile_readExact {} {}: {}", file, length, err));
@@ -126,7 +129,7 @@ pub extern "C" fn VfsFile_seekFromStart(
     out_position: *mut u64,
 ) -> bool {
     forget_rust_error();
-    let file = unsafe_mut(file);
+    let file = &mut unsafe_mut(file).0;
     let out_position = unsafe_mut_option(out_position);
     match file.seek(SeekFrom::Start(offset)) {
         Err(err) => {
@@ -152,7 +155,7 @@ pub extern "C" fn VfsFile_seekFromEnd(
     out_position: *mut u64,
 ) -> bool {
     forget_rust_error();
-    let file = unsafe_mut(file);
+    let file = &mut unsafe_mut(file).0;
     let out_position = unsafe_mut_option(out_position);
     match file.seek(SeekFrom::End(offset)) {
         Err(err) => {
@@ -178,7 +181,7 @@ pub extern "C" fn VfsFile_seekFromCurrent(
     out_position: *mut u64,
 ) -> bool {
     forget_rust_error();
-    let file = unsafe_mut(file);
+    let file = &mut unsafe_mut(file).0;
     let out_position = unsafe_mut_option(out_position);
     match file.seek(SeekFrom::Current(offset)) {
         Err(err) => {
@@ -198,7 +201,7 @@ pub extern "C" fn VfsFile_seekFromCurrent(
 #[no_mangle]
 pub extern "C" fn VfsFile_writeAll(file: *mut VfsFile, buffer: *const u8, length: usize) -> bool {
     forget_rust_error();
-    let file = unsafe_mut(file);
+    let file = &mut unsafe_mut(file).0;
     let buffer = unsafe_slice(buffer, length);
     while let Err(err) = file.write_all(buffer) {
         remember_rust_error(format!("VfsFile_writeAll {}: {}", length, err));


### PR DESCRIPTION
Next step for proper AssetManagerFs support: Allow to load mods from Android assets.

This kind of got out of hand because now we have to support to create an `SlfFs` from another Vfs layer. I fixed this by introducing a trait for `VfsLayer` which allows to abstract away the `VfsLayer` (which also allowed me to remove a bunch of wrapper code). Currently it allows `open` for files and `read_dir` for directories. This allows to use `read_dir` on a VfsLayer to list all SLF files and `open` to open the `SlfFs` from the other VfsLayer. This is currently used for `DirFs` and `AndroidAssetFs`.

From the C++ side there were no changes needed, although I needed to wrap the `Box<VfsFile>` into another struct in the API, because it seems like we need to return concrete types to C++. But since this is an opaque pointer on C++ side anyways, it worked out fine.

Unfortunately there is no UI for this yet, so I tested by just adding the mods to `ja2.json` manually in the LauncherActivity. This would probably be the next step for proper Android support.