### PR TITLE
Externalize cache sectors

### DIFF
--- a/assets/externalized/strategic-map-cache-sectors.json
+++ b/assets/externalized/strategic-map-cache-sectors.json
@@ -1,0 +1,18 @@
+/**
+ * Choose one cache map out of five possible maps. Select the sector randomly,
+ * set up the flags to use the alternate map, then place 8-12 regular troops
+ * there (no AI though).
+ *
+ * Number of enemies and variances are specified as array of integer, in the
+ * form of [ n_EASY, n_MEDIUM, n_HARD]. defaults to [0,0,0] if not given.
+ *
+ * Fields:
+ *  - sectors:    Locations of all the possible cache sectors
+ *  - numTroops:    The number of troops in cache sector, by game difficulty
+ *  - numTroopsVariance:    The max number of extra troops in sector, by game difficulty
+ */
+{
+    "sectors": [ "E11", "H5", "H10", "J12", "M9" ],
+    "numTroops": [ 8, 10, 12 ],
+    "numTroopsVariance": [ 0, 0, 0 ]
+}

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -17,6 +17,7 @@
 class ArmyCompositionModel;
 class BloodCatPlacementsModel;
 class BloodCatSpawnsModel;
+class CacheSectorsModel;
 class CreatureLairModel;
 class DealerInventory;
 class DealerModel;
@@ -166,7 +167,7 @@ public:
 	virtual const ST::string getTownName(uint8_t townId) const = 0;
 	virtual const ST::string getTownLocative(uint8_t townId) const = 0;
 	virtual const std::vector <const UndergroundSectorModel*> & getUndergroundSectors() const = 0;
-
+	virtual const CacheSectorsModel* getCacheSectors() const = 0;
 	virtual const MovementCostsModel* getMovementCosts() const = 0;
 	/* Returns land type index for special sectors. Return -1 if no special land type is defined */
 	virtual int16_t getSectorLandType(uint8_t sectorID, uint8_t sectorLevel) const = 0;

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -15,6 +15,7 @@
 #include "sgp/MemMan.h"
 
 #include "AmmoTypeModel.h"
+#include "CacheSectorsModel.h"
 #include "CalibreModel.h"
 #include "ContentMusic.h"
 #include "DealerInventory.h"
@@ -197,6 +198,7 @@ DefaultContentManager::DefaultContentManager(GameVersion gameVersion,
 	m_impPolicy = NULL;
 	m_gamePolicy = NULL;
 
+	m_cacheSectors = NULL;
 	m_movementCosts = NULL;
 	m_loadingScreenModel = NULL;
 	m_samSitesAirControl = NULL;
@@ -307,6 +309,7 @@ DefaultContentManager::~DefaultContentManager()
 
 	m_sectorLandTypes.clear();
 
+	delete m_cacheSectors;
 	delete m_movementCosts;
 	delete m_samSitesAirControl;
 }
@@ -1217,6 +1220,10 @@ bool DefaultContentManager::loadStrategicLayerData()
 	}
 
 	CreatureLairModel::validateData(m_creatureLairs, m_undergroundSectors, m_mines.size());
+
+	json = readJsonDataFile("strategic-map-cache-sectors.json");
+	m_cacheSectors = CacheSectorsModel::deserialize(*json);
+
 	return true;
 }
 
@@ -1415,6 +1422,11 @@ int16_t DefaultContentManager::getSectorLandType(uint8_t const sectorID, uint8_t
 		return -1;
 	}
 	return m_sectorLandTypes.at(key);
+}
+
+const CacheSectorsModel* DefaultContentManager::getCacheSectors() const
+{
+	return m_cacheSectors;
 }
 
 const std::vector<const StrategicMapSecretModel*>& DefaultContentManager::getMapSecrets() const

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -172,6 +172,7 @@ public:
 	virtual const MovementCostsModel* getMovementCosts() const override;
 	virtual int16_t getSectorLandType(uint8_t sectorID, uint8_t sectorLevel) const override;
 	virtual const std::vector<const StrategicMapSecretModel*>& getMapSecrets() const override;
+	virtual const CacheSectorsModel* getCacheSectors() const override;
 	virtual const std::map<uint8_t, const NpcPlacementModel*>& listNpcPlacements() const override;
 	virtual const NpcPlacementModel* getNpcPlacement(uint8_t profileId) const override;
 	virtual const RPCSmallFaceModel* getRPCSmallFaceOffsets(uint8_t profileID) const override;
@@ -232,6 +233,7 @@ protected:
 	const IMPPolicy *m_impPolicy;
 	const GamePolicy *m_gamePolicy;
 
+	const CacheSectorsModel* m_cacheSectors;
 	const LoadingScreenModel* m_loadingScreenModel;
 	const MovementCostsModel* m_movementCosts;
 	std::map<std::tuple<uint8_t, uint8_t>, uint8_t> m_sectorLandTypes;

--- a/src/externalized/JsonUtility.h
+++ b/src/externalized/JsonUtility.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "GameSettings.h"
 #include "rapidjson/document.h"
 #include <string_theory/string>
 
@@ -16,4 +17,16 @@ namespace JsonUtility
 
 	/** Parse value as list of strings. */
 	bool parseListStrings(const rapidjson::Value &value, std::vector<ST::string> &strings);
+
+	/** Parse a sector string to sector ID */
+	uint8_t parseSectorID(const char* sectorShortString);
+
+	/** Parse a given string field to sector ID */
+	uint8_t parseSectorID(const rapidjson::Value& json, const char* fieldName);
+
+	/** Parse a given string array field to list of sector IDs */
+	std::vector<uint8_t> parseSectorList(const rapidjson::Value& json, const char* fieldName);
+
+	/** Parse a given integer array field into a list keyed by game difficulty */
+	std::array<uint8_t, NUM_DIF_LEVELS> readIntArrayByDiff(const rapidjson::Value& obj, const char* fieldName);
 }

--- a/src/externalized/army/GarrisonGroupModel.cc
+++ b/src/externalized/army/GarrisonGroupModel.cc
@@ -2,7 +2,7 @@
 #include "Campaign_Types.h"
 #include "JsonUtility.h"
 
-GARRISON_GROUP GarrisonGroupModel::deserialize(JsonObjectReader& obj, std::map<std::string, uint8_t> armyCompMapping)
+GARRISON_GROUP GarrisonGroupModel::deserialize(JsonObjectReader& obj, const std::map<std::string, uint8_t>& armyCompMapping)
 {
 	auto sector = obj.GetString("sector");
 	uint8_t sectorId = JsonUtility::parseSectorID(sector);
@@ -14,7 +14,7 @@ GARRISON_GROUP GarrisonGroupModel::deserialize(JsonObjectReader& obj, std::map<s
 	return group;
 }
 
-void GarrisonGroupModel::validateData(std::vector<GARRISON_GROUP> garrisonGroups)
+void GarrisonGroupModel::validateData(const std::vector<GARRISON_GROUP>& garrisonGroups)
 {
 	if (garrisonGroups.size() > SAVED_GARRISON_GROUPS)
 	{

--- a/src/externalized/army/GarrisonGroupModel.cc
+++ b/src/externalized/army/GarrisonGroupModel.cc
@@ -1,14 +1,11 @@
 #include "GarrisonGroupModel.h"
 #include "Campaign_Types.h"
+#include "JsonUtility.h"
 
 GARRISON_GROUP GarrisonGroupModel::deserialize(JsonObjectReader& obj, std::map<std::string, uint8_t> armyCompMapping)
 {
 	auto sector = obj.GetString("sector");
-	if (!IS_VALID_SECTOR_SHORT_STRING(sector))
-	{
-		throw std::runtime_error("Not a valid sector string");
-	}
-	uint8_t sectorId = SECTOR_FROM_SECTOR_SHORT_STRING(sector);
+	uint8_t sectorId = JsonUtility::parseSectorID(sector);
 	uint8_t compositionId = armyCompMapping.at(std::string(obj.GetString("composition")));
 
 	GARRISON_GROUP group{};

--- a/src/externalized/army/GarrisonGroupModel.h
+++ b/src/externalized/army/GarrisonGroupModel.h
@@ -11,6 +11,6 @@
 class GarrisonGroupModel
 {
 public:
-	static GARRISON_GROUP deserialize(JsonObjectReader& obj, std::map<std::string, uint8_t> armyCompMapping);
-	static void validateData(std::vector<GARRISON_GROUP> garrisonGroups);
+	static GARRISON_GROUP deserialize(JsonObjectReader& obj, const std::map<std::string, uint8_t>& armyCompMapping);
+	static void validateData(const std::vector<GARRISON_GROUP>& garrisonGroups);
 };

--- a/src/externalized/army/PatrolGroupModel.cc
+++ b/src/externalized/army/PatrolGroupModel.cc
@@ -1,5 +1,6 @@
 #include "PatrolGroupModel.h"
 #include "Campaign_Types.h"
+#include "JsonUtility.h"
 
 void ReadPatrolPoints(const rapidjson::Value& arr, uint8_t (&points)[4])
 {
@@ -15,11 +16,7 @@ void ReadPatrolPoints(const rapidjson::Value& arr, uint8_t (&points)[4])
 	for (rapidjson::SizeType i = 0; i < arraySize; i++)
 	{
 		auto sector = arr[i].GetString();
-		if (!IS_VALID_SECTOR_SHORT_STRING(sector))
-		{
-			throw std::runtime_error("Invalid sector string given");
-		}
-		points[i] = SECTOR_FROM_SECTOR_SHORT_STRING(sector);
+		points[i] = JsonUtility::parseSectorID(sector);
 	}
 }
 

--- a/src/externalized/army/PatrolGroupModel.cc
+++ b/src/externalized/army/PatrolGroupModel.cc
@@ -2,7 +2,7 @@
 #include "Campaign_Types.h"
 #include "JsonUtility.h"
 
-void ReadPatrolPoints(const rapidjson::Value& arr, uint8_t (&points)[4])
+static void ReadPatrolPoints(const rapidjson::Value& arr, uint8_t (&points)[4])
 {
 	if (!arr.IsArray())
 	{
@@ -31,7 +31,7 @@ PATROL_GROUP PatrolGroupModel::deserialize(const rapidjson::Value& val)
 	return g;
 }
 
-void PatrolGroupModel::validateData(std::vector<PATROL_GROUP> patrolGroups)
+void PatrolGroupModel::validateData(const std::vector<PATROL_GROUP>& patrolGroups)
 {
 	if (patrolGroups.size() > SAVED_PATROL_GROUPS)
 	{

--- a/src/externalized/army/PatrolGroupModel.h
+++ b/src/externalized/army/PatrolGroupModel.h
@@ -9,5 +9,5 @@ class PatrolGroupModel
 {
 public:
 	static PATROL_GROUP deserialize(const rapidjson::Value& val);
-	static void validateData(std::vector<PATROL_GROUP> patrolGroups);
+	static void validateData(const std::vector<PATROL_GROUP>& patrolGroups);
 };

--- a/src/externalized/strategic/BloodCatPlacementsModel.cc
+++ b/src/externalized/strategic/BloodCatPlacementsModel.cc
@@ -1,5 +1,5 @@
 #include "BloodCatPlacementsModel.h"
-
+#include "JsonUtility.h"
 
 BloodCatPlacementsModel::BloodCatPlacementsModel(uint8_t sectorId_, int8_t bloodCatPlacements_)
 		:sectorId(sectorId_), bloodCatPlacements(bloodCatPlacements_)
@@ -7,7 +7,7 @@ BloodCatPlacementsModel::BloodCatPlacementsModel(uint8_t sectorId_, int8_t blood
 
 BloodCatPlacementsModel* BloodCatPlacementsModel::deserialize(JsonObjectReader & obj)
 {
-	uint8_t sectorId = SECTOR_FROM_SECTOR_SHORT_STRING(obj.GetString("sector"));
+	uint8_t sectorId = JsonUtility::parseSectorID(obj.GetString("sector"));
 	return new BloodCatPlacementsModel(	
 		sectorId,
 		obj.GetInt("bloodCatPlacements")

--- a/src/externalized/strategic/BloodCatSpawnsModel.cc
+++ b/src/externalized/strategic/BloodCatSpawnsModel.cc
@@ -1,5 +1,6 @@
 #include "BloodCatSpawnsModel.h"
 #include "GameSettings.h"
+#include "JsonUtility.h"
 
 BloodCatSpawnsModel::BloodCatSpawnsModel(uint8_t sectorId_, 
 	bool isLair_, bool isArena_,
@@ -24,7 +25,7 @@ const int8_t BloodCatSpawnsModel::getSpawnsByDifficulty(uint8_t difficultyLevel)
 
 BloodCatSpawnsModel* BloodCatSpawnsModel::deserialize(JsonObjectReader& obj)
 {
-	uint8_t sectorId = SECTOR_FROM_SECTOR_SHORT_STRING( obj.GetString("sector") );
+	uint8_t sectorId = JsonUtility::parseSectorID(obj.GetString("sector"));
 	return new BloodCatSpawnsModel(
 		sectorId,
 		obj.GetBool("isLair"),

--- a/src/externalized/strategic/CMakeLists.txt
+++ b/src/externalized/strategic/CMakeLists.txt
@@ -4,6 +4,7 @@ set(JA2_SOURCES
     ${LOCAL_JA2_HEADERS}
     ${CMAKE_CURRENT_SOURCE_DIR}/BloodCatPlacementsModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/BloodCatSpawnsModel.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/CacheSectorsModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/CreatureLairModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/FactParamsModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/MineModel.cc

--- a/src/externalized/strategic/CacheSectorsModel.cc
+++ b/src/externalized/strategic/CacheSectorsModel.cc
@@ -1,0 +1,34 @@
+#include "CacheSectorsModel.h"
+#include "JsonUtility.h"
+#include "Random.h"
+#include <utility>
+
+CacheSectorsModel::CacheSectorsModel(std::vector<uint8_t> sectors_,
+	std::array<uint8_t, NUM_DIF_LEVELS> numTroops_,
+	std::array<uint8_t, NUM_DIF_LEVELS> numTroopsVariance_)
+	: sectors(std::move(sectors_)), numTroops(numTroops_), numTroopsVariance(numTroopsVariance_) {}
+
+const CacheSectorsModel* CacheSectorsModel::deserialize(const rapidjson::Document& doc)
+{
+	auto sectorIDs = JsonUtility::parseSectorList(doc, "sectors");
+	return new CacheSectorsModel(
+		sectorIDs,
+		JsonUtility::readIntArrayByDiff(doc, "numTroops"),
+		JsonUtility::readIntArrayByDiff(doc, "numTroopsVariance")
+		);
+}
+
+int16_t CacheSectorsModel::pickSector() const
+{
+	return sectors.empty() ? -1 : sectors[Random(sectors.size())];
+}
+
+uint8_t CacheSectorsModel::getNumTroops(uint8_t difficultyLevel) const
+{
+	if (difficultyLevel < 1 || difficultyLevel > NUM_DIF_LEVELS)
+	{
+		ST::string err = ST::format("invalid difficulty level {}", difficultyLevel);
+		throw std::runtime_error(err.to_std_string());
+	}
+	return numTroops[difficultyLevel - 1] + Random(numTroopsVariance[difficultyLevel - 1]);
+}

--- a/src/externalized/strategic/CacheSectorsModel.h
+++ b/src/externalized/strategic/CacheSectorsModel.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "GameSettings.h"
+#include <array>
+#include <vector>
+#include <rapidjson/document.h>
+
+class CacheSectorsModel
+{
+public:
+	CacheSectorsModel(std::vector<uint8_t> sectors_,
+		std::array<uint8_t, NUM_DIF_LEVELS> numTroops_,
+		std::array<uint8_t, NUM_DIF_LEVELS> numTroopsVariance_);
+
+	static const CacheSectorsModel* deserialize(const rapidjson::Document& doc);
+
+	// randomly pick one sector from list; returns -1 if the list is empty
+	int16_t pickSector() const;
+
+	// randomly generate the number of troops guarding a cache sector, according to game difficulty
+	uint8_t getNumTroops(uint8_t difficultyLevel) const;
+
+	// the list of all possible cache sectors
+	const std::vector<uint8_t> sectors;
+
+protected:
+	const std::array<uint8_t, NUM_DIF_LEVELS> numTroops;
+	const std::array<uint8_t, NUM_DIF_LEVELS> numTroopsVariance;
+};

--- a/src/externalized/strategic/CreatureLairModel.cc
+++ b/src/externalized/strategic/CreatureLairModel.cc
@@ -2,6 +2,7 @@
 
 #include "Campaign_Types.h"
 #include "Creature_Spreading.h"
+#include "JsonUtility.h"
 #include "Random.h"
 #include <set>
 
@@ -50,13 +51,9 @@ std::vector<CreatureLairSector> readLairSectors(const rapidjson::Value& json)
 	{
 		auto arr = el.GetArray();
 		auto sectorString = arr[0].GetString();
-		if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
-		{
-			throw new std::runtime_error("Creature lair sector is invalid");
-		}
 
 		CreatureLairSector sec = {};
-		sec.sectorId = SECTOR_FROM_SECTOR_SHORT_STRING(sectorString);
+		sec.sectorId = JsonUtility::parseSectorID(sectorString);
 		sec.sectorLevel = arr[1].GetUint();
 		sec.habitatType = creatureHabitatFromString(arr[2].GetString());
 
@@ -78,18 +75,13 @@ std::vector<CreatureAttackSector> readAttackSectors(const rapidjson::Value& json
 	for (auto& el : json.GetArray())
 	{
 		JsonObjectReader obj(el);
-
 		auto sectorString = obj.GetString("sector");
-		if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
-		{
-			throw new std::runtime_error("Creature attack sector is invalid");
-		}
 
-		CreatureAttackSector sectorAttack;
+		CreatureAttackSector sectorAttack = {};
 		sectorAttack.chance = obj.GetUInt("chance");
 		sectorAttack.insertionCode = insertionCodeFromString(obj.GetString("insertionCode"));
 		sectorAttack.insertionGridNo = obj.getOptionalInt("insertionGridNo");
-		sectorAttack.sectorId = SECTOR_FROM_SECTOR_SHORT_STRING(sectorString);
+		sectorAttack.sectorId = JsonUtility::parseSectorID(sectorString);
 		attacks.push_back(sectorAttack);
 	}
 
@@ -155,20 +147,12 @@ CreatureLairModel* CreatureLairModel::deserialize(const rapidjson::Value& json)
 
 	auto entrance = json["entranceSector"].GetArray();
 	auto sectorString = entrance[0].GetString();
-	if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
-	{
-		throw new std::runtime_error("Entrance sector is invalid");
-	}
-	uint8_t entranceSector = SECTOR_FROM_SECTOR_SHORT_STRING(sectorString);
+	uint8_t entranceSector = JsonUtility::parseSectorID(sectorString);
 	uint8_t entranceSectorLevel = entrance[1].GetUint();
 
 	auto warpExit = JsonObjectReader(json["warpExit"]);
 	sectorString = warpExit.GetString("sector");
-	if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
-	{
-		throw new std::runtime_error("Warp exit sector is invalid");
-	}
-	uint8_t warpExitSector = SECTOR_FROM_SECTOR_SHORT_STRING(sectorString);
+	uint8_t warpExitSector = JsonUtility::parseSectorID(sectorString);
 	uint16_t warpExitGridNo = warpExit.GetUInt("gridNo");
 
 	return new CreatureLairModel(

--- a/src/externalized/strategic/CreatureLairModel.cc
+++ b/src/externalized/strategic/CreatureLairModel.cc
@@ -13,7 +13,7 @@ CreatureLairModel::CreatureLairModel(const uint8_t lairId_, const uint8_t associ
 	lairSectors(lairSectors_), attackSectors(attackSectors_),
 	warpExitSector(warpExitSector_), warpExitGridNo(warpExitGridNo_) {}
 
-uint8_t creatureHabitatFromString(std::string habitat)
+uint8_t creatureHabitatFromString(const std::string& habitat)
 {
 	if (habitat == "QUEEN_LAIR") return QUEEN_LAIR;
 	if (habitat == "LAIR") return LAIR;
@@ -27,7 +27,7 @@ uint8_t creatureHabitatFromString(std::string habitat)
 	throw std::runtime_error(err.to_std_string());
 }
 
-InsertionCode insertionCodeFromString(std::string code)
+InsertionCode insertionCodeFromString(const std::string& code)
 {
 	if (code == "NORTH") return INSERTION_CODE_NORTH;
 	if (code == "SOUTH") return INSERTION_CODE_SOUTH;

--- a/src/externalized/strategic/MineModel.cc
+++ b/src/externalized/strategic/MineModel.cc
@@ -2,7 +2,7 @@
 
 #include "JsonUtility.h"
 #include "Strategic_Mines.h"
-
+#include <utility>
 
 MineModel::MineModel(const uint8_t mineId_, const uint8_t entranceSector_, const uint8_t associatedTownId_, 
 	const uint8_t mineType_, const uint16_t minimumMineProduction_, const bool headMinerAssigned_,
@@ -11,14 +11,14 @@ MineModel::MineModel(const uint8_t mineId_, const uint8_t entranceSector_, const
 		mineId(mineId_), entranceSector(entranceSector_), associatedTownId(associatedTownId_),
 		mineType(mineType_), minimumMineProduction(minimumMineProduction_), headMinerAssigned(headMinerAssigned_),
 		noDepletion(noDepletion_), delayDepletion(delayDepletion_),
-		mineSectors(mineSectors_), faceDisplayYOffset(faceDisplayYOffset_) {}
+		mineSectors(std::move(mineSectors_)), faceDisplayYOffset(faceDisplayYOffset_) {}
 
 bool MineModel::isAbandoned() const
 {
 	return minimumMineProduction == 0;
 }
 
-uint8_t mineTypeFromString(std::string mineType)
+uint8_t mineTypeFromString(const std::string& mineType)
 {
 	if (mineType == "GOLD_MINE") return GOLD_MINE;
 	if (mineType == "SILVER_MINE") return SILVER_MINE;
@@ -33,7 +33,7 @@ std::vector<std::array<uint8_t, 2>> readMineSectors(const rapidjson::Value& sect
 	for (auto& s: sectorsJson.GetArray())
 	{
 		auto sector = s.GetArray();
-		if (sector.Size() != 2) throw new std::runtime_error("Elements in mineSector must be arrays of 2");
+		if (sector.Size() != 2) throw std::runtime_error("Elements in mineSector must be arrays of 2");
 
 		auto sectorString = sector[0].GetString();
 		auto sectorLevel = sector[1].GetUint();
@@ -66,7 +66,7 @@ MineModel* MineModel::deserialize(uint8_t index, const rapidjson::Value& json)
 	);
 }
 
-void MineModel::validateData(std::vector<const MineModel*> models)
+void MineModel::validateData(std::vector<const MineModel*>& models)
 {
 	if (models.size() != MAX_NUMBER_OF_MINES)
 	{

--- a/src/externalized/strategic/MineModel.h
+++ b/src/externalized/strategic/MineModel.h
@@ -30,5 +30,5 @@ public:
 	const int16_t faceDisplayYOffset;
 	
 	static MineModel* deserialize(uint8_t index, const rapidjson::Value& json);
-	static void validateData(std::vector<const MineModel*> models);
+	static void validateData(std::vector<const MineModel*>& models);
 };

--- a/src/externalized/strategic/NpcPlacementModel.cc
+++ b/src/externalized/strategic/NpcPlacementModel.cc
@@ -1,5 +1,5 @@
 #include "NpcPlacementModel.h"
-#include "Campaign_Types.h"
+#include "JsonUtility.h"
 #include "Random.h"
 #include <utility>
 
@@ -10,16 +10,7 @@ NpcPlacementModel::NpcPlacementModel(uint8_t profileId_, std::vector<uint8_t> se
 
 NpcPlacementModel* NpcPlacementModel::deserialize(const rapidjson::Value& element)
 {
-	std::vector<uint8_t> sectorIds;
-	for (auto& sector : element["sectors"].GetArray())
-	{
-		auto sectorString = sector.GetString();
-		if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
-		{
-			throw std::runtime_error("Invalid sector string");
-		}
-		sectorIds.push_back(SECTOR_FROM_SECTOR_SHORT_STRING(sectorString));
-	}
+	std::vector<uint8_t> sectorIds = JsonUtility::parseSectorList(element, "sectors");
 
 	JsonObjectReader r(element);
 	return new NpcPlacementModel(

--- a/src/externalized/strategic/SamSiteModel.cc
+++ b/src/externalized/strategic/SamSiteModel.cc
@@ -1,9 +1,9 @@
 #include "SamSiteModel.h"
 
 #include "Campaign_Types.h"
+#include "JsonUtility.h"
 #include "SAM_Sites.h"
 #include "WorldDef.h"
-
 #include <algorithm>
 
 
@@ -28,11 +28,7 @@ const bool SamSiteModel::doesSamExistHere(INT16 const x, INT16 const y, GridNo c
 SamSiteModel* SamSiteModel::deserialize(const rapidjson::Value& obj)
 {
 	const char* sector = obj["sector"].GetString();
-	if (!IS_VALID_SECTOR_SHORT_STRING(sector))
-	{
-		throw std::runtime_error("SAM site sector is not a valid string");
-	}
-	uint8_t sectorId = SECTOR_FROM_SECTOR_SHORT_STRING(sector);
+	uint8_t sectorId = JsonUtility::parseSectorID(sector);
 
 	auto g = obj["gridNos"].GetArray();
 	if (g.Size() != 2)

--- a/src/externalized/strategic/StrategicMapSecretModel.cc
+++ b/src/externalized/strategic/StrategicMapSecretModel.cc
@@ -1,6 +1,7 @@
 #include "StrategicMapSecretModel.h"
 #include "Campaign_Types.h"
 #include "JsonObject.h"
+#include "JsonUtility.h"
 #include "SamSiteModel.h"
 #include <set>
 #include <stdexcept>
@@ -15,12 +16,7 @@ StrategicMapSecretModel::StrategicMapSecretModel(
 StrategicMapSecretModel* StrategicMapSecretModel::deserialize(const rapidjson::Value& json, const TraversibilityMap &mapping)
 {
 	JsonObjectReader r(json);
-	auto sector = r.GetString("sector");
-	if (!IS_VALID_SECTOR_SHORT_STRING(sector))
-	{
-		throw std::runtime_error("not a valid sector");
-	}
-
+	auto sector         = JsonUtility::parseSectorID(r.GetString("sector"));
 	auto landTypeString = r.GetString("secretLandType");
 	auto secretLandType = mapping.at(landTypeString);
 
@@ -28,7 +24,7 @@ StrategicMapSecretModel* StrategicMapSecretModel::deserialize(const rapidjson::V
 	auto foundLandType = mapping.at(landTypeString);
 
 	return new StrategicMapSecretModel(
-		SECTOR_FROM_SECTOR_SHORT_STRING(sector),
+		sector,
 		r.getOptionalBool("isSAMSite"),
 		r.getOptionalString("secretMapIcon") ,
 		secretLandType,

--- a/src/externalized/strategic/TownModel.cc
+++ b/src/externalized/strategic/TownModel.cc
@@ -1,6 +1,7 @@
 #include "TownModel.h"
 
 #include "JsonObject.h"
+#include "JsonUtility.h"
 
 TownModel::TownModel(int8_t townId_, std::vector<uint8_t> sectorIDs_, SGPPoint townPoint_, bool isMilitiaTrainingAllowed_)
 		: townId(townId_), sectorIDs(sectorIDs_), townPoint(townPoint_), isMilitiaTrainingAllowed(isMilitiaTrainingAllowed_) {}
@@ -18,12 +19,7 @@ const uint8_t TownModel::getBaseSector() const
 
 TownModel* TownModel::deserialize(const rapidjson::Value& obj)
 {
-	Assert( obj.HasMember("sectors") && obj["sectors"].IsArray() );
-	std::vector<uint8_t> sectorIDs;
-	for ( auto& s : obj["sectors"].GetArray() ) 
-	{
-		sectorIDs.push_back( SECTOR_FROM_SECTOR_SHORT_STRING( s.GetString() ) );
-	}
+	std::vector<uint8_t> sectorIDs = JsonUtility::parseSectorList(obj, "sectors");
 
 	Assert( obj.HasMember("townPoint") && obj["townPoint"].IsObject() );
 	auto tp = obj["townPoint"].GetObject();

--- a/src/externalized/strategic/TownModel.cc
+++ b/src/externalized/strategic/TownModel.cc
@@ -2,9 +2,10 @@
 
 #include "JsonObject.h"
 #include "JsonUtility.h"
+#include <utility>
 
 TownModel::TownModel(int8_t townId_, std::vector<uint8_t> sectorIDs_, SGPPoint townPoint_, bool isMilitiaTrainingAllowed_)
-		: townId(townId_), sectorIDs(sectorIDs_), townPoint(townPoint_), isMilitiaTrainingAllowed(isMilitiaTrainingAllowed_) {}
+		: townId(townId_), sectorIDs(std::move(sectorIDs_)), townPoint(townPoint_), isMilitiaTrainingAllowed(isMilitiaTrainingAllowed_) {}
 
 const uint8_t TownModel::getBaseSector() const
 {

--- a/src/externalized/strategic/UndergroundSectorModel.cc
+++ b/src/externalized/strategic/UndergroundSectorModel.cc
@@ -80,7 +80,7 @@ UndergroundSectorModel* UndergroundSectorModel::deserialize(const rapidjson::Val
 	);
 }
 
-void UndergroundSectorModel::validateData(const std::vector<const UndergroundSectorModel*> ugSectors)
+void UndergroundSectorModel::validateData(const std::vector<const UndergroundSectorModel*>& ugSectors)
 {
 	// check for existence of hard-coded references
 	// the list below is based on the occurrences of FindUnderGroundSector in codebase

--- a/src/externalized/strategic/UndergroundSectorModel.cc
+++ b/src/externalized/strategic/UndergroundSectorModel.cc
@@ -1,5 +1,6 @@
 #include "UndergroundSectorModel.h"
 
+#include "JsonUtility.h"
 #include "Random.h"
 
 UndergroundSectorModel::UndergroundSectorModel(uint8_t sectorId_, uint8_t sectorZ_, uint8_t adjacentSectors_, 
@@ -25,36 +26,9 @@ UNDERGROUND_SECTORINFO* UndergroundSectorModel::createUndergroundSectorInfo(uint
 	return u;
 }
 
-std::array<uint8_t, NUM_DIF_LEVELS> readIntArray(const rapidjson::Value& obj, const char* fieldName)
-{
-	std::array<uint8_t, NUM_DIF_LEVELS> vals = {};
-	if (!obj.HasMember(fieldName))
-	{
-		return vals;
-	}
-	auto arr = obj[fieldName].GetArray();
-	if (arr.Size() != NUM_DIF_LEVELS)
-	{
-		ST::string err = ST::format("The number of values in {} is not same as NUM_DIF_LEVELS({})", fieldName, NUM_DIF_LEVELS);
-		throw std::runtime_error(err.to_std_string());
-	}
-	for (auto i = 0; i < NUM_DIF_LEVELS; i++)
-	{
-		vals[i] = static_cast<uint8_t>(arr[i].GetUint());
-	}
-
-	return vals;
-}
-
 UndergroundSectorModel* UndergroundSectorModel::deserialize(const rapidjson::Value& obj)
 {
-	auto sectorString = obj["sector"].GetString();
-	if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
-	{
-		ST::string err = ST::format("'{}' is not valid sector", sectorString);
-		throw std::runtime_error(err.to_std_string());
-	}
-	uint8_t sectorId = SECTOR_FROM_SECTOR_SHORT_STRING(sectorString);
+	uint8_t sectorId = JsonUtility::parseSectorID(obj["sector"].GetString());
 	uint8_t sectorZ = obj["sectorLevel"].GetUint();
 	if (sectorZ == 0 || sectorZ > 3)
 	{
@@ -97,8 +71,12 @@ UndergroundSectorModel* UndergroundSectorModel::deserialize(const rapidjson::Val
 	
 	return new UndergroundSectorModel(
 		sectorId, sectorZ, adjacencyFlag,
-		readIntArray(obj, "numTroops"), readIntArray(obj, "numElites"), readIntArray(obj, "numCreatures"),
-		readIntArray(obj, "numTroopsVariance"), readIntArray(obj, "numElitesVariance"), readIntArray(obj, "numCreaturesVariance")
+		JsonUtility::readIntArrayByDiff(obj, "numTroops"),
+		JsonUtility::readIntArrayByDiff(obj, "numElites"),
+		JsonUtility::readIntArrayByDiff(obj, "numCreatures"),
+		JsonUtility::readIntArrayByDiff(obj, "numTroopsVariance"),
+		JsonUtility::readIntArrayByDiff(obj, "numElitesVariance"),
+		JsonUtility::readIntArrayByDiff(obj, "numCreaturesVariance")
 	);
 }
 

--- a/src/externalized/strategic/UndergroundSectorModel.h
+++ b/src/externalized/strategic/UndergroundSectorModel.h
@@ -24,7 +24,7 @@ public:
 	UNDERGROUND_SECTORINFO* createUndergroundSectorInfo(uint8_t difficultyLevel) const;
 
 	static UndergroundSectorModel* deserialize(const rapidjson::Value& obj);
-	static void validateData(const std::vector<const UndergroundSectorModel*> ugSectors);
+	static void validateData(const std::vector<const UndergroundSectorModel*>& ugSectors);
 
 	uint8_t sectorId;
 	uint8_t sectorZ;

--- a/src/game/Strategic/Strategic_AI.cc
+++ b/src/game/Strategic/Strategic_AI.cc
@@ -32,6 +32,7 @@
 #include "ContentManager.h"
 #include "ArmyCompositionModel.h"
 #include "GarrisonGroupModel.h"
+#include "CacheSectorsModel.h"
 #include "MemMan.h"
 #include "Debug.h"
 #include "FileMan.h"
@@ -643,10 +644,15 @@ void InitStrategicAI()
 	 * set up the flags to use the alternate map, then place 8-12 regular troops
 	 * there (no AI though). Changing MAX_STRATEGIC_TEAM_SIZE may require changes
 	 * to to the defending force here. */
-	static UINT8 const cache_sectors[] = { SEC_E11, SEC_H5, SEC_H10, SEC_J12, SEC_M9 };
-	SECTORINFO& si = SectorInfo[cache_sectors[Random(lengthof(cache_sectors))]];
-	si.uiFlags     |= SF_USE_ALTERNATE_MAP;
-	si.ubNumTroops  = 6 + difficulty * 2;
+	auto model = GCM->getCacheSectors();
+	INT16 sSectorID = model->pickSector();
+	if (sSectorID >= 0)
+	{
+		SECTORINFO &si = SectorInfo[sSectorID];
+		si.uiFlags |= SF_USE_ALTERNATE_MAP;
+		si.ubNumTroops = model->getNumTroops(difficulty);
+		SLOGD(ST::format("Weapon cache is at {}", SECTOR_SHORT_STRING(sSectorID)));
+	}
 }
 
 


### PR DESCRIPTION
Externalizes the cache sectors data (#665). The game randomly chooses one of the five possible sectors to put a weapon cache.

This PR also includes some minor refactoring, for better code re-use and good general practice of passing const-ref (recommended by clang-tidy, might also be trivial marginal performance improvement).