### PR TITLE
Fix some memory leaks

### DIFF
--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -899,6 +899,7 @@ bool DefaultContentManager::loadArmyData()
 		mapping[armyComp->name] = armyComp->compositionId;
 		m_armyCompositions.push_back(armyComp->toArmyComposition());
 	}
+	deleteElements(armyCompModels);
 	armyCompModels.clear();
 
 	auto jsonGG = readJsonDataFile("army-garrison-groups.json");

--- a/src/game/GameScreen.cc
+++ b/src/game/GameScreen.cc
@@ -146,9 +146,9 @@ void MainGameScreenInit(void)
 void MainGameScreenShutdown(void)
 {
 	ShutdownZBuffer(gpZBuffer);
-	ShutdownBackgroundRects();
 	RemoveVideoOverlay(g_fps_overlay);
 	RemoveVideoOverlay(g_counter_period_overlay);
+	ShutdownBackgroundRects();
 }
 
 

--- a/src/game/TileEngine/Render_Dirty.cc
+++ b/src/game/TileEngine/Render_Dirty.cc
@@ -350,11 +350,13 @@ void InvalidateBackgroundRects(void)
 
 void ShutdownBackgroundRects(void)
 {
-	for (UINT32 i = 0; i < guiNumBackSaves; ++i)
+	for (auto backgroundSave : gBackSaves)
 	{
-		BACKGROUND_SAVE* const b = gBackSaves[i];
-		if (b->fAllocated) FreeBackgroundRectNow(b);
+		if (backgroundSave->fAllocated) FreeBackgroundRectNow(backgroundSave);
+		delete backgroundSave;
 	}
+	gBackSaves.clear();
+	guiNumBackSaves = 0;
 }
 
 

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -281,9 +281,34 @@ void ShutdownVideoManager(void)
 	/* Toggle the state of the video manager to indicate to the refresh thread
 	 * that it needs to shut itself down */
 
-	SDL_QuitSubSystem(SDL_INIT_VIDEO);
-
 	guiVideoManagerState = VIDEO_OFF;
+
+	if (ScreenBuffer != NULL) {
+		SDL_FreeSurface(ScreenBuffer);
+		ScreenBuffer = NULL;
+	}
+
+	if (ScreenTexture != NULL) {
+		SDL_DestroyTexture(ScreenTexture);
+		ScreenTexture = NULL;
+	}
+
+	if (ScaledScreenTexture != NULL) {
+		SDL_DestroyTexture(ScaledScreenTexture);
+		ScaledScreenTexture = NULL;
+	}
+
+	if (GameRenderer != NULL) {
+		SDL_DestroyRenderer(GameRenderer);
+		GameRenderer = NULL;
+	}
+
+	if (g_game_window != NULL) {
+		SDL_DestroyWindow(g_game_window);
+		g_game_window = NULL;
+	}
+
+	SDL_QuitSubSystem(SDL_INIT_VIDEO);
 
 	// ATE: Release mouse cursor!
 	FreeMouseCursor();


### PR DESCRIPTION
Fixes some memory leaks found with the `valgrind` tool. This is especially important for Android, as we use `ja2-stracciatella` as a library there, so memory leaks will accumulate over time. I omitted leaks in `SoundMan.cc`, as I have another branch (that I wanted to actually test for memory leaks) that does a big refactoring there...