### PR TITLE
Replacing const char* in model classes

### DIFF
--- a/src/externalized/AmmoTypeModel.cc
+++ b/src/externalized/AmmoTypeModel.cc
@@ -1,19 +1,16 @@
 #include "AmmoTypeModel.h"
-
 #include "JsonObject.h"
-
-#include <string_theory/format>
-
 #include <stdexcept>
+#include <string_theory/format>
+#include <utility>
 
 AmmoTypeModel::AmmoTypeModel(uint16_t index_,
-				const char* internalName_)
-	:index(index_), internalName(internalName_)
+				ST::string internalName_)
+	:index(index_), internalName(std::move(internalName_))
 {
 }
 
-// This could be default in C++11
-AmmoTypeModel::~AmmoTypeModel() {}
+AmmoTypeModel::~AmmoTypeModel() = default;
 
 void AmmoTypeModel::serializeTo(JsonObject &obj) const
 {
@@ -24,15 +21,15 @@ void AmmoTypeModel::serializeTo(JsonObject &obj) const
 AmmoTypeModel* AmmoTypeModel::deserialize(JsonObjectReader &obj)
 {
 	int index = obj.GetInt("index");
-	const char *internalName = obj.GetString("internalName");
+	ST::string internalName = obj.GetString("internalName");
 	return new AmmoTypeModel(index, internalName);
 }
 
 
-const AmmoTypeModel* getAmmoType(const char *ammoTypeName,
+const AmmoTypeModel* getAmmoType(const ST::string& ammoTypeName,
 					const std::map<ST::string, const AmmoTypeModel*> &ammoTypeMap)
 {
-	std::map<ST::string, const AmmoTypeModel*>::const_iterator it = ammoTypeMap.find(ammoTypeName);
+	auto it = ammoTypeMap.find(ammoTypeName);
 	if(it != ammoTypeMap.end())
 	{
 		return it->second;

--- a/src/externalized/AmmoTypeModel.h
+++ b/src/externalized/AmmoTypeModel.h
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <stdint.h>
+#include <string_theory/string>
 
 
 class JsonObject;
@@ -11,7 +12,7 @@ class JsonObjectReader;
 
 struct AmmoTypeModel
 {
-	AmmoTypeModel(uint16_t index, const char* internalName);
+	AmmoTypeModel(uint16_t index, ST::string internalName);
 
 	// This could be default in C++11
 	virtual ~AmmoTypeModel();
@@ -24,5 +25,5 @@ struct AmmoTypeModel
 	ST::string internalName;
 };
 
-const AmmoTypeModel* getAmmoType(const char *calibreName,
+const AmmoTypeModel* getAmmoType(const ST::string& calibreName,
 					const std::map<ST::string, const AmmoTypeModel*> &calibreMap);

--- a/src/externalized/CalibreModel.cc
+++ b/src/externalized/CalibreModel.cc
@@ -1,31 +1,28 @@
 #include "CalibreModel.h"
-
-#include "game/Utils/Text.h"
-
-#include "JsonObject.h"
-
 #include "ContentManager.h"
 #include "GameInstance.h"
-
+#include "JsonObject.h"
+#include "Text.h"
 #include <string_theory/format>
-
+#include <string_theory/string>
 #include <stdexcept>
+#include <utility>
 
 CalibreModel::CalibreModel(uint16_t index_,
-				const char* internalName_,
-				const char* burstSoundString_,
+				ST::string internalName_,
+				ST::string burstSoundString_,
 				bool showInHelpText_,
 				bool monsterWeapon_,
 				int silencerSound_)
-	:index(index_), internalName(internalName_),
-	burstSoundString(burstSoundString_),
+	:index(index_), internalName(std::move(internalName_)),
+	burstSoundString(std::move(burstSoundString_)),
 	showInHelpText(showInHelpText_),
 	monsterWeapon(monsterWeapon_),
 	silencerSound(silencerSound_)
 {
 }
 
-CalibreModel::~CalibreModel() {}
+CalibreModel::~CalibreModel() = default;
 
 void CalibreModel::serializeTo(JsonObject &obj) const
 {
@@ -40,8 +37,8 @@ void CalibreModel::serializeTo(JsonObject &obj) const
 CalibreModel* CalibreModel::deserialize(JsonObjectReader &obj)
 {
 	int index = obj.GetInt("index");
-	const char *internalName = obj.GetString("internalName");
-	const char *burstSoundString = obj.GetString("burstSoundString");
+	ST::string internalName = obj.GetString("internalName");
+	ST::string burstSoundString = obj.GetString("burstSoundString");
 	return new CalibreModel(index, internalName, burstSoundString,
 				obj.GetBool("showInHelpText"),
 				obj.GetBool("monsterWeapon"),
@@ -61,10 +58,10 @@ const CalibreModel* CalibreModel::getNoCalibreObject()
 }
 
 
-const CalibreModel* getCalibre(const char *calibreName,
+const CalibreModel* getCalibre(const ST::string& calibreName,
 				const std::map<ST::string, const CalibreModel*> &calibreMap)
 {
-	std::map<ST::string, const CalibreModel*>::const_iterator it = calibreMap.find(calibreName);
+	auto it = calibreMap.find(calibreName);
 	if(it != calibreMap.end())
 	{
 		return it->second;

--- a/src/externalized/CalibreModel.h
+++ b/src/externalized/CalibreModel.h
@@ -14,8 +14,8 @@ class JsonObjectReader;
 struct CalibreModel
 {
 	CalibreModel(uint16_t index,
-			const char* internalName,
-			const char* burstSoundString,
+			ST::string internalName,
+			ST::string burstSoundString,
 			bool showInHelpText,
 			bool monsterWeapon,
 			int silencerSound
@@ -39,5 +39,5 @@ struct CalibreModel
 	int silencerSound;
 };
 
-const CalibreModel* getCalibre(const char *calibreName,
+const CalibreModel* getCalibre(const ST::string& calibreName,
 				const std::map<ST::string, const CalibreModel*> &calibreMap);

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -893,7 +893,7 @@ bool DefaultContentManager::loadArmyData()
 	auto armyCompModels = ArmyCompositionModel::deserialize(*jsonAC);
 	ArmyCompositionModel::validateData(armyCompModels);
 
-	std::map<std::string, uint8_t> mapping;
+	std::map<ST::string, uint8_t> mapping;
 	for (auto& armyComp : armyCompModels)
 	{
 		mapping[armyComp->name] = armyComp->compositionId;

--- a/src/externalized/DefaultContentManagerUT.cc
+++ b/src/externalized/DefaultContentManagerUT.cc
@@ -10,7 +10,7 @@ DefaultContentManagerUT::DefaultContentManagerUT(GameVersion gameVersion,
 	: DefaultContentManager(gameVersion, configFolder, gameResRootPath, externalizedDataPath)
 {}
 
-void DefaultContentManagerUT::init()
+void DefaultContentManagerUT::init(EngineOptions* engine_options)
 {
 	Vfs_addDir(m_vfs.get(), m_externalizedDataPath.c_str());
 }
@@ -30,7 +30,7 @@ DefaultContentManagerUT* DefaultContentManagerUT::createDefaultCMForTesting()
 	DefaultContentManagerUT* cm = new DefaultContentManagerUT(GameVersion::ENGLISH,
 					configFolderPath,
 					gameResRootPath, externalizedDataPath);
-	cm->init();
+	cm->init(NULL);
 
 	return cm;
 }

--- a/src/externalized/DefaultContentManagerUT.h
+++ b/src/externalized/DefaultContentManagerUT.h
@@ -3,12 +3,14 @@
 #include "GameRes.h"
 #include "externalized/DefaultContentManager.h"
 
+struct EngineOptions;
+
 class DefaultContentManagerUT : public DefaultContentManager
 {
 public:
 	DefaultContentManagerUT(GameVersion gameVersion, const ST::string& configFolder, const ST::string& gameResRootPath, const ST::string& externalizedDataPath);
 	
-	virtual void init();
+	virtual void init(EngineOptions*);
 
 	// expose this method to unit tests
 	std::unique_ptr<rapidjson::Document> _readJsonDataFile(const char* fileName) const;

--- a/src/externalized/DefaultContentManager_unittests.cc
+++ b/src/externalized/DefaultContentManager_unittests.cc
@@ -144,8 +144,8 @@ TEST(ExternalizedData, readEveryFile)
 	std::vector<ST::string> results = FindFilesInDir(dataPath, "json", true, false, false, true);
 	for (ST::string f : results)
 	{
-		auto json = cm->_readJsonDataFile(f.c_str()).get();
-		ASSERT_FALSE(json == NULL);
+		auto json = cm->_readJsonDataFile(f.c_str());
+		ASSERT_FALSE(json.get() == NULL);
 	}
 }
 #endif

--- a/src/externalized/ItemModel.cc
+++ b/src/externalized/ItemModel.cc
@@ -1,18 +1,20 @@
 #include "ItemModel.h"
 
+#include <utility>
+
 #include "JsonObject.h"
 #include "MagazineModel.h"
 #include "WeaponModels.h"
 
 
 ItemModel::ItemModel(uint16_t itemIndex,
-			const char* internalName,
+			ST::string internalName,
 			uint32_t usItemClass,
 			uint8_t classIndex,
 			ItemCursor cursor)
 {
 	this->itemIndex             = itemIndex;
-	this->internalName          = internalName;
+	this->internalName          = std::move(internalName);
 	this->usItemClass           = usItemClass;
 	this->ubClassIndex          = classIndex;
 	this->ubCursor              = cursor;
@@ -28,7 +30,7 @@ ItemModel::ItemModel(uint16_t itemIndex,
 }
 
 ItemModel::ItemModel(uint16_t   itemIndex,
-			const char* internalName,
+			ST::string internalName,
 			uint32_t   usItemClass,
 			uint8_t    ubClassIndex,
 			ItemCursor ubCursor,
@@ -58,8 +60,7 @@ ItemModel::ItemModel(uint16_t   itemIndex,
 	this->fFlags                = fFlags;
 }
 
-// This could be default in C++11
-ItemModel::~ItemModel() {}
+ItemModel::~ItemModel() = default;
 
 const ST::string& ItemModel::getInternalName() const  { return internalName;          }
 

--- a/src/externalized/ItemModel.h
+++ b/src/externalized/ItemModel.h
@@ -1,7 +1,5 @@
 #pragma once
-
-#include "game/Tactical/Item_Types.h"
-
+#include "Item_Types.h"
 #include <string_theory/string>
 
 class JsonObject;
@@ -13,14 +11,14 @@ struct ItemModel
 {
 	ItemModel(
 		uint16_t itemIndex,
-		const char* internalName,
+		ST::string internalName,
 		uint32_t usItemClass,
 		uint8_t classIndex=0,
 		ItemCursor cursor=INVALIDCURS);
 
 	ItemModel(
 		uint16_t   itemIndex,
-		const char* internalName,
+		ST::string internalName,
 		uint32_t   usItemClass,
 		uint8_t    ubClassIndex,
 		ItemCursor ubCursor,

--- a/src/externalized/JsonUtility.cc
+++ b/src/externalized/JsonUtility.cc
@@ -59,14 +59,14 @@ bool JsonUtility::parseListStrings(const rapidjson::Value &value, std::vector<ST
 	return false;
 }
 
-uint8_t JsonUtility::parseSectorID(const char* sectorString)
+uint8_t JsonUtility::parseSectorID(const ST::string& sectorString)
 {
 	if (!IS_VALID_SECTOR_SHORT_STRING(sectorString))
 	{
 		ST::string err = ST::format("{} is not a valid sector", sectorString);
 		throw std::runtime_error(err.to_std_string());
 	}
-	return SECTOR_FROM_SECTOR_SHORT_STRING(sectorString);
+	return SECTOR_FROM_SECTOR_SHORT_STRING(sectorString.c_str());
 }
 
 uint8_t JsonUtility::parseSectorID(const rapidjson::Value& json, const char* fieldName)

--- a/src/externalized/JsonUtility.h
+++ b/src/externalized/JsonUtility.h
@@ -19,7 +19,7 @@ namespace JsonUtility
 	bool parseListStrings(const rapidjson::Value &value, std::vector<ST::string> &strings);
 
 	/** Parse a sector string to sector ID */
-	uint8_t parseSectorID(const char* sectorShortString);
+	uint8_t parseSectorID(const ST::string& sectorShortString);
 
 	/** Parse a given string field to sector ID */
 	uint8_t parseSectorID(const rapidjson::Value& json, const char* fieldName);

--- a/src/externalized/MagazineModel.cc
+++ b/src/externalized/MagazineModel.cc
@@ -3,16 +3,17 @@
 #include "AmmoTypeModel.h"
 #include "CalibreModel.h"
 #include "JsonObject.h"
+#include <utility>
 
 MagazineModel::MagazineModel(uint16_t itemIndex_,
-				const char* internalName_,
+				ST::string internalName_,
 				uint32_t itemClass_,
 				const CalibreModel *calibre_,
 				uint16_t capacity_,
 				const AmmoTypeModel *ammoType_,
 				bool dontUseAsDefaultMagazine_
 )
-	:ItemModel(itemIndex_, internalName_, itemClass_, 0, INVALIDCURS),
+	:ItemModel(itemIndex_, std::move(internalName_), itemClass_, 0, INVALIDCURS),
 	calibre(calibre_), capacity(capacity_), ammoType(ammoType_),
 	dontUseAsDefaultMagazine(dontUseAsDefaultMagazine_)
 {
@@ -56,7 +57,7 @@ MagazineModel* MagazineModel::deserialize(
 	const std::map<ST::string, const AmmoTypeModel*> &ammoTypeMap)
 {
 	int itemIndex                 = obj.GetInt("itemIndex");
-	const char *internalName      = obj.GetString("internalName");
+	ST::string internalName       = obj.GetString("internalName");
 	const CalibreModel *calibre   = getCalibre(obj.GetString("calibre"), calibreMap);
 	uint32_t itemClass            = (calibre->index != NOAMMO) ? IC_AMMO : IC_NONE;
 	uint16_t capacity             = obj.GetInt("capacity");
@@ -74,8 +75,8 @@ MagazineModel* MagazineModel::deserialize(
 	mag->usPrice          = obj.GetInt("usPrice");
 	mag->ubCoolness       = obj.GetInt("ubCoolness");
 
-	const char *replacement = obj.getOptionalString("standardReplacement");
-	if(replacement)
+	ST::string replacement = obj.getOptionalString("standardReplacement");
+	if (!replacement.empty())
 	{
 		mag->standardReplacement = replacement;
 	}

--- a/src/externalized/MagazineModel.h
+++ b/src/externalized/MagazineModel.h
@@ -15,7 +15,7 @@ struct CalibreModel;
 struct MagazineModel : ItemModel
 {
 	MagazineModel(uint16_t itemIndex,
-			const char* internalName,
+			ST::string internalName,
 			uint32_t  itemClass,
 			const CalibreModel *calibre,
 			uint16_t capacity,

--- a/src/externalized/WeaponModels.cc
+++ b/src/externalized/WeaponModels.cc
@@ -1,14 +1,12 @@
 #include "WeaponModels.h"
-
-#include "game/Tactical/Items.h"
-#include "game/Tactical/Points.h"
-#include "game/Utils/Sound_Control.h"
-
 #include "CalibreModel.h"
+#include "Items.h"
 #include "JsonObject.h"
-#include "MagazineModel.h"
-
 #include "Logger.h"
+#include "MagazineModel.h"
+#include "Points.h"
+#include "Sound_Control.h"
+#include <utility>
 
 // exact gun types
 // used as an index in WeaponType[] string array
@@ -25,8 +23,8 @@ enum
 	GUN_SHOTGUN
 };
 
-WeaponModel::WeaponModel(uint32_t itemClass, uint8_t weaponType, uint8_t cursor, uint16_t itemIndex, const char* internalName, const char* internalType)
-	:ItemModel(itemIndex, internalName, itemClass, itemIndex, (ItemCursor)cursor),
+WeaponModel::WeaponModel(uint32_t itemClass, uint8_t weaponType, uint8_t cursor, uint16_t itemIndex, ST::string internalName_, ST::string internalType_)
+	:ItemModel(itemIndex, std::move(internalName_), itemClass, itemIndex, (ItemCursor)cursor),
 	sound(NO_WEAPON_SOUND_STR),
 	burstSound(NO_WEAPON_SOUND_STR),
 	attachSilencer(false),
@@ -39,7 +37,7 @@ WeaponModel::WeaponModel(uint32_t itemClass, uint8_t weaponType, uint8_t cursor,
 	attachGunBarrelExtender(false),
 	m_rateOfFire(0)
 {
-	strlcpy(this->internalType, internalType, sizeof(this->internalType));
+	internalType         = std::move(internalType_);
 	ubWeaponType         = weaponType;
 	ubWeaponClass        = NOGUNCLASS;
 	calibre              = CalibreModel::getNoCalibreObject();
@@ -99,40 +97,34 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 {
 	WeaponModel *wep = NULL;
 	int itemIndex = obj.GetInt("itemIndex");
-	const char *internalName = obj.GetString("internalName");
-	const char *internalType = obj.GetString("internalType");
+	ST::string internalName = obj.GetString("internalName");
+	ST::string internalType = obj.GetString("internalType");
 
-	if (!strcmp(internalType, WEAPON_TYPE_NOWEAPON))
+	if (internalType == WEAPON_TYPE_NOWEAPON)
 	{
 		wep = new NoWeapon(itemIndex, internalName);
 	}
-	else if (!strcmp(internalType, WEAPON_TYPE_PUNCH))
+	else if (internalType == WEAPON_TYPE_PUNCH)
 	{
 		wep = new NoWeapon(itemIndex, internalName, IC_PUNCH, PUNCHCURS);
 	}
-	else if (!strcmp(internalType, WEAPON_TYPE_THROWN))
+	else if (internalType == WEAPON_TYPE_THROWN)
 	{
 		wep = new NoWeapon(itemIndex, internalName, IC_THROWN, TOSSCURS);
 	}
-	else if(!strcmp(internalType, "PISTOL"))
+	else if (internalType == "PISTOL")
 	{
 		const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
 		uint8_t  ReadyTime       = obj.GetInt("ubReadyTime");
 		uint8_t  ShotsPer4Turns  = obj.GetInt("ubShotsPer4Turns");
-		// uint8_t  ShotsPerBurst   = obj.GetInt("ubShotsPerBurst");
-		// uint8_t  BurstPenalty    = obj.GetInt("ubBurstPenalty");
 		uint8_t  BulletSpeed     = obj.GetInt("ubBulletSpeed");
 		uint8_t  Impact          = obj.GetInt("ubImpact");
 		uint8_t  Deadliness      = obj.GetInt("ubDeadliness");
 		uint8_t  MagSize         = obj.GetInt("ubMagSize");
 		uint16_t Range           = obj.GetInt("usRange");
-		// uint16_t ReloadDelay     = obj.GetInt("usReloadDelay");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
 		uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
-		const char * Sound       = obj.GetString("Sound");
-		// const char * BurstSound  = obj.GetString("BurstSound");
-		// SoundID  ReloadSound     = (SoundID) obj.GetInt("sReloadSound");
-		// SoundID  LocknLoadSound  = (SoundID) obj.GetInt("sLocknLoadSound");
+		ST::string Sound       = obj.GetString("Sound");
 		wep = new Pistol(itemIndex, internalName,
 					calibre,
 					BulletSpeed,
@@ -146,7 +138,7 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 					HitVolume,
 					Sound);
 	}
-	else if(!strcmp(internalType, "M_PISTOL"))
+	else if (internalType == "M_PISTOL")
 	{
 		const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
 		uint8_t  ReadyTime       = obj.GetInt("ubReadyTime");
@@ -161,8 +153,8 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 		// uint16_t ReloadDelay     = obj.GetInt("usReloadDelay");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
 		uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
-		const char * Sound       = obj.GetString("Sound");
-		const char * BurstSound  = obj.GetString("BurstSound");
+		ST::string Sound         = obj.GetString("Sound");
+		ST::string BurstSound    = obj.GetString("BurstSound");
 		// SoundID  ReloadSound     = (SoundID) obj.GetInt("sReloadSound");
 		// SoundID  LocknLoadSound  = (SoundID) obj.GetInt("sLocknLoadSound");
 		wep = new MPistol(itemIndex, internalName,
@@ -181,7 +173,7 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 					Sound,
 					BurstSound);
 	}
-	else if(!strcmp(internalType, "SMG"))
+	else if (internalType == "SMG")
 	{
 		const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
 		uint8_t  ReadyTime       = obj.GetInt("ubReadyTime");
@@ -196,8 +188,8 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 		// uint16_t ReloadDelay     = obj.GetInt("usReloadDelay");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
 		uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
-		const char * Sound       = obj.GetString("Sound");
-		const char * BurstSound  = obj.GetString("BurstSound");
+		ST::string Sound         = obj.GetString("Sound");
+		ST::string BurstSound    = obj.GetString("BurstSound");
 		// SoundID  ReloadSound     = (SoundID) obj.GetInt("sReloadSound");
 		// SoundID  LocknLoadSound  = (SoundID) obj.GetInt("sLocknLoadSound");
 		wep = new SMG(itemIndex, internalName,
@@ -216,7 +208,7 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 				Sound,
 				BurstSound);
 	}
-	else if(!strcmp(internalType, "SN_RIFLE"))
+	else if (internalType == "SN_RIFLE")
 	{
 		const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
 		uint8_t  ReadyTime       = obj.GetInt("ubReadyTime");
@@ -231,8 +223,8 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 		// uint16_t ReloadDelay     = obj.GetInt("usReloadDelay");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
 		uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
-		const char * Sound       = obj.GetString("Sound");
-		// const char * BurstSound  = obj.GetString("BurstSound");
+		ST::string Sound       = obj.GetString("Sound");
+		// ST::string BurstSound  = obj.GetString("BurstSound");
 		// SoundID  ReloadSound     = (SoundID) obj.GetInt("sReloadSound");
 		// SoundID  LocknLoadSound  = (SoundID) obj.GetInt("sLocknLoadSound");
 		wep = new SniperRifle(itemIndex, internalName,
@@ -248,7 +240,7 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 					HitVolume,
 					Sound);
 	}
-	else if(!strcmp(internalType, "RIFLE"))
+	else if(internalType == "RIFLE")
 	{
 		const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
 		uint8_t  ReadyTime       = obj.GetInt("ubReadyTime");
@@ -263,8 +255,8 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 		// uint16_t ReloadDelay     = obj.GetInt("usReloadDelay");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
 		uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
-		const char * Sound       = obj.GetString("Sound");
-		// const char * BurstSound  = obj.GetString("BurstSound");
+		ST::string Sound       = obj.GetString("Sound");
+		// ST::string BurstSound  = obj.GetString("BurstSound");
 		// SoundID  ReloadSound     = (SoundID) obj.GetInt("sReloadSound");
 		// SoundID  LocknLoadSound  = (SoundID) obj.GetInt("sLocknLoadSound");
 		wep = new Rifle(itemIndex, internalName,
@@ -280,7 +272,7 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 				HitVolume,
 				Sound);
 	}
-	else if(!strcmp(internalType, "ASRIFLE"))
+	else if (internalType == "ASRIFLE")
 	{
 		const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
 		uint8_t  ReadyTime       = obj.GetInt("ubReadyTime");
@@ -295,8 +287,8 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 		// uint16_t ReloadDelay     = obj.GetInt("usReloadDelay");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
 		uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
-		const char * Sound       = obj.GetString("Sound");
-		const char * BurstSound  = obj.GetString("BurstSound");
+		ST::string Sound       = obj.GetString("Sound");
+		ST::string BurstSound  = obj.GetString("BurstSound");
 		// SoundID  ReloadSound     = (SoundID) obj.GetInt("sReloadSound");
 		// SoundID  LocknLoadSound  = (SoundID) obj.GetInt("sLocknLoadSound");
 		wep = new AssaultRifle(itemIndex, internalName,
@@ -315,7 +307,7 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 					Sound,
 					BurstSound);
 	}
-	else if(!strcmp(internalType, "SHOTGUN"))
+	else if (internalType == "SHOTGUN")
 	{
 		const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
 		uint8_t  ReadyTime       = obj.GetInt("ubReadyTime");
@@ -330,8 +322,8 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 		// uint16_t ReloadDelay     = obj.GetInt("usReloadDelay");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
 		uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
-		const char * Sound       = obj.GetString("Sound");
-		const char * BurstSound  = obj.GetString("BurstSound");
+		ST::string Sound         = obj.GetString("Sound");
+		ST::string BurstSound    = obj.GetString("BurstSound");
 		// SoundID  ReloadSound     = (SoundID) obj.GetInt("sReloadSound");
 		// SoundID  LocknLoadSound  = (SoundID) obj.GetInt("sLocknLoadSound");
 		wep = new Shotgun(itemIndex, internalName,
@@ -350,7 +342,7 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 					Sound,
 					BurstSound);
 	}
-	else if(!strcmp(internalType, "LMG"))
+	else if (internalType == "LMG")
 	{
 		const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
 		uint8_t  ReadyTime       = obj.GetInt("ubReadyTime");
@@ -365,8 +357,8 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 		// uint16_t ReloadDelay     = obj.GetInt("usReloadDelay");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
 		uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
-		const char * Sound       = obj.GetString("Sound");
-		const char * BurstSound  = obj.GetString("BurstSound");
+		ST::string Sound       = obj.GetString("Sound");
+		ST::string BurstSound  = obj.GetString("BurstSound");
 		// SoundID  ReloadSound     = (SoundID) obj.GetInt("sReloadSound");
 		// SoundID  LocknLoadSound  = (SoundID) obj.GetInt("sLocknLoadSound");
 		wep = new LMG(itemIndex, internalName,
@@ -385,25 +377,14 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 				Sound,
 				BurstSound);
 	}
-	else if(!strcmp(internalType, "BLADE"))
+	else if (internalType == "BLADE")
 	{
-		// const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
-		// uint8_t  ReadyTime       = obj.GetInt("ubReadyTime");
 		uint8_t  ShotsPer4Turns  = obj.GetInt("ubShotsPer4Turns");
-		// uint8_t  ShotsPerBurst   = obj.GetInt("ubShotsPerBurst");
-		// uint8_t  BurstPenalty    = obj.GetInt("ubBurstPenalty");
-		// uint8_t  BulletSpeed     = obj.GetInt("ubBulletSpeed");
 		uint8_t  Impact          = obj.GetInt("ubImpact");
 		uint8_t  Deadliness      = obj.GetInt("ubDeadliness");
-		// uint8_t  MagSize         = obj.GetInt("ubMagSize");
 		uint16_t Range           = obj.GetInt("usRange");
-		// uint16_t ReloadDelay     = obj.GetInt("usReloadDelay");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
-		// uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
-		const char * Sound       = obj.GetString("Sound");
-		// const char * BurstSound  = obj.GetString("BurstSound");
-		// SoundID  ReloadSound     = (SoundID) obj.GetInt("sReloadSound");
-		// SoundID  LocknLoadSound  = (SoundID) obj.GetInt("sLocknLoadSound");
+		ST::string Sound       = obj.GetString("Sound");
 		wep = new Blade(itemIndex, internalName,
 				Impact,
 				ShotsPer4Turns,
@@ -412,25 +393,14 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 				AttackVolume,
 				Sound);
 	}
-	else if(!strcmp(internalType, "THROWINGBLADE"))
+	else if (internalType == "THROWINGBLADE")
 	{
-		// const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
-		// uint8_t  ReadyTime       = obj.GetInt("ubReadyTime");
 		uint8_t  ShotsPer4Turns  = obj.GetInt("ubShotsPer4Turns");
-		// uint8_t  ShotsPerBurst   = obj.GetInt("ubShotsPerBurst");
-		// uint8_t  BurstPenalty    = obj.GetInt("ubBurstPenalty");
-		// uint8_t  BulletSpeed     = obj.GetInt("ubBulletSpeed");
 		uint8_t  Impact          = obj.GetInt("ubImpact");
 		uint8_t  Deadliness      = obj.GetInt("ubDeadliness");
-		// uint8_t  MagSize         = obj.GetInt("ubMagSize");
 		uint16_t Range           = obj.GetInt("usRange");
-		// uint16_t ReloadDelay     = obj.GetInt("usReloadDelay");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
-		// uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
-		const char * Sound       = obj.GetString("Sound");
-		// const char * BurstSound  = obj.GetString("BurstSound");
-		// SoundID  ReloadSound     = (SoundID) obj.GetInt("sReloadSound");
-		// SoundID  LocknLoadSound  = (SoundID) obj.GetInt("sLocknLoadSound");
+		ST::string Sound         = obj.GetString("Sound");
 		wep = new ThrowingBlade(itemIndex, internalName,
 					Impact,
 					ShotsPer4Turns,
@@ -439,25 +409,13 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 					AttackVolume,
 					Sound);
 	}
-	else if(!strcmp(internalType, "PUNCHWEAPON"))
+	else if (internalType == "PUNCHWEAPON")
 	{
-		// const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
-		// uint8_t  ReadyTime       = obj.GetInt("ubReadyTime");
 		uint8_t  ShotsPer4Turns  = obj.GetInt("ubShotsPer4Turns");
-		// uint8_t  ShotsPerBurst   = obj.GetInt("ubShotsPerBurst");
-		// uint8_t  BurstPenalty    = obj.GetInt("ubBurstPenalty");
-		// uint8_t  BulletSpeed     = obj.GetInt("ubBulletSpeed");
 		uint8_t  Impact          = obj.GetInt("ubImpact");
 		uint8_t  Deadliness      = obj.GetInt("ubDeadliness");
-		// uint8_t  MagSize         = obj.GetInt("ubMagSize");
-		// uint16_t Range           = obj.GetInt("usRange");
-		// uint16_t ReloadDelay     = obj.GetInt("usReloadDelay");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
-		// uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
-		const char * Sound       = obj.GetString("Sound");
-		// const char * BurstSound  = obj.GetString("BurstSound");
-		// SoundID  ReloadSound     = (SoundID) obj.GetInt("sReloadSound");
-		// SoundID  LocknLoadSound  = (SoundID) obj.GetInt("sLocknLoadSound");
+		ST::string Sound         = obj.GetString("Sound");
 		wep = new PunchWeapon(itemIndex, internalName,
 					Impact,
 					ShotsPer4Turns,
@@ -465,25 +423,16 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 					AttackVolume,
 					Sound);
 	}
-	else if(!strcmp(internalType, "LAUNCHER"))
+	else if (internalType == "LAUNCHER")
 	{
-		// const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
 		uint8_t  ReadyTime       = obj.GetInt("ubReadyTime");
 		uint8_t  ShotsPer4Turns  = obj.GetInt("ubShotsPer4Turns");
-		// uint8_t  ShotsPerBurst   = obj.GetInt("ubShotsPerBurst");
-		// uint8_t  BurstPenalty    = obj.GetInt("ubBurstPenalty");
 		uint8_t  BulletSpeed     = obj.GetInt("ubBulletSpeed");
-		// uint8_t  Impact          = obj.GetInt("ubImpact");
 		uint8_t  Deadliness      = obj.GetInt("ubDeadliness");
-		// uint8_t  MagSize         = obj.GetInt("ubMagSize");
 		uint16_t Range           = obj.GetInt("usRange");
-		// uint16_t ReloadDelay     = obj.GetInt("usReloadDelay");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
 		uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
-		const char * Sound       = obj.GetString("Sound");
-		// const char * BurstSound  = obj.GetString("BurstSound");
-		// SoundID  ReloadSound     = (SoundID) obj.GetInt("sReloadSound");
-		// SoundID  LocknLoadSound  = (SoundID) obj.GetInt("sLocknLoadSound");
+		ST::string Sound         = obj.GetString("Sound");
 		wep = new Launcher(itemIndex, internalName,
 					BulletSpeed,
 					ReadyTime,
@@ -494,25 +443,16 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 					HitVolume,
 					Sound);
 	}
-	else if(!strcmp(internalType, "LAW"))
+	else if (internalType == "LAW")
 	{
-		// const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
 		uint8_t  ReadyTime       = obj.GetInt("ubReadyTime");
 		uint8_t  ShotsPer4Turns  = obj.GetInt("ubShotsPer4Turns");
-		// uint8_t  ShotsPerBurst   = obj.GetInt("ubShotsPerBurst");
-		// uint8_t  BurstPenalty    = obj.GetInt("ubBurstPenalty");
 		uint8_t  BulletSpeed     = obj.GetInt("ubBulletSpeed");
-		// uint8_t  Impact          = obj.GetInt("ubImpact");
 		uint8_t  Deadliness      = obj.GetInt("ubDeadliness");
-		// uint8_t  MagSize         = obj.GetInt("ubMagSize");
 		uint16_t Range           = obj.GetInt("usRange");
-		// uint16_t ReloadDelay     = obj.GetInt("usReloadDelay");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
 		uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
-		const char * Sound       = obj.GetString("Sound");
-		// const char * BurstSound  = obj.GetString("BurstSound");
-		// SoundID  ReloadSound     = (SoundID) obj.GetInt("sReloadSound");
-		// SoundID  LocknLoadSound  = (SoundID) obj.GetInt("sLocknLoadSound");
+		ST::string Sound       = obj.GetString("Sound");
 		wep = new LAW(itemIndex, internalName,
 				BulletSpeed,
 				ReadyTime,
@@ -523,25 +463,16 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 				HitVolume,
 				Sound);
 	}
-	else if(!strcmp(internalType, "CANNON"))
+	else if (internalType == "CANNON")
 	{
-		// const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
 		uint8_t  ReadyTime       = obj.GetInt("ubReadyTime");
 		uint8_t  ShotsPer4Turns  = obj.GetInt("ubShotsPer4Turns");
-		// uint8_t  ShotsPerBurst   = obj.GetInt("ubShotsPerBurst");
-		// uint8_t  BurstPenalty    = obj.GetInt("ubBurstPenalty");
 		uint8_t  BulletSpeed     = obj.GetInt("ubBulletSpeed");
-		// uint8_t  Impact          = obj.GetInt("ubImpact");
 		uint8_t  Deadliness      = obj.GetInt("ubDeadliness");
-		// uint8_t  MagSize         = obj.GetInt("ubMagSize");
 		uint16_t Range           = obj.GetInt("usRange");
-		// uint16_t ReloadDelay     = obj.GetInt("usReloadDelay");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
 		uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
-		const char * Sound       = obj.GetString("Sound");
-		// const char * BurstSound  = obj.GetString("BurstSound");
-		// SoundID  ReloadSound     = (SoundID) obj.GetInt("sReloadSound");
-		// SoundID  LocknLoadSound  = (SoundID) obj.GetInt("sLocknLoadSound");
+		ST::string Sound       = obj.GetString("Sound");
 		wep = new Cannon(itemIndex, internalName,
 					BulletSpeed,
 					ReadyTime,
@@ -552,7 +483,7 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 					HitVolume,
 					Sound);
 	}
-	else if(!strcmp(internalType, "MONSTSPIT"))
+	else if (internalType == "MONSTSPIT")
 	{
 		const CalibreModel *calibre = getCalibre(obj.GetString("calibre"), calibreMap);
 		uint8_t  ShotsPer4Turns  = obj.GetInt("ubShotsPer4Turns");
@@ -562,7 +493,7 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 		uint16_t Range           = obj.GetInt("usRange");
 		uint8_t  AttackVolume    = obj.GetInt("ubAttackVolume");
 		uint8_t  HitVolume       = obj.GetInt("ubHitVolume");
-		const char * Sound       = obj.GetString("Sound");
+		ST::string Sound         = obj.GetString("Sound");
 		uint16_t smokeEffect     = obj.GetInt("usSmokeEffect");
 		wep = new MonsterSpit(itemIndex, internalName,
 					calibre,
@@ -604,8 +535,8 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 
 	wep->fFlags |= wep->deserializeFlags(obj);
 
-	const char *replacement = obj.getOptionalString("standardReplacement");
-	if(replacement)
+	ST::string replacement = obj.getOptionalString("standardReplacement");
+	if (!replacement.empty())
 	{
 		wep->standardReplacement = replacement;
 	}
@@ -668,12 +599,12 @@ int WeaponModel::getRateOfFire() const
 //
 ////////////////////////////////////////////////////////////
 
-NoWeapon::NoWeapon(uint16_t itemIndex, const char * internalName)
+NoWeapon::NoWeapon(uint16_t itemIndex, const ST::string& internalName)
 	:NoWeapon(itemIndex, internalName, IC_NONE, INVALIDCURS)
 {
 }
 
-NoWeapon::NoWeapon(uint16_t itemIndex, const char* internalName, uint32_t itemClass, uint8_t cursor)
+NoWeapon::NoWeapon(uint16_t itemIndex, const ST::string& internalName, uint32_t itemClass, uint8_t cursor)
 	: WeaponModel(itemClass, NOT_GUN, cursor, itemIndex, internalName, WEAPON_TYPE_NOWEAPON)
 {
 }
@@ -687,7 +618,7 @@ void NoWeapon::serializeTo(JsonObject &obj) const
 }
 
 
-Pistol::Pistol(uint16_t itemIndex, const char * internalName,
+Pistol::Pistol(uint16_t itemIndex, ST::string internalName,
 		const CalibreModel *calibre,
 		uint8_t BulletSpeed,
 		uint8_t Impact,
@@ -698,7 +629,7 @@ Pistol::Pistol(uint16_t itemIndex, const char * internalName,
 		uint16_t Range,
 		uint8_t AttackVolume,
 		uint8_t HitVolume,
-		const char * Sound)
+		ST::string Sound)
 	:WeaponModel(IC_GUN, GUN_PISTOL, TARGETCURS, itemIndex, internalName, "PISTOL")
 {
 	ubWeaponClass        = HANDGUNCLASS;
@@ -736,7 +667,7 @@ void Pistol::serializeTo(JsonObject &obj) const
 	serializeFlags(obj);
 }
 
-MPistol::MPistol(uint16_t itemIndex, const char * internalName,
+MPistol::MPistol(uint16_t itemIndex, ST::string internalName,
 			const CalibreModel *calibre,
 			uint8_t BulletSpeed,
 			uint8_t Impact,
@@ -749,8 +680,8 @@ MPistol::MPistol(uint16_t itemIndex, const char * internalName,
 			uint16_t Range,
 			uint8_t AttackVolume,
 			uint8_t HitVolume,
-			const char * Sound,
-			const char * BurstSound)
+			ST::string Sound,
+			ST::string BurstSound)
 	:WeaponModel(IC_GUN, GUN_M_PISTOL, TARGETCURS, itemIndex, internalName, "M_PISTOL")
 {
 	ubWeaponClass        = HANDGUNCLASS;
@@ -794,7 +725,7 @@ void MPistol::serializeTo(JsonObject &obj) const
 	serializeFlags(obj);
 }
 
-SMG::SMG(uint16_t itemIndex, const char * internalName,
+SMG::SMG(uint16_t itemIndex, ST::string internalName,
 		const CalibreModel *calibre,
 		uint8_t BulletSpeed,
 		uint8_t Impact,
@@ -807,8 +738,8 @@ SMG::SMG(uint16_t itemIndex, const char * internalName,
 		uint16_t Range,
 		uint8_t AttackVolume,
 		uint8_t HitVolume,
-		const char * Sound,
-		const char * BurstSound)
+		ST::string Sound,
+		ST::string BurstSound)
 	:WeaponModel(IC_GUN, GUN_SMG, TARGETCURS, itemIndex, internalName, "SMG")
 {
 	ubWeaponClass        = SMGCLASS;
@@ -852,7 +783,7 @@ void SMG::serializeTo(JsonObject &obj) const
 	serializeFlags(obj);
 }
 
-SniperRifle::SniperRifle(uint16_t itemIndex, const char * internalName,
+SniperRifle::SniperRifle(uint16_t itemIndex, ST::string internalName,
 				const CalibreModel *calibre,
 				uint8_t BulletSpeed,
 				uint8_t Impact,
@@ -863,7 +794,7 @@ SniperRifle::SniperRifle(uint16_t itemIndex, const char * internalName,
 				uint16_t Range,
 				uint8_t AttackVolume,
 				uint8_t HitVolume,
-				const char * Sound)
+				ST::string Sound)
 	:WeaponModel(IC_GUN, GUN_SN_RIFLE, TARGETCURS, itemIndex, internalName, "SN_RIFLE")
 {
 	ubWeaponClass        = RIFLECLASS;
@@ -901,7 +832,7 @@ void SniperRifle::serializeTo(JsonObject &obj) const
 	serializeFlags(obj);
 }
 
-Rifle::Rifle(uint16_t itemIndex, const char * internalName,
+Rifle::Rifle(uint16_t itemIndex, ST::string internalName,
 		const CalibreModel *calibre,
 		uint8_t BulletSpeed,
 		uint8_t Impact,
@@ -912,7 +843,7 @@ Rifle::Rifle(uint16_t itemIndex, const char * internalName,
 		uint16_t Range,
 		uint8_t AttackVolume,
 		uint8_t HitVolume,
-		const char * Sound)
+		ST::string Sound)
 	:WeaponModel(IC_GUN, GUN_RIFLE, TARGETCURS, itemIndex, internalName, "RIFLE")
 {
 	ubWeaponClass        = RIFLECLASS;
@@ -950,7 +881,7 @@ void Rifle::serializeTo(JsonObject &obj) const
 	serializeFlags(obj);
 }
 
-AssaultRifle::AssaultRifle(uint16_t itemIndex, const char * internalName,
+AssaultRifle::AssaultRifle(uint16_t itemIndex, ST::string internalName,
 				const CalibreModel *calibre,
 				uint8_t BulletSpeed,
 				uint8_t Impact,
@@ -963,8 +894,8 @@ AssaultRifle::AssaultRifle(uint16_t itemIndex, const char * internalName,
 				uint16_t Range,
 				uint8_t AttackVolume,
 				uint8_t HitVolume,
-				const char * Sound,
-				const char * BurstSound)
+				ST::string Sound,
+				ST::string BurstSound)
 	:WeaponModel(IC_GUN, GUN_AS_RIFLE, TARGETCURS, itemIndex, internalName, "ASRIFLE")
 {
 	ubWeaponClass        = RIFLECLASS;
@@ -1008,7 +939,7 @@ void AssaultRifle::serializeTo(JsonObject &obj) const
 	serializeFlags(obj);
 }
 
-Shotgun::Shotgun(uint16_t itemIndex, const char * internalName,
+Shotgun::Shotgun(uint16_t itemIndex, ST::string internalName,
 			const CalibreModel *calibre,
 			uint8_t BulletSpeed,
 			uint8_t Impact,
@@ -1021,8 +952,8 @@ Shotgun::Shotgun(uint16_t itemIndex, const char * internalName,
 			uint16_t Range,
 			uint8_t AttackVolume,
 			uint8_t HitVolume,
-			const char * Sound,
-			const char * BurstSound)
+			ST::string Sound,
+			ST::string BurstSound)
 	:WeaponModel(IC_GUN, GUN_SHOTGUN, TARGETCURS, itemIndex, internalName, "SHOTGUN")
 {
 	ubWeaponClass        = SHOTGUNCLASS;
@@ -1066,7 +997,7 @@ void Shotgun::serializeTo(JsonObject &obj) const
 	serializeFlags(obj);
 }
 
-LMG::LMG(uint16_t itemIndex, const char * internalName,
+LMG::LMG(uint16_t itemIndex, ST::string internalName,
 		const CalibreModel *calibre,
 		uint8_t BulletSpeed,
 		uint8_t Impact,
@@ -1079,8 +1010,8 @@ LMG::LMG(uint16_t itemIndex, const char * internalName,
 		uint16_t Range,
 		uint8_t AttackVolume,
 		uint8_t HitVolume,
-		const char * Sound,
-		const char * BurstSound)
+		ST::string Sound,
+		ST::string BurstSound)
 	:WeaponModel(IC_GUN, GUN_LMG, TARGETCURS, itemIndex, internalName, "LMG")
 {
 	ubWeaponClass        = MGCLASS;
@@ -1124,13 +1055,13 @@ void LMG::serializeTo(JsonObject &obj) const
 	serializeFlags(obj);
 }
 
-Blade::Blade(uint16_t itemIndex, const char * internalName,
+Blade::Blade(uint16_t itemIndex, ST::string internalName,
 		uint8_t Impact,
 		uint8_t ShotsPer4Turns,
 		uint8_t Deadliness,
 		uint16_t Range,
 		uint8_t AttackVolume,
-		const char * Sound)
+		ST::string Sound)
 	:WeaponModel(IC_BLADE, NOT_GUN, KNIFECURS, itemIndex, internalName, "BLADE")
 {
 	ubWeaponClass        = KNIFECLASS;
@@ -1157,13 +1088,13 @@ void Blade::serializeTo(JsonObject &obj) const
 	serializeFlags(obj);
 }
 
-ThrowingBlade::ThrowingBlade(uint16_t itemIndex, const char * internalName,
+ThrowingBlade::ThrowingBlade(uint16_t itemIndex, ST::string internalName,
 				uint8_t Impact,
 				uint8_t ShotsPer4Turns,
 				uint8_t Deadliness,
 				uint16_t Range,
 				uint8_t AttackVolume,
-				const char * Sound)
+				ST::string Sound)
 	:WeaponModel(IC_THROWING_KNIFE, NOT_GUN, TARGETCURS, itemIndex, internalName, "THROWINGBLADE")
 {
 	ubWeaponClass        = KNIFECLASS;
@@ -1190,12 +1121,12 @@ void ThrowingBlade::serializeTo(JsonObject &obj) const
 	serializeFlags(obj);
 }
 
-PunchWeapon::PunchWeapon(uint16_t itemIndex, const char * internalName,
+PunchWeapon::PunchWeapon(uint16_t itemIndex, ST::string internalName,
 				uint8_t Impact,
 				uint8_t ShotsPer4Turns,
 				uint8_t Deadliness,
 				uint8_t AttackVolume,
-				const char * Sound)
+				ST::string Sound)
 	:WeaponModel(IC_PUNCH, NOT_GUN, PUNCHCURS, itemIndex, internalName, "PUNCHWEAPON")
 {
 	ubWeaponClass        = KNIFECLASS;
@@ -1221,7 +1152,7 @@ void PunchWeapon::serializeTo(JsonObject &obj) const
 	serializeFlags(obj);
 }
 
-Launcher::Launcher(uint16_t itemIndex, const char * internalName,
+Launcher::Launcher(uint16_t itemIndex, ST::string internalName,
 			uint8_t BulletSpeed,
 			uint8_t ReadyTime,
 			uint8_t ShotsPer4Turns,
@@ -1229,7 +1160,7 @@ Launcher::Launcher(uint16_t itemIndex, const char * internalName,
 			uint16_t Range,
 			uint8_t AttackVolume,
 			uint8_t HitVolume,
-			const char * Sound)
+			ST::string Sound)
 	:WeaponModel(IC_LAUNCHER, NOT_GUN, TRAJECTORYCURS, itemIndex, internalName, "LAUNCHER")
 {
 	ubWeaponClass        = RIFLECLASS;
@@ -1260,7 +1191,7 @@ void Launcher::serializeTo(JsonObject &obj) const
 	serializeFlags(obj);
 }
 
-LAW::LAW(uint16_t itemIndex, const char * internalName,
+LAW::LAW(uint16_t itemIndex, ST::string internalName,
 		uint8_t BulletSpeed,
 		uint8_t ReadyTime,
 		uint8_t ShotsPer4Turns,
@@ -1268,7 +1199,7 @@ LAW::LAW(uint16_t itemIndex, const char * internalName,
 		uint16_t Range,
 		uint8_t AttackVolume,
 		uint8_t HitVolume,
-		const char * Sound)
+		ST::string Sound)
 	:WeaponModel(IC_GUN, NOT_GUN, TARGETCURS, itemIndex, internalName, "LAW")
 {
 	ubWeaponClass        = RIFLECLASS;
@@ -1300,7 +1231,7 @@ void LAW::serializeTo(JsonObject &obj) const
 	serializeFlags(obj);
 }
 
-Cannon::Cannon(uint16_t itemIndex, const char * internalName,
+Cannon::Cannon(uint16_t itemIndex, ST::string internalName,
 		uint8_t BulletSpeed,
 		uint8_t ReadyTime,
 		uint8_t ShotsPer4Turns,
@@ -1308,7 +1239,7 @@ Cannon::Cannon(uint16_t itemIndex, const char * internalName,
 		uint16_t Range,
 		uint8_t AttackVolume,
 		uint8_t HitVolume,
-		const char * Sound)
+		ST::string Sound)
 	:WeaponModel(IC_GUN, NOT_GUN, TARGETCURS, itemIndex, internalName, "CANNON")
 {
 	ubWeaponClass        = RIFLECLASS;
@@ -1340,7 +1271,7 @@ void Cannon::serializeTo(JsonObject &obj) const
 	serializeFlags(obj);
 }
 
-MonsterSpit::MonsterSpit(uint16_t itemIndex, const char * internalName,
+MonsterSpit::MonsterSpit(uint16_t itemIndex, ST::string internalName,
 				const CalibreModel *calibre,
 				uint8_t Impact,
 				uint8_t ShotsPer4Turns,
@@ -1349,7 +1280,7 @@ MonsterSpit::MonsterSpit(uint16_t itemIndex, const char * internalName,
 				uint16_t Range,
 				uint8_t AttackVolume,
 				uint8_t HitVolume,
-				const char * Sound,
+				ST::string Sound,
 				uint16_t smokeEffect)
 	:WeaponModel(IC_GUN, NOT_GUN, TARGETCURS, itemIndex, internalName, "MONSTSPIT")
 {

--- a/src/externalized/WeaponModels.cc
+++ b/src/externalized/WeaponModels.cc
@@ -510,7 +510,7 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 
 	if(!wep)
 	{
-		SLOGE("Weapon type '%s' is not found", internalType);
+		SLOGE(ST::format("Weapon type '{}' is not found", internalType));
 		return wep;
 	}
 

--- a/src/externalized/WeaponModels.h
+++ b/src/externalized/WeaponModels.h
@@ -29,8 +29,8 @@ struct WeaponModel : ItemModel
 			uint8_t weaponType,
 			uint8_t cursor,
 			uint16_t itemIndex,
-			const char* internalName,
-			const char* internalType);
+			ST::string internalName,
+			ST::string internalType);
 
 	virtual void serializeTo(JsonObject &obj) const;
 
@@ -67,7 +67,7 @@ struct WeaponModel : ItemModel
 	bool attachGunBarrelExtender;
 	int m_rateOfFire;
 
-	char     internalType[20];
+	ST::string internalType;
 	UINT8    ubWeaponClass;    // handgun/shotgun/rifle/knife
 	UINT8    ubWeaponType;     // exact type (for display purposes)
 	const CalibreModel *calibre;  // type of ammunition needed
@@ -93,16 +93,16 @@ protected:
 
 struct NoWeapon : WeaponModel
 {
-	NoWeapon(uint16_t indexIndex, const char * internalName);
+	NoWeapon(uint16_t indexIndex, const ST::string& internalName);
 
-	NoWeapon(uint16_t itemIndex, const char* internalName, uint32_t itemClass, uint8_t cursor);
+	NoWeapon(uint16_t itemIndex, const ST::string& internalName, uint32_t itemClass, uint8_t cursor);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };
 
 struct Pistol : WeaponModel
 {
-	Pistol(uint16_t indexIndex, const char * internalName,
+	Pistol(uint16_t indexIndex, ST::string internalName,
 		const CalibreModel *calibre,
 		uint8_t BulletSpeed,
 		uint8_t Impact,
@@ -113,7 +113,7 @@ struct Pistol : WeaponModel
 		uint16_t Range,
 		uint8_t AttackVolume,
 		uint8_t HitVolume,
-		const char * Sound);
+		ST::string Sound);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };
@@ -122,7 +122,7 @@ struct Pistol : WeaponModel
 
 struct MPistol : WeaponModel
 {
-	MPistol(uint16_t indexIndex, const char * internalName,
+	MPistol(uint16_t indexIndex, ST::string internalName,
 		const CalibreModel *calibre,
 		uint8_t BulletSpeed,
 		uint8_t Impact,
@@ -135,8 +135,8 @@ struct MPistol : WeaponModel
 		uint16_t Range,
 		uint8_t AttackVolume,
 		uint8_t HitVolume,
-		const char * Sound,
-		const char * BurstSound);
+		ST::string Sound,
+		ST::string BurstSound);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };
@@ -145,7 +145,7 @@ struct MPistol : WeaponModel
 
 struct SMG : WeaponModel
 {
-	SMG(uint16_t indexIndex, const char * internalName,
+	SMG(uint16_t indexIndex, ST::string internalName,
 		const CalibreModel *calibre,
 		uint8_t BulletSpeed,
 		uint8_t Impact,
@@ -158,8 +158,8 @@ struct SMG : WeaponModel
 		uint16_t Range,
 		uint8_t AttackVolume,
 		uint8_t HitVolume,
-		const char * Sound,
-		const char * BurstSound);
+		ST::string Sound,
+		ST::string BurstSound);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };
@@ -167,7 +167,7 @@ struct SMG : WeaponModel
 
 struct SniperRifle : WeaponModel
 {
-	SniperRifle(uint16_t indexIndex, const char * internalName,
+	SniperRifle(uint16_t indexIndex, ST::string internalName,
 			const CalibreModel *calibre,
 			uint8_t BulletSpeed,
 			uint8_t Impact,
@@ -178,7 +178,7 @@ struct SniperRifle : WeaponModel
 			uint16_t Range,
 			uint8_t AttackVolume,
 			uint8_t HitVolume,
-			const char * Sound);
+			ST::string Sound);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };
@@ -186,7 +186,7 @@ struct SniperRifle : WeaponModel
 
 struct Rifle : WeaponModel
 {
-	Rifle(uint16_t indexIndex, const char * internalName,
+	Rifle(uint16_t indexIndex, ST::string internalName,
 		const CalibreModel *calibre,
 		uint8_t BulletSpeed,
 		uint8_t Impact,
@@ -197,7 +197,7 @@ struct Rifle : WeaponModel
 		uint16_t Range,
 		uint8_t AttackVolume,
 		uint8_t HitVolume,
-		const char * Sound);
+		ST::string Sound);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };
@@ -205,7 +205,7 @@ struct Rifle : WeaponModel
 
 struct AssaultRifle : WeaponModel
 {
-	AssaultRifle(uint16_t indexIndex, const char * internalName,
+	AssaultRifle(uint16_t indexIndex, ST::string internalName,
 			const CalibreModel *calibre,
 			uint8_t BulletSpeed,
 			uint8_t Impact,
@@ -218,8 +218,8 @@ struct AssaultRifle : WeaponModel
 			uint16_t Range,
 			uint8_t AttackVolume,
 			uint8_t HitVolume,
-			const char * Sound,
-			const char * BurstSound);
+			ST::string Sound,
+			ST::string BurstSound);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };
@@ -227,7 +227,7 @@ struct AssaultRifle : WeaponModel
 
 struct Shotgun : WeaponModel
 {
-	Shotgun(uint16_t indexIndex, const char * internalName,
+	Shotgun(uint16_t indexIndex, ST::string internalName,
 		const CalibreModel *calibre,
 		uint8_t BulletSpeed,
 		uint8_t Impact,
@@ -240,8 +240,8 @@ struct Shotgun : WeaponModel
 		uint16_t Range,
 		uint8_t AttackVolume,
 		uint8_t HitVolume,
-		const char * Sound,
-		const char * BurstSound);
+		ST::string Sound,
+		ST::string BurstSound);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };
@@ -249,7 +249,7 @@ struct Shotgun : WeaponModel
 
 struct LMG : WeaponModel
 {
-	LMG(uint16_t indexIndex, const char * internalName,
+	LMG(uint16_t indexIndex, ST::string internalName,
 		const CalibreModel *calibre,
 		uint8_t BulletSpeed,
 		uint8_t Impact,
@@ -262,8 +262,8 @@ struct LMG : WeaponModel
 		uint16_t Range,
 		uint8_t AttackVolume,
 		uint8_t HitVolume,
-		const char * Sound,
-		const char * BurstSound);
+		ST::string Sound,
+		ST::string BurstSound);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };
@@ -271,13 +271,14 @@ struct LMG : WeaponModel
 
 struct Blade : WeaponModel
 {
-	Blade(uint16_t indexIndex, const char * internalName,
+	Blade(uint16_t indexIndex,
+		ST::string internalName,
 		uint8_t Impact,
 		uint8_t ShotsPer4Turns,
 		uint8_t Deadliness,
 		uint16_t Range,
 		uint8_t AttackVolume,
-		const char * Sound);
+		ST::string Sound);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };
@@ -285,13 +286,13 @@ struct Blade : WeaponModel
 
 struct ThrowingBlade : WeaponModel
 {
-	ThrowingBlade(uint16_t indexIndex, const char * internalName,
+	ThrowingBlade(uint16_t indexIndex, ST::string internalName,
 			uint8_t Impact,
 			uint8_t ShotsPer4Turns,
 			uint8_t Deadliness,
 			uint16_t Range,
 			uint8_t AttackVolume,
-			const char * Sound);
+			ST::string Sound);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };
@@ -299,12 +300,12 @@ struct ThrowingBlade : WeaponModel
 
 struct PunchWeapon : WeaponModel
 {
-	PunchWeapon(uint16_t indexIndex, const char * internalName,
+	PunchWeapon(uint16_t indexIndex, ST::string internalName,
 			uint8_t Impact,
 			uint8_t ShotsPer4Turns,
 			uint8_t Deadliness,
 			uint8_t AttackVolume,
-			const char * Sound);
+			ST::string Sound);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };
@@ -312,7 +313,7 @@ struct PunchWeapon : WeaponModel
 
 struct Launcher : WeaponModel
 {
-	Launcher(uint16_t indexIndex, const char * internalName,
+	Launcher(uint16_t indexIndex, ST::string internalName,
 			uint8_t BulletSpeed,
 			uint8_t ReadyTime,
 			uint8_t ShotsPer4Turns,
@@ -320,7 +321,7 @@ struct Launcher : WeaponModel
 			uint16_t Range,
 			uint8_t AttackVolume,
 			uint8_t HitVolume,
-			const char * Sound);
+			ST::string Sound);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };
@@ -328,7 +329,7 @@ struct Launcher : WeaponModel
 
 struct LAW : WeaponModel
 {
-	LAW(uint16_t indexIndex, const char * internalName,
+	LAW(uint16_t indexIndex, ST::string internalName,
 		uint8_t BulletSpeed,
 		uint8_t ReadyTime,
 		uint8_t ShotsPer4Turns,
@@ -336,7 +337,7 @@ struct LAW : WeaponModel
 		uint16_t Range,
 		uint8_t AttackVolume,
 		uint8_t HitVolume,
-		const char * Sound);
+		ST::string Sound);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };
@@ -344,7 +345,7 @@ struct LAW : WeaponModel
 
 struct Cannon : WeaponModel
 {
-	Cannon(uint16_t indexIndex, const char * internalName,
+	Cannon(uint16_t indexIndex, ST::string internalName,
 		uint8_t BulletSpeed,
 		uint8_t ReadyTime,
 		uint8_t ShotsPer4Turns,
@@ -352,7 +353,7 @@ struct Cannon : WeaponModel
 		uint16_t Range,
 		uint8_t AttackVolume,
 		uint8_t HitVolume,
-		const char * Sound);
+		ST::string Sound);
 
 	virtual void serializeTo(JsonObject &obj) const;
 };
@@ -360,7 +361,7 @@ struct Cannon : WeaponModel
 
 struct MonsterSpit : WeaponModel
 {
-	MonsterSpit(uint16_t indexIndex, const char * internalName,
+	MonsterSpit(uint16_t indexIndex, ST::string internalName,
 			const CalibreModel *calibre,
 			uint8_t Impact,
 			uint8_t ShotsPer4Turns,
@@ -369,7 +370,7 @@ struct MonsterSpit : WeaponModel
 			uint16_t Range,
 			uint8_t AttackVolume,
 			uint8_t HitVolume,
-			const char * Sound,
+			ST::string Sound,
 			uint16_t smokeEffect);
 
 	virtual void serializeTo(JsonObject &obj) const;

--- a/src/externalized/army/ArmyCompositionModel.cc
+++ b/src/externalized/army/ArmyCompositionModel.cc
@@ -1,10 +1,12 @@
 #include "ArmyCompositionModel.h"
+#include "Logger.h"
+#include <utility>
 
 
-ArmyCompositionModel::ArmyCompositionModel(uint8_t compositionId_, const char* name_, int8_t priority_,
+ArmyCompositionModel::ArmyCompositionModel(uint8_t compositionId_, ST::string name_, int8_t priority_,
 		int8_t adminPercentage_, int8_t elitePercentage_, int8_t troopPercentage_,
 		int8_t desiredPopulation_, int8_t startPopulation_) :
-			compositionId(compositionId_), name(name_), priority(priority_),
+			compositionId(compositionId_), name(std::move(name_)), priority(priority_),
 			adminPercentage(adminPercentage_), elitePercentage(elitePercentage_), troopPercentage(troopPercentage_),
 			desiredPopulation(desiredPopulation_), startPopulation(startPopulation_) {}
 
@@ -43,7 +45,7 @@ std::vector<const ArmyCompositionModel*> ArmyCompositionModel::deserialize(const
 }
 
 #define EXPECTS_STR(s) \
-	if (strcmp(s, comp->name) != 0) SLOGW(ST::format("Army Composition has an unexpected name. We recommmend leaving the default army compositions unchanged. Expected: {}; Actual: {}", comp->name, s));
+	if (comp->name != s) SLOGW(ST::format("Army Composition has an unexpected name. We recommend leaving the default army compositions unchanged. Expected: {}; Actual: {}", comp->name, s));
 
 void ArmyCompositionModel::validateData(const std::vector<const ArmyCompositionModel*> compositions)
 {

--- a/src/externalized/army/ArmyCompositionModel.h
+++ b/src/externalized/army/ArmyCompositionModel.h
@@ -5,12 +5,13 @@
 
 #include "JsonObject.h"
 #include "rapidjson/document.h"
+#include <string_theory/string>
 
 
 class ArmyCompositionModel
 {
 public:
-	ArmyCompositionModel(uint8_t compositionId_, const char* name_, int8_t priority_,
+	ArmyCompositionModel(uint8_t compositionId_, ST::string name_, int8_t priority_,
 		int8_t adminPercentage_, int8_t elitePercentage_, int8_t troopPercentage_,
 		int8_t desiredPopulation_, int8_t startPopulation_
 	);
@@ -25,7 +26,7 @@ public:
 	static void validateLoadedData(const std::vector<ARMY_COMPOSITION>& armyCompositions);
 
 	uint8_t compositionId;
-	const char* name;
+	ST::string name;
 	int8_t priority;
 	int8_t adminPercentage;
 	int8_t elitePercentage;

--- a/src/externalized/army/GarrisonGroupModel.cc
+++ b/src/externalized/army/GarrisonGroupModel.cc
@@ -2,7 +2,7 @@
 #include "Campaign_Types.h"
 #include "JsonUtility.h"
 
-GARRISON_GROUP GarrisonGroupModel::deserialize(JsonObjectReader& obj, const std::map<std::string, uint8_t>& armyCompMapping)
+GARRISON_GROUP GarrisonGroupModel::deserialize(JsonObjectReader& obj, const std::map<ST::string, uint8_t>& armyCompMapping)
 {
 	auto sector = obj.GetString("sector");
 	uint8_t sectorId = JsonUtility::parseSectorID(sector);

--- a/src/externalized/army/GarrisonGroupModel.h
+++ b/src/externalized/army/GarrisonGroupModel.h
@@ -6,11 +6,12 @@
 #include "rapidjson/document.h"
 
 #include <map>
+#include <string_theory/string>
 #include <vector>
 
 class GarrisonGroupModel
 {
 public:
-	static GARRISON_GROUP deserialize(JsonObjectReader& obj, const std::map<std::string, uint8_t>& armyCompMapping);
+	static GARRISON_GROUP deserialize(JsonObjectReader& obj, const std::map<ST::string, uint8_t>& armyCompMapping);
 	static void validateData(const std::vector<GARRISON_GROUP>& garrisonGroups);
 };

--- a/src/externalized/mercs/MercProfileInfo.cc
+++ b/src/externalized/mercs/MercProfileInfo.cc
@@ -4,6 +4,7 @@
 #include "Soldier_Profile_Type.h"
 #include <string_theory/format>
 #include <string_theory/string>
+#include <utility>
 
 
 std::function<const MercProfileInfo*(ProfileID)> MercProfileInfo::load = {};
@@ -22,8 +23,8 @@ static MercType MercTypeFromString(const std::string& name)
 	throw std::runtime_error(err.to_std_string());
 }
 
-MercProfileInfo::MercProfileInfo(uint8_t profileID_, const char* internalName_, MercType mercType_)
-	: profileID(profileID_), internalName(ST::string(internalName_)), mercType(mercType_)
+MercProfileInfo::MercProfileInfo(uint8_t profileID_, ST::string internalName_, MercType mercType_)
+	: profileID(profileID_), internalName(std::move(internalName_)), mercType(mercType_)
 {
 }
 

--- a/src/externalized/mercs/MercProfileInfo.h
+++ b/src/externalized/mercs/MercProfileInfo.h
@@ -35,5 +35,5 @@ public:
 	static void validateData(const std::map<uint8_t, const MercProfileInfo*>& models);
 
 protected:
-	MercProfileInfo(uint8_t profileID_, const char* internalName_, MercType mercType_);
+	MercProfileInfo(uint8_t profileID_, ST::string internalName_, MercType mercType_);
 };

--- a/src/externalized/strategic/SamSiteModel.cc
+++ b/src/externalized/strategic/SamSiteModel.cc
@@ -27,7 +27,7 @@ const bool SamSiteModel::doesSamExistHere(INT16 const x, INT16 const y, GridNo c
 
 SamSiteModel* SamSiteModel::deserialize(const rapidjson::Value& obj)
 {
-	const char* sector = obj["sector"].GetString();
+	ST::string sector = obj["sector"].GetString();
 	uint8_t sectorId = JsonUtility::parseSectorID(sector);
 
 	auto g = obj["gridNos"].GetArray();

--- a/src/externalized/strategic/UndergroundSectorModel.cc
+++ b/src/externalized/strategic/UndergroundSectorModel.cc
@@ -42,8 +42,8 @@ UndergroundSectorModel* UndergroundSectorModel::deserialize(const rapidjson::Val
 		auto adjacencies = obj["adjacentSectors"].GetArray();
 		for (auto& el : adjacencies)
 		{
-			const char* adj = el.GetString();
-			if (strlen(adj) != 1)
+			ST::string adj = el.GetString();
+			if (adj.size() != 1)
 			{
 				ST::string err = ST::format("'{}' is not a valid adjacency direction.", adj);
 				throw std::runtime_error(err.to_std_string());

--- a/src/game/Strategic/Campaign_Types.h
+++ b/src/game/Strategic/Campaign_Types.h
@@ -16,9 +16,9 @@ static inline UINT8 SECTOR(UINT8 const x, UINT8 const y)
 	return (y - 1) * 16 + x - 1;
 }
 
-static inline bool IS_VALID_SECTOR_SHORT_STRING(const char* shortString)
+static inline bool IS_VALID_SECTOR_SHORT_STRING(ST::string shortString)
 {
-	size_t len = strlen(shortString);
+	size_t len = shortString.size();
 	if (len < 2 || len > 3) return false;
 
 	char y = shortString[0], x = shortString[1];


### PR DESCRIPTION
Continuing #1056.

Replacing `const char *` with `ST::string` in all model classes in `src/externalized`. Also a little clean up in WeaponModel.

## Example of changes

- `const char*` => `ST::string`
- `if (!strcmp(s1, "STR"))` => `if (s1 == "STR")`
- `strlen(str)` => `str.size()`
- `#include "game/Tactical/Item_Types.h"` => `#include "Item_Types.h"`
- `ST::string str` (constructor args) => `std::move(str)` (see also [performance-unnecessary-value-param](https://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-value-param.html))
- `Class::~Class() {}` => `Class::~Class() = default;`
- `std::map<ST::string, const ModelClass*>::const_iterator` => `auto`