### PR TITLE
Externalizing I.M.P. activation code

### DIFF
--- a/assets/externalized/imp.json
+++ b/assets/externalized/imp.json
@@ -1,4 +1,7 @@
 {
+    // I.M.P. homepage activation code
+    "activation_codes": ["XEP624", "xep624"],
+
     // Experience level of a new I.M.P. merc
     // vanilla setting: 1
     "starting_level": 1,

--- a/src/externalized/policy/DefaultIMPPolicy.cc
+++ b/src/externalized/policy/DefaultIMPPolicy.cc
@@ -20,6 +20,8 @@ static void readListOfItems(rapidjson::Value &value, std::vector<const ItemModel
 
 DefaultIMPPolicy::DefaultIMPPolicy(rapidjson::Document *json, const ItemSystem *itemSystem)
 {
+	JsonUtility::parseListStrings((*json)["activation_codes"], m_activationCodes);
+
 	JsonObjectReader r(*json);
 	m_startingLevel = r.getOptionalUInt("starting_level", 1);
 
@@ -27,6 +29,15 @@ DefaultIMPPolicy::DefaultIMPPolicy(rapidjson::Document *json, const ItemSystem *
 
 	readListOfItems((*json)["if_good_shooter"], m_goodShooterItems, itemSystem);
 	readListOfItems((*json)["if_normal_shooter"], m_normalShooterItems, itemSystem);
+}
+
+bool DefaultIMPPolicy::isCodeAccepted(const ST::string& code) const
+{
+	for (auto& s : m_activationCodes)
+	{
+		if (s == code) return true;
+	}
+	return false;
 }
 
 uint8_t DefaultIMPPolicy::getStartingLevel() const

--- a/src/externalized/policy/DefaultIMPPolicy.h
+++ b/src/externalized/policy/DefaultIMPPolicy.h
@@ -4,6 +4,8 @@
 #include "ItemModel.h"
 
 #include "rapidjson/document.h"
+#include <string_theory/string>
+#include <vector>
 
 class ItemSystem;
 
@@ -12,6 +14,7 @@ class DefaultIMPPolicy : public IMPPolicy
 public:
 	DefaultIMPPolicy(rapidjson::Document *json, const ItemSystem *itemSystem);
 
+	virtual bool isCodeAccepted(const ST::string& code) const;
 	virtual uint8_t getStartingLevel() const;
 	virtual const std::vector<const ItemModel *> & getInventory() const;
 	virtual const std::vector<const ItemModel *> & getGoodShooterItems() const;
@@ -19,6 +22,7 @@ public:
 
 protected:
 	uint8_t m_startingLevel;
+	std::vector<ST::string> m_activationCodes;
 	std::vector<const ItemModel *> m_inventory;
 	std::vector<const ItemModel *> m_goodShooterItems;
 	std::vector<const ItemModel *> m_normalShooterItems;

--- a/src/externalized/policy/IMPPolicy.h
+++ b/src/externalized/policy/IMPPolicy.h
@@ -9,6 +9,7 @@ class ItemSystem;
 class IMPPolicy
 {
 public:
+	virtual bool isCodeAccepted(const ST::string& code) const = 0;
 	virtual uint8_t getStartingLevel() const = 0;
 	virtual const std::vector<const ItemModel *> & getInventory() const = 0;
 	virtual const std::vector<const ItemModel *> & getGoodShooterItems() const = 0;

--- a/src/game/Laptop/IMP_HomePage.cc
+++ b/src/game/Laptop/IMP_HomePage.cc
@@ -12,6 +12,9 @@
 #include "Text_Input.h"
 #include "LaptopSave.h"
 #include "Font_Control.h"
+#include "GameInstance.h"
+#include "ContentManager.h"
+#include "IMPPolicy.h"
 
 #include <string_theory/string>
 
@@ -55,7 +58,7 @@ static void InitImpHomepageTextInputBoxes(void) {
 static void ProcessPlayerInputActivationString(void)
 {
 	ST::string str = GetStringFromField(0);
-	bool stringMatchesCode = str == "XEP624" || str == "xep624";
+	bool stringMatchesCode = GCM->getIMPPolicy()->isCodeAccepted(str);
 
 	if (stringMatchesCode && !LaptopSaveInfo.fIMPCompletedFlag) {
 		iCurrentImpPage = IMP_MAIN_PAGE;


### PR DESCRIPTION
This PR externalizes the activiation code to `imp.json`. Player can proceed to I.M.P. creation if the given code matches any.

You usually do not want to change the activation code, because it is fixed in the email text. Unless you are playing [Unfinished Business](https://github.com/ja2-derek/ja2-ub-comparison/commit/9770aba9), in which the `email.edt` is changed as well.

And also, if you insist (I don't know why), you can name your IMP character `XEP624` and still use [I.M.P. import](https://github.com/ja2-stracciatella/ja2-stracciatella/pull/1133).


