### PR TITLE
Fixing Coverity scans

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -10,7 +10,7 @@ env:
   COVERITY_PROJECT: ja2-stracciatella/ja2-stracciatella
   COV_TOOLS_DIR: ${{ github.workspace }}/cov-analysis-linux64
   COV_BUILD_DIR: ${{ github.workspace }}/coverity-build
-  COV_RESULTS_DIR: coverity-results
+  COV_RESULTS_DIR: cov-int
   COV_RESULTS_FILE: analysis-results.tgz
 
 jobs:


### PR DESCRIPTION
Coverity expects analysis results under `cov-int/`. See https://github.com/ja2-stracciatella/ja2-stracciatella/issues/1276#issuecomment-735913970
