### PR TITLE
Safer method to determine source path length

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,10 +259,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-missing-braces -Wno-unused-function")
 endif()
 
-# This is used for performant log calls from C++ to Rust that use non-absolute file name
-string(LENGTH "${CMAKE_SOURCE_DIR}/src/" SOURCE_PATH_SIZE)
-add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
-
 set(
     JA2_LIBRARIES
     ${SDL2_LIBRARY}

--- a/src/sgp/CMakeLists.txt
+++ b/src/sgp/CMakeLists.txt
@@ -34,6 +34,7 @@ if (WITH_UNITTESTS)
         ${LOCAL_JA2_SOURCES}
         ${CMAKE_CURRENT_SOURCE_DIR}/FileMan_unittest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/LoadSaveData_unittest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/Logger_unittest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/SGPStrings_unittest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/string_unittest.cc
     )

--- a/src/sgp/Logger_unittest.cc
+++ b/src/sgp/Logger_unittest.cc
@@ -1,0 +1,25 @@
+// -*-coding: utf-8-unix;-*-
+
+#include "gtest/gtest.h"
+
+#include "Logger.h"
+
+
+TEST(Logger, sourcePathLength)
+{
+#if defined(_WIN32) && !defined(__MINGW32__)
+	static_assert(std::string_view(__FILENAME__) == "sgp\\Logger_unittest.cc");
+
+	EXPECT_EQ(GetSourcePathSize("C:\\Jagged Alliance 2\\src\\sgp\\Logger.h"), strlen("C:\\Jagged Alliance 2\\src\\"));
+	EXPECT_EQ(GetSourcePathSize("..\\src\\game\\Init.cc"), strlen("..\\src\\"));
+	EXPECT_EQ(GetSourcePathSize("sgp\\Logger.src"), 0);
+#else
+	static_assert(std::string_view(__FILENAME__) == "sgp/Logger_unittest.cc");
+
+	EXPECT_EQ(GetSourcePathSize("/usr/share/ja2/src/sgp/Logger.h"), strlen("/usr/share/ja2/src/"));
+	EXPECT_EQ(GetSourcePathSize("../src/game/Init.cc"), strlen("../src/"));
+	EXPECT_EQ(GetSourcePathSize("sgp/Logger.src"), 0);
+#endif
+}
+
+#undef EXPECTED_FILENAME

--- a/src/sgp/Platform.h
+++ b/src/sgp/Platform.h
@@ -17,6 +17,12 @@
 #define PATH_SEPARATOR_STR  "/"
 #endif
 
+#if defined(_WIN32) && !defined(__MINGW32__)
+#define SOURCE_ROOT ("src\\")
+#else
+#define SOURCE_ROOT ("src/")
+#endif
+
 /* #if CASE_SENSITIVE_FS */
 /* #include <dirent.h> */
 /* #endif */


### PR DESCRIPTION
This should clear up all the "Illegal address computation" defects on Coverity.

Coverity is flagging problems with log statements and `SOURCE_PATH_SIZE`. In CMake everything is absolute path, but somehow the Scan analysis uses relative path for `__FILE__`:

![image](https://user-images.githubusercontent.com/63151803/100878255-e5f29400-34e4-11eb-9567-544fcf1af0e9.png)

This PR moves the `SOURCE_PATH_SIZE` into C++ using `constexpr` with bound checks. The `SOURCE_PATH_SIZE` is calculated at compile-time for every source file.