### PR TITLE
Fixing Coverity scan build

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   coverity_scan:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Now we are using C++ 17 and should need a newer builder image.

Last build failed because of `string_view` (added in C++ 17), built on Ubuntu 16.04:

```
 Building CXX object CMakeFiles/ja2.dir/src/externalized/army/ArmyCompositionModel.cc.o
In file included from /home/runner/work/ja2-stracciatella/ja2-stracciatella/src/sgp/Debug.h:4:0,
                 from /home/runner/work/ja2-stracciatella/ja2-stracciatella/src/game/Strategic/Campaign_Types.h:4,
                 from /home/runner/work/ja2-stracciatella/ja2-stracciatella/src/externalized/army/ArmyCompositionModel.h:3,
                 from /home/runner/work/ja2-stracciatella/ja2-stracciatella/src/externalized/army/ArmyCompositionModel.cc:1:
/home/runner/work/ja2-stracciatella/ja2-stracciatella/src/sgp/Logger.h:6:23: fatal error: string_view: No such file or directory
compilation terminated.
```