### PR TITLE
Fixing tileset files fallback logic

### DIFF
--- a/src/game/TileEngine/Overhead_Map.cc
+++ b/src/game/TileEngine/Overhead_Map.cc
@@ -104,7 +104,7 @@ void InitNewOverheadDB(TileSetID const ubTilesetID)
 		}
 		catch (std::exception &e)
 		{
-			SLOGE("%s", e.what());
+			SLOGD(ST::string(e.what()));
 			// Load one we know about
 			vo = AddVideoObjectFromFile(GCM->getTilesetResourceName(GetDefaultTileset(), ST::string("t/") + "grass.sti").c_str());
 		}

--- a/src/game/TileEngine/Overhead_Map.cc
+++ b/src/game/TileEngine/Overhead_Map.cc
@@ -102,10 +102,11 @@ void InitNewOverheadDB(TileSetID const ubTilesetID)
 		{
 			vo = AddVideoObjectFromFile(res.resourceFileName.c_str());
 		}
-		catch (...)
+		catch (std::exception &e)
 		{
+			SLOGE("%s", e.what());
 			// Load one we know about
-			vo = AddVideoObjectFromFile(GCM->getTilesetResourceName(res.tilesetID, ST::string("t/") + "grass.sti").c_str());
+			vo = AddVideoObjectFromFile(GCM->getTilesetResourceName(GetDefaultTileset(), ST::string("t/") + "grass.sti").c_str());
 		}
 
 		gSmTileSurf[i].vo = vo;

--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -206,17 +206,23 @@ void DeinitializeWorld( )
 
 static void AddTileSurface(const ST::string filename, UINT32 const tileType);
 
+TileSetID GetDefaultTileset() {
+	return (gubNumTilesets == JA25_NUM_TILESETS) // If we have the number of tilesets for JA25 useJA25 default, else vanilla default
+		? DEFAULT_JA25_TILESET
+		: GENERIC_1;
+}
+
 TILE_SURFACE_RESOURCE GetAdjustedTilesetResource(TileSetID tilesetID, UINT32 uiTileType, const ST::string filePrefix)
 {
-	if (tilesetID >= gubNumTilesets) throw std::logic_error("invavlid tilesetID");
+	if (tilesetID >= gubNumTilesets) throw std::logic_error("invalid tilesetID");
 
 	ST::string  filename = gTilesets[tilesetID].zTileSurfaceFilenames[uiTileType];
 	if (filename.empty())
 	{
 		// Try loading from default tileset
-		tilesetID = (tilesetID >= DEFAULT_JA25_TILESET || (gubNumTilesets == JA25_NUM_TILESETS && uiTileType == SPECIALTILES))
-			? DEFAULT_JA25_TILESET     //If the map uses JA25 tilesets ( 50 - 69 ) or it is SPECIALTILES (and JA25 tilesets available), use DEFAULT_JA25_TILESET
-			: GENERIC_1                //If the map uses tilesets from Ja2 ( 0 - 49 ), use t0 as the default
+		tilesetID = (gubNumTilesets == JA25_NUM_TILESETS && uiTileType == SPECIALTILES)
+			? DEFAULT_JA25_TILESET     // If the map is SPECIALTILES (and JA25 tilesets available), use DEFAULT_JA25_TILESET
+			: GetDefaultTileset()      // Else use default
 		;
 		filename = gTilesets[tilesetID].zTileSurfaceFilenames[uiTileType];
 	}

--- a/src/game/TileEngine/WorldDef.h
+++ b/src/game/TileEngine/WorldDef.h
@@ -277,6 +277,7 @@ void CompileWorldMovementCosts(void);
 void RecompileLocalMovementCosts( INT16 sCentreGridNo );
 void RecompileLocalMovementCostsFromRadius( INT16 sCentreGridNo, INT8 bRadius );
 
+TileSetID GetDefaultTileset();
 // Tilesets may not provide all tile types.If a tile type is not available in a tileset, we fall back and use the surface in the default tileset.
 TILE_SURFACE_RESOURCE GetAdjustedTilesetResource(TileSetID tilesetID, UINT32 uiTileType, const ST::string filePrefix = "");
 


### PR DESCRIPTION
Resolves #1288. Thanks to @JRF-github for reporting and @selaux for the fix!

## Background

As mentioned in #1288, the bug was introduced in a previous tileset refactor and UB support work. The refactor only handled one of the cases. When a tileset filename is missing for a certain tileset, it can fall back to the corresponding entry in tileset `0`. 

However, it missed and actually broke the support for the other case. When the filename is defined in the tileset database (for example `17/a-sign4.sti`) but has no corresponding file for the overhead map (`17/t/a-sign4.sti`), we should fall back to the generic `0/t/grass.sti`.

The commit fixes the crash, and it should now match vanilla behaviour.