### PR TITLE
Add new logging macros for ST format strings

### DIFF
--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -388,7 +388,7 @@ ST::string DefaultContentManager::getMapPath(const ST::string& mapName) const
 	result += '/';
 	result += mapName.c_str();
 
-	SLOGD(ST::format("map file {}", result));
+	STLOGD("map file {}", result);
 
 	return result;
 }
@@ -400,7 +400,7 @@ ST::string DefaultContentManager::getRadarMapResourceName(const ST::string &mapN
 	result += "/";
 	result += mapName;
 
-	SLOGD(ST::format("map file {}", result));
+	STLOGD("map file {}", result);
 
 	return result;
 }
@@ -490,7 +490,7 @@ SGPFile* DefaultContentManager::openGameResForReading(const ST::string& filename
 		RustPointer<File> file = FileMan::openFileForReading(filename);
 		if (file)
 		{
-			SLOGD(ST::format("Opened file (current dir): '{}'", filename));
+			STLOGD("Opened file (current dir): '{}'", filename);
 			return FileMan::getSGPFileFromFile(file.release());
 		}
 	}
@@ -501,7 +501,7 @@ SGPFile* DefaultContentManager::openGameResForReading(const ST::string& filename
 		RustPointer<char> err{getRustError()};
 		throw std::runtime_error(ST::format("openGameResForReading: {}", err.get()).to_std_string());
 	}
-	SLOGD(ST::format("Opened file (vfs): '{}'", filename));
+	STLOGD("Opened file (vfs): '{}'", filename);
 	SGPFile *file = new SGPFile{};
 	file->flags = SGPFILE_NONE;
 	file->u.vfile = vfile.release();
@@ -570,7 +570,7 @@ ST::string DefaultContentManager::loadEncryptedString(const ST::string& fileName
 	ST::string str = LoadEncryptedData(err_msg, getStringEncType(), File, seek_chars, read_chars);
 	if (!err_msg.empty())
 	{
-		SLOGW(ST::format("DefaultContentManager::loadEncryptedString '{}' {} {}: {}", fileName, seek_chars, read_chars, err_msg));
+		STLOGW("DefaultContentManager::loadEncryptedString '{}' {} {}: {}", fileName, seek_chars, read_chars, err_msg);
 	}
 	return str;
 }
@@ -581,7 +581,7 @@ ST::string DefaultContentManager::loadEncryptedString(SGPFile* File, uint32_t se
 	ST::string str = LoadEncryptedData(err_msg, getStringEncType(), File, seek_chars, read_chars);
 	if (!err_msg.empty())
 	{
-		SLOGW(ST::format("DefaultContentManager::loadEncryptedString ? {} {}: {}", seek_chars, read_chars, err_msg));
+		STLOGW("DefaultContentManager::loadEncryptedString ? {} {}: {}", seek_chars, read_chars, err_msg);
 	}
 	return str;
 }
@@ -595,7 +595,7 @@ ST::string* DefaultContentManager::loadDialogQuoteFromFile(const ST::string& fil
 	ST::string quote = LoadEncryptedData(err_msg, getStringEncType(), File, quote_number * DIALOGUESIZE, DIALOGUESIZE);
 	if (!err_msg.empty())
 	{
-		SLOGW(ST::format("DefaultContentManager::loadDialogQuoteFromFile '{}' {}: {}", fileName, quote_number, err_msg));
+		STLOGW("DefaultContentManager::loadDialogQuoteFromFile '{}' {}: {}", fileName, quote_number, err_msg);
 	}
 	return new ST::string(quote);
 }
@@ -613,7 +613,7 @@ void DefaultContentManager::loadAllDialogQuotes(STRING_ENC_TYPE encType, const S
 		ST::string quote = LoadEncryptedData(err, encType, File, i * DIALOGUESIZE, DIALOGUESIZE);
 		if (!err.empty())
 		{
-			SLOGW(ST::format("DefaultContentManager::loadAllDialogQuotes '{}' {}: {}", fileName, i, err));
+			STLOGW("DefaultContentManager::loadAllDialogQuotes '{}' {}: {}", fileName, i, err);
 		}
 		quotes.push_back(new ST::string(quote));
 	}
@@ -630,7 +630,7 @@ const WeaponModel* DefaultContentManager::getWeaponByName(const ST::string &inte
 	std::map<ST::string, const WeaponModel*>::const_iterator it = m_weaponMap.find(internalName);
 	if(it == m_weaponMap.end())
 	{
-		SLOGE(ST::format("weapon '{}' is not found", internalName));
+		STLOGE("weapon '{}' is not found", internalName);
 		throw std::runtime_error(ST::format("weapon '{}' is not found", internalName).to_std_string());
 	}
 	return it->second;//m_weaponMap[internalName];
@@ -640,7 +640,7 @@ const MagazineModel* DefaultContentManager::getMagazineByName(const ST::string &
 {
 	if(m_magazineMap.find(internalName) == m_magazineMap.end())
 	{
-		SLOGE(ST::format("magazine '{}' is not found", internalName));
+		STLOGE("magazine '{}' is not found", internalName);
 		throw std::runtime_error(ST::format("magazine '{}' is not found", internalName).to_std_string());
 	}
 	return m_magazineMap[internalName];
@@ -686,11 +686,11 @@ bool DefaultContentManager::loadWeapons()
 		{
 			JsonObjectReader obj(a[i]);
 			WeaponModel *w = WeaponModel::deserialize(obj, m_calibreMap);
-			SLOGD(ST::format("Loaded weapon {} {}", w->getItemIndex(), w->getInternalName()));
+			STLOGD("Loaded weapon {} {}", w->getItemIndex(), w->getInternalName());
 
 			if (w->getItemIndex() > MAX_WEAPONS)
 			{
-				SLOGE(ST::format("Weapon index must be in the interval 0 - {}", MAX_WEAPONS));
+				STLOGE("Weapon index must be in the interval 0 - {}", MAX_WEAPONS);
 				return false;
 			}
 
@@ -712,11 +712,11 @@ bool DefaultContentManager::loadMagazines()
 		{
 			JsonObjectReader obj(a[i]);
 			MagazineModel *mag = MagazineModel::deserialize(obj, m_calibreMap, m_ammoTypeMap);
-			SLOGD(ST::format("Loaded magazine {} {}", mag->getItemIndex(), mag->getInternalName()));
+			STLOGD("Loaded magazine {} {}", mag->getItemIndex(), mag->getInternalName());
 
 			if((mag->getItemIndex() < FIRST_AMMO) || (mag->getItemIndex() > LAST_AMMO))
 			{
-				SLOGE(ST::format("Magazine item index must be in the interval {} - {}", FIRST_AMMO, LAST_AMMO));
+				STLOGE("Magazine item index must be in the interval {} - {}", FIRST_AMMO, LAST_AMMO);
 				return false;
 			}
 
@@ -738,7 +738,7 @@ bool DefaultContentManager::loadCalibres()
 		{
 			JsonObjectReader obj(a[i]);
 			CalibreModel *calibre = CalibreModel::deserialize(obj);
-			SLOGD(ST::format("Loaded calibre {} {}", calibre->index, calibre->internalName));
+			STLOGD("Loaded calibre {} {}", calibre->index, calibre->internalName);
 
 			if(m_calibres.size() <= calibre->index)
 			{
@@ -766,7 +766,7 @@ bool DefaultContentManager::loadAmmoTypes()
 		{
 			JsonObjectReader obj(a[i]);
 			AmmoTypeModel *ammoType = AmmoTypeModel::deserialize(obj);
-			SLOGD(ST::format("Loaded ammo type {} {}", ammoType->index, ammoType->internalName));
+			STLOGD("Loaded ammo type {} {}", ammoType->index, ammoType->internalName);
 
 			if(m_ammoTypes.size() <= ammoType->index)
 			{
@@ -794,7 +794,7 @@ bool DefaultContentManager::loadMusicModeList(const MusicMode mode, rapidjson::V
 	for (const ST::string &str : utf8_encoded)
 	{
 		musicModeList->push_back(new ST::string(str));
-		SLOGD(ST::format("Loaded music {}", str));
+		STLOGD("Loaded music {}", str);
 	}
 
 	m_musicMap[mode] = musicModeList;
@@ -1069,7 +1069,7 @@ const ItemModel* DefaultContentManager::getItemByName(const ST::string &internal
 	std::map<ST::string, const ItemModel*>::const_iterator it = m_itemMap.find(internalName);
 	if(it == m_itemMap.end())
 	{
-		SLOGE(ST::format("item '{}' is not found", internalName));
+		STLOGE("item '{}' is not found", internalName);
 		throw std::runtime_error(ST::format("item '{}' is not found", internalName).to_std_string());
 	}
 	return it->second;
@@ -1089,7 +1089,7 @@ const ST::string* DefaultContentManager::getMusicForMode(MusicMode mode) const {
 	const uint32_t index = Random((uint32_t)m_musicMap.find(mode)->second->size());
 	const ST::string* chosen = m_musicMap.find(mode)->second->at(index);
 
-	SLOGD(ST::format("Choosing music index {} of {} for: '{}'", index, m_musicMap.find(mode)->second->size(), chosen));
+	STLOGD("Choosing music index {} of {} for: '{}'", index, m_musicMap.find(mode)->second->size(), chosen);
 	return chosen;
 }
 
@@ -1390,7 +1390,7 @@ const std::map<int8_t, const TownModel*>& DefaultContentManager::getTowns() cons
 const ST::string DefaultContentManager::getTownName(uint8_t townId) const
 {
 	if (townId >= m_townNames.size()) {
-		SLOGD(ST::format("Town name not defined for index {}", townId));
+		STLOGD("Town name not defined for index {}", townId);
 		return ST::null;
 	}
 	return *m_townNames[townId];
@@ -1399,7 +1399,7 @@ const ST::string DefaultContentManager::getTownName(uint8_t townId) const
 const ST::string DefaultContentManager::getTownLocative(uint8_t townId) const
 {
 	if (townId >= m_townNameLocatives.size()) {
-		SLOGD(ST::format("Town name locative not defined for index {}", townId));
+		STLOGD("Town name locative not defined for index {}", townId);
 		return ST::null;
 	}
 	return *m_townNameLocatives[townId];
@@ -1466,7 +1466,7 @@ const MercProfileInfo* DefaultContentManager::getMercProfileInfo(uint8_t const p
 		return m_mercProfileInfo.at(profileID);
 	}
 	
-	SLOGD(ST::format("MercProfileInfo is not defined at {}", profileID));
+	STLOGD("MercProfileInfo is not defined at {}", profileID);
 	return &EMPTY_MERC_PROFILE_INFO;
 }
 

--- a/src/externalized/LoadingScreenModel.cc
+++ b/src/externalized/LoadingScreenModel.cc
@@ -68,7 +68,7 @@ void LoadingScreenModel::validateData(ContentManager* cm) const
 	{
 		if (cm->doesGameResExists(screensList[i].filename))
 		{
-			SLOGW(ST::format("Load Screen image '{}' cannot be opened", screensList[i].filename));
+			STLOGW("Load Screen image '{}' cannot be opened", screensList[i].filename);
 		}
 		if (screensList[i].index != i)
 		{

--- a/src/externalized/WeaponModels.cc
+++ b/src/externalized/WeaponModels.cc
@@ -510,7 +510,7 @@ WeaponModel* WeaponModel::deserialize(JsonObjectReader &obj,
 
 	if(!wep)
 	{
-		SLOGE(ST::format("Weapon type '{}' is not found", internalType));
+		STLOGE("Weapon type '{}' is not found", internalType);
 		return wep;
 	}
 

--- a/src/externalized/army/ArmyCompositionModel.cc
+++ b/src/externalized/army/ArmyCompositionModel.cc
@@ -45,14 +45,14 @@ std::vector<const ArmyCompositionModel*> ArmyCompositionModel::deserialize(const
 }
 
 #define EXPECTS_STR(s) \
-	if (comp->name != s) SLOGW(ST::format("Army Composition has an unexpected name. We recommend leaving the default army compositions unchanged. Expected: {}; Actual: {}", comp->name, s));
+	if (comp->name != s) STLOGW("Army Composition has an unexpected name. We recommend leaving the default army compositions unchanged. Expected: {}; Actual: {}", comp->name, s);
 
 void ArmyCompositionModel::validateData(const std::vector<const ArmyCompositionModel*> compositions)
 {
 	if (compositions.size() < NUM_ARMY_COMPOSITIONS || compositions.size() > SAVED_ARMY_COMPOSITIONS)
 	{
 		// Invalid data will crash the game
-		SLOGE(ST::format("Number of Army Composition must be between {} and {}. Got {}.", NUM_ARMY_COMPOSITIONS, SAVED_ARMY_COMPOSITIONS, compositions.size()));
+		STLOGE("Number of Army Composition must be between {} and {}. Got {}.", NUM_ARMY_COMPOSITIONS, SAVED_ARMY_COMPOSITIONS, compositions.size());
 		throw std::runtime_error("Too many or too few Army Compositions");
 	}
 	for (size_t i = 0; i < compositions.size(); i++)
@@ -61,7 +61,7 @@ void ArmyCompositionModel::validateData(const std::vector<const ArmyCompositionM
 		auto comp = compositions[i];
 		if (comp->compositionId != i)
 		{
-			SLOGW(ST::format("Army Composition has incorrect ID. Expected: {}; Actual: {}", i, comp->compositionId));
+			STLOGW("Army Composition has incorrect ID. Expected: {}; Actual: {}", i, comp->compositionId);
 		}
 
 		switch (comp->compositionId) // these army-comps are referenced in code
@@ -93,7 +93,7 @@ void ArmyCompositionModel::validateLoadedData(const std::vector<ARMY_COMPOSITION
 {
 	if (armyCompositions.size() < NUM_ARMY_COMPOSITIONS)
 	{
-		SLOGW(ST::format("There are too few loaded Army Compositions. Expected: {}; Actual: {}", NUM_ARMY_COMPOSITIONS, armyCompositions.size()));
+		STLOGW("There are too few loaded Army Compositions. Expected: {}; Actual: {}", NUM_ARMY_COMPOSITIONS, armyCompositions.size());
 	}
 	for (size_t i = 0; i < armyCompositions.size(); i++)
 	{
@@ -101,7 +101,7 @@ void ArmyCompositionModel::validateLoadedData(const std::vector<ARMY_COMPOSITION
 		auto comp = armyCompositions[i];
 		if (comp.iReadability != static_cast<int32_t>(i))
 		{
-			SLOGW(ST::format("Army Composition has incorrect ID. The save might be corrupted. Expected: {}; Actual: {}", i, comp.iReadability));
+			STLOGW("Army Composition has incorrect ID. The save might be corrupted. Expected: {}; Actual: {}", i, comp.iReadability);
 		}
 	}
 }

--- a/src/externalized/army/GarrisonGroupModel.cc
+++ b/src/externalized/army/GarrisonGroupModel.cc
@@ -18,7 +18,7 @@ void GarrisonGroupModel::validateData(const std::vector<GARRISON_GROUP>& garriso
 {
 	if (garrisonGroups.size() > SAVED_GARRISON_GROUPS)
 	{
-		SLOGE(ST::format("There cannot be more than {} Garrison Groups", SAVED_GARRISON_GROUPS));
+		STLOGE("There cannot be more than {} Garrison Groups", SAVED_GARRISON_GROUPS);
 		throw std::runtime_error("Too many Garrison Groups");
 	}
 }

--- a/src/externalized/army/PatrolGroupModel.cc
+++ b/src/externalized/army/PatrolGroupModel.cc
@@ -35,7 +35,7 @@ void PatrolGroupModel::validateData(const std::vector<PATROL_GROUP>& patrolGroup
 {
 	if (patrolGroups.size() > SAVED_PATROL_GROUPS)
 	{
-		SLOGE(ST::format("There cannot be more than {} Patrol Groups", SAVED_PATROL_GROUPS));
+		STLOGE("There cannot be more than {} Patrol Groups", SAVED_PATROL_GROUPS);
 		throw std::runtime_error("Too many Patrol Groups");
 	}
 }

--- a/src/externalized/scripting/ScriptingExtensionsLua.cc
+++ b/src/externalized/scripting/ScriptingExtensionsLua.cc
@@ -59,11 +59,11 @@ void JA2Require(std::string scriptFileName)
 
 	if (loadedScripts.find(scriptFileName) != loadedScripts.end())
 	{
-		SLOGW(ST::format("Script file '{}' has already been loaded", scriptFileName));
+		STLOGW("Script file '{}' has already been loaded", scriptFileName);
 		return;
 	}
 	
-	SLOGD(ST::format("Loading LUA script file: {}", scriptFileName));
+	STLOGD("Loading LUA script file: {}", scriptFileName);
 	std::string scriptbody = FileMan::fileReadText(
 		AutoSGPFile(GCM->openGameResForReading(SCRIPTS_DIR "/" + scriptFileName))
 	).to_std_string();
@@ -104,7 +104,7 @@ void InitScriptingEngine()
 	} 
 	catch (const std::exception &ex)
 	{
-		SLOGE(ST::format("Lua script engine has failed to initialize:\n {}", ex.what()));
+		STLOGE("Lua script engine has failed to initialize:\n {}", ex.what());
 		ST::string err = "The game cannot be started due to an error in the mod scripts. Check the logs for more details.";
 		std::throw_with_nested(std::runtime_error(err.to_std_string()));
 	}
@@ -269,7 +269,7 @@ static void InvokeFunction(ST::string functionName, A... args)
 	sol::protected_function func = lua[functionName.to_std_string()];
 	if (!func.valid())
 	{
-		SLOGE(ST::format("Function {} is not defined", functionName));
+		STLOGE("Function {} is not defined", functionName);
 		isLuaDisabled = true;
 		return;
 	}
@@ -278,7 +278,7 @@ static void InvokeFunction(ST::string functionName, A... args)
 	if (!result.valid())
 	{
 		sol::error err = result;
-		SLOGE(ST::format("Lua script had an error. Scripting engine is now DISABLED. The error was:\n{}", err.what()));
+		STLOGE("Lua script had an error. Scripting engine is now DISABLED. The error was:\n{}", err.what());
 		isLuaDisabled = true;
 	}
 }

--- a/src/externalized/strategic/CreatureLairModel.cc
+++ b/src/externalized/strategic/CreatureLairModel.cc
@@ -195,7 +195,7 @@ void CreatureLairModel::validateData(const std::vector<const CreatureLairModel*>
 		// The first lair sector in list should be QUEEN_LAIR
 		if (lair->lairSectors.size() < 1 || lair->lairSectors[0].habitatType != QUEEN_LAIR)
 		{
-			SLOGW(ST::format("The list of lair sectors should be non-empty and begin with the QUEEN_LAIR. Lair ID: {}", lair->lairId));
+			STLOGW("The list of lair sectors should be non-empty and begin with the QUEEN_LAIR. Lair ID: {}", lair->lairId);
 		}
 
 		// all lair sectors should be adjacent and defined as underground sector
@@ -207,7 +207,7 @@ void CreatureLairModel::validateData(const std::vector<const CreatureLairModel*>
 				int distance = abs(SECTORX(sec.sectorId) - x) + abs(SECTORY(sec.sectorId) - y) + abs(sec.sectorLevel - z);
 				if (distance != 1)
 				{
-					SLOGW(ST::format("The current lair sector ({},{}) is not adjacent to the previous. This may indicate data issues", sec.sectorId, sec.sectorLevel));
+					STLOGW("The current lair sector ({},{}) is not adjacent to the previous. This may indicate data issues", sec.sectorId, sec.sectorLevel);
 				}
 			}
 			x = SECTORX(sec.sectorId);
@@ -220,7 +220,7 @@ void CreatureLairModel::validateData(const std::vector<const CreatureLairModel*>
 		{
 			if (sec.sectorLevel == 0)
 			{
-				SLOGW(ST::format("Lair sector ({}) is not in the underground. This may cause problems.", sec.sectorId));
+				STLOGW("Lair sector ({}) is not in the underground. This may cause problems.", sec.sectorId);
 				continue;
 			}
 			bool isDefined = false;

--- a/src/externalized/strategic/FactParamsModel.cc
+++ b/src/externalized/strategic/FactParamsModel.cc
@@ -10,7 +10,7 @@ int16_t FactParamsModel::getGridNo(const int16_t defaultValue) const
 {
 	if (gridNo <= 0) 
 	{
-		SLOGW(ST::format("Falling back to default gridNo for FACT #{}. Param values should always be defined in JSON.", fact));
+		STLOGW("Falling back to default gridNo for FACT #{}. Param values should always be defined in JSON.", fact);
 		return defaultValue;
 	}
 	return gridNo;

--- a/src/externalized/strategic/MineModel.cc
+++ b/src/externalized/strategic/MineModel.cc
@@ -70,7 +70,7 @@ void MineModel::validateData(std::vector<const MineModel*>& models)
 {
 	if (models.size() != MAX_NUMBER_OF_MINES)
 	{
-		SLOGW(ST::format("There are {} mines defined. Expected {} mines. This breaks vanilla save compatability", models.size(), MAX_NUMBER_OF_MINES));
+		STLOGW("There are {} mines defined. Expected {} mines. This breaks vanilla save compatability", models.size(), MAX_NUMBER_OF_MINES);
 	}
 	if (models.size() < MAX_NUMBER_OF_MINES)
 	{

--- a/src/externalized/strategic/SamSiteModel.cc
+++ b/src/externalized/strategic/SamSiteModel.cc
@@ -57,7 +57,7 @@ void SamSiteModel::validateData(const std::vector<const SamSiteModel*>& models)
 	if (models.size() != NUMBER_OF_SAMS)
 	{
 		// Game saves, Skyrider and Meanwhile dialogues all assume 4 SAM sites
-		SLOGE(ST::format("There must be exactly {} SAM sites defined", NUMBER_OF_SAMS));
+		STLOGE("There must be exactly {} SAM sites defined", NUMBER_OF_SAMS);
 		throw std::runtime_error("Unexpected number of SAM sites");
 	}
 }

--- a/src/externalized/tactical/NpcActionParamsModel.cc
+++ b/src/externalized/tactical/NpcActionParamsModel.cc
@@ -10,7 +10,7 @@ int16_t NpcActionParamsModel::getGridNo(const int16_t defaultValue) const
 {
 	if (gridNo <= 0)
 	{
-		SLOGW(ST::format("Falling back to default gridNo for NPC_ACTION #{}. Param values should always be defined in JSON.", actionCode));
+		STLOGW("Falling back to default gridNo for NPC_ACTION #{}. Param values should always be defined in JSON.", actionCode);
 		return defaultValue;
 	}
 	return gridNo;
@@ -20,7 +20,7 @@ int32_t NpcActionParamsModel::getAmount(const int32_t defaultValue) const
 {
 	if (amount == 0)
 	{
-		SLOGW(ST::format("Falling back to default amount for NPC_ACTION #{}. Param values should always be defined in JSON.", actionCode));
+		STLOGW("Falling back to default amount for NPC_ACTION #{}. Param values should always be defined in JSON.", actionCode);
 		return defaultValue;
 	}
 	return amount;

--- a/src/game/Editor/EditScreen.cc
+++ b/src/game/Editor/EditScreen.cc
@@ -1410,7 +1410,7 @@ static void HandleKeyboardShortcuts(void)
 
 				case SDLK_F4:
 					MusicPlay( GCM->getMusicForMode(giMusicMode) );
-					SLOGD(ST::format("Testing music {}", GCM->getMusicForMode(giMusicMode)));
+					STLOGD("Testing music {}", GCM->getMusicForMode(giMusicMode));
 					giMusicMode = (MusicMode)(giMusicMode + 1);
 					if( giMusicMode >= MAX_MUSIC_MODES )
 						giMusicMode = MUSIC_MAIN_MENU;

--- a/src/game/JAScreens.cc
+++ b/src/game/JAScreens.cc
@@ -118,7 +118,7 @@ ScreenID ErrorScreenHandle(void)
 
 	if ( !fFirstTime )
 	{
-		SLOGE(ST::format("Runtime Error: {} ", gubErrorText));
+		STLOGE("Runtime Error: {} ", gubErrorText);
 		fFirstTime = TRUE;
 	}
 

--- a/src/game/Laptop/IMP_Compile_Character.cc
+++ b/src/game/Laptop/IMP_Compile_Character.cc
@@ -221,7 +221,7 @@ static void CreatePlayerSkills(void)
 		else if (iLastElementInSkillsList > 2)
 		{
 			// This should be impossible
-			SLOGA(ST::format("Invalid number ({}) of skills selected", iLastElementInSkillsList));
+			STLOGA("Invalid number ({}) of skills selected", iLastElementInSkillsList);
 		}
 	
 		return;

--- a/src/game/Strategic/Creature_Spreading.cc
+++ b/src/game/Strategic/Creature_Spreading.cc
@@ -1042,7 +1042,7 @@ void LoadCreatureDirectives(HWFILE const hFile, UINT32 const uiSavedGameVersion)
 		auto lair = GCM->getCreatureLair(giLairID);
 		if (!lair)
 		{
-			SLOGE(ST::format("Invalid restoration of creature lair ID of {}.  Save game potentially hosed.", giLairID));
+			STLOGE("Invalid restoration of creature lair ID of {}.  Save game potentially hosed.", giLairID);
 			break;
 		}
 		InitCreatureLair(lair);

--- a/src/game/Strategic/Game_Init.cc
+++ b/src/game/Strategic/Game_Init.cc
@@ -82,7 +82,7 @@ static void InitNPCs()
 		if (placement->useAlternateMap)
 		{
 			SectorInfo[sector].uiFlags |= SF_USE_ALTERNATE_MAP;
-			SLOGD(ST::format("Alternate map in {}", SECTOR_SHORT_STRING(sector)));
+			STLOGD("Alternate map in {}", SECTOR_SHORT_STRING(sector));
 		}
 		if (placement->isPlacedAtStart)
 		{
@@ -90,7 +90,7 @@ static void InitNPCs()
 			merc.sSectorX = SECTORX(sector);
 			merc.sSectorY = SECTORY(sector);
 			merc.bSectorZ = 0;
-			SLOGD(ST::format("{} in {}", merc.zNickname, SECTOR_SHORT_STRING(sector)));
+			STLOGD("{} in {}", merc.zNickname, SECTOR_SHORT_STRING(sector));
 		}
 	}
 

--- a/src/game/Strategic/Map_Screen_Interface_Map_Inventory.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map_Inventory.cc
@@ -1368,7 +1368,7 @@ static void CheckGridNoOfItemsInMapScreenMapInventory(void)
 
 	if( uiNumFlagsNotSet > 0 )
 	{
-		SLOGD(ST::format("Item with invalid gridno doesnt have flag set: {}", uiNumFlagsNotSet));
+		STLOGD("Item with invalid gridno doesnt have flag set: {}", uiNumFlagsNotSet);
 	}
 }
 

--- a/src/game/Strategic/Queen_Command.cc
+++ b/src/game/Strategic/Queen_Command.cc
@@ -648,7 +648,7 @@ void ProcessQueenCmdImplicationsOfDeath(const SOLDIERTYPE* const pSoldier)
 		}
 		if( pGroup->fPlayer )
 		{
-			SLOGW(ST::format("Attempting to process player group thinking it's an enemy group (#{}) in ProcessQueenCmdImplicationsOfDeath()", pSoldier->ubGroupID));
+			STLOGW("Attempting to process player group thinking it's an enemy group (#{}) in ProcessQueenCmdImplicationsOfDeath()", pSoldier->ubGroupID);
 			return;
 		}
 		switch( pSoldier->ubSoldierClass )

--- a/src/game/Strategic/SAM_Sites.cc
+++ b/src/game/Strategic/SAM_Sites.cc
@@ -41,7 +41,7 @@ void UpdateSAMDoneRepair(INT16 const x, INT16 const y, INT16 const z)
 	auto samSite = GCM->findSamSiteBySector(sector);
 	if (samSite == NULL)
 	{
-		SLOGW(ST::format("There is no SAM site at sector {}", GetShortSectorString(x, y)));
+		STLOGW("There is no SAM site at sector {}", GetShortSectorString(x, y));
 		return;
 	}
 
@@ -160,7 +160,7 @@ static void UpdateAndDamageSAMIfFound(INT16 sSectorX, INT16 sSectorY, INT16 sSec
 
 	// Damage.....
 	INT16 sSectorNo = CALCULATE_STRATEGIC_INDEX(sSectorX, sSectorY);
-	SLOGD(ST::format("SAM site at sector #{} is damaged by {} points", sSectorNo, ubDamage));
+	STLOGD("SAM site at sector #{} is damaged by {} points", sSectorNo, ubDamage);
 	if (StrategicMap[sSectorNo].bSAMCondition >= ubDamage)
 	{
 		StrategicMap[sSectorNo].bSAMCondition -= ubDamage;

--- a/src/game/Strategic/StrategicMap_Secrets.cc
+++ b/src/game/Strategic/StrategicMap_Secrets.cc
@@ -25,7 +25,7 @@ BOOLEAN IsTownFound(INT8 const bTownID)
 	auto town = GCM->getTown(bTownID);
 	if (!town)
 	{
-		SLOGW(ST::format("Town #{} not found", bTownID));
+		STLOGW("Town #{} not found", bTownID);
 		return FALSE;
 	}
 
@@ -45,7 +45,7 @@ BOOLEAN IsSecretFoundAt(UINT8 const sectorID)
 		// The game always try to find secrets at J9 and K4, but they
 		// may not be present in a modded set up. So we will just
 		// return TRUE and continue.
-		SLOGW(ST::format("No secret defined at sector {}", sectorID));
+		STLOGW("No secret defined at sector {}", sectorID);
 		return TRUE;
 	}
 	return isSecretFound[sectorID];
@@ -59,7 +59,7 @@ void SetTownAsFound(INT8 const bTownID, BOOLEAN const fFound)
 		// The game has hard-coded references to TIXA and
 		// ORTA, but they may not be present in a modded
 		// set up.
-		SLOGW(ST::format("Town #{} is not defined", bTownID));
+		STLOGW("Town #{} is not defined", bTownID);
 		return;
 	}
 
@@ -141,7 +141,7 @@ BOOLEAN GetMapSecretStateForSave(unsigned int const index)
 			return IsSecretFoundAt(s->sectorID);
 		}
 	}
-	SLOGW(ST::format("There is no secret at slot #{}", index));
+	STLOGW("There is no secret at slot #{}", index);
 	return FALSE;  // write something to maintain save compatibility
 }
 
@@ -164,5 +164,5 @@ void SetMapSecretStateFromSave(unsigned int const index, BOOLEAN const fFound)
 			return;
 		}
 	}
-	SLOGW(ST::format("There is no secret at slot #{}", index));
+	STLOGW("There is no secret at slot #{}", index);
 }

--- a/src/game/Strategic/Strategic_AI.cc
+++ b/src/game/Strategic/Strategic_AI.cc
@@ -651,7 +651,7 @@ void InitStrategicAI()
 		SECTORINFO &si = SectorInfo[sSectorID];
 		si.uiFlags |= SF_USE_ALTERNATE_MAP;
 		si.ubNumTroops = model->getNumTroops(difficulty);
-		SLOGD(ST::format("Weapon cache is at {}", SECTOR_SHORT_STRING(sSectorID)));
+		STLOGD("Weapon cache is at {}", SECTOR_SHORT_STRING(sSectorID));
 	}
 }
 
@@ -2296,7 +2296,7 @@ void LoadStrategicAI(HWFILE const hFile)
 	//Restore the patrol group definitions
 	if (iPatrolArraySize != GCM->getPatrolGroups().size())
 	{
-		SLOGW(ST::format("Number of Patrol Groups in save ({}) is different from definition ({}). Save might not work properly.", iPatrolArraySize, GCM->getPatrolGroups().size()));
+		STLOGW("Number of Patrol Groups in save ({}) is different from definition ({}). Save might not work properly.", iPatrolArraySize, GCM->getPatrolGroups().size());
 	}
 	auto buffPG = new PATROL_GROUP[SAVED_PATROL_GROUPS]{};
 	FileRead(hFile, buffPG, SAVED_PATROL_GROUPS * sizeof(PATROL_GROUP));
@@ -2307,7 +2307,7 @@ void LoadStrategicAI(HWFILE const hFile)
 	//Load the garrison information!
 	if (iGarrisonArraySize != GCM->getGarrisonGroups().size())
 	{
-		SLOGW(ST::format("Number of Garrison Groups in save ({}) is different from definition ({}). Save might not work properly.", iGarrisonArraySize, GCM->getGarrisonGroups().size()));
+		STLOGW("Number of Garrison Groups in save ({}) is different from definition ({}). Save might not work properly.", iGarrisonArraySize, GCM->getGarrisonGroups().size());
 	}
 	auto buffGG = new GARRISON_GROUP[SAVED_GARRISON_GROUPS]{};
 	FileRead(hFile, buffGG, SAVED_GARRISON_GROUPS * sizeof(GARRISON_GROUP));
@@ -2323,7 +2323,7 @@ void LoadStrategicAI(HWFILE const hFile)
 	gArmyComp.resize(numArmyCompositions);
 	if (gArmyComp.size() != GCM->getArmyCompositions().size())
 	{
-		SLOGW(ST::format("Number of Army Compositions in save ({}) is different from definition ({}). Save might not work properly.", gArmyComp.size(), GCM->getArmyCompositions().size()));
+		STLOGW("Number of Army Compositions in save ({}) is different from definition ({}). Save might not work properly.", gArmyComp.size(), GCM->getArmyCompositions().size());
 	}
 	ArmyCompositionModel::validateLoadedData(gArmyComp);
 

--- a/src/game/Strategic/Strategic_Mines.cc
+++ b/src/game/Strategic/Strategic_Mines.cc
@@ -494,7 +494,7 @@ static INT32 MineAMine(UINT8 ubMineIndex)
 		if( iAmtExtracted > 0 )
 		{
 			// debug message
-			SLOGD(ST::format("{} - Mine income from {} = ${}", WORLDTIMESTR, GCM->getTownName(GetTownAssociatedWithMine(ubMineIndex)), iAmtExtracted));
+			STLOGD("{} - Mine income from {} = ${}", WORLDTIMESTR, GCM->getTownName(GetTownAssociatedWithMine(ubMineIndex)), iAmtExtracted);
 
 			// if this is the first time this mine has produced income for the player in the game
 			if ( !gMineStatus[ ubMineIndex ].fMineHasProducedForPlayer )

--- a/src/game/Tactical/Animation_Cache.cc
+++ b/src/game/Tactical/Animation_Cache.cc
@@ -91,14 +91,14 @@ void GetCachedAnimationSurface(UINT16 const usSoldierID, AnimationSurfaceCacheTy
 
 			if ( pAnimCache->usCachedSurfaces[ cnt ] == usCurrentAnimSurface )
 			{
-				SLOGD(ST::format("Anim Cache: REJECTING Slot {} EXISTING ANIM SURFACE ( Soldier {}, Surface {} )", cnt, usSoldierID, usCurrentAnimSurface));
+				STLOGD("Anim Cache: REJECTING Slot {} EXISTING ANIM SURFACE ( Soldier {}, Surface {} )", cnt, usSoldierID, usCurrentAnimSurface);
 			}
 			else if (pAnimCache->usCachedSurfaces[cnt] == pSoldier->usAnimSurface)
 			{
 				// The result of DetermineSoldierAnimationSurface may be inconsistent
 				// with the actual usAnimSurface, for example when player is re-assigning
 				// mercs in strategic view.
-				SLOGD(ST::format("Anim Cache: REJECTING Slot {} IN-USE ANIM SURFACE ( Soldier {}, Surface {} )", cnt, usSoldierID, pSoldier->usAnimSurface));
+				STLOGD("Anim Cache: REJECTING Slot {} IN-USE ANIM SURFACE ( Soldier {}, Surface {} )", cnt, usSoldierID, pSoldier->usAnimSurface);
 			}
 			else
 			{
@@ -112,7 +112,7 @@ void GetCachedAnimationSurface(UINT16 const usSoldierID, AnimationSurfaceCacheTy
 
 		if (ubLowestIndex == UINT8_MAX)
 		{
-			SLOGW(ST::format("Anim Cache: No preferred cache slot for eviction ( Soldier {} )", usSoldierID));
+			STLOGW("Anim Cache: No preferred cache slot for eviction ( Soldier {} )", usSoldierID);
 			ubLowestIndex = 0;
 		}
 		
@@ -145,7 +145,7 @@ void GetCachedAnimationSurface(UINT16 const usSoldierID, AnimationSurfaceCacheTy
 		}
 	}
 
-	SLOGW(ST::format("Anim Cache: Failed to find slot to load surface ( Soldier {} )", usSoldierID));
+	STLOGW("Anim Cache: Failed to find slot to load surface ( Soldier {} )", usSoldierID);
 }
 
 

--- a/src/game/Tactical/Interface_Dialogue.cc
+++ b/src/game/Tactical/Interface_Dialogue.cc
@@ -2194,7 +2194,7 @@ void HandleNPCDoAction( UINT8 ubTargetNPC, UINT16 usActionCode, UINT8 ubQuoteNum
 					OBJECTTYPE Object;
 					INT16      sGridNo  = params->getGridNo(14952);
 					UINT32     uiAmount = params->getAmount(10000);
-					SLOGI(ST::format("add a money item with ${} to tile {} in front of Kyle", uiAmount, sGridNo));
+					STLOGI("add a money item with ${} to tile {} in front of Kyle", uiAmount, sGridNo);
 
 					SOLDIERTYPE* const pSoldier = FindSoldierByProfileID(ubTargetNPC);
 					if (pSoldier)
@@ -4063,7 +4063,7 @@ add_log:
 				}
 				break;
 			default:
-				SLOGD(ST::format("No code support for NPC action {}", usActionCode));
+				STLOGD("No code support for NPC action {}", usActionCode);
 				break;
 		}
 	}

--- a/src/game/Tactical/Keys.cc
+++ b/src/game/Tactical/Keys.cc
@@ -1007,7 +1007,7 @@ static void SynchronizeDoorStatusToStructureData(DOOR_STATUS const& d)
 	STRUCTURE *base = FindBaseStructure(s);
 	if (!base)
 	{
-		SLOGW(ST::format("Door structure data at {} was not found", d.sGridNo));
+		STLOGW("Door structure data at {} was not found", d.sGridNo);
 		return;
 	}
 	INT16 sBaseGridNo = base->sGridNo;

--- a/src/game/Tactical/LOS.cc
+++ b/src/game/Tactical/LOS.cc
@@ -2469,7 +2469,7 @@ static UINT8 CalcChanceToGetThrough(BULLET* pBullet)
 		// check a particular tile
 		// retrieve values from world for this particular tile
 		iGridNo = pBullet->iCurrTileX + pBullet->iCurrTileY * WORLD_COLS;
-		SLOGD(ST::format("CTGT now at {}", iGridNo));
+		STLOGD("CTGT now at {}", iGridNo);
 		pMapElement = &(gpWorldLevelData[ iGridNo ] );
 		qLandHeight = INT32_TO_FIXEDPT( CONVERT_PIXELS_TO_HEIGHTUNITS( pMapElement->sHeight ) );
 		qWallHeight = gqStandardWallHeight + qLandHeight;

--- a/src/game/Tactical/LoadSaveObjectType.cc
+++ b/src/game/Tactical/LoadSaveObjectType.cc
@@ -17,7 +17,7 @@ void ExtractObject(DataReader& d, OBJECTTYPE* const o)
 	const ItemModel* item = GCM->getItem(o->usItem);
 	if (!item)
 	{
-		SLOGW(ST::format("Item (index {}) is not defined and will be ignored. Maybe the file was saved for a different game version", o->usItem));
+		STLOGW("Item (index {}) is not defined and will be ignored. Maybe the file was saved for a different game version", o->usItem);
 		item = GCM->getItem(NONE);
 	}
 

--- a/src/game/Tactical/PathAI.cc
+++ b/src/game/Tactical/PathAI.cc
@@ -982,7 +982,7 @@ INT32 FindBestPath(SOLDIERTYPE* s, INT16 sDestination, INT8 ubLevel, INT16 usMov
 
 			if ( newLoc < 0 || newLoc >= GRIDSIZE )
 			{
-				SLOGW(ST::format("Path Finding algorithm tried to go out of bounds at {}, in an attempt to find path from {} to {}", newLoc, iOrigination, iDestination));
+				STLOGW("Path Finding algorithm tried to go out of bounds at {}, in an attempt to find path from {} to {}", newLoc, iOrigination, iDestination);
 				goto NEXTDIR;
 			}
 

--- a/src/game/Tactical/World_Items.cc
+++ b/src/game/Tactical/World_Items.cc
@@ -279,18 +279,18 @@ void LoadWorldItemsFromMap(HWFILE const f)
 				auto item = itemReplacements.at(o.usItem);
 				if (item == 0) 
 				{
-					SLOGW(ST::format("Map item #{} removed", o.usItem));
+					STLOGW("Map item #{} removed", o.usItem);
 					continue;
 				}
 
-				SLOGD(ST::format("Map item #{} replaced by #{}", o.usItem, item));
+				STLOGD("Map item #{} replaced by #{}", o.usItem, item);
 				o.usItem = item;
 			}
 
 			const ItemModel* item = GCM->getItem(o.usItem);
 			if (item->getFlags() & ITEM_NOT_EDITOR) {
 				// This item is not placable by Editor. Maybe the map was created for a different item set.
-				SLOGW(ST::format("Skipping non-Editor item #{}({}) at gridNo {}", item->getItemIndex(), item->getInternalName(), wi.sGridNo));
+				STLOGW("Skipping non-Editor item #{}({}) at gridNo {}", item->getItemIndex(), item->getInternalName(), wi.sGridNo);
 				continue;
 			}
 

--- a/src/game/TacticalAI/AIMain.cc
+++ b/src/game/TacticalAI/AIMain.cc
@@ -600,7 +600,7 @@ void EndAIDeadlock()
 			SLOGD("Ending turn for %d because breaking deadlock", s.ubID);
 		}
 
-		SLOGD(ST::format("Number of bullets in the air is {}", guiNumBullets));
+		STLOGD("Number of bullets in the air is {}", guiNumBullets);
 		SLOGD("Setting attack busy count to 0 from deadlock break");
 		gTacticalStatus.ubAttackBusyCount = 0;
 

--- a/src/game/TacticalAI/AIUtils.cc
+++ b/src/game/TacticalAI/AIUtils.cc
@@ -1203,7 +1203,7 @@ static INT16 FindClosestClimbPointAvailableToAI(SOLDIERTYPE* pSoldier, INT16 sSt
 		if (pSoldier->bOrders == ONGUARD || pSoldier->bOrders == CLOSEPATROL)
 		{
 			//Make it so he cant climb down off the roof
-			SLOGD(ST::format("TacticalAI: soldier #{} is on guard ({}) and not allowed to climb down", pSoldier->ubID, pSoldier->bOrders));
+			STLOGD("TacticalAI: soldier #{} is on guard ({}) and not allowed to climb down", pSoldier->ubID, pSoldier->bOrders);
 			return NOWHERE;
 		}
 	}

--- a/src/game/TacticalAI/DecideAction.cc
+++ b/src/game/TacticalAI/DecideAction.cc
@@ -177,7 +177,7 @@ static INT8 DecideActionSchedule(SOLDIERTYPE* pSoldier)
 							}
 							else
 							{
-								SLOGW(ST::format("Schedule involved locked door at {} but there's no lock there!", usGridNo1));
+								STLOGW("Schedule involved locked door at {} but there's no lock there!", usGridNo1);
 								fDoUseDoor = FALSE;
 							}
 						}
@@ -297,7 +297,7 @@ static INT8 DecideActionSchedule(SOLDIERTYPE* pSoldier)
 									else
 									{
 										// WTF?  Warning time!
-										SLOGW(ST::format("Schedule involved locked door at {} but there's no lock there!", usGridNo1));
+										STLOGW("Schedule involved locked door at {} but there's no lock there!", usGridNo1);
 										fDoUseDoor = FALSE;
 									}
 								}
@@ -1991,7 +1991,7 @@ INT8 DecideActionRed(SOLDIERTYPE *pSoldier, UINT8 ubUnconsciousOK)
 								{
 									// abort! abort!
 									pSoldier->usActionData = NOWHERE;
-									SLOGD(ST::format("TacticalAI: soldier #{} avoiding ambush trap on seeing corpses (warning level {})", pSoldier->ubID, ubWarnLevel));
+									STLOGD("TacticalAI: soldier #{} avoiding ambush trap on seeing corpses (warning level {})", pSoldier->ubID, ubWarnLevel);
 								}
 							}
 						}
@@ -3044,7 +3044,7 @@ static INT8 DecideActionBlack(SOLDIERTYPE* pSoldier)
 			if ( ( (pSoldier->bTeam == MILITIA_TEAM) && (PreRandom( 20 ) > BestAttack.ubChanceToReallyHit) )
 				|| ( (pSoldier->bTeam != MILITIA_TEAM) && (PreRandom( 40 ) > BestAttack.ubChanceToReallyHit) ) )
 			{
-				SLOGD(ST::format("AI {} allowing cover check, chance to hit is only {}, at range {}", pSoldier->ubID, BestAttack.ubChanceToReallyHit, PythSpacesAway(pSoldier->sGridNo, BestAttack.sTarget)));
+				STLOGD("AI {} allowing cover check, chance to hit is only {}, at range {}", pSoldier->ubID, BestAttack.ubChanceToReallyHit, PythSpacesAway(pSoldier->sGridNo, BestAttack.sTarget));
 				// maybe taking cover would be better!
 				fAllowCoverCheck = TRUE;
 				if ( PreRandom( 10 ) > BestAttack.ubChanceToReallyHit )

--- a/src/game/TacticalAI/NPC.cc
+++ b/src/game/TacticalAI/NPC.cc
@@ -316,7 +316,7 @@ try
 }
 catch (const std::exception& e)
 {
-	SLOGE(ST::format("caught exception: {}", e.what()));
+	STLOGE("caught exception: {}", e.what());
 	return 0;
 }
 catch (...) { return 0; }
@@ -1614,7 +1614,7 @@ void ConverseFull(UINT8 const ubNPC, UINT8 const ubMerc, Approach bApproach, UIN
 					break;
 				case TRIGGER_NPC:
 					// if triggering, pass in the approach data as the record to consider
-					SLOGD(ST::format("Handling trigger {}/{} at {}", gMercProfiles[ubNPC].zNickname.c_str(), approach_record, GetJA2Clock()));
+					STLOGD("Handling trigger {}/{} at {}", gMercProfiles[ubNPC].zNickname.c_str(), approach_record, GetJA2Clock());
 					NPCConsiderTalking(ubNPC, ubMerc, bApproach, approach_record, pNPCQuoteInfoArray, &pQuotePtr, &ubRecordNum);
 					break;
 				default:

--- a/src/game/TileEngine/Buildings.cc
+++ b/src/game/TileEngine/Buildings.cc
@@ -191,7 +191,7 @@ static BUILDING* GenerateBuilding(INT16 sDesiredSpot)
 		if (sCurrGridNo == sPrevGridNo)
 		{
 			// not progressing, we are just repeating the same gridNo
-			SLOGW(ST::format("Dead loop detected in GenerateBuilding. This may indicate a problem with the current map. Probably reached edge of map. (starting GridNo:{})", sStartGridNo));
+			STLOGW("Dead loop detected in GenerateBuilding. This may indicate a problem with the current map. Probably reached edge of map. (starting GridNo:{})", sStartGridNo);
 			break;
 		}
 

--- a/src/game/TileEngine/Physics.cc
+++ b/src/game/TileEngine/Physics.cc
@@ -832,7 +832,7 @@ static BOOLEAN PhysicsCheckForCollisions(REAL_OBJECT* pObject, INT32* piCollisio
 			if ( !pObject->fTestObject )
 			{
 				// Break window!
-				SLOGD(ST::format("Object {}: Collision Window", REALOBJ2ID(pObject)));
+				STLOGD("Object {}: Collision Window", REALOBJ2ID(pObject));
 
 				sGridNo = MAPROWCOLTOPOS( ( (INT16)pObject->Position.y / CELL_Y_SIZE ), ( (INT16)pObject->Position.x / CELL_X_SIZE ) );
 
@@ -1034,7 +1034,7 @@ static BOOLEAN PhysicsCheckForCollisions(REAL_OBJECT* pObject, INT32* piCollisio
 
 			if ( pObject->fPotentialForDebug )
 			{
-				SLOGD(ST::format("Object {}: Collision {}", REALOBJ2ID(pObject), iCollisionCode));
+				STLOGD("Object {}: Collision {}", REALOBJ2ID(pObject), iCollisionCode);
 				SLOGD(ST::format("Object {}: Collision Normal {} {} {}", REALOBJ2ID(pObject),
 					vTemp.x, vTemp.y, vTemp.z));
 				SLOGD(ST::format("Object {}: Collision OldPos {} {} {}", REALOBJ2ID(pObject),
@@ -1195,7 +1195,7 @@ static BOOLEAN PhysicsMoveObject(REAL_OBJECT* pObject)
 
 		if ( pObject->fPotentialForDebug )
 		{
-			SLOGD(ST::format("Object {}d: uiNumTilesMoved: {}", REALOBJ2ID(pObject), pObject->uiNumTilesMoved));
+			STLOGD("Object {}d: uiNumTilesMoved: {}", REALOBJ2ID(pObject), pObject->uiNumTilesMoved);
 		}
 	}
 
@@ -1311,7 +1311,7 @@ static vector_3 FindBestForceForTrajectory(INT16 sSrcGridNo, INT16 sGridNo, INT1
 	{
 		(*pdMagForce) = dForce;
 	}
-	SLOGD(ST::format("Number of integration: {}", iNumChecks));
+	STLOGD("Number of integration: {}", iNumChecks);
 
 	return( vForce );
 }

--- a/src/game/TileEngine/Render_Fun.cc
+++ b/src/game/TileEngine/Render_Fun.cc
@@ -120,7 +120,7 @@ void SetGridNoRevealedFlag(UINT16 const grid_no)
 		}
 		catch (const std::logic_error& e)
 		{
-			SLOGW(ST::format("Failed to find LEVELNODE for a structure at grid {}. ({})", grid_no, e.what()));
+			STLOGW("Failed to find LEVELNODE for a structure at grid {}. ({})", grid_no, e.what());
 		}
 	}
 

--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -324,7 +324,7 @@ void NormalizeStructureTiles(DB_STRUCTURE_TILE** pTiles, UINT8 ubNumTiles)
 		return;
 	}
 
-	SLOGD(ST::format("Adjusting tiles relative positions by {}", -minDistFromBase));
+	STLOGD("Adjusting tiles relative positions by {}", -minDistFromBase);
 	int xDist = minDistFromBase % WORLD_COLS;
 	int yDist = minDistFromBase / WORLD_COLS;
 	for (UINT8 i = 0; i < ubNumTiles; i++)
@@ -417,7 +417,7 @@ static STRUCTURE* CreateStructureFromDB(DB_STRUCTURE_REF const* const pDBStructu
 	pStructure->pDBStructureRef = pDBStructureRef;
 	if (pTile->sPosRelToBase != 0 && ubTileNum == 0)
 	{
-		SLOGW(ST::format("Possible bad structure {}", pDBStructureRef->pDBStructure->usStructureNumber));
+		STLOGW("Possible bad structure {}", pDBStructureRef->pDBStructure->usStructureNumber);
 	}
 	if (pTile->sPosRelToBase == 0)
 	{	// base tile

--- a/src/game/TileEngine/TileDef.cc
+++ b/src/game/TileEngine/TileDef.cc
@@ -59,7 +59,7 @@ void CreateTileDatabase()
 			NumRegions = gNumTilesPerType[cnt1];
 		}
 
-		SLOGD(ST::format("Type: {} Size: {} Index: {}", gTileSurfaceName[cnt1], gNumTilesPerType[cnt1], gTileDatabaseSize));
+		STLOGD("Type: {} Size: {} Index: {}", gTileSurfaceName[cnt1], gNumTilesPerType[cnt1], gTileDatabaseSize);
 
 		UINT32 cnt2;
 		for (cnt2 = 0; cnt2 < NumRegions; ++cnt2)
@@ -138,9 +138,9 @@ void CreateTileDatabase()
 	}
 
 	//Calculate mem usgae
-	SLOGD(ST::format("Database Sizes: {} vs {}", gTileDatabaseSize, NUMBEROFTILES));
-	SLOGD(ST::format("Database Types: {}", NUMBEROFTILETYPES));
-	SLOGD(ST::format("Database Item Mem: {}", gTileDatabaseSize * sizeof(TILE_ELEMENT)));
+	STLOGD("Database Sizes: {} vs {}", gTileDatabaseSize, NUMBEROFTILES);
+	STLOGD("Database Types: {}", NUMBEROFTILETYPES);
+	STLOGD("Database Item Mem: {}", gTileDatabaseSize * sizeof(TILE_ELEMENT));
 }
 
 

--- a/src/game/Utils/Observable.h
+++ b/src/game/Utils/Observable.h
@@ -51,7 +51,7 @@ public:
 	{
 		if (listeners.find(key) == listeners.end())
 		{
-			SLOGW(ST::format("There is no listener for key '{}'", key));
+			STLOGW("There is no listener for key '{}'", key);
 			return *this;
 		}
 

--- a/src/sgp/FileMan.cc
+++ b/src/sgp/FileMan.cc
@@ -26,13 +26,13 @@ void FileMan::switchTmpFolder(const ST::string& home)
 	if (!Fs_isDir(tmpPath.get()) && !Fs_createDir(tmpPath.get()))
 	{
 		RustPointer<char> err{getRustError()};
-		SLOGE(ST::format("Unable to create tmp directory '{}': {}", tmpPath.get(), err.get()));
+		STLOGE("Unable to create tmp directory '{}': {}", tmpPath.get(), err.get());
 		throw std::runtime_error("Unable to create tmp directory");
 	}
 	if (!Env_setCurrentDir(tmpPath.get()))
 	{
 		RustPointer<char> err{getRustError()};
-		SLOGE(ST::format("Unable to switch to tmp directory '{}': {}", tmpPath.get(), err.get()));
+		STLOGE("Unable to switch to tmp directory '{}': {}", tmpPath.get(), err.get());
 		throw std::runtime_error("Unable to switch to tmp directory");
 	}
 }
@@ -49,7 +49,7 @@ void FileDelete(const ST::string& path)
 	if (Fs_exists(path.c_str()) && !Fs_removeFile(path.c_str()))
 	{
 		RustPointer<char> err{getRustError()};
-		SLOGE(ST::format("Deleting file '{}' failed: {}", path, err.get()));
+		STLOGE("Deleting file '{}' failed: {}", path, err.get());
 		throw std::runtime_error("Deleting file failed");
 	}
 }
@@ -249,12 +249,12 @@ INT32 FileGetPos(const SGPFile* f)
 	if (!success)
 	{
 		RustPointer<char> err{getRustError()};
-		SLOGE(ST::format("FileGetPos: {}", err.get()));
+		STLOGE("FileGetPos: {}", err.get());
 		throw std::runtime_error("Getting file position failed");
 	}
 	if (position > INT32_MAX)
 	{
-		SLOGW(ST::format("FileGetPos: truncating from {} to {}", position, INT32_MAX));
+		STLOGW("FileGetPos: truncating from {} to {}", position, INT32_MAX);
 		position = INT32_MAX;
 	}
 	return static_cast<INT32>(position);
@@ -278,12 +278,12 @@ UINT32 FileGetSize(const SGPFile* f)
 	if (!success)
 	{
 		RustPointer<char> err{getRustError()};
-		SLOGE(ST::format("FileGetSize: {}", err.get()));
+		STLOGE("FileGetSize: {}", err.get());
 		throw std::runtime_error("Getting file size failed");
 	}
 	if (len > UINT32_MAX)
 	{
-		SLOGW(ST::format("FileGetSize: truncating from {} to {}", len, UINT32_MAX));
+		STLOGW("FileGetSize: truncating from {} to {}", len, UINT32_MAX);
 		len = UINT32_MAX;
 	}
 	return static_cast<UINT32>(len);
@@ -295,7 +295,7 @@ void FileMan::createDir(const ST::string& path)
 	if (!Fs_isDir(path.c_str()) && !Fs_createDir(path.c_str()))
 	{
 		RustPointer<char> err{getRustError()};
-		SLOGE(ST::format("Failed to created directory '{}': {}", path, err.get()));
+		STLOGE("Failed to created directory '{}': {}", path, err.get());
 		throw std::runtime_error("Failed to create directory");
 	}
 }
@@ -313,7 +313,7 @@ void EraseDirectory(const ST::string& dirPath)
 		catch (const std::runtime_error& ex)
 		{
 			if (Fs_isDir(path.c_str())) continue;
-			SLOGE(ST::format("EraseDirectory '{}' '{}': {}", dirPath, path, ex.what()));
+			STLOGE("EraseDirectory '{}' '{}': {}", dirPath, path, ex.what());
 			throw;
 		}
 	}
@@ -389,7 +389,7 @@ SGPFile* FileMan::openForWriting(const ST::string& filename, bool truncate)
 	if (!file)
 	{
 		RustPointer<char> err{getRustError()};
-		SLOGE(ST::format("FileMan::openForWriting '{}' {}: {}", filename, truncate, err.get()));
+		STLOGE("FileMan::openForWriting '{}' {}: {}", filename, truncate, err.get());
 		throw std::runtime_error("FileMan::openForWriting failed");
 	}
 	return getSGPFileFromFile(file.release());
@@ -404,7 +404,7 @@ SGPFile* FileMan::openForAppend(const ST::string& filename)
 	if (!file)
 	{
 		RustPointer<char> err{getRustError()};
-		SLOGE(ST::format("FileMan::openForAppend '{}': {}", filename, err.get()));
+		STLOGE("FileMan::openForAppend '{}': {}", filename, err.get());
 		throw std::runtime_error("FileMan::openForAppend failed");
 	}
 	return getSGPFileFromFile(file.release());
@@ -419,7 +419,7 @@ SGPFile* FileMan::openForReadWrite(const ST::string& filename)
 	if (!file)
 	{
 		RustPointer<char> err{getRustError()};
-		SLOGE(ST::format("FileMan::openForReadWrite '{}': {}", filename, err.get()));
+		STLOGE("FileMan::openForReadWrite '{}': {}", filename, err.get());
 		throw std::runtime_error("FileMan::openForReadWrite failed");
 	}
 	return getSGPFileFromFile(file.release());
@@ -432,7 +432,7 @@ SGPFile* FileMan::openForReading(const ST::string &filename)
 	if (!file)
 	{
 		RustPointer<char> err{getRustError()};
-		SLOGE(ST::format("FileMan::openForReading '{}': {}", filename, err.get()));
+		STLOGE("FileMan::openForReading '{}': {}", filename, err.get());
 		throw std::runtime_error("FileMan::openForReading failed");
 	}
 	return getSGPFileFromFile(file.release());
@@ -497,7 +497,7 @@ FindAllFilesInDir(const ST::string& dirPath, bool sortResults, bool recursive)
 	if (!vec)
 	{
 		RustPointer<char> err{getRustError()};
-		SLOGW(ST::format("FindAllFilesInDir: {}", err.get()));
+		STLOGW("FindAllFilesInDir: {}", err.get());
 		return paths;
 	}
 	size_t len = VecCString_len(vec.get());
@@ -601,7 +601,7 @@ void FileMan::moveFile(const ST::string& from, const ST::string& to)
 	if (!Fs_rename(from.c_str(), to.c_str()))
 	{
 		RustPointer<char> err{getRustError()};
-		SLOGE(ST::format("FileMan::moveFile '{}' '{}': {}", from, to, err.get()));
+		STLOGE("FileMan::moveFile '{}' '{}': {}", from, to, err.get());
 		throw std::runtime_error("FileMan::moveFile failed");
 	}
 }

--- a/src/sgp/LoadSaveData.cc
+++ b/src/sgp/LoadSaveData.cc
@@ -22,7 +22,7 @@ void DataWriter::writeUTF8(const ST::string& str, size_t numChars)
 	size_t n = std::min<size_t>(str.size() + 1, numChars);
 	if (str.size() > n)
 	{
-		SLOGW(ST::format("DataWriter::writeUTF8: truncating '{}' {}->{}", str, str.size(), n));
+		STLOGW("DataWriter::writeUTF8: truncating '{}' {}->{}", str, str.size(), n);
 	}
 	writeArray(str.c_str(), n);
 	skip(sizeof(char) * (numChars - n));
@@ -34,7 +34,7 @@ void DataWriter::writeUTF16(const ST::string& str, size_t numChars)
 	size_t n = std::min<size_t>(buf.size() + 1, numChars);
 	if (buf.size() > n)
 	{
-		SLOGW(ST::format("DataWriter::writeUTF16: truncating '{}' {}->{}", str, buf.size(), n));
+		STLOGW("DataWriter::writeUTF16: truncating '{}' {}->{}", str, buf.size(), n);
 	}
 	writeArray(buf.c_str(), n);
 	skip(sizeof(char16_t) * (numChars - n));
@@ -46,7 +46,7 @@ void DataWriter::writeUTF32(const ST::string& str, size_t numChars)
 	size_t n = std::min<size_t>(buf.size() + 1, numChars);
 	if (buf.size() > n)
 	{
-		SLOGW(ST::format("DataWriter::writeUTF32: truncating '{}' {}->{}", str, buf.size(), n));
+		STLOGW("DataWriter::writeUTF32: truncating '{}' {}->{}", str, buf.size(), n);
 	}
 	writeArray(buf.c_str(), n);
 	skip(sizeof(char32_t) * (numChars - n));

--- a/src/sgp/Logger.cc
+++ b/src/sgp/Logger.cc
@@ -33,7 +33,7 @@ void LogMessage(bool isAssert, LogLevel level, const char *file, const char *for
 	ST::string str = st_checked_buffer_to_string(err_msg, ST::char_buffer(message, lengthof(message)));
 	if (!err_msg.empty())
 	{
-		SLOGW(ST::format("LogMessage: {}", err_msg));
+		STLOGW("LogMessage: {}", err_msg);
 	}
 	LogMessage(isAssert, level, file, str);
 }

--- a/src/sgp/Logger.h
+++ b/src/sgp/Logger.h
@@ -4,6 +4,7 @@
 #include "Platform.h"
 #include "RustInterface.h"
 #include <string_view>
+#include <string_theory/format>
 #include <string_theory/string>
 #include <stracciatella.h>
 
@@ -42,7 +43,33 @@ template <size_t p> constexpr const char* ToRelativePath(const char* filename)
 /** Print error message macro. */
 #define SLOGE(FORMAT, ...) LogMessage(false, LogLevel::Error, __FILENAME__, FORMAT, ##__VA_ARGS__)
 
-/** Print error message macro. */
+/** Print error message macro and assert if ENABLE_ASSERTS is defined. */
 #define SLOGA(FORMAT, ...) LogMessage(true, LogLevel::Error, __FILENAME__, FORMAT, ##__VA_ARGS__)
+
+/*
+
+   As above, but for string_theory style formatted strings.
+
+*/
+
+template<typename... Args>
+constexpr void LogMessageST(bool isAssert, LogLevel level, const char* file, Args... args)
+{
+	LogMessage(isAssert, level, file, ST::format(args...));
+}
+/** Print debug message macro. */
+#define STLOGD(...) LogMessageST(false, LogLevel::Debug, __FILENAME__, ##__VA_ARGS__)
+
+/** Print info message macro. */
+#define STLOGI(...) LogMessageST(false, LogLevel::Info,  __FILENAME__, ##__VA_ARGS__)
+
+/** Print warning message macro. */
+#define STLOGW(...) LogMessageST(false, LogLevel::Warn, __FILENAME__, ##__VA_ARGS__)
+
+/** Print error message macro. */
+#define STLOGE(...) LogMessageST(false, LogLevel::Error, __FILENAME__, ##__VA_ARGS__)
+
+/** Print error message macro and assert if ENABLE_ASSERTS is defined. */
+#define STLOGA(...) LogMessageST(true,  LogLevel::Error, __FILENAME__, ##__VA_ARGS__)
 
 #endif//SGP_LOGGER_H_

--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -572,7 +572,7 @@ void SoundServiceStreams(void)
 		SOUNDTAG* Sound = &pSoundList[i];
 		if (Sound->State == CHANNEL_DEAD)
 		{
-			SLOGD(ST::format("DEAD channel {} file \"{}\" (refcount {})", i, Sound->pSample->pName, Sound->pSample->uiInstances));
+			STLOGD("DEAD channel {} file \"{}\" (refcount {})", i, Sound->pSample->pName, Sound->pSample->uiInstances);
 			if (Sound->EOSCallback != NULL) Sound->EOSCallback(Sound->pCallbackData);
 			assert(Sound->pSample->uiInstances != 0);
 			Sound->pSample->uiInstances--;
@@ -820,7 +820,7 @@ static BOOLEAN SoundCleanCache(void)
 
 	if (candidate != NULL)
 	{
-		SLOGD(ST::format("freeing sample {} \"{}\" with {} hits", candidate - pSampleList, candidate->pName, candidate->uiCacheHits));
+		STLOGD("freeing sample {} \"{}\" with {} hits", candidate - pSampleList, candidate->pName, candidate->uiCacheHits);
 		SoundFreeSample(candidate);
 		return TRUE;
 	}
@@ -1092,7 +1092,7 @@ static UINT32 SoundGetUniqueID(void);
  * Returns: Unique sound ID if successful, SOUND_ERROR if not. */
 static UINT32 SoundStartSample(SAMPLETAG* sample, SOUNDTAG* channel, UINT32 volume, UINT32 pan, UINT32 loop, void (*end_callback)(void*), void* data)
 {
-	SLOGD(ST::format("playing channel {} sample {} file \"{}\"", channel - pSoundList, sample - pSampleList, sample->pName));
+	STLOGD("playing channel {} sample {} file \"{}\"", channel - pSoundList, sample - pSampleList, sample->pName);
 
 	if (!fSoundSystemInit) return SOUND_ERROR;
 
@@ -1145,7 +1145,7 @@ static BOOLEAN SoundStopChannel(SOUNDTAG* channel)
 
 	if (channel->pSample == NULL) return FALSE;
 
-	SLOGD(ST::format("stopping channel channel {}", (channel - pSoundList)));
+	STLOGD("stopping channel channel {}", (channel - pSoundList));
 	channel->State = CHANNEL_STOP;
 	return TRUE;
 }


### PR DESCRIPTION
In many places of the code base, the old C-Style formatting strings in the logging macros were replaced with string_theory formatting strings and while the improved type safety and not having to remember the correct conversion specifier for size_t is nice, the current syntax is a bit clunky. This change introduces new STLOGx macros, where STLOGx(args) is equivalent to SLOGx(ST::format(args)). 

As a demonstration this changeset includes an updated DefaultContentManager.cc which was created with sed -E 's/SLOG(.)\(ST\:\:format\((.*)\)\);/STLOG\1\(\2\);/