### PR TITLE
Remove reinterpret_casts in LoadSaveData.cc

### DIFF
--- a/src/sgp/LoadSaveData.cc
+++ b/src/sgp/LoadSaveData.cc
@@ -12,7 +12,7 @@
 
 /** Constructor.
  * @param buf Pointer to the buffer for writing data. */
-DataWriter::DataWriter(void* buf)
+DataWriter::DataWriter(uint8_t* buf)
 	:m_buf(buf), m_original(buf)
 {
 }
@@ -69,20 +69,20 @@ void DataWriter::writeU32(uint32_t value)
 
 void DataWriter::skip(size_t numBytes)
 {
-	std::fill_n(reinterpret_cast<uint8_t*>(m_buf), numBytes, 0);
+	std::fill_n(m_buf, numBytes, 0);
 	move(numBytes);
 }
 
 /** Move pointer to \a numBytes bytes forward. */
 void DataWriter::move(size_t numBytes)
 {
-	m_buf = reinterpret_cast<uint8_t*>(m_buf) + numBytes;
+	m_buf += numBytes;
 }
 
 /** Get number of the consumed bytes during writing. */
 size_t DataWriter::getConsumed() const
 {
-	return reinterpret_cast<uint8_t*>(m_buf) - reinterpret_cast<uint8_t*>(m_original);
+	return m_buf - m_original;
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -90,7 +90,7 @@ size_t DataWriter::getConsumed() const
 ////////////////////////////////////////////////////////////////////////////
 
 
-DataReader::DataReader(const void* buf)
+DataReader::DataReader(const uint8_t* buf)
 	: m_buf(buf), m_original(buf)
 {
 }
@@ -149,12 +149,12 @@ void DataReader::skip(size_t numBytes)
 
 void DataReader::move(size_t numBytes)
 {
-	m_buf = reinterpret_cast<const uint8_t*>(m_buf) + numBytes;
+	m_buf += numBytes;
 }
 
 size_t DataReader::getConsumed() const
 {
-	return reinterpret_cast<const uint8_t*>(m_buf) - reinterpret_cast<const uint8_t*>(m_original);
+	return m_buf - m_original;
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/src/sgp/LoadSaveData.h
+++ b/src/sgp/LoadSaveData.h
@@ -25,7 +25,7 @@ private:
 public:
 	/** Constructor.
 	 * @param buf Pointer to the buffer for writing data. */
-	DataWriter(void* buf);
+	explicit DataWriter(uint8_t* buf);
 
 	/** Write UTF-8 encoded string.
 	 * @param str      String to write
@@ -73,8 +73,8 @@ public:
 	size_t getConsumed() const;
 
 protected:
-	void* m_buf;
-	void* m_original;
+	uint8_t* m_buf;
+	uint8_t* m_original;
 
 	/** Move pointer to \a numBytes bytes forward. */
 	void move(size_t numBytes);
@@ -96,7 +96,7 @@ private:
 public:
 	/** Constructor.
 	 * @param buf Pointer to the buffer for writing data. */
-	DataReader(const void* buf);
+	explicit DataReader(const uint8_t* buf);
 
 	/** Read UTF-8 encoded string.
 	 * @param numChars Number of `char` characters to read.
@@ -150,8 +150,8 @@ public:
 	size_t getConsumed() const;
 
 protected:
-	const void* m_buf;
-	const void* m_original;
+	const uint8_t* m_buf;
+	const uint8_t* m_original;
 
 	/** Move pointer to \a numBytes bytes forward. */
 	void move(size_t numBytes);

--- a/src/sgp/LoadSaveData_unittest.cc
+++ b/src/sgp/LoadSaveData_unittest.cc
@@ -10,7 +10,7 @@
 
 TEST(LoadSaveData, integers)
 {
-	char buf[100];
+	BYTE buf[100];
 
 	{
 		DataWriter writer(buf);
@@ -60,7 +60,7 @@ TEST(LoadSaveData, integers)
 
 TEST(LoadSaveData, writeUTF16English)
 {
-	char buf[100];
+	BYTE buf[100];
 
 	DataWriter writer(buf);
 	writer.writeUTF16("test", 5);
@@ -81,7 +81,7 @@ TEST(LoadSaveData, writeUTF16English)
 
 TEST(LoadSaveData, writeUTF16Russian)
 {
-	char buf[100];
+	BYTE buf[100];
 
 	DataWriter writer(buf);
 	writer.writeUTF16("тест", 5);
@@ -99,7 +99,7 @@ TEST(LoadSaveData, writeUTF16Russian)
 
 TEST(LoadSaveData, readUTF16)
 {
-	char buf[100];
+	BYTE buf[100];
 	DataWriter writer(buf);
 
 	writer.writeU16(0x0442);
@@ -119,7 +119,7 @@ TEST(LoadSaveData, readUTF16)
 
 TEST(LoadSaveData, readUTF32)
 {
-	char buf[100];
+	BYTE buf[100];
 	DataWriter writer(buf);
 
 	writer.writeU32(0x00000442);


### PR DESCRIPTION
There are currently several reinterpret_casts from void* to uint8_t* in the DataReader and DataWriter classes, all of which can easily be avoided by declaring the member variables as uint8_t*.

I decided to change char[] to BYTE[], not uint8_t[] in LoadSaveData_unittest.cc because that's what all the users of DataReader and DataWriter currently use.