### PR TITLE
Clean up the event queue management

### DIFF
--- a/src/game/Tactical/OppList.h
+++ b/src/game/Tactical/OppList.h
@@ -102,7 +102,7 @@ void DebugSoldierPage2(void);
 void DebugSoldierPage3(void);
 void DebugSoldierPage4(void);
 
-UINT8 MovementNoise( SOLDIERTYPE *pSoldier );
+UINT8 MovementNoise( SOLDIERTYPE const *pSoldier );
 UINT8 DoorOpeningNoise( SOLDIERTYPE *pSoldier );
 void MakeNoise(SOLDIERTYPE* noise_maker, INT16 sGridNo, INT8 bLevel, UINT8 ubVolume, NoiseKind);
 void OurNoise(SOLDIERTYPE* noise_maker, INT16 sGridNo, INT8 bLevel, UINT8 ubVolume, NoiseKind);

--- a/src/game/Utils/Event_Pump.cc
+++ b/src/game/Utils/Event_Pump.cc
@@ -45,32 +45,14 @@ static void AddEvent(GAMEEVENT const& gameEvent, UINT16 const usDelay, EventQueu
 	GetQueue(ubQueueID).push_back(pEvent);
 }
 
-
-static EVENT* RemoveEvent(UINT32 uiIndex, EventQueueID ubQueueID)
-try
+// Remove the first element from a queue and return it.
+// Calling this function on an empty queue is undefined behavior, don't do it.
+static EVENT* PopFrontEvent(EventQueueID ubQueueID)
 {
 	EventList& queue = GetQueue(ubQueueID);
-	EVENT* ret = queue[uiIndex];
-	queue.erase(queue.begin() + uiIndex);
+	EVENT* const ret = queue.front();
+	queue.erase(queue.begin());
 	return ret;
-}
-catch (const std::exception&)
-{
-	return 0;
-}
-
-
-static EVENT* PeekEvent(UINT32 uiIndex, EventQueueID ubQueueID)
-{
-	return GetQueue(ubQueueID)[uiIndex];
-}
-
-
-static BOOLEAN FreeEvent(EVENT* pEvent)
-{
-	if (!pEvent) return FALSE;
-	delete pEvent;
-	return TRUE;
 }
 
 
@@ -107,16 +89,12 @@ void AddGameEvent(GAMEEVENT const& gameEvent, UINT16 usDelay)
 
 static void ExecuteGameEvent(EVENT* pEvent);
 
-BOOLEAN DequeAllGameEvents(void)
+void DequeAllGameEvents(void)
 {
-	UINT32  uiQueueSize;
-	UINT32  cnt;
-
 	// First dequeue all primary events
 	while (EventQueueSize(EventQueueID::PRIMARY_EVENT_QUEUE) > 0)
 	{
-		EVENT* pEvent = RemoveEvent(0, EventQueueID::PRIMARY_EVENT_QUEUE);
-		if (pEvent == NULL) return FALSE;
+		EVENT* pEvent = PopFrontEvent(EventQueueID::PRIMARY_EVENT_QUEUE);
 
 		// Check if event has a delay and add to secondary queue if so
 		if (pEvent->usDelay > 0)
@@ -128,16 +106,13 @@ BOOLEAN DequeAllGameEvents(void)
 			ExecuteGameEvent(pEvent);
 		}
 
-		FreeEvent(pEvent);
+		delete pEvent;
 	}
 
 	// NOW CHECK SECONDARY QUEUE FOR ANY EXPRIED EVENTS
-	uiQueueSize = EventQueueSize(EventQueueID::SECONDARY_EVENT_QUEUE);
-	for (cnt = 0; cnt < uiQueueSize; cnt++)
+	EventList& queue = GetQueue(EventQueueID::SECONDARY_EVENT_QUEUE);
+	for (EVENT* const pEvent : queue)
 	{
-		EVENT* pEvent = PeekEvent(cnt, EventQueueID::SECONDARY_EVENT_QUEUE);
-		if (pEvent == NULL) return FALSE;
-
 		// Check time
 		if (GetJA2Clock() - pEvent->TimeStamp > pEvent->usDelay)
 		{
@@ -146,40 +121,24 @@ BOOLEAN DequeAllGameEvents(void)
 		}
 	}
 
-	do
-	{
-		uiQueueSize = EventQueueSize(EventQueueID::SECONDARY_EVENT_QUEUE);
-		for (cnt = 0; cnt < uiQueueSize; cnt++)
+	// Remove and free all expired events from the secondary queue.
+	queue.erase(std::remove_if(queue.begin(), queue.end(),
+		[](EVENT* const ep)
 		{
-			EVENT* pEvent = PeekEvent(cnt, EventQueueID::SECONDARY_EVENT_QUEUE);
-			if (pEvent == NULL)
-			{
-				return FALSE;
-			}
-
-			// Check time
-			if (pEvent->eventExpired)
-			{
-				pEvent = RemoveEvent(cnt, EventQueueID::SECONDARY_EVENT_QUEUE);
-				FreeEvent(pEvent);
-				// Restart loop
-				break;
-			}
-		}
-	} while (cnt != uiQueueSize);
-
-	return TRUE;
+			if (!ep->eventExpired) return false;
+			delete ep;
+			return true;
+		}), queue.end());
 }
 
 
-BOOLEAN DequeueAllDemandGameEvents(void)
+void DequeueAllDemandGameEvents(void)
 {
 	// Dequeue all events on the demand queue (only)
 
 	while (EventQueueSize(EventQueueID::DEMAND_EVENT_QUEUE) > 0)
 	{
-		EVENT* pEvent = RemoveEvent(0, EventQueueID::DEMAND_EVENT_QUEUE);
-		if (pEvent == NULL) return FALSE;
+		EVENT* pEvent = PopFrontEvent(EventQueueID::DEMAND_EVENT_QUEUE);
 
 		// Check if event has a delay and add to secondary queue if so
 		if (pEvent->usDelay > 0)
@@ -191,10 +150,8 @@ BOOLEAN DequeueAllDemandGameEvents(void)
 			ExecuteGameEvent(pEvent);
 		}
 
-		FreeEvent(pEvent);
+		delete pEvent;
 	}
-
-	return TRUE;
 }
 
 
@@ -317,15 +274,10 @@ static void ExecuteGameEvent(EVENT* pEvent)
 }
 
 
-BOOLEAN ClearEventQueue(void)
+void ClearEventQueue(void)
 {
 	// clear out the event queue
-	while (EventQueueSize(EventQueueID::PRIMARY_EVENT_QUEUE) > 0)
-	{
-		EVENT* Event = RemoveEvent(0, EventQueueID::PRIMARY_EVENT_QUEUE);
-		if (Event == NULL) return FALSE;
-		FreeEvent(Event);
-	}
-
-	return TRUE;
+	EventList& queue = GetQueue(EventQueueID::PRIMARY_EVENT_QUEUE);
+	for (EVENT *pEvent : queue) delete pEvent;
+	queue.clear();
 }

--- a/src/game/Utils/Event_Pump.cc
+++ b/src/game/Utils/Event_Pump.cc
@@ -50,6 +50,7 @@ static void AddEvent(GAMEEVENT const& gameEvent, UINT16 const usDelay, EventQueu
 static EVENT* PopFrontEvent(EventQueueID ubQueueID)
 {
 	EventList& queue = GetQueue(ubQueueID);
+	Assert(!queue.empty());
 	EVENT* const ret = queue.front();
 	queue.erase(queue.begin());
 	return ret;

--- a/src/game/Utils/Event_Pump.h
+++ b/src/game/Utils/Event_Pump.h
@@ -79,11 +79,11 @@ using GAMEEVENT = std::variant<
 	EV_S_NOISE>;
 
 
-void    AddGameEvent(GAMEEVENT const&, UINT16 usDelay);
-BOOLEAN DequeAllGameEvents(void);
-BOOLEAN DequeueAllDemandGameEvents(void);
+void AddGameEvent(GAMEEVENT const&, UINT16 usDelay);
+void DequeAllGameEvents(void);
+void DequeueAllDemandGameEvents(void);
 
 // clean out the event queue
-BOOLEAN ClearEventQueue(void);
+void ClearEventQueue(void);
 
 #endif


### PR DESCRIPTION
After selaux's question in #1302 about `RemoveEvent` I had a closer look at the rest of the event pump code and found quite a bit of questionable logic. I am unsure whether any of these issues could cause actual problems in the game but since a more robust implementation isn't that hard and also more concise and more performant, why not?

Copy and paste of my commit message:

- `PeekEvent` and `RemoveEvent` were using try-catch blocks to return NULL in case they were called with an out-of-bounds-index but vector::operator[] does not throw an exception in that case.
- So, all null checks after `PeekEvent` and `RemoveEvent` were pointless.
- Removing all expired events in `DequeAllGameEvents` can be written more concisely and more performant with an STL algorithm.
- This eliminates the only use of `RemoveEvent` with an index other than 0, so that function can be simplified. I renamed it `PopFrontEvent`.
- `PeekEvent` had only one user left, which also was better implemented with a range-based for loop so it got removed.
- `DequeAllGameEvents`, `DequeueAllDemandGameEvents` and `ClearEventQueue` never fail, so their return type got changed to void.
- `FreeEvent` also had useless null checks, replaced it with direct delete statements.