### PR TITLE
Fixing incorrect item flags checks

### DIFF
--- a/src/game/Tactical/Arms_Dealer_Init.cc
+++ b/src/game/Tactical/Arms_Dealer_Init.cc
@@ -1023,12 +1023,12 @@ BOOLEAN CanDealerRepairItem(ArmsDealerID const ubArmsDealer, UINT16 const usItem
 		if (dealer->hasFlag(ArmsDealerFlag::REPAIRS_ELECTRONICS))
 		{
 			// repairs ONLY electronics
-			return (uiFlags & ITEM_ELECTRONIC);
+			return (uiFlags & ITEM_ELECTRONIC) > 0;
 		}
 		else
 		{
 			// repairs ANYTHING non-electronic
-			return !(uiFlags & ITEM_ELECTRONIC);
+			return (uiFlags & ITEM_ELECTRONIC) == 0;
 		}
 	}
 	else


### PR DESCRIPTION
Fixes  #1309.

Bitwise-and operator returns `16384` in this case, and it does not convert well back to `BOOLEAN` (which is 8-bit char). Tested with Fredo and Arnie with the attached save.

