### PR TITLE
Fix brew-install in Mac build

### DIFF
--- a/.ci/ci-functions.sh
+++ b/.ci/ci-functions.sh
@@ -47,7 +47,7 @@ macOS-install-via-brew () {
 }
 
 macOS-install-via-brew-cask () {
-    brew cask install google-cloud-sdk
+    brew install --cask google-cloud-sdk
 }
 
 windows-install-via-chocolatey () {


### PR DESCRIPTION
brew is complaining: `Error: Calling brew cask install is disabled! Use brew install [--cask] instead.`