### PR TITLE
Fix: Buttons stay disabled after leaving the shop keeper interface

### DIFF
--- a/src/game/Editor/Sector_Summary.cc
+++ b/src/game/Editor/Sector_Summary.cc
@@ -47,7 +47,6 @@
 #include <string_theory/format>
 #include <string_theory/string>
 
-#include <algorithm>
 #include <vector>
 
 #define DEVINFO_DIR "../DevInfo"
@@ -594,7 +593,6 @@ static void RenderItemDetails(void)
 	OBJECTTYPE *pItem;
 	INT32 index, i;
 	UINT32 uiQuantity, uiExistChance, uiStatus;
-	UINT32 uiTriggerQuantity[8], uiActionQuantity[8], uiTriggerExistChance[8], uiActionExistChance[8];
 	UINT32 xp, yp;
 	INT8 bFreqIndex;
 	SetFontAttributes(FONT10ARIAL, FONT_GRAY2);
@@ -605,10 +603,10 @@ static void RenderItemDetails(void)
 	xp = 5;
 	if (gubSummaryItemMode != ITEMMODE_ENEMY)
 	{
-		std::fill_n(uiTriggerQuantity, 32, 0);
-		std::fill_n(uiActionQuantity, 32, 0);
-		std::fill_n(uiTriggerExistChance, 32, 0);
-		std::fill_n(uiActionExistChance, 32, 0);
+		UINT32 uiTriggerQuantity[8] {};
+		UINT32 uiActionQuantity[8] {};
+		UINT32 uiTriggerExistChance[8] {};
+		UINT32 uiActionExistChance[8] {};
 		for( index = 1; index < MAXITEMS; index++ )
 		{
 			uiQuantity = 0;

--- a/src/game/Tactical/Interface_Panels.cc
+++ b/src/game/Tactical/Interface_Panels.cc
@@ -3566,38 +3566,38 @@ void KeyRingSlotInvClickCallback( MOUSE_REGION * pRegion, INT32 iReason )
 }
 
 
-void DisableSMPpanelButtonsWhenInShopKeeperInterface(void)
+void ShopKeeperInterface_SetSMpanelButtonsState(bool const enabled)
 {
 	//Go through the buttons that will be under the ShopKeepers ATM panel and disable them
-	DisableButton( iSMPanelButtons[ STANCEUP_BUTTON ] );
-	DisableButton( iSMPanelButtons[ UPDOWN_BUTTON ] );
-	DisableButton( iSMPanelButtons[ CLIMB_BUTTON ] );
-	DisableButton( iSMPanelButtons[ STANCEDOWN_BUTTON ] );
-	DisableButton( iSMPanelButtons[ HANDCURSOR_BUTTON ] );
-	DisableButton( iSMPanelButtons[ BURSTMODE_BUTTON ] );
-	DisableButton( iSMPanelButtons[ LOOK_BUTTON ] );
-	DisableButton( iSMPanelButtons[ TALK_BUTTON ] );
-	DisableButton( iSMPanelButtons[ MUTE_BUTTON ] );
+	EnableButton( iSMPanelButtons[ STANCEUP_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ UPDOWN_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ CLIMB_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ STANCEDOWN_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ HANDCURSOR_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ BURSTMODE_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ LOOK_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ TALK_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ MUTE_BUTTON ], enabled );
 
-	DisableButton( giSMStealthButton );
+	EnableButton( giSMStealthButton, enabled );
 
 	//Make sure the options button is disabled
-	DisableButton( iSMPanelButtons[ OPTIONS_BUTTON ] );
+	EnableButton( iSMPanelButtons[ OPTIONS_BUTTON ], enabled );
 
 	//Make sure the mapscreen button is disabled
-	DisableButton( iSMPanelButtons[ SM_MAP_SCREEN_BUTTON ] );
+	EnableButton( iSMPanelButtons[ SM_MAP_SCREEN_BUTTON ], enabled );
 
-	DisableButton( iSMPanelButtons[ STANCEUP_BUTTON ] );
-	DisableButton( iSMPanelButtons[ UPDOWN_BUTTON ] );
-	DisableButton( iSMPanelButtons[ CLIMB_BUTTON ] );
-	DisableButton( iSMPanelButtons[ STANCEDOWN_BUTTON ] );
-	DisableButton( iSMPanelButtons[ HANDCURSOR_BUTTON ] );
-	DisableButton( iSMPanelButtons[ BURSTMODE_BUTTON ] );
-	DisableButton( iSMPanelButtons[ LOOK_BUTTON ] );
-	DisableButton( iSMPanelButtons[ TALK_BUTTON ] );
-	DisableButton( iSMPanelButtons[ MUTE_BUTTON ] );
+	EnableButton( iSMPanelButtons[ STANCEUP_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ UPDOWN_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ CLIMB_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ STANCEDOWN_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ HANDCURSOR_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ BURSTMODE_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ LOOK_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ TALK_BUTTON ], enabled );
+	EnableButton( iSMPanelButtons[ MUTE_BUTTON ], enabled );
 
-	DisableButton( giSMStealthButton );
+	EnableButton( giSMStealthButton, enabled );
 }
 
 

--- a/src/game/Tactical/Interface_Panels.h
+++ b/src/game/Tactical/Interface_Panels.h
@@ -89,7 +89,7 @@ extern BOOLEAN gfDisableTacticalPanelButtons;
 
 
 //Used when the shop keeper interface is active
-void DisableSMPpanelButtonsWhenInShopKeeperInterface(void);
+void ShopKeeperInterface_SetSMpanelButtonsState(bool enabled);
 
 void ReEvaluateDisabledINVPanelButtons(void);
 

--- a/src/game/Tactical/ShopKeeper_Interface.cc
+++ b/src/game/Tactical/ShopKeeper_Interface.cc
@@ -479,7 +479,7 @@ ScreenID ShopKeeperScreenHandle()
 	}
 
 	// render buttons marked dirty
-	DisableSMPpanelButtonsWhenInShopKeeperInterface();
+	ShopKeeperInterface_SetSMpanelButtonsState(false);
 	RenderButtons( );
 
 	// render help
@@ -846,6 +846,7 @@ static void ExitShopKeeperInterface(void)
 	gRadarRegion.Enable();
 
 	gfSMDisableForItems = FALSE;
+	ShopKeeperInterface_SetSMpanelButtonsState(true);
 }
 
 static void DisplayArmsDealerCurrentInventoryPage(void);
@@ -867,7 +868,7 @@ static void HandleShopKeeperInterface(void)
 	//if we are in the item desc panel, disable the buttons
 	if( InItemDescriptionBox( ) && pShopKeeperItemDescObject != NULL )
 	{
-		DisableSMPpanelButtonsWhenInShopKeeperInterface();
+		ShopKeeperInterface_SetSMpanelButtonsState(false);
 		DisableButton( guiSKI_InvPageUpButton );
 		DisableButton( guiSKI_InvPageDownButton );
 		DisableButton( guiSKI_TransactionButton );


### PR DESCRIPTION
The saved game from #1309 can be used to see this bug: give Fredo or Arnold something to repair and finish the transaction. The buttons that were disabled when you enter the interface stay disabled.

git bisect says this bug was introduced by 97e943d9b01692eb305f14e43f669223d312911b, so this bug is quite old and in the 0.17.0 release. Since that commit supposedly was needed to fix other bugs I took another approach to fix this one.

Btw., ShopKeeperInterface_SetSMpanelButtonsState isn't the prettiest function name I've ever written. Have your considered adding some namespaces?