### PR TITLE
Avoid unnecessary string copies in Tile_Surface.cc and WorldDef.cc

### DIFF
--- a/src/game/TileEngine/Tile_Surface.cc
+++ b/src/game/TileEngine/Tile_Surface.cc
@@ -20,7 +20,7 @@
 TILE_IMAGERY				*gTileSurfaceArray[ NUMBEROFTILETYPES ];
 
 
-TILE_IMAGERY* LoadTileSurface(ST::string cFilename)
+TILE_IMAGERY* LoadTileSurface(ST::string const& cFilename)
 try
 {
 	// Add tile surface
@@ -97,27 +97,27 @@ void DeleteTileSurface(TILE_IMAGERY* const pTileSurf)
 }
 
 
-void SetRaisedObjectFlag(const ST::string filename, TILE_IMAGERY* const t)
+void SetRaisedObjectFlag(ST::string const& filename, TILE_IMAGERY* const t)
 {
-	static std::array<const ST::string, 11> raisedObjectFiles = {
-		"bones",
-		"bones2",
-		"grass2",
-		"grass3",
-		"l_weed3",
-		"litter",
-		"miniweed",
-		"sblast",
-		"sweeds",
-		"twigs",
-		"wing"
+	static std::array<const ST::string, 11> const raisedObjectFiles = {
+		ST_LITERAL("bones"),
+		ST_LITERAL("bones2"),
+		ST_LITERAL("grass2"),
+		ST_LITERAL("grass3"),
+		ST_LITERAL("l_weed3"),
+		ST_LITERAL("litter"),
+		ST_LITERAL("miniweed"),
+		ST_LITERAL("sblast"),
+		ST_LITERAL("sweeds"),
+		ST_LITERAL("twigs"),
+		ST_LITERAL("wing")
 	};
 
 	if (DEBRISWOOD != t->fType && t->fType != DEBRISWEEDS && t->fType != DEBRIS2MISC && t->fType != ANOTHERDEBRIS) return;
 
 	// Loop through array of RAISED objecttype imagery and set global value
-	ST::string rootfile = FileMan::getFileNameWithoutExt(filename);
-	for (ST::string i : raisedObjectFiles)
+	ST::string const rootfile = FileMan::getFileNameWithoutExt(filename);
+	for (ST::string const& i : raisedObjectFiles)
 	{
 		if (i.compare_i(rootfile) == 0)
 		{

--- a/src/game/TileEngine/Tile_Surface.h
+++ b/src/game/TileEngine/Tile_Surface.h
@@ -8,10 +8,10 @@ struct TILE_IMAGERY;
 extern TILE_IMAGERY* gTileSurfaceArray[NUMBEROFTILETYPES];
 
 
-TILE_IMAGERY* LoadTileSurface(const ST::string cFilename);
+TILE_IMAGERY* LoadTileSurface(ST::string const& cFilename);
 
 void DeleteTileSurface(TILE_IMAGERY* pTileSurf);
 
-void SetRaisedObjectFlag(const ST::string filename, TILE_IMAGERY*);
+void SetRaisedObjectFlag(ST::string const& filename, TILE_IMAGERY*);
 
 #endif

--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -204,7 +204,7 @@ void DeinitializeWorld( )
 }
 
 
-static void AddTileSurface(const ST::string filename, UINT32 const tileType);
+static void AddTileSurface(ST::string const& filename, UINT32 const tileType);
 
 TileSetID GetDefaultTileset() {
 	return (gubNumTilesets == JA25_NUM_TILESETS) // If we have the number of tilesets for JA25 useJA25 default, else vanilla default
@@ -212,28 +212,28 @@ TileSetID GetDefaultTileset() {
 		: GENERIC_1;
 }
 
-TILE_SURFACE_RESOURCE GetAdjustedTilesetResource(TileSetID tilesetID, UINT32 uiTileType, const ST::string filePrefix)
+TILE_SURFACE_RESOURCE GetAdjustedTilesetResource(TileSetID tilesetID, UINT32 uiTileType, ST::string const& filePrefix)
 {
 	if (tilesetID >= gubNumTilesets) throw std::logic_error("invalid tilesetID");
 
-	ST::string  filename = gTilesets[tilesetID].zTileSurfaceFilenames[uiTileType];
-	if (filename.empty())
+	ST::string *filename = &gTilesets[tilesetID].zTileSurfaceFilenames[uiTileType];
+	if (filename->empty())
 	{
 		// Try loading from default tileset
 		tilesetID = (gubNumTilesets == JA25_NUM_TILESETS && uiTileType == SPECIALTILES)
 			? DEFAULT_JA25_TILESET     // If the map is SPECIALTILES (and JA25 tilesets available), use DEFAULT_JA25_TILESET
 			: GetDefaultTileset()      // Else use default
 		;
-		filename = gTilesets[tilesetID].zTileSurfaceFilenames[uiTileType];
+		filename = &gTilesets[tilesetID].zTileSurfaceFilenames[uiTileType];
 	}
 
 	TILE_SURFACE_RESOURCE res;
 	res.tilesetID = tilesetID;
-	res.resourceFileName = GCM->getTilesetResourceName(tilesetID, filePrefix + filename);
+	res.resourceFileName = GCM->getTilesetResourceName(tilesetID, filePrefix + *filename);
 	return res;
 }
 
-static void LoadTileSurfaces(const ST::string tile_surface_filenames[NUMBEROFTILETYPES], TileSetID const tileset_id)
+static void LoadTileSurfaces(TileSetID const tileset_id)
 try
 {
 	SetRelativeStartAndEndPercentage(0, 1, 35, "Tile Surfaces");
@@ -261,7 +261,7 @@ catch (...)
 }
 
 
-static void AddTileSurface(const ST::string filename, UINT32 const type)
+static void AddTileSurface(ST::string const& filename, UINT32 const type)
 {
 	TILE_IMAGERY*& slot = gTileSurfaceArray[type];
 
@@ -411,9 +411,6 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 	{
 		return;
 	}
-
-/*
-*/
 
 	if ( GridNoOnVisibleWorldTile( usGridNo ) )
 	{
@@ -2650,7 +2647,7 @@ void LoadMapTileset(TileSetID const id)
 	if (id == giCurrentTilesetID) return;
 
 	TILESET const& t = gTilesets[id];
-	LoadTileSurfaces(t.zTileSurfaceFilenames, id);
+	LoadTileSurfaces(id);
 
 	// Set terrain costs
 	if (t.MovementCostFnc)

--- a/src/game/TileEngine/WorldDef.h
+++ b/src/game/TileEngine/WorldDef.h
@@ -279,7 +279,7 @@ void RecompileLocalMovementCostsFromRadius( INT16 sCentreGridNo, INT8 bRadius );
 
 TileSetID GetDefaultTileset();
 // Tilesets may not provide all tile types.If a tile type is not available in a tileset, we fall back and use the surface in the default tileset.
-TILE_SURFACE_RESOURCE GetAdjustedTilesetResource(TileSetID tilesetID, UINT32 uiTileType, const ST::string filePrefix = "");
+TILE_SURFACE_RESOURCE GetAdjustedTilesetResource(TileSetID tilesetID, UINT32 uiTileType, ST::string const& filePrefix = "");
 
 void LoadMapTileset(TileSetID);
 


### PR DESCRIPTION
Several locations made string copies where a reference could have been used instead.

The most egregious case is `LoadTileSurfaces(), which copies an array of 151 strings it does not even use. I was surprised what a difference ST_LITERAL makes, that change alone reduced the size of a release build by about 8 KB.