### PR TITLE
Change signature of GetMapTempFileName()

### DIFF
--- a/src/game/Tactical/Enemy_Soldier_Save.cc
+++ b/src/game/Tactical/Enemy_Soldier_Save.cc
@@ -35,9 +35,7 @@ static void RemoveTempFile(INT16 const x, INT16 const y, INT8 const z, SectorFla
 
 	// Delete any temp file that is here and toast the flag that says one exists.
 	ReSetSectorFlag(x, y, z, file_flag);
-	char filename[128];
-	GetMapTempFileName(file_flag, filename, x, y, z);
-	FileDelete(filename);
+	FileDelete(GetMapTempFileName(file_flag, x, y, z));
 }
 
 
@@ -51,9 +49,7 @@ void LoadEnemySoldiersFromTempFile()
 	INT8  const z = gbWorldSectorZ;
 
 	// STEP ONE: Set up the temp file to read from.
-	char map_name[128];
-	GetMapTempFileName(SF_ENEMY_PRESERVED_TEMP_FILE_EXISTS, map_name, x, y, z);
-	AutoSGPFile f(GCM->openGameResForReading(map_name));
+	AutoSGPFile f(GCM->openGameResForReading(GetMapTempFileName(SF_ENEMY_PRESERVED_TEMP_FILE_EXISTS, x, y, z)));
 
 	// STEP TWO: Determine whether or not we should use this data.  Because it
 	// is the demo, it is automatically used.
@@ -319,9 +315,7 @@ void NewWayOfLoadingEnemySoldiersFromTempFile()
 	ubNumCreatures = 0;
 
 	// STEP ONE:  Set up the temp file to read from.
-	char map_name[128];
-	GetMapTempFileName(SF_ENEMY_PRESERVED_TEMP_FILE_EXISTS, map_name, x, y, z);
-	AutoSGPFile f(GCM->openGameResForReading(map_name));
+	AutoSGPFile f(GCM->openGameResForReading(GetMapTempFileName(SF_ENEMY_PRESERVED_TEMP_FILE_EXISTS, x, y, z)));
 
 	// STEP TWO:  Determine whether or not we should use this data.  Because it
 	// is the demo, it is automatically used.
@@ -505,9 +499,7 @@ void NewWayOfLoadingCiviliansFromTempFile()
 	INT8  const z = gbWorldSectorZ;
 
 	// STEP ONE: Set up the temp file to read from.
-	char map_name[128];
-	GetMapTempFileName(SF_CIV_PRESERVED_TEMP_FILE_EXISTS, map_name, x, y, z);
-	AutoSGPFile f(GCM->openGameResForReading(map_name));
+	AutoSGPFile f(GCM->openGameResForReading(GetMapTempFileName(SF_CIV_PRESERVED_TEMP_FILE_EXISTS, x, y, z)));
 
 	// STEP TWO:  Determine whether or not we should use this data.  Because it
 	// is the demo, it is automatically used.
@@ -788,9 +780,7 @@ void NewWayOfSavingEnemyAndCivliansToTempFile(INT16 const sSectorX, INT16 const 
 
 	// STEP TWO:  Set up the temp file to write to.
 
-	char map_name[128];
-	GetMapTempFileName(file_flag, map_name, sSectorX, sSectorY, bSectorZ);
-	AutoSGPFile f(FileMan::openForWriting(map_name));
+	AutoSGPFile f(FileMan::openForWriting(GetMapTempFileName(file_flag, sSectorX, sSectorY, bSectorZ)));
 
 	FileWrite(f, &sSectorY, 2);
 
@@ -862,9 +852,7 @@ static void CountNumberOfElitesRegularsAdminsAndCreaturesFromEnemySoldiersTempFi
 	INT8  const z = gbWorldSectorZ;
 
 	// STEP ONE: Set up the temp file to read from.
-	char map_name[128];
-	GetMapTempFileName(SF_ENEMY_PRESERVED_TEMP_FILE_EXISTS, map_name, x, y, z);
-	AutoSGPFile f(GCM->openGameResForReading(map_name));
+	AutoSGPFile f(GCM->openGameResForReading(GetMapTempFileName(SF_ENEMY_PRESERVED_TEMP_FILE_EXISTS, x, y, z)));
 
 	// STEP TWO: Determine whether or not we should use this data.  Because it
 	// is the demo, it is automatically used.

--- a/src/game/Tactical/Keys.cc
+++ b/src/game/Tactical/Keys.cc
@@ -784,9 +784,7 @@ void UpdateDoorPerceivedValue( DOOR *pDoor )
 
 void SaveDoorTableToDoorTableTempFile(INT16 const x, INT16 const y, INT8 const z)
 {
-	char map_name[128];
-	GetMapTempFileName(SF_DOOR_TABLE_TEMP_FILES_EXISTS, map_name, x, y, z);
-	AutoSGPFile f(FileMan::openForWriting(map_name));
+	AutoSGPFile f(FileMan::openForWriting(GetMapTempFileName(SF_DOOR_TABLE_TEMP_FILES_EXISTS, x, y, z)));
 	Assert(DoorTable.size() <= UINT8_MAX);
 	UINT8 numDoors = static_cast<UINT8>(DoorTable.size());
 	FileWriteArray(f, numDoors, DoorTable.data());
@@ -797,11 +795,7 @@ void SaveDoorTableToDoorTableTempFile(INT16 const x, INT16 const y, INT8 const z
 
 void LoadDoorTableFromDoorTableTempFile()
 {
-	CHAR8 zMapName[ 128 ];
-
-	//return( TRUE );
-
-	GetMapTempFileName( SF_DOOR_TABLE_TEMP_FILES_EXISTS, zMapName, gWorldSectorX, gWorldSectorY, gbWorldSectorZ );
+	ST::string const zMapName = GetMapTempFileName( SF_DOOR_TABLE_TEMP_FILES_EXISTS, gWorldSectorX, gWorldSectorY, gbWorldSectorZ );
 
 	//If the file doesnt exists, its no problem.
 	if (!GCM->doesGameResExists(zMapName)) return;
@@ -1157,9 +1151,7 @@ void SaveDoorStatusArrayToDoorStatusTempFile(INT16 const x, INT16 const y, INT8 
 	// Turn off any door busy flags
 	FOR_EACH_DOOR_STATUS(d) d.ubFlags &= ~DOOR_BUSY;
 
-	char map_name[128];
-	GetMapTempFileName(SF_DOOR_STATUS_TEMP_FILE_EXISTS, map_name, x, y, z);
-	AutoSGPFile f(FileMan::openForWriting(map_name));
+	AutoSGPFile f(FileMan::openForWriting(GetMapTempFileName(SF_DOOR_STATUS_TEMP_FILE_EXISTS, x, y, z)));
 	Assert(gpDoorStatus.size() <= UINT8_MAX);
 	UINT8 numDoorStatus = static_cast<UINT8>(gpDoorStatus.size());
 	FileWriteArray(f, numDoorStatus, gpDoorStatus.data());
@@ -1173,9 +1165,7 @@ void LoadDoorStatusArrayFromDoorStatusTempFile()
 {
 	TrashDoorStatusArray();
 
-	char map_name[128];
-	GetMapTempFileName(SF_DOOR_STATUS_TEMP_FILE_EXISTS, map_name, gWorldSectorX, gWorldSectorY, gbWorldSectorZ);
-	AutoSGPFile f(GCM->openGameResForReading(map_name));
+	AutoSGPFile f(GCM->openGameResForReading(GetMapTempFileName(SF_DOOR_STATUS_TEMP_FILE_EXISTS, gWorldSectorX, gWorldSectorY, gbWorldSectorZ)));
 
 	// Load the number of elements in the door status array
 	UINT8 numDoorStatus = 0;

--- a/src/game/Tactical/Tactical_Save.h
+++ b/src/game/Tactical/Tactical_Save.h
@@ -6,9 +6,8 @@
 #include "World_Items.h"
 #include "WorldDef.h"
 #include "Rotting_Corpses.h"
-
 #include "Soldier_Profile_Type.h"
-
+#include <string_theory/string>
 #include <vector>
 
 
@@ -86,7 +85,7 @@ void InitExitGameDialogBecauseFileHackDetected(void);
 
 void HandleAllReachAbleItemsInTheSector(INT16 x, INT16 y, INT8 z);
 
-void GetMapTempFileName(SectorFlags uiType, char* pMapName, INT16 sMapX, INT16 sMapY, INT8 bMapZ);
+ST::string GetMapTempFileName(SectorFlags uiType, INT16 sMapX, INT16 sMapY, INT8 bMapZ);
 
 
 UINT32	GetNumberOfVisibleWorldItemsFromSectorStructureForSector( INT16 sMapX, INT16 sMapY, INT8 bMapZ );

--- a/src/game/TileEngine/LightEffects.cc
+++ b/src/game/TileEngine/LightEffects.cc
@@ -198,10 +198,9 @@ void LoadLightEffectsFromLoadGameFile(HWFILE const hFile)
 void SaveLightEffectsToMapTempFile(INT16 const sMapX, INT16 const sMapY, INT8 const bMapZ)
 {
 	UINT32	uiNumLightEffects=0;
-	CHAR8		zMapName[ 128 ];
 
 	//get the name of the map
-	GetMapTempFileName( SF_LIGHTING_EFFECTS_TEMP_FILE_EXISTS, zMapName, sMapX, sMapY, bMapZ );
+	ST::string const zMapName = GetMapTempFileName( SF_LIGHTING_EFFECTS_TEMP_FILE_EXISTS, sMapX, sMapY, bMapZ );
 
 	//delete file the file.
 	FileDelete( zMapName );
@@ -238,9 +237,8 @@ void SaveLightEffectsToMapTempFile(INT16 const sMapX, INT16 const sMapY, INT8 co
 void LoadLightEffectsFromMapTempFile(INT16 const sMapX, INT16 const sMapY, INT8 const bMapZ)
 {
 	UINT32	uiCnt=0;
-	CHAR8		zMapName[ 128 ];
 
-	GetMapTempFileName( SF_LIGHTING_EFFECTS_TEMP_FILE_EXISTS, zMapName, sMapX, sMapY, bMapZ );
+	ST::string const zMapName = GetMapTempFileName( SF_LIGHTING_EFFECTS_TEMP_FILE_EXISTS, sMapX, sMapY, bMapZ );
 
 	AutoSGPFile hFile(GCM->openGameResForReading(zMapName));
 

--- a/src/game/TileEngine/SaveLoadMap.cc
+++ b/src/game/TileEngine/SaveLoadMap.cc
@@ -43,9 +43,7 @@ static std::unique_ptr<AutoSGPFile> OpenMapModificationTempFile(INT16 const sSec
 {
 	SetSectorFlag(sSectorX, sSectorY, bSectorZ, SF_MAP_MODIFICATIONS_TEMP_FILE_EXISTS);
 
-	CHAR8 zMapName[128];
-	GetMapTempFileName(SF_MAP_MODIFICATIONS_TEMP_FILE_EXISTS, zMapName, sSectorX, sSectorY, bSectorZ);	
-	return std::make_unique<AutoSGPFile>(FileMan::openForAppend(zMapName));
+	return std::make_unique<AutoSGPFile>(FileMan::openForAppend(GetMapTempFileName(SF_MAP_MODIFICATIONS_TEMP_FILE_EXISTS, sSectorX, sSectorY, bSectorZ)));
 }
 
 // Writes map modification to the open temp file
@@ -72,12 +70,11 @@ static void SetOpenableStructStatusFromMapTempFile(UINT32 uiMapIndex, BOOLEAN fO
 
 void LoadAllMapChangesFromMapTempFileAndApplyThem()
 {
-	CHAR8      zMapName[ 128 ];
 	UINT32     uiNumberOfElementsSavedBackToFile = 0; // added becuase if no files get saved back to disk, the flag needs to be erased
 	UINT32     cnt;
 	MODIFY_MAP *pMap;
 
-	GetMapTempFileName( SF_MAP_MODIFICATIONS_TEMP_FILE_EXISTS, zMapName, gWorldSectorX, gWorldSectorY, gbWorldSectorZ );
+	ST::string const zMapName = GetMapTempFileName( SF_MAP_MODIFICATIONS_TEMP_FILE_EXISTS, gWorldSectorX, gWorldSectorY, gbWorldSectorZ );
 
 	//If the file doesnt exists, its no problem.
 	if (!GCM->doesGameResExists(zMapName)) return;
@@ -417,13 +414,9 @@ static void AddBloodOrSmellFromMapTempFileToMap(MODIFY_MAP* pMap)
 
 void SaveRevealedStatusArrayToRevealedTempFile(INT16 const sSectorX, INT16 const sSectorY, INT8 const bSectorZ)
 {
-	CHAR8		zMapName[ 128 ];
-
 	Assert( gpRevealedMap != NULL );
 
-	GetMapTempFileName( SF_REVEALED_STATUS_TEMP_FILE_EXISTS, zMapName, sSectorX, sSectorY, bSectorZ );
-
-	AutoSGPFile hFile(FileMan::openForWriting(zMapName));
+	AutoSGPFile hFile(FileMan::openForWriting(GetMapTempFileName( SF_REVEALED_STATUS_TEMP_FILE_EXISTS, sSectorX, sSectorY, bSectorZ )));
 
 	//Write the revealed array to the Revealed temp file
 	FileWrite(hFile, gpRevealedMap, NUM_REVEALED_BYTES);
@@ -440,9 +433,7 @@ static void SetMapRevealedStatus(void);
 
 void LoadRevealedStatusArrayFromRevealedTempFile()
 {
-	CHAR8		zMapName[ 128 ];
-
-	GetMapTempFileName( SF_REVEALED_STATUS_TEMP_FILE_EXISTS, zMapName, gWorldSectorX, gWorldSectorY, gbWorldSectorZ );
+	ST::string const zMapName = GetMapTempFileName( SF_REVEALED_STATUS_TEMP_FILE_EXISTS, gWorldSectorX, gWorldSectorY, gbWorldSectorZ );
 
 	//If the file doesnt exists, its no problem.
 	if (!GCM->doesGameResExists(zMapName)) return;
@@ -622,12 +613,11 @@ void AddExitGridToMapTempFile( UINT16 usGridNo, EXITGRID *pExitGrid, INT16 sSect
 BOOLEAN RemoveGraphicFromTempFile( UINT32 uiMapIndex, UINT16 usIndex, INT16 sSectorX, INT16 sSectorY, UINT8 ubSectorZ )
 try
 {
-	CHAR8		zMapName[ 128 ];
 	MODIFY_MAP *pMap;
 	BOOLEAN	fRetVal=FALSE;
 	UINT32	cnt;
 
-	GetMapTempFileName( SF_MAP_MODIFICATIONS_TEMP_FILE_EXISTS, zMapName, sSectorX, sSectorY, ubSectorZ );
+	ST::string const zMapName = GetMapTempFileName( SF_MAP_MODIFICATIONS_TEMP_FILE_EXISTS, sSectorX, sSectorY, ubSectorZ );
 
 	UINT32                  uiNumberOfElements;
 	SGP::Buffer<MODIFY_MAP> pTempArrayOfMaps;
@@ -759,8 +749,7 @@ static void SetOpenableStructStatusFromMapTempFile(UINT32 uiMapIndex, BOOLEAN fO
 
 void ChangeStatusOfOpenableStructInUnloadedSector(UINT16 const usSectorX, UINT16 const usSectorY, INT8 const bSectorZ, UINT16 const usGridNo, BOOLEAN const fChangeToOpen)
 {
-	char map_name[128];
-	GetMapTempFileName(SF_MAP_MODIFICATIONS_TEMP_FILE_EXISTS, map_name, usSectorX, usSectorY, bSectorZ);
+	ST::string const map_name = GetMapTempFileName(SF_MAP_MODIFICATIONS_TEMP_FILE_EXISTS, usSectorX, usSectorY, bSectorZ);
 
 	// If the file doesn't exists, it's no problem.
 	if (!GCM->doesGameResExists(map_name)) return;

--- a/src/game/TileEngine/SmokeEffects.cc
+++ b/src/game/TileEngine/SmokeEffects.cc
@@ -488,10 +488,9 @@ void LoadSmokeEffectsFromLoadGameFile(HWFILE const hFile, UINT32 const savegame_
 void SaveSmokeEffectsToMapTempFile(INT16 const sMapX, INT16 const sMapY, INT8 const bMapZ)
 {
 	UINT32	uiNumSmokeEffects=0;
-	CHAR8		zMapName[ 128 ];
 
 	//get the name of the map
-	GetMapTempFileName( SF_SMOKE_EFFECTS_TEMP_FILE_EXISTS, zMapName, sMapX, sMapY, bMapZ );
+	ST::string const zMapName = GetMapTempFileName( SF_SMOKE_EFFECTS_TEMP_FILE_EXISTS, sMapX, sMapY, bMapZ );
 
 	//delete file the file.
 	FileDelete( zMapName );
@@ -524,9 +523,8 @@ void SaveSmokeEffectsToMapTempFile(INT16 const sMapX, INT16 const sMapY, INT8 co
 void LoadSmokeEffectsFromMapTempFile(INT16 const sMapX, INT16 const sMapY, INT8 const bMapZ)
 {
 	UINT32	uiCnt=0;
-	CHAR8		zMapName[ 128 ];
 
-	GetMapTempFileName( SF_SMOKE_EFFECTS_TEMP_FILE_EXISTS, zMapName, sMapX, sMapY, bMapZ );
+	ST::string const zMapName = GetMapTempFileName( SF_SMOKE_EFFECTS_TEMP_FILE_EXISTS, sMapX, sMapY, bMapZ );
 
 	AutoSGPFile hFile(GCM->openGameResForReading(zMapName));
 


### PR DESCRIPTION
This function constructs a filename in an out char array. Since almost all of its users then pass that char array to functions taking ST::string it makes sense to construct a string directly.

This also fixes a format-overflow warning where GCC complains about the fact that we try to `sprintf()` a 512 char buffer into a 128 char buffer. It's not really a problem because the filenames cannot get that long but ironically the warnings generated are so huge they overflow my terminal window buffer.