### PR TITLE
Address #1292 item 1: support Urban Chaos quasi-empty smacker files

### DIFF
--- a/dependencies/lib-smacker/libsmacker/smacker.c
+++ b/dependencies/lib-smacker/libsmacker/smacker.c
@@ -486,8 +486,11 @@ void smk_close(smk s)
 	{
 		for (u = 0; u < 4; u ++)
 		{
-			smk_huff_free(s->video->tree[u]->t);
-			smk_free(s->video->tree[u]);
+			if (s->video->tree[u])
+			{
+				smk_huff_free(s->video->tree[u]->t);
+				smk_free(s->video->tree[u]);
+			}
 		}
 		smk_free(s->video->palette);
 		smk_free(s->video->frame);

--- a/src/game/Intro.cc
+++ b/src/game/Intro.cc
@@ -4,6 +4,7 @@
 #include "English.h"
 #include "FileMan.h"
 #include "Game_Init.h"
+#include "GameSettings.h"
 #include "Input.h"
 #include "Intro.h"
 #include "Local.h"
@@ -22,8 +23,6 @@
 #include "VSurface.h"
 #include "UILayout.h"
 
-#include "GameSettings.h"
-#include "MessageBoxScreen.h"
 
 static BOOLEAN gfIntroScreenEntry = TRUE;
 static BOOLEAN gfIntroScreenExit;
@@ -349,15 +348,10 @@ static void StartPlayingIntroFlic(INT32 iIndexOfFlicToPlay)
 		//start playing a flic
 		gpSmackFlic = SmkPlayFlic( gpzSmackerFileNames[ iIndexOfFlicToPlay ], STD_SCREEN_X, STD_SCREEN_Y , TRUE );
 
-		if( gpSmackFlic != NULL )
-		{
-			giCurrentIntroBeingPlayed = iIndexOfFlicToPlay;
-		}
-		else
-		{
-			//do a check
-			DoScreenIndependantMessageBox(gzIntroScreen, MSG_BOX_FLAG_OK, CDromEjectionErrorMessageBoxCallBack);
-		}
+		// Urban Chaos support: UC contains some quasi-empty smacker videos for which
+		// SmkPlayFlic returns nullptr. Ignoring this result will cause us to continue
+		// with the next video.
+		giCurrentIntroBeingPlayed = iIndexOfFlicToPlay;
 	}
 }
 


### PR DESCRIPTION
- Fix crash in libsmacker
- Change Intro.cc to continue with the next video after an invalid one

With this commit the Urban Chaos intro sequence plays as intended.