### PR TITLE
Fix the hot spot of the hand cursor

### DIFF
--- a/src/game/Utils/Cursors.cc
+++ b/src/game/Utils/Cursors.cc
@@ -472,7 +472,7 @@ static CursorData CursorDatabase[] =
 		SUBNONE(),
 		SUBNONE(),
 		SUBNONE(),
-		1,	0,  0, 0, 0									, 0, 0 },
+		1,	4,  0, 0, 0									, 0, 0 },
 
 	{ SUBNORM(C_LAPTOPSCREEN,        0),
 		SUBNONE(),


### PR DESCRIPTION
Put the hot spot of CURSOR_WWW where you would expect it to be, at the top of the index finger.

Fixes #683