### PR TITLE
Cleanup Items.cc a bit

### DIFF
--- a/src/externalized/VanillaWeapons_unittests.cc
+++ b/src/externalized/VanillaWeapons_unittests.cc
@@ -174,4 +174,19 @@ TEST(Items, ValidAttachment)
 	GCM = oldGCM;
 }
 
+TEST(Items, CompatibleFaceItem)
+{
+	EXPECT_TRUE(CompatibleFaceItem(ITEMDEFINE::NIGHTGOGGLES, ITEMDEFINE::EXTENDEDEAR));
+	EXPECT_TRUE(CompatibleFaceItem(ITEMDEFINE::EXTENDEDEAR, ITEMDEFINE::NIGHTGOGGLES));
+	EXPECT_FALSE(CompatibleFaceItem(ITEMDEFINE::EXTENDEDEAR, ITEMDEFINE::EXTENDEDEAR));
+	EXPECT_TRUE(CompatibleFaceItem(ITEMDEFINE::WALKMAN, ITEMDEFINE::GASMASK));
+	EXPECT_FALSE(CompatibleFaceItem(ITEMDEFINE::UVGOGGLES, ITEMDEFINE::RDX));
+	EXPECT_TRUE(CompatibleFaceItem(0xda83, NOTHING)); // item2 == NOTHING is a special case
+	EXPECT_FALSE(CompatibleFaceItem(0x75e4, 0xcafe));
+	for (int i = 0; i <= 0xffff; ++i)
+	{
+		EXPECT_FALSE(CompatibleFaceItem(i, ITEMDEFINE::STEEL_HELMET));
+	}
+}
+
 #endif

--- a/src/externalized/VanillaWeapons_unittests.cc
+++ b/src/externalized/VanillaWeapons_unittests.cc
@@ -104,4 +104,30 @@ TEST(Items, bug120_spas15DefaultMag)
 	delete cm;
 }
 
+TEST(Items, ValidLaunchable)
+{
+	EXPECT_TRUE(ValidLaunchable(MORTAR_SHELL, MORTAR));
+	EXPECT_FALSE(ValidLaunchable(MORTAR_SHELL, MORTAR_SHELL));
+	EXPECT_FALSE(ValidLaunchable(MORTAR_SHELL, TANK_CANNON));
+	EXPECT_FALSE(ValidLaunchable(MORTAR, MORTAR_SHELL));
+	EXPECT_TRUE(ValidLaunchable(GL_HE_GRENADE, GLAUNCHER));
+	EXPECT_TRUE(ValidLaunchable(GL_HE_GRENADE, UNDER_GLAUNCHER));
+
+	// Check if the function handles some random garbage input
+	EXPECT_FALSE(ValidLaunchable(BATTERIES, WINE));
+	EXPECT_FALSE(ValidLaunchable(0xf123, 0x97b2));
+}
+
+TEST(Items, GetLauncherFromLaunchable)
+{
+	EXPECT_EQ(GetLauncherFromLaunchable(GL_TEARGAS_GRENADE), GLAUNCHER);
+	EXPECT_EQ(GetLauncherFromLaunchable(MORTAR_SHELL), MORTAR);
+	EXPECT_EQ(GetLauncherFromLaunchable(TANK_SHELL), TANK_CANNON);
+	EXPECT_EQ(GetLauncherFromLaunchable(TANK_CANNON), NOTHING);
+
+	// Check if the function handles some random garbage input
+	EXPECT_EQ(GetLauncherFromLaunchable(G11), NOTHING);
+	EXPECT_EQ(GetLauncherFromLaunchable(0xe941), NOTHING);
+}
+
 #endif

--- a/src/game/Tactical/Items.cc
+++ b/src/game/Tactical/Items.cc
@@ -100,132 +100,35 @@ static const AttachmentInfoStruct AttachmentInfo[] =
 	{NONE,				0,		0,						0}
 };
 
-static UINT16 const g_attachments[][2] =
+static std::map<UINT16, std::set<UINT16> const> const g_attachments
 {
-	{DETONATOR, TNT},
-	{DETONATOR, HMX},
-	{DETONATOR, C1},
-	{DETONATOR, C4},
-
-	{REMDETONATOR, TNT},
-	{REMDETONATOR, HMX},
-	{REMDETONATOR, C1},
-	{REMDETONATOR, C4},
-
-	{CERAMIC_PLATES, FLAK_JACKET},
-	{CERAMIC_PLATES, FLAK_JACKET_18},
-	{CERAMIC_PLATES, FLAK_JACKET_Y},
-	{CERAMIC_PLATES, KEVLAR_VEST},
-	{CERAMIC_PLATES, KEVLAR_VEST_18},
-	{CERAMIC_PLATES, KEVLAR_VEST_Y},
-	{CERAMIC_PLATES, SPECTRA_VEST},
-	{CERAMIC_PLATES, SPECTRA_VEST_18},
-	{CERAMIC_PLATES, SPECTRA_VEST_Y},
-	{CERAMIC_PLATES, KEVLAR2_VEST},
-	{CERAMIC_PLATES, KEVLAR2_VEST_18},
-	{CERAMIC_PLATES, KEVLAR2_VEST_Y},
-
-	{SPRING, ALUMINUM_ROD},
-	{QUICK_GLUE, STEEL_ROD},
-	{DUCT_TAPE, STEEL_ROD},
-	{XRAY_BULB, FUMBLE_PAK},
-	{CHEWING_GUM, FUMBLE_PAK},
-	{BATTERIES, XRAY_DEVICE},
-	{COPPER_WIRE, LAME_BOY},
-
-	{0, 0}
+	{DETONATOR, {TNT, HMX, C1, C4}},
+	{REMDETONATOR, {TNT, HMX, C1, C4}},
+	{CERAMIC_PLATES, {FLAK_JACKET, FLAK_JACKET_18, FLAK_JACKET_Y, KEVLAR_VEST, KEVLAR_VEST_18, KEVLAR_VEST_Y,
+	                  KEVLAR2_VEST, KEVLAR2_VEST_18, KEVLAR2_VEST_Y, SPECTRA_VEST, SPECTRA_VEST_18, SPECTRA_VEST_Y}},
+	{SPRING, {ALUMINUM_ROD}},
+	{QUICK_GLUE, {STEEL_ROD}},
+	{DUCT_TAPE, {STEEL_ROD}},
+	{XRAY_BULB, {FUMBLE_PAK}},
+	{CHEWING_GUM, {FUMBLE_PAK}},
+	{BATTERIES, {XRAY_DEVICE}},
+	{COPPER_WIRE, {LAME_BOY}}
 };
 
-static UINT16 const g_attachments_mod[][2] =
+// additional possible attachments if the extra_attachments game policy is set
+static std::set<UINT16> const g_helmets {STEEL_HELMET, KEVLAR_HELMET, KEVLAR_HELMET_18, KEVLAR_HELMET_Y, SPECTRA_HELMET, SPECTRA_HELMET_18, SPECTRA_HELMET_Y};
+static std::set<UINT16> const g_leggings {KEVLAR_LEGGINGS, KEVLAR_LEGGINGS_18, KEVLAR_LEGGINGS_Y, SPECTRA_LEGGINGS, SPECTRA_LEGGINGS_18, SPECTRA_LEGGINGS_Y};
+static std::map<UINT16, decltype(g_helmets) *> const g_attachments_mod
 {
-	{DETONATOR, TNT},
-	{DETONATOR, HMX},
-	{DETONATOR, C1},
-	{DETONATOR, C4},
+	{NIGHTGOGGLES, &g_helmets},
+	{UVGOGGLES, &g_helmets},
+	{SUNGOGGLES, &g_helmets},
+	{ROBOT_REMOTE_CONTROL, &g_helmets},
 
-	{REMDETONATOR, TNT},
-	{REMDETONATOR, HMX},
-	{REMDETONATOR, C1},
-	{REMDETONATOR, C4},
-
-	{CERAMIC_PLATES, FLAK_JACKET},
-	{CERAMIC_PLATES, FLAK_JACKET_18},
-	{CERAMIC_PLATES, FLAK_JACKET_Y},
-	{CERAMIC_PLATES, KEVLAR_VEST},
-	{CERAMIC_PLATES, KEVLAR_VEST_18},
-	{CERAMIC_PLATES, KEVLAR_VEST_Y},
-	{CERAMIC_PLATES, SPECTRA_VEST},
-	{CERAMIC_PLATES, SPECTRA_VEST_18},
-	{CERAMIC_PLATES, SPECTRA_VEST_Y},
-	{CERAMIC_PLATES, KEVLAR2_VEST},
-	{CERAMIC_PLATES, KEVLAR2_VEST_18},
-	{CERAMIC_PLATES, KEVLAR2_VEST_Y},
-
-	{SPRING, ALUMINUM_ROD},
-	{QUICK_GLUE, STEEL_ROD},
-	{DUCT_TAPE, STEEL_ROD},
-	{XRAY_BULB, FUMBLE_PAK},
-	{CHEWING_GUM, FUMBLE_PAK},
-	{BATTERIES, XRAY_DEVICE},
-	{COPPER_WIRE, LAME_BOY},
-
-	// extras
-	{NIGHTGOGGLES, STEEL_HELMET},
-	{NIGHTGOGGLES, KEVLAR_HELMET},
-	{NIGHTGOGGLES, KEVLAR_HELMET_18},
-	{NIGHTGOGGLES, KEVLAR_HELMET_Y},
-	{NIGHTGOGGLES, SPECTRA_HELMET},
-	{NIGHTGOGGLES, SPECTRA_HELMET_18},
-	{NIGHTGOGGLES, SPECTRA_HELMET_Y},
-
-	{UVGOGGLES, STEEL_HELMET},
-	{UVGOGGLES, KEVLAR_HELMET},
-	{UVGOGGLES, KEVLAR_HELMET_18},
-	{UVGOGGLES, KEVLAR_HELMET_Y},
-	{UVGOGGLES, SPECTRA_HELMET},
-	{UVGOGGLES, SPECTRA_HELMET_18},
-	{UVGOGGLES, SPECTRA_HELMET_Y},
-
-	{SUNGOGGLES, STEEL_HELMET},
-	{SUNGOGGLES, KEVLAR_HELMET},
-	{SUNGOGGLES, KEVLAR_HELMET_18},
-	{SUNGOGGLES, KEVLAR_HELMET_Y},
-	{SUNGOGGLES, SPECTRA_HELMET},
-	{SUNGOGGLES, SPECTRA_HELMET_18},
-	{SUNGOGGLES, SPECTRA_HELMET_Y},
-
-	{ROBOT_REMOTE_CONTROL, STEEL_HELMET},
-	{ROBOT_REMOTE_CONTROL, KEVLAR_HELMET},
-	{ROBOT_REMOTE_CONTROL, KEVLAR_HELMET_18},
-	{ROBOT_REMOTE_CONTROL, KEVLAR_HELMET_Y},
-	{ROBOT_REMOTE_CONTROL, SPECTRA_HELMET},
-	{ROBOT_REMOTE_CONTROL, SPECTRA_HELMET_18},
-	{ROBOT_REMOTE_CONTROL, SPECTRA_HELMET_Y},
-
-	{BREAK_LIGHT, KEVLAR_LEGGINGS},
-	{BREAK_LIGHT, KEVLAR_LEGGINGS_18},
-	{BREAK_LIGHT, KEVLAR_LEGGINGS_Y},
-	{BREAK_LIGHT, SPECTRA_LEGGINGS},
-	{BREAK_LIGHT, SPECTRA_LEGGINGS_18},
-	{BREAK_LIGHT, SPECTRA_LEGGINGS_Y},
-
-	{REGEN_BOOSTER, KEVLAR_LEGGINGS},
-	{REGEN_BOOSTER, KEVLAR_LEGGINGS_18},
-	{REGEN_BOOSTER, KEVLAR_LEGGINGS_Y},
-	{REGEN_BOOSTER, SPECTRA_LEGGINGS},
-	{REGEN_BOOSTER, SPECTRA_LEGGINGS_18},
-	{REGEN_BOOSTER, SPECTRA_LEGGINGS_Y},
-
-	{ADRENALINE_BOOSTER, KEVLAR_LEGGINGS},
-	{ADRENALINE_BOOSTER, KEVLAR_LEGGINGS_18},
-	{ADRENALINE_BOOSTER, KEVLAR_LEGGINGS_Y},
-	{ADRENALINE_BOOSTER, SPECTRA_LEGGINGS},
-	{ADRENALINE_BOOSTER, SPECTRA_LEGGINGS_18},
-	{ADRENALINE_BOOSTER, SPECTRA_LEGGINGS_Y},
-
-	{0, 0}
+	{BREAK_LIGHT, &g_leggings},
+	{REGEN_BOOSTER, &g_leggings},
+	{ADRENALINE_BOOSTER, &g_leggings}
 };
-
 
 static std::map<UINT16, std::set<UINT16> const> const Launchable
 {
@@ -236,7 +139,6 @@ static std::map<UINT16, std::set<UINT16> const> const Launchable
 	{MORTAR_SHELL, {MORTAR}},
 	{TANK_SHELL, {TANK_CANNON}}
 };
-
 
 static UINT16 const CompatibleFaceItems[][2] =
 {
@@ -792,24 +694,23 @@ static const AttachmentInfoStruct* GetAttachmentInfo(const UINT16 usItem)
 bool ValidAttachment(UINT16 const attachment, UINT16 const item)
 {
 	const ItemModel *itemModel = GCM->getItem(item);
-	if(itemModel->canBeAttached(attachment))
+	if (itemModel && itemModel->canBeAttached(attachment))
 	{
 		return true;
 	}
 
-	UINT16 const (*i)[2] = gamepolicy(extra_attachments) ? g_attachments_mod : g_attachments;
-	for (;; ++i)
 	{
-		UINT16 const (&a)[2] = *i;
-		if (a[0] == NOTHING)    return false; // Cannot be attached to anything
-		if (a[0] == attachment) break;
+		auto const it = g_attachments.find(attachment);
+		if (it != g_attachments.end() && it->second.count(item) == 1) return true;
 	}
-	for (;; ++i)
+
+	if (gamepolicy(extra_attachments))
 	{
-		UINT16 const (&a)[2] = *i;
-		if (a[0] != attachment) return false; // Cannot be attached to item
-		if (a[1] == item)       return true;
+		auto const it = g_attachments_mod.find(attachment);
+		if (it != g_attachments_mod.end() && (*it->second).count(item) == 1) return true;
 	}
+
+	return false;
 }
 
 
@@ -960,7 +861,7 @@ BOOLEAN ValidLaunchable( UINT16 usLaunchable, UINT16 usItem )
 	auto const it = Launchable.find(usLaunchable);
 	if (it != Launchable.end())
 	{
-		return it->second.find(usItem) != it->second.end();
+		return it->second.count(usItem) == 1;
 	}
 
 	return FALSE;

--- a/src/game/Tactical/Items.cc
+++ b/src/game/Tactical/Items.cc
@@ -49,10 +49,8 @@
 #include <array>
 #include <initializer_list>
 #include <map>
-#include <optional>
 #include <set>
 #include <stdexcept>
-#include <utility>
 
 constexpr UINT8 ANY_MAGSIZE = 255; // magic number for FindAmmo's mag_size parameter
 
@@ -715,22 +713,6 @@ BOOLEAN ValidItemAttachment(const OBJECTTYPE* const pObj, const UINT16 usAttachm
 		if ( (FindAttachment( pObj, UNDER_GLAUNCHER ) != ITEM_NOT_FOUND) && ValidLaunchable( usAttachment, UNDER_GLAUNCHER ) )
 		{
 			return ( TRUE );
-			/*
-			if ( fAttemptingAttachment )
-			{
-				// if there is no other grenade attached already, then we can attach it
-				if (FindAttachmentByClass( pObj, IC_GRENADE) != ITEM_NOT_FOUND)
-				{
-					return( FALSE );
-				}
-				// keep going, it can be attached to the grenade launcher
-			}
-			else
-			{
-				// logically, can be added
-				return( TRUE );
-			}
-			*/
 		}
 		else
 		{
@@ -767,20 +749,6 @@ BOOLEAN ValidItemAttachment(const OBJECTTYPE* const pObj, const UINT16 usAttachm
 				usSimilarItem = BIPOD;
 			}
 			break;
-	/*
-		case LASERSCOPE:
-			if (FindAttachment( pObj, SNIPERSCOPE ) != ITEM_NOT_FOUND)
-			{
-				return( FALSE );
-			}
-			break;
-		case SNIPERSCOPE:
-			if (FindAttachment( pObj, LASERSCOPE ) != ITEM_NOT_FOUND)
-			{
-				return( FALSE );
-			}
-			break;
-			*/
 		case DETONATOR:
 			if( FindAttachment( pObj, REMDETONATOR ) != ITEM_NOT_FOUND )
 			{
@@ -1427,51 +1395,6 @@ BOOLEAN EmptyWeaponMagazine( OBJECTTYPE * pWeapon, OBJECTTYPE *pAmmo )
 		return( FALSE );
 	}
 }
-
-/*
-BOOLEAN ReloadLauncher( OBJECTTYPE * pLauncher, OBJECTTYPE * pAmmo )
-{
-	BOOLEAN    fOldAmmo;
-	OBJECTTYPE OldAmmo;
-
-	if (pLauncher->ubGunShotsLeft == 0)
-	{
-		fOldAmmo = FALSE;
-	}
-	else
-	{
-		if (pAmmo->ubNumberOfObjects > 1)
-		{
-			// can't do the swap out to the cursor
-			return( FALSE );
-		}
-		// otherwise temporarily store the launcher's old ammo
-		OldAmmo = OBJECTTYPE{};
-		fOldAmmo = TRUE;
-		OldAmmo.usItem = pLauncher->usGunAmmoItem;
-		OldAmmo.ubNumberOfObjects = 1;
-		OldAmmo.bStatus[0] = pLauncher->bGunAmmoStatus;
-	}
-
-	// put the new ammo in the gun
-	pLauncher->usGunAmmoItem = pAmmo->usItem;
-	pLauncher->ubGunShotsLeft = 1;
-	pLauncher->ubGunAmmoType = AMMO_GRENADE;
-	pLauncher->bGunAmmoStatus = pAmmo->bStatus[0];
-
-
-	if (fOldAmmo)
-	{
-		// copy the old ammo back to the item in the cursor
-		*pAmmo = OldAmmo;
-	}
-	else
-	{
-		// reduce the number of objects in the cursor by 1
-		RemoveObjs( pAmmo, 1 );
-	}
-	return( TRUE );
-}*/
 
 
 INT8 FindAmmo(const SOLDIERTYPE* s, const CalibreModel * calibre, UINT8 const mag_size, INT8 const exclude_slot)
@@ -2132,7 +2055,6 @@ BOOLEAN PlaceObject( SOLDIERTYPE * pSoldier, INT8 bPos, OBJECTTYPE * pObj )
 						{
 							// invalid ammo
 							break;
-							//return( FALSE );
 						}
 					}
 					break;
@@ -2727,12 +2649,6 @@ static void CreateGun(UINT16 usItem, INT8 bStatus, OBJECTTYPE* pObj)
 		pObj->ubGunAmmoType = GCM->getItem(usAmmo)->asAmmo()->ammoType->index;
 		pObj->bGunAmmoStatus = 100;
 		pObj->ubGunShotsLeft = GCM->getItem(usAmmo)->asAmmo()->capacity;
-		/*
-		if (usItem == CAWS)
-		{
-			pObj->usAttachItem[0] = DUCKBILL;
-			pObj->bAttachStatus[0] = 100;
-		}*/
 	}
 }
 
@@ -3058,12 +2974,9 @@ BOOLEAN PlaceObjectInSoldierProfile( UINT8 ubProfile, OBJECTTYPE *pObject )
 		}
 	}
 
-	//uiMoneyAmount
 	if ( fReturnVal )
 	{
 		// ATE: Manage soldier pointer as well....
-		//pSoldier = FindSoldierByProfileID(ubProfile);
-
 		// Do we have a valid profile?
 		if ( pSoldier != NULL )
 		{
@@ -3141,9 +3054,7 @@ BOOLEAN RemoveObjectFromSoldierProfile( UINT8 ubProfile, UINT16 usItem )
 
 void SetMoneyInSoldierProfile( UINT8 ubProfile, UINT32 uiMoney )
 {
-	//INT8 bSlot;
 	OBJECTTYPE Object;
-	//SOLDIERTYPE *pSoldier;
 	BOOLEAN fRet;
 
 	// remove all money from soldier

--- a/src/game/Tactical/Items.cc
+++ b/src/game/Tactical/Items.cc
@@ -49,6 +49,8 @@
 #include "ItemModel.h"
 #include "MagazineModel.h"
 #include "WeaponModels.h"
+#include <map>
+#include <set>
 
 #define ANY_MAGSIZE 255
 
@@ -224,20 +226,17 @@ static UINT16 const g_attachments_mod[][2] =
 	{0, 0}
 };
 
-UINT16 Launchable[][2] =
+
+static std::map<UINT16, std::set<UINT16> const> const Launchable
 {
-	{GL_HE_GRENADE, GLAUNCHER},
-	{GL_HE_GRENADE, UNDER_GLAUNCHER},
-	{GL_TEARGAS_GRENADE, GLAUNCHER},
-	{GL_TEARGAS_GRENADE, UNDER_GLAUNCHER},
-	{GL_STUN_GRENADE, GLAUNCHER},
-	{GL_STUN_GRENADE, UNDER_GLAUNCHER},
-	{GL_SMOKE_GRENADE, GLAUNCHER},
-	{GL_SMOKE_GRENADE, UNDER_GLAUNCHER},
-	{MORTAR_SHELL, MORTAR},
-	{TANK_SHELL, TANK_CANNON},
-	{0, 0}
+	{GL_HE_GRENADE, {GLAUNCHER, UNDER_GLAUNCHER}},
+	{GL_TEARGAS_GRENADE, {GLAUNCHER, UNDER_GLAUNCHER}},
+	{GL_STUN_GRENADE, {GLAUNCHER, UNDER_GLAUNCHER}},
+	{GL_SMOKE_GRENADE, {GLAUNCHER, UNDER_GLAUNCHER}},
+	{MORTAR_SHELL, {MORTAR}},
+	{TANK_SHELL, {TANK_CANNON}}
 };
+
 
 static UINT16 const CompatibleFaceItems[][2] =
 {
@@ -955,62 +954,23 @@ static BOOLEAN TwoHandedItem(UINT16 usItem)
 	return FALSE;
 }
 
+
 BOOLEAN ValidLaunchable( UINT16 usLaunchable, UINT16 usItem )
 {
-	INT32 iLoop = 0;
+	auto const it = Launchable.find(usLaunchable);
+	if (it != Launchable.end())
+	{
+		return it->second.find(usItem) != it->second.end();
+	}
 
-	// look for the section of the array pertaining to this launchable item...
-	while( 1 )
-	{
-		if (Launchable[iLoop][0] == usLaunchable)
-		{
-			break;
-		}
-		iLoop++;
-		if (Launchable[iLoop][0] == 0)
-		{
-			// the proposed item cannot be attached to anything!
-			return( FALSE );
-		}
-	}
-	// now look through this section for the item in question
-	while( 1 )
-	{
-		if (Launchable[iLoop][1] == usItem)
-		{
-			break;
-		}
-		iLoop++;
-		if (Launchable[iLoop][0] != usLaunchable)
-		{
-			// the proposed item cannot be attached to the item in question
-			return( FALSE );
-		}
-	}
-	return( TRUE );
+	return FALSE;
 }
 
 
 UINT16 GetLauncherFromLaunchable( UINT16 usLaunchable )
 {
-	INT32 iLoop = 0;
-
-	// look for the section of the array pertaining to this launchable item...
-	while( 1 )
-	{
-		if (Launchable[iLoop][0] == usLaunchable)
-		{
-			break;
-		}
-		iLoop++;
-		if (Launchable[iLoop][0] == 0)
-		{
-			// the proposed item cannot be attached to anything!
-			return( NOTHING );
-		}
-	}
-
-	return( Launchable[iLoop][1] );
+	auto const it = Launchable.find(usLaunchable);
+	return it != Launchable.end() ? *it->second.begin() : NOTHING;
 }
 
 


### PR DESCRIPTION
Summary of these commits:

- Replace old school lookup with standard container methods
- Replace classic for loops with ranged-for
- Remove outdated comments, commented-out code, a pointless function and a duplicate entry in `AttachmentInfo`
- Add unit tests for `ValidLaunchable`, `GetLauncherFromLaunchable`, `GetLauncherFromLaunchable` and `CompatibleFaceItem`
- Remove code duplication in `g_attachments_mod`
