### PR TITLE
Adding NO_PROFILE checks before creating MercProfile object

### DIFF
--- a/src/game/Strategic/Strategic_Merc_Handler.cc
+++ b/src/game/Strategic/Strategic_Merc_Handler.cc
@@ -177,6 +177,7 @@ void MercDailyUpdate()
 			if (--s->bCorpseQuoteTolerance < 0) s->bCorpseQuoteTolerance = 0;
 
 			MERCPROFILESTRUCT& p = GetProfile(s->ubProfile);
+			MercProfile const profile(s->ubProfile);
 
 			// CJC: For some personalities, reset personality quote said flag
 			switch (p.bPersonalityTrait)
@@ -206,7 +207,7 @@ void MercDailyUpdate()
 			p.ubMiscFlags3 |= PROFILE_MISC_FLAG3_PLAYER_HAD_CHANCE_TO_HIRE;
 
 			//if the character is an RPC
-			if (MercProfile(s->ubProfile).isRPC())
+			if (profile.isRPC())
 			{
 				//increment the number of days the mercs has been on the team
 				++s->iTotalContractLength;

--- a/src/game/Tactical/Handle_Items.cc
+++ b/src/game/Tactical/Handle_Items.cc
@@ -2437,7 +2437,7 @@ void SoldierGiveItemFromAnimation( SOLDIERTYPE *pSoldier )
 		}
 
 		// OK< FOR NOW HANDLE NPC's DIFFERENT!
-		MercProfile profile(pTSoldier->ubProfile);
+		UINT8 const ubProfileID = pTSoldier->ubProfile;
 
 		// 1 ) PLayer to NPC = NPC
 		// 2 ) Player to player = player;
@@ -2446,7 +2446,7 @@ void SoldierGiveItemFromAnimation( SOLDIERTYPE *pSoldier )
 
 		// Switch on target...
 		// Are we a player dude.. ( target? )
-		if (profile.isPlayerMerc() || RPC_RECRUITED(pTSoldier))
+		if ((ubProfileID != NO_PROFILE && MercProfile(ubProfileID).isPlayerMerc()) || RPC_RECRUITED(pTSoldier))
 		{
 			fToTargetPlayer = TRUE;
 		}

--- a/src/game/Tactical/Interface.cc
+++ b/src/game/Tactical/Interface.cc
@@ -1115,7 +1115,7 @@ void DrawSelectedUIAboveGuy(SOLDIERTYPE& s)
 
 		PrintAboveGuy(sXPos, raise_name ? sYPos - 10 : sYPos, s.name);
 
-		if (MercProfile(s.ubProfile).isPlayerMerc() ||
+		if ((s.ubProfile != NO_PROFILE && MercProfile(s.ubProfile).isPlayerMerc()) ||
 			RPC_RECRUITED(&s) ||
 			AM_AN_EPC(&s) ||
 			s.uiStatusFlags & SOLDIER_VEHICLE)

--- a/src/game/Tactical/Interface_Items.cc
+++ b/src/game/Tactical/Interface_Items.cc
@@ -3469,7 +3469,7 @@ BOOLEAN HandleItemPointerClick( UINT16 usMapPos )
 					EndItemPointer( );
 
 					// If we are giving it to somebody not on our team....
-					if (!MercProfile(tgt->ubProfile).isPlayerMerc() && !RPC_RECRUITED(tgt))
+					if (tgt->ubProfile != NO_PROFILE && !MercProfile(tgt->ubProfile).isPlayerMerc() && !RPC_RECRUITED(tgt))
 					{
 						SetEngagedInConvFromPCAction( gpItemPointerSoldier );
 					}

--- a/src/game/Tactical/OppList.cc
+++ b/src/game/Tactical/OppList.cc
@@ -3013,14 +3013,15 @@ void DebugSoldierPage3()
 		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, "Anim non-int:",       s->fInNonintAnim);
 		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, "RT Anim non-int:",    s->fRTInNonintAnim);
 
-		// OPIONION OF SELECTED MERC
+		// OPINION OF SELECTED MERC
 		const SOLDIERTYPE* const sel = GetSelectedMan();
-		MercProfile const p          = MercProfile(s->ubProfile);
-		if (sel != NULL &&
-				s->ubProfile != NO_PROFILE &&
-				(p.isPlayerMerc() || p.isRPC()))
+		if (sel != NULL && s->ubProfile != NO_PROFILE)
 		{
-			MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, "NPC Opinion:", GetProfile(s->ubProfile).bMercOpinion[sel->ubProfile]);
+			MercProfile const p = MercProfile(s->ubProfile);
+			if (p.isPlayerMerc() || p.isRPC())
+			{
+				MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, "NPC Opinion:", GetProfile(s->ubProfile).bMercOpinion[sel->ubProfile]);
+			}
 		}
 	}
 	else


### PR DESCRIPTION
Creating MercProfile object with invalid ID will result in an exception. This has caused problems in the QDS (and maybe some other places).

Resolves #1332.