### PR TITLE
Create ja2.log in temp directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,10 @@ if (MINGW)
     LIST(APPEND JA2_LIBRARIES mingw_stdthreads)
 endif()
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    LIST(APPEND JA2_LIBRARIES stdc++fs)
+endif()
+
 if(ANDROID)
     add_library(${JA2_BINARY} SHARED ${JA2_SOURCES})
 else()

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -63,15 +63,15 @@
 #else
 	#if defined(__GNUC__) && __GNUC__ < 8
 	#include <experimental/filesystem>
-	using std::experimental::filesystem::temp_directory_path;
+	namespace fs = std::experimental::filesystem;
 	#else
 	#include <filesystem>
-	using std::filesystem::temp_directory_path;
+	namespace fs = std::filesystem;
 	#endif
 
 	static inline ST::string get_temp_filename(void)
 	{
-		return ST::string{temp_directory_path().append("ja2.log")};
+		return ST::string{fs::temp_directory_path().append("ja2.log")};
 	}
 #endif
 
@@ -890,5 +890,19 @@ TEST(cpp_language, sizeof_type)
 	EXPECT_EQ(sizeof(char16_t), 2);
 	EXPECT_EQ(sizeof(char32_t), 4);
 }
+
+#ifndef __ANDROID__
+TEST(cpp_language, filesystem)
+{
+	EXPECT_FALSE(fs::temp_directory_path().empty());
+	EXPECT_TRUE(fs::temp_directory_path().is_absolute());
+
+	auto const tmpFilename{fs::temp_directory_path().append("ja2.log")};
+	EXPECT_EQ(tmpFilename, fs::temp_directory_path() / "ja2.log");
+	EXPECT_EQ(tmpFilename.filename(), "ja2.log");
+	EXPECT_EQ(tmpFilename.extension(), ".log");
+	EXPECT_EQ(tmpFilename.stem(), "ja2");
+}
+#endif
 
 #endif // WITH_UNITTESTS


### PR DESCRIPTION
Addresses #1257

Quoting [cppreference](https://en.cppreference.com/w/cpp/filesystem/temp_directory_path):

> On POSIX systems, the path may be the one specified in the environment variables TMPDIR, TMP, TEMP, TEMPDIR, and, if none of them are specified, the path "/tmp" is returned.
> 
> On Windows systems, the path is typically the one returned by GetTempPath 