### PR TITLE
Create ja2-launcher.log in temp directory

### DIFF
--- a/.ci/ci-functions.sh
+++ b/.ci/ci-functions.sh
@@ -42,6 +42,13 @@ linux-install-via-android-sdkmanager () {
     done
 }
 
+linux-set-gcc-version () {
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9
+    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
+    sudo update-alternatives --set gcc "/usr/bin/gcc-9"
+    sudo update-alternatives --set g++ "/usr/bin/g++-9"
+}
+
 macOS-install-via-brew () {
     brew install $@
 }

--- a/.ci/ci-setup.sh
+++ b/.ci/ci-setup.sh
@@ -14,6 +14,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/ci-functions.sh"
 
 echo "## prepare environment ##"
 if [[ "$CI_TARGET" == "linux" ]]; then
+    # choose a new-enough gcc version
+    linux-set-gcc-version
+
     # SDL2 and FLTK to link against
     linux-install-via-apt-get libsdl2-dev libfltk1.3-dev
     
@@ -29,6 +32,9 @@ if [[ "$CI_TARGET" == "linux" ]]; then
     # Appimage build tools (linuxdeploy and appimagelint)
     linux-install-appimage-build-tools
 elif [[ "$CI_TARGET" == "linux-mingw64" ]]; then
+    # choose a new-enough version of gcc
+    linux-set-gcc-version
+
     # MinGW compiler for cross-compiling
     linux-install-via-apt-get build-essential mingw-w64
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,12 +269,17 @@ set(
     string_theory-internal
     lua
 )
+set(
+    LAUNCHER_LIBRARIES
+    string_theory-internal
+)
 if (MINGW)
     LIST(APPEND JA2_LIBRARIES mingw_stdthreads)
 endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     LIST(APPEND JA2_LIBRARIES stdc++fs)
+    LIST(APPEND LAUNCHER_LIBRARIES stdc++fs)
 endif()
 
 if(ANDROID)
@@ -289,7 +294,7 @@ set_property(SOURCE ${CMAKE_SOURCE_DIR}/src/game/GameVersion.cc APPEND PROPERTY 
 
 if(BUILD_LAUNCHER)
     add_executable(${LAUNCHER_BINARY} ${LAUNCHER_SOURCES})
-    target_link_libraries(${LAUNCHER_BINARY} ${FLTK_LIBRARIES} ${STRACCIATELLA_LIBRARIES} string_theory-internal)
+    target_link_libraries(${LAUNCHER_BINARY} ${FLTK_LIBRARIES} ${STRACCIATELLA_LIBRARIES} ${LAUNCHER_LIBRARIES})
     add_dependencies(${LAUNCHER_BINARY} stracciatella)
 endif()
 

--- a/src/launcher/main.cc
+++ b/src/launcher/main.cc
@@ -1,13 +1,19 @@
-#include <Launcher.h>
+#include "Launcher.h"
 #include "RustInterface.h"
-
 #include <FL/Fl.H>
-#include <filesystem>
+#include <string_theory/string>
 
+#if defined(__GNUC__) && __GNUC__ < 8
+	#include <experimental/filesystem>
+	namespace fs = std::experimental::filesystem;
+#else
+	#include <filesystem>
+	namespace fs = std::filesystem;
+#endif
 
 int main(int argc, char* argv[]) 
 {
-	auto logPath = std::filesystem::temp_directory_path().append("ja2-launcher.log");
+	ST::string logPath { fs::temp_directory_path().append("ja2-launcher.log") };
 	Logger_initialize(logPath.c_str());
 
 #ifdef _WIN32

--- a/src/launcher/main.cc
+++ b/src/launcher/main.cc
@@ -2,11 +2,13 @@
 #include "RustInterface.h"
 
 #include <FL/Fl.H>
+#include <filesystem>
 
 
 int main(int argc, char* argv[]) 
 {
-	Logger_initialize("ja2-launcher.log");
+	auto logPath = std::filesystem::temp_directory_path().append("ja2-launcher.log");
+	Logger_initialize(logPath.c_str());
 
 #ifdef _WIN32
 	// Ensure quick-edit mode is off, or else it will block execution


### PR DESCRIPTION
For #1257, see also https://github.com/ja2-stracciatella/ja2-stracciatella/pull/1335#issuecomment-795058271.

We have changed log location of the main process. This updates the same for the `ja2-launcher`.

 