### PR TITLE
Fix directory chooser on Android 11

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     implementation 'androidx.activity:activity-ktx:1.1.0'
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'com.github.codekidX:storage-chooser:2.0.4.4'
+    implementation 'com.github.noelchew:storage-chooser:2.0.4.4a'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'


### PR DESCRIPTION
com.github.noelchew:storage-chooser is a fork of the old dependency with a patch for Android 11 applied.

Closing #1348.