### PR TITLE
Externalizing starting sector

### DIFF
--- a/assets/externalized/game.json
+++ b/assets/externalized/game.json
@@ -172,5 +172,17 @@
     //  vanilla settings: 1, 2, 3
     "unhired_merc_deaths_easy": 1,
     "unhired_merc_deaths_medium": 2,
-    "unhired_merc_deaths_hard": 3
+    "unhired_merc_deaths_hard": 3,
+
+    //  Settings for newly started campaigns.
+    //  Most probably you do not need to change these unless you are running a full conversion mod.
+    "campaign": {
+        //  The sector where your team lands at the start.
+        //  vanilla settings: A9
+        "start_sector": "A9",
+
+        //  Is the start sector revealed at game start?
+        //  vanilla settings: true
+        "start_sector_revealed": true
+    }
 }

--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -1,7 +1,7 @@
 #include "DefaultGamePolicy.h"
+#include "Campaign_Types.h"
 #include "JsonObject.h"
 
-#include "game/Tactical/Item_Types.h"
 
 DefaultGamePolicy::DefaultGamePolicy(rapidjson::Document *json)
 {
@@ -75,6 +75,11 @@ DefaultGamePolicy::DefaultGamePolicy(rapidjson::Document *json)
 	unhired_merc_deaths_easy = gp.getOptionalInt("unhired_merc_deaths_easy", 1);
 	unhired_merc_deaths_medium = gp.getOptionalInt("unhired_merc_deaths_medium", 2);
 	unhired_merc_deaths_hard = gp.getOptionalInt("unhired_merc_deaths_hard", 3);
+
+	JsonObjectReader campaign = JsonObjectReader(gp.GetValue("campaign"));
+	const char* sector_string = campaign.getOptionalString("start_sector");
+	start_sector = SECTOR_FROM_SECTOR_SHORT_STRING(sector_string != NULL ? sector_string : "A9");
+	reveal_start_sector = campaign.getOptionalBool("start_sector_revealed", false);
 }
 
 /** Check if a hotkey is enabled. */

--- a/src/externalized/policy/GamePolicy.h
+++ b/src/externalized/policy/GamePolicy.h
@@ -96,6 +96,9 @@ public:
 	int8_t unhired_merc_deaths_medium;       // Maximum unhired mercs KIA difficulty Medium
 	int8_t unhired_merc_deaths_hard;       // Maximum unhired mercs KIA difficulty Hard
 
+	uint16_t start_sector;        // Starting sector
+	bool reveal_start_sector;     // Should the start sector radar map be shown at start
+
 	////////////////////////////////////////////////////////////
 	//
 	////////////////////////////////////////////////////////////

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -1996,7 +1996,7 @@ static void LoadGeneralInfo(HWFILE const f, UINT32 const savegame_version)
 	g_merc_arrive_sector =
 		1 <= merc_arrive_x && merc_arrive_x <= 16 &&
 		1 <= merc_arrive_y && merc_arrive_y <= 16 ? SECTOR(merc_arrive_x, merc_arrive_y) :
-		START_SECTOR;
+		gamepolicy(start_sector);
 	EXTR_BOOL( d, gfCreatureMeanwhileScenePlayed)
 	EXTR_SKIP_U8(d)
 	EXTR_BOOL( d, gfPersistantPBI)

--- a/src/game/Strategic/Campaign_Init.cc
+++ b/src/game/Strategic/Campaign_Init.cc
@@ -4,6 +4,7 @@
 #include "ContentManager.h"
 #include "Creature_Spreading.h"
 #include "GameInstance.h"
+#include "GamePolicy.h"
 #include "GameSettings.h"
 #include "MemMan.h"
 #include "Overhead.h"
@@ -113,9 +114,12 @@ void InitNewCampaign()
 
 	BuildUndergroundSectorInfoList();
 
-	// Allow overhead view of start sector on game onset.
-	SetSectorFlag(SECTORX(START_SECTOR), SECTORY(START_SECTOR), 0, SF_ALREADY_VISITED);
-
+	if (gamepolicy(reveal_start_sector))
+	{
+		// Allow overhead view of start sector on game onset.
+		UINT16 uiStartSector = gamepolicy(start_sector);
+		SetSectorFlag(SECTORX(uiStartSector), SECTORY(uiStartSector), 0, SF_ALREADY_VISITED);
+	}
 	//Generates the initial forces in a new campaign.  The idea is to randomize numbers and sectors
 	//so that no two games are the same.
 	InitStrategicAI();

--- a/src/game/Strategic/Game_Init.cc
+++ b/src/game/Strategic/Game_Init.cc
@@ -179,7 +179,7 @@ void InitStrategicLayer( void )
 	SetGameTimeCompressionLevel( TIME_COMPRESS_X0 );
 
 	// Select the start sector as the initial selected sector
-	ChangeSelectedMapSector(SECTORX(START_SECTOR), SECTORY(START_SECTOR), 0);
+	ChangeSelectedMapSector(SECTORX(gamepolicy(start_sector)), SECTORY(gamepolicy(start_sector)), 0);
 
 	// Reset these flags or mapscreen could be disabled and cause major headache.
 	fDisableDueToBattleRoster = FALSE;

--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -1459,7 +1459,7 @@ try
 		if (!AnyMercsHired())
 		{
 			// Select starting sector.
-			ChangeSelectedMapSector(SECTORX(START_SECTOR), SECTORY(START_SECTOR), 0);
+			ChangeSelectedMapSector(SECTORX(gamepolicy(start_sector)), SECTORY(gamepolicy(start_sector)), 0);
 		}
 		else if( ( gWorldSectorX > 0 ) && ( gWorldSectorY > 0 ) && ( gbWorldSectorZ != -1 ) )
 		{
@@ -1471,7 +1471,7 @@ try
 			// Only select start sector, if there is no current selection, otherwise leave it as is.
 			if ( ( sSelMapX == 0 ) || ( sSelMapY == 0 ) || ( iCurrentMapSectorZ == -1 ) )
 			{
-				ChangeSelectedMapSector(SECTORX(START_SECTOR), SECTORY(START_SECTOR), 0);
+				ChangeSelectedMapSector(SECTORX(gamepolicy(start_sector)), SECTORY(gamepolicy(start_sector)), 0);
 			}
 		}
 

--- a/src/game/Strategic/Map_Screen_Interface.cc
+++ b/src/game/Strategic/Map_Screen_Interface.cc
@@ -11,6 +11,7 @@
 #include "Game_Event_Hook.h"
 #include "Game_Init.h"
 #include "GameInstance.h"
+#include "GamePolicy.h"
 #include "GameSettings.h"
 #include "HImage.h"
 #include "Interface_Items.h"
@@ -1074,7 +1075,7 @@ static void HandleEquipmentLeft(UINT32 const slot_idx, INT const sector, GridNo 
 
 void HandleEquipmentLeftInOmerta(const UINT32 uiSlotIndex)
 {
-	HandleEquipmentLeft(uiSlotIndex, START_SECTOR, START_SECTOR_LEAVE_EQUIP_GRIDNO);
+	HandleEquipmentLeft(uiSlotIndex, gamepolicy(start_sector), START_SECTOR_LEAVE_EQUIP_GRIDNO);
 }
 
 
@@ -3678,12 +3679,12 @@ BOOLEAN HandleTimeCompressWithTeamJackedInAndGearedToGo( void )
 	if (!DidGameJustStart()) return FALSE;
 
 	// Select starting sector.
-	ChangeSelectedMapSector(SECTORX(START_SECTOR), SECTORY(START_SECTOR), 0);
+	ChangeSelectedMapSector(SECTORX(gamepolicy(start_sector)), SECTORY(gamepolicy(start_sector)), 0);
 
 	// load starting sector
 	try
 	{
-		SetCurrentWorldSector(SECTORX(START_SECTOR), SECTORY(START_SECTOR), 0);
+		SetCurrentWorldSector(SECTORX(gamepolicy(start_sector)), SECTORY(gamepolicy(start_sector)), 0);
 	}
 	catch (...) /* XXX exception should probably propagate; caller ignores return value */
 	{
@@ -3693,8 +3694,8 @@ BOOLEAN HandleTimeCompressWithTeamJackedInAndGearedToGo( void )
 	//Setup variables in the PBI for this first battle.  We need to support the
 	//non-persistant PBI in case the user goes to mapscreen.
 	gfBlitBattleSectorLocator = TRUE;
-	gubPBSectorX = SECTORX(START_SECTOR);
-	gubPBSectorY = SECTORY(START_SECTOR);
+	gubPBSectorX = SECTORX(gamepolicy(start_sector));
+	gubPBSectorY = SECTORY(gamepolicy(start_sector));
 	gubPBSectorZ = 0;
 	gubEnemyEncounterCode = ENTERING_ENEMY_SECTOR_CODE;
 

--- a/src/game/Strategic/Map_Screen_Interface.cc
+++ b/src/game/Strategic/Map_Screen_Interface.cc
@@ -3678,26 +3678,33 @@ BOOLEAN HandleTimeCompressWithTeamJackedInAndGearedToGo( void )
 	// make sure the game just started
 	if (!DidGameJustStart()) return FALSE;
 
+	UINT8 usStartSectorX = SECTORX(gamepolicy(start_sector));
+	UINT8 usStartSectorY = SECTORY(gamepolicy(start_sector));
+
 	// Select starting sector.
-	ChangeSelectedMapSector(SECTORX(gamepolicy(start_sector)), SECTORY(gamepolicy(start_sector)), 0);
+	ChangeSelectedMapSector(usStartSectorX, usStartSectorY, 0);
 
 	// load starting sector
 	try
 	{
-		SetCurrentWorldSector(SECTORX(gamepolicy(start_sector)), SECTORY(gamepolicy(start_sector)), 0);
+		SetCurrentWorldSector(usStartSectorX, usStartSectorY, 0);
 	}
 	catch (...) /* XXX exception should probably propagate; caller ignores return value */
 	{
 		return FALSE;
 	}
 
-	//Setup variables in the PBI for this first battle.  We need to support the
-	//non-persistant PBI in case the user goes to mapscreen.
-	gfBlitBattleSectorLocator = TRUE;
-	gubPBSectorX = SECTORX(gamepolicy(start_sector));
-	gubPBSectorY = SECTORY(gamepolicy(start_sector));
-	gubPBSectorZ = 0;
-	gubEnemyEncounterCode = ENTERING_ENEMY_SECTOR_CODE;
+	if (NumEnemiesInSector(usStartSectorX, usStartSectorY) > 0)
+	{
+		//Setup variables in the PBI for this first battle.  We need to support the
+		//non-persistant PBI in case the user goes to mapscreen.
+		gfBlitBattleSectorLocator = TRUE;
+		gubPBSectorX = SECTORX(gamepolicy(start_sector));
+		gubPBSectorY = SECTORY(gamepolicy(start_sector));
+		gubPBSectorZ = 0;
+
+		gubEnemyEncounterCode = ENTERING_ENEMY_SECTOR_CODE;
+	}
 
 	InitHelicopterEntranceByMercs( );
 

--- a/src/game/Strategic/Merc_Contract.cc
+++ b/src/game/Strategic/Merc_Contract.cc
@@ -37,6 +37,7 @@
 #include "GameInstance.h"
 #include "ShippingDestinationModel.h"
 #include "MercProfile.h"
+#include "GamePolicy.h"
 
 #include <string_theory/string>
 
@@ -779,7 +780,7 @@ static void NotifyPlayerOfMercDepartureAndPromptEquipmentPlacement(SOLDIERTYPE& 
 	{ // The character is not an RPC
 		INT16 const elsewhere =
 			!StrategicMap[SECTOR_INFO_TO_STRATEGIC_INDEX(AIRPORT_SECTOR)].fEnemyControlled ? AIRPORT_SECTOR :
-			START_SECTOR;
+			gamepolicy(start_sector);
 		if (elsewhere == SECTOR(x, y) && z == 0) goto no_choice;
 
 		// Set strings for generic buttons

--- a/src/game/Strategic/Quests.h
+++ b/src/game/Strategic/Quests.h
@@ -199,7 +199,6 @@ enum Quests
 #define PABLOS_STOLEN_DEST_GRIDNO	1
 #define LOST_SHIPMENT_GRIDNO		2
 
-#define START_SECTOR			SEC_A9
 #define START_SECTOR_LEAVE_EQUIP_GRIDNO	4868
 
 // NB brothel rooms 88-90 removed because they are the antechamber

--- a/src/game/Strategic/StrategicMap.cc
+++ b/src/game/Strategic/StrategicMap.cc
@@ -29,6 +29,7 @@
 #include "Font_Control.h"
 #include "GameInstance.h"
 #include "GameLoop.h"
+#include "GamePolicy.h"
 #include "GameScreen.h"
 #include "GameSettings.h"
 #include "Game_Clock.h"
@@ -1183,8 +1184,8 @@ check_entry:
 
 		case INSERTION_CODE_ARRIVING_GAME:
 			// Are we in the start sector?
-			if (SECTOR(x,             y)             == START_SECTOR && z              == 0 &&
-					SECTOR(gWorldSectorX, gWorldSectorY) == START_SECTOR && gbWorldSectorZ == 0)
+			if (SECTOR(x,             y)             == gamepolicy(start_sector) && z              == 0 &&
+					SECTOR(gWorldSectorX, gWorldSectorY) == gamepolicy(start_sector) && gbWorldSectorZ == 0)
 			{ // Try another location and walk into map
 				gridno = 4379;
 			}
@@ -2307,7 +2308,7 @@ void SetupNewStrategicGame()
 	StrategicTurnsNewGame();
 
 	// Move the landing zone over to the start sector.
-	g_merc_arrive_sector = START_SECTOR;
+	g_merc_arrive_sector = gamepolicy(start_sector);
 }
 
 
@@ -2352,7 +2353,7 @@ static void HandleAirspaceControlUpdated()
 		ST::string sMsgSubString1 = GetSectorIDString(SECTORX(g_merc_arrive_sector), SECTORY(g_merc_arrive_sector), 0, FALSE);
 
 		// Move the landing zone over to the start sector.
-		g_merc_arrive_sector = START_SECTOR;
+		g_merc_arrive_sector = gamepolicy(start_sector);
 
 		// get the name of the new sector
 		ST::string sMsgSubString2 = GetSectorIDString(SECTORX(g_merc_arrive_sector), SECTORY(g_merc_arrive_sector), 0, FALSE);
@@ -3278,7 +3279,7 @@ try
 		return FALSE;
 	}
 
-	if (DidGameJustStart() && SECTOR(gWorldSectorX, gWorldSectorY) == START_SECTOR && gbWorldSectorZ == 0)
+	if (DidGameJustStart() && SECTOR(gWorldSectorX, gWorldSectorY) == gamepolicy(start_sector) && gbWorldSectorZ == 0)
 	{
 		return FALSE;
 	}

--- a/src/game/Tactical/Merc_Entering.cc
+++ b/src/game/Tactical/Merc_Entering.cc
@@ -31,6 +31,9 @@
 #include "Music_Control.h"
 #include "ContentMusic.h"
 #include "UILayout.h"
+#include "GamePolicy.h"
+#include "GameInstance.h"
+#include "ContentManager.h"
 
 
 #define MAX_MERC_IN_HELI		20
@@ -468,7 +471,7 @@ void HandleHeliDrop( )
 				// Add merc to sector
 				SOLDIERTYPE& s = *gHeliSeats[cnt];
 				s.ubStrategicInsertionCode = INSERTION_CODE_NORTH;
-				UpdateMercInSector(s, SECTORX(START_SECTOR), SECTORY(START_SECTOR), 0);
+				UpdateMercInSector(s, SECTORX(gamepolicy(start_sector)), SECTORY(gamepolicy(start_sector)), 0);
 
 				// Check for merc arrives quotes...
 				HandleMercArrivesQuotes(s);
@@ -601,7 +604,7 @@ void HandleHeliDrop( )
 						// Change insertion code
 						s.ubStrategicInsertionCode = INSERTION_CODE_NORTH;
 
-						UpdateMercInSector(s, SECTORX(START_SECTOR), SECTORY(START_SECTOR), 0);
+						UpdateMercInSector(s, SECTORX(gamepolicy(start_sector)), SECTORY(gamepolicy(start_sector)), 0);
 
 						// IF the first guy down, set squad!
 						if ( gfFirstGuyDown )

--- a/src/game/Tactical/Merc_Entering.cc
+++ b/src/game/Tactical/Merc_Entering.cc
@@ -792,8 +792,11 @@ static void HandleFirstHeliDropOfGame(void)
 		// Call people to area
 		CallAvailableEnemiesTo( gsGridNoSweetSpot );
 
-		// Say quote.....
-		SayQuoteFromAnyBodyInSector( QUOTE_ENEMY_PRESENCE );
+		if (NumEnemyInSector() > 0)
+		{
+			// Say quote.....
+			SayQuoteFromAnyBodyInSector(QUOTE_ENEMY_PRESENCE);
+		}
 
 		// Start music
 		SetMusicMode( MUSIC_TACTICAL_ENEMYPRESENT );

--- a/src/game/Tactical/Merc_Hiring.cc
+++ b/src/game/Tactical/Merc_Hiring.cc
@@ -42,6 +42,9 @@
 #include "Map_Screen_Interface_Bottom.h"
 #include "Quests.h"
 #include "Logger.h"
+#include "GamePolicy.h"
+#include "GameInstance.h"
+#include "ContentManager.h"
 
 #include <string_theory/string>
 
@@ -54,7 +57,7 @@ extern BOOLEAN gfFirstHeliRun;
 // ATE: Globals that dictate where the mercs will land once being hired
 // Default to start sector
 // Saved in general saved game structure
-INT16 g_merc_arrive_sector = START_SECTOR;
+INT16 g_merc_arrive_sector = 0;
 
 void CreateSpecialItem(SOLDIERTYPE* const s, UINT16 item)
 {
@@ -235,13 +238,13 @@ void MercArrivesCallback(SOLDIERTYPE& s)
 {
 	UINT32 uiTimeOfPost;
 
-	if (!DidGameJustStart() && g_merc_arrive_sector == START_SECTOR)
+	if (!DidGameJustStart() && g_merc_arrive_sector == gamepolicy(start_sector))
 	{
 		// Mercs arriving in start sector. This sector has been deemed as the always
 		// safe sector. Seeing we don't support entry into a hostile sector (except
 		// for the beginning), we will nuke any enemies in this sector first.
-		if (gWorldSectorX != SECTORX(START_SECTOR) ||
-			gWorldSectorY != SECTORY(START_SECTOR) ||
+		if (gWorldSectorX != SECTORX(gamepolicy(start_sector)) ||
+			gWorldSectorY != SECTORY(gamepolicy(start_sector)) ||
 			gbWorldSectorZ != 0)
 		{
 			EliminateAllEnemies(SECTORX(g_merc_arrive_sector), SECTORY(g_merc_arrive_sector));
@@ -274,7 +277,7 @@ void MercArrivesCallback(SOLDIERTYPE& s)
 		// ( which means we are at beginning of game if so )
 		// Setup chopper....
 		if (s.ubStrategicInsertionCode != INSERTION_CODE_CHOPPER &&
-				SECTOR(s.sSectorX, s.sSectorY) == START_SECTOR)
+				SECTOR(s.sSectorX, s.sSectorY) == gamepolicy(start_sector))
 		{
 			gfTacticalDoHeliRun = TRUE;
 


### PR DESCRIPTION
This adds 2 new configuration in `game.json`. These only takes effect for new campaigns 

It may not make much sense on a vanilla campaign, and this is intended for full map mods. Mercs are arrives on heli at the designated sector, so the sector must also be outside of SAM site coverage.
