### PR TITLE
CI-build with gcc-8

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -89,6 +89,13 @@ if [[ "$RUN_TESTS" == "true" ]]; then
   if [[ "$CI_TARGET" == "linux" ]]; then
     ./AppDir/usr/bin/ja2 -unittests
     ./AppDir/usr/bin/ja2-launcher -help
+
+    # Smoke test to check if the binary can run on older distros
+    DISTRO_IMAGE="debian:10"
+    PACKAGES="libfontconfig1 libx11-6 libsdl2-2.0.0 libfltk1.3 libfltk-images1.3"
+    SETUP_COMMAND="apt-get update && apt-get -yq install $PACKAGES"
+    docker run -v "$(pwd)/AppDir/usr/bin:/ja2" "$DISTRO_IMAGE" bash -c "$SETUP_COMMAND && /ja2/ja2 -help"
+
   else
     ./ja2 -unittests
     ./ja2-launcher -help

--- a/.ci/ci-functions.sh
+++ b/.ci/ci-functions.sh
@@ -43,10 +43,10 @@ linux-install-via-android-sdkmanager () {
 }
 
 linux-set-gcc-version () {
-    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 8
-    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 8
-    sudo update-alternatives --set gcc "/usr/bin/gcc-8"
-    sudo update-alternatives --set g++ "/usr/bin/g++-8"
+    sudo update-alternatives --install /usr/bin/gcc gcc "/usr/bin/gcc-$1" "$1"
+    sudo update-alternatives --install /usr/bin/g++ g++ "/usr/bin/g++-$1" "$1"
+    sudo update-alternatives --set gcc "/usr/bin/gcc-$1"
+    sudo update-alternatives --set g++ "/usr/bin/g++-$1"
 }
 
 macOS-install-via-brew () {

--- a/.ci/ci-functions.sh
+++ b/.ci/ci-functions.sh
@@ -43,10 +43,10 @@ linux-install-via-android-sdkmanager () {
 }
 
 linux-set-gcc-version () {
-    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 9
-    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
-    sudo update-alternatives --set gcc "/usr/bin/gcc-9"
-    sudo update-alternatives --set g++ "/usr/bin/g++-9"
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 8
+    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 8
+    sudo update-alternatives --set gcc "/usr/bin/gcc-8"
+    sudo update-alternatives --set g++ "/usr/bin/g++-8"
 }
 
 macOS-install-via-brew () {

--- a/.ci/ci-setup.sh
+++ b/.ci/ci-setup.sh
@@ -14,12 +14,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/ci-functions.sh"
 
 echo "## prepare environment ##"
 if [[ "$CI_TARGET" == "linux" ]]; then
+    GCC_VER="${TARGET_GCC_MAJOR_VERSION:-8}"
 
     # SDL2 and FLTK to link against
-    linux-install-via-apt-get libsdl2-dev libfltk1.3-dev gcc-8 g++-8
+    linux-install-via-apt-get libsdl2-dev libfltk1.3-dev "gcc-$GCC_VER" "g++-$GCC_VER"
 
     # choose a new-enough gcc version
-    linux-set-gcc-version
+    linux-set-gcc-version "$GCC_VER"
 
     # sccache for compilation caching
     linux-install-sccache
@@ -33,11 +34,13 @@ if [[ "$CI_TARGET" == "linux" ]]; then
     # Appimage build tools (linuxdeploy and appimagelint)
     linux-install-appimage-build-tools
 elif [[ "$CI_TARGET" == "linux-mingw64" ]]; then
+    GCC_VER="${TARGET_GCC_MAJOR_VERSION:-8}"
+
     # MinGW compiler for cross-compiling
-    linux-install-via-apt-get build-essential mingw-w64 gcc-8 g++-8
+    linux-install-via-apt-get build-essential mingw-w64 "gcc-$GCC_VER" "g++-$GCC_VER"
 
     # choose a new-enough version of gcc
-    linux-set-gcc-version
+    linux-set-gcc-version "$GCC_VER"
 
     # sccache for compilation caching
     linux-install-sccache

--- a/.ci/ci-setup.sh
+++ b/.ci/ci-setup.sh
@@ -14,12 +14,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/ci-functions.sh"
 
 echo "## prepare environment ##"
 if [[ "$CI_TARGET" == "linux" ]]; then
+
+    # SDL2 and FLTK to link against
+    linux-install-via-apt-get libsdl2-dev libfltk1.3-dev gcc-8 g++-8
+
     # choose a new-enough gcc version
     linux-set-gcc-version
 
-    # SDL2 and FLTK to link against
-    linux-install-via-apt-get libsdl2-dev libfltk1.3-dev
-    
     # sccache for compilation caching
     linux-install-sccache
 
@@ -32,11 +33,11 @@ if [[ "$CI_TARGET" == "linux" ]]; then
     # Appimage build tools (linuxdeploy and appimagelint)
     linux-install-appimage-build-tools
 elif [[ "$CI_TARGET" == "linux-mingw64" ]]; then
+    # MinGW compiler for cross-compiling
+    linux-install-via-apt-get build-essential mingw-w64 gcc-8 g++-8
+
     # choose a new-enough version of gcc
     linux-set-gcc-version
-
-    # MinGW compiler for cross-compiling
-    linux-install-via-apt-get build-essential mingw-w64
 
     # sccache for compilation caching
     linux-install-sccache


### PR DESCRIPTION
For #1360.

The problem is that JA2:S, being a maintained runtime of an old video game, does not run on a relatively old Linux (Debian 10). The current CI build on GitHub Action uses Ubuntu 18:04 and gcc-9.

We do not have much choice over the build environment on GitHub Action. Ubuntu-16.04 is [scheduled to be decommissioned later this year](https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/), so the only reasonable choice now is Ubuntu-18.04.

If the build still doesn't work, we may need to do the build inside a docker container of an old-stable Debian or CentOS.

## What's done so far

- Downgraded CI build to use `gcc-8` (on Ubuntu 18.04, GLIBC 2.27)
- Smoke test to run `./ja2 -help` on Debian 10
- `gcc` major version can be set via the environment variable `TARGET_GCC_MAJOR_VERSION`