### PR TITLE
Read tilecache names from VFS

### DIFF
--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -71,9 +71,6 @@ public:
 	/** Get tileset db resource name. */
 	virtual ST::string getTilesetDBResName() const = 0;
 
-	/** Get directory for storing new map file. */
-	virtual ST::string getNewMapFolder() const = 0;
-
 	/** Get all available tilecache. */
 	virtual std::vector<ST::string> getAllTilecache() const = 0;
 

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -43,9 +43,6 @@ public:
 	/** Open map for reading. */
 	virtual SGPFile* openMapForReading(const ST::string& mapName) const override;
 
-	/** Get directory for storing new map file. */
-	virtual ST::string getNewMapFolder() const override;
-
 	/** Get all available tilecache. */
 	virtual std::vector<ST::string> getAllTilecache() const override;
 
@@ -77,7 +74,6 @@ public:
 	virtual ST::string getVideoCaptureFolder() const override;
 
 	const ST::string& getDataDir() { return m_dataDir; }
-	const ST::string& getTileDir() { return m_tileDir; }
 
 	const ST::string& getExternalizedDataDir() { return m_externalizedDataPath; }
 
@@ -176,7 +172,6 @@ public:
 protected:
 	RustPointer<EngineOptions> m_engineOptions;
 	ST::string m_dataDir;
-	ST::string m_tileDir;
 	ST::string m_userHomeDir;
 	ST::string m_externalizedDataPath;
 

--- a/src/game/GameRes.cc
+++ b/src/game/GameRes.cc
@@ -134,20 +134,6 @@ FLOAT getMajorMapVersion()
 	return (s_gameVersion == GameVersion::RUSSIAN) ? 6.00 : 5.00;
 }
 
-/** Get list of resource libraries. */
-std::vector<ST::string> GetResourceLibraries(const ST::string &dataDir)
-{
-	std::vector<ST::string> libraries = FindFilesInDir(dataDir, "slf", true, true);
-
-	// for (int i = 0; i < libraries.size(); i++)
-	// {
-	//   SLOGW("%s", libraries[i].c_str());
-	// }
-
-	return libraries;
-}
-
-
 #define STI(LNG, x) LNG "/" x "_" LNG ".sti"
 #define PCX(LNG, x) LNG "/" x "_" LNG ".pcx"
 

--- a/src/game/GameRes.h
+++ b/src/game/GameRes.h
@@ -58,9 +58,6 @@ char const* GetMLGFilename(MultiLanguageGraphic);
 /** Choose game version. */
 void setGameVersion(GameVersion ver);
 
-/** Get list of resource libraries. */
-std::vector<ST::string> GetResourceLibraries(const ST::string &dataDir);
-
 /**
  * Get encoding corrector for strings in data files.
  * @return NULL when no encoding corrector is required */

--- a/src/sgp/FileMan.cc
+++ b/src/sgp/FileMan.cc
@@ -588,12 +588,6 @@ RustPointer<File> FileMan::openFileForReading(const ST::string& path)
 	return RustPointer<File>{File_open(path.c_str(), FILE_OPEN_READ)};
 }
 
-/** Replace all \ with / */
-void FileMan::slashifyPath(ST::string &path)
-{
-	path = path.replace("\\", "/");
-}
-
 ST::string FileMan::fileReadText(SGPFile* file)
 {
 	uint32_t size = FileGetSize(file);

--- a/src/sgp/FileMan.h
+++ b/src/sgp/FileMan.h
@@ -112,9 +112,6 @@ public:
 	/** Convert File to HWFile. */
 	static SGPFile* getSGPFileFromFile(File* f);
 
-	/** Replace all \ with / */
-	static void slashifyPath(ST::string &path);
-
 	/** Check file existance. */
 	static bool checkFileExistance(const ST::string& folder, const ST::string& fileName);
 

--- a/src/sgp/FileMan_unittest.cc
+++ b/src/sgp/FileMan_unittest.cc
@@ -225,13 +225,6 @@ TEST(FileManTest, ReplaceExtension)
 	EXPECT_EQ(FileMan::replaceExtension("c:\\a\\foo.txt", "bin"),   "c:\\a\\foo.bin");
 }
 
-TEST(FileManTest, SlashifyPath)
-{
-	ST::string test("foo\\bar\\baz");
-	FileMan::slashifyPath(test);
-	EXPECT_STREQ(test.c_str(), "foo/bar/baz");
-}
-
 TEST(FileManTest, FreeSpace)
 {
 	EXPECT_NE(GetFreeSpaceOnHardDriveWhereGameIsRunningFrom(), 0u);


### PR DESCRIPTION
Also a part of #1275. This reads tile cache files from VFS, not by listing the data directory directly.