### PR TITLE
Added option for mouse cursor to always be visible in tactical view

### DIFF
--- a/assets/externalized/game.json
+++ b/assets/externalized/game.json
@@ -113,6 +113,10 @@
     "chance_to_hit_maximum": 99,
     "tactical_head_damage_multiplier": 1.5,
     "tactical_legs_damage_multiplier": 0.5,
+	
+	//  Always show mouse cursor during tactical view (if false, no mourse cursor is shown when moving in real-time mode, selecting a merc, etc)
+	//  vanilla setting: false
+	"always_show_cursor_in_tactical": false,
 
     //  IMP creation tweaks
     "imp": {

--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -47,6 +47,8 @@ DefaultGamePolicy::DefaultGamePolicy(rapidjson::Document *json)
 	chance_to_hit_maximum = gp.getOptionalInt("chance_to_hit_maximum", 99);
 	chance_to_hit_minimum = gp.getOptionalInt("chance_to_hit_minimum", 1);
 
+	always_show_cursor_in_tactical = gp.getOptionalBool("always_show_cursor_in_tactical", false);
+
 	JsonObjectReader imp = JsonObjectReader(gp.GetValue("imp"));
 	imp_load_saved_merc_by_nickname = imp.getOptionalBool("load_saved_merc_by_nickname");
 	imp_load_keep_inventory = imp.getOptionalBool("load_keep_inventory");

--- a/src/externalized/policy/GamePolicy.h
+++ b/src/externalized/policy/GamePolicy.h
@@ -70,6 +70,8 @@ public:
 	int8_t chance_to_hit_minimum;         //Minimum chance to hit (0 - chance_to_hit_maximum) vanilla 1
 	int8_t chance_to_hit_maximum;         //Maximum chance to hit (chance_to_hit_minimum - 100) vanilla 99
 
+	bool always_show_cursor_in_tactical;  // Always show mouse cursor during tactical view (if false, no mourse cursor is shown when moving in real-time mode, selecting a merc, etc)
+
 	/* IMP */
 	int8_t imp_attribute_max;             // IMP character attribute maximum 0 to 100, vanilla 85
 	int8_t imp_attribute_min;             // IMP character attribute minimum 0 to imp_attribute_max, vanilla 35

--- a/src/game/Tactical/Interface_Cursors.cc
+++ b/src/game/Tactical/Interface_Cursors.cc
@@ -45,11 +45,11 @@ const UICursor gUICursors[NUM_UI_CURSORS] =
 	{ALL_MOVE_PRONE_UICURSOR,            UICURSOR_SNAPPING | UICURSOR_SHOWTILE | UICURSOR_DONTSHOW2NDLEVEL,                                    0,                         FIRSTPOINTERS5  },
 	{ALL_MOVE_VEHICLE_UICURSOR,          UICURSOR_SNAPPING | UICURSOR_SHOWTILE | UICURSOR_DONTSHOW2NDLEVEL,                                    0,                         FIRSTPOINTERS5  },
 
-	{MOVE_REALTIME_UICURSOR,             UICURSOR_FREEFLOWING | UICURSOR_SHOWTILEAPDEPENDENT | UICURSOR_DONTSHOW2NDLEVEL,                      VIDEO_NO_CURSOR,           FIRSTPOINTERS2  },
-	{MOVE_RUN_REALTIME_UICURSOR,         UICURSOR_FREEFLOWING | UICURSOR_SHOWTILE | UICURSOR_DONTSHOW2NDLEVEL,                                 VIDEO_NO_CURSOR,           FIRSTPOINTERS7  },
+	{MOVE_REALTIME_UICURSOR,             UICURSOR_FREEFLOWING | UICURSOR_SHOWTILEAPDEPENDENT | UICURSOR_DONTSHOW2NDLEVEL,                      VIDEO_DEFAULT_TO_NO_CURSOR,           FIRSTPOINTERS2  },
+	{MOVE_RUN_REALTIME_UICURSOR,         UICURSOR_FREEFLOWING | UICURSOR_SHOWTILE | UICURSOR_DONTSHOW2NDLEVEL,                                 VIDEO_DEFAULT_TO_NO_CURSOR,           FIRSTPOINTERS7  },
 
-	{CONFIRM_MOVE_REALTIME_UICURSOR,     UICURSOR_FREEFLOWING | UICURSOR_SHOWTILE | UICURSOR_DONTSHOW2NDLEVEL,                                 VIDEO_NO_CURSOR,           FIRSTPOINTERS4  },
-	{ALL_MOVE_REALTIME_UICURSOR,         UICURSOR_FREEFLOWING | UICURSOR_SHOWTILE | UICURSOR_DONTSHOW2NDLEVEL,                                 VIDEO_NO_CURSOR,           FIRSTPOINTERS5  },
+	{CONFIRM_MOVE_REALTIME_UICURSOR,     UICURSOR_FREEFLOWING | UICURSOR_SHOWTILE | UICURSOR_DONTSHOW2NDLEVEL,                                 VIDEO_DEFAULT_TO_NO_CURSOR,           FIRSTPOINTERS4  },
+	{ALL_MOVE_REALTIME_UICURSOR,         UICURSOR_FREEFLOWING | UICURSOR_SHOWTILE | UICURSOR_DONTSHOW2NDLEVEL,                                 VIDEO_DEFAULT_TO_NO_CURSOR,           FIRSTPOINTERS5  },
 
 	{ON_OWNED_MERC_UICURSOR,             UICURSOR_SNAPPING,                                                                                    0,                         0               },
 	{ON_OWNED_SELMERC_UICURSOR,          UICURSOR_SNAPPING,                                                                                    0,                         0               },
@@ -238,7 +238,7 @@ void DrawUICursor()
 
 		if ( guiCurUICursor == NO_UICURSOR )
 		{
-			gViewportRegion.ChangeCursor(VIDEO_NO_CURSOR);
+			gViewportRegion.ChangeCursor(VIDEO_DEFAULT_TO_NO_CURSOR);
 			return;
 		}
 
@@ -338,7 +338,7 @@ void DrawUICursor()
 		if ( gUICursors[ guiCurUICursor ].uiFlags & UICURSOR_SNAPPING )
 		{
 			// Hide mouse region cursor
-			gViewportRegion.ChangeCursor(VIDEO_NO_CURSOR);
+			gViewportRegion.ChangeCursor(VIDEO_DEFAULT_TO_NO_CURSOR);
 
 			// Set Snapping Cursor
 			DrawSnappingCursor( );

--- a/src/game/Utils/Cursors.cc
+++ b/src/game/Utils/Cursors.cc
@@ -1413,6 +1413,7 @@ static void DrawMouseText(void)
 
 void UpdateAnimatedCursorFrames(UINT32 uiCursorIndex)
 {
+	uiCursorIndex = ReturnCursorIndex(uiCursorIndex);
 	if (uiCursorIndex == VIDEO_NO_CURSOR) return;
 
 	CursorData* pCurData = &CursorDatabase[uiCursorIndex];
@@ -1435,6 +1436,7 @@ void UpdateAnimatedCursorFrames(UINT32 uiCursorIndex)
 
 static void UpdateFlashingCursorFrames(UINT32 uiCursorIndex)
 {
+	uiCursorIndex = ReturnCursorIndex(uiCursorIndex);
 	if (uiCursorIndex == VIDEO_NO_CURSOR) return;
 
 	CursorData* pCurData = &CursorDatabase[uiCursorIndex];

--- a/src/game/Utils/Cursors.cc
+++ b/src/game/Utils/Cursors.cc
@@ -1413,7 +1413,7 @@ static void DrawMouseText(void)
 
 void UpdateAnimatedCursorFrames(UINT32 uiCursorIndex)
 {
-	uiCursorIndex = ReturnCursorIndex(uiCursorIndex);
+	uiCursorIndex = ModifyCursorIndex(uiCursorIndex);
 	if (uiCursorIndex == VIDEO_NO_CURSOR) return;
 
 	CursorData* pCurData = &CursorDatabase[uiCursorIndex];
@@ -1436,7 +1436,7 @@ void UpdateAnimatedCursorFrames(UINT32 uiCursorIndex)
 
 static void UpdateFlashingCursorFrames(UINT32 uiCursorIndex)
 {
-	uiCursorIndex = ReturnCursorIndex(uiCursorIndex);
+	uiCursorIndex = ModifyCursorIndex(uiCursorIndex);
 	if (uiCursorIndex == VIDEO_NO_CURSOR) return;
 
 	CursorData* pCurData = &CursorDatabase[uiCursorIndex];

--- a/src/sgp/Cursor_Control.cc
+++ b/src/sgp/Cursor_Control.cc
@@ -1,12 +1,14 @@
+#include "ContentManager.h"
 #include "Cursor_Control.h"
+#include "Cursors.h"
 #include "Debug.h"
+#include "GameInstance.h"
 #include "HImage.h"
 #include "Timer.h"
 #include "VObject.h"
 #include "Video.h"
 #include "VSurface.h"
-#include "ContentManager.h"
-#include "GameInstance.h"
+
 #include "policy/GamePolicy.h"
 
 
@@ -192,7 +194,7 @@ void CursorDatabaseClear(void)
 
 BOOLEAN SetCurrentCursorFromDatabase(UINT32 uiCursorIndex)
 {
-	uiCursorIndex = ReturnCursorIndex(uiCursorIndex);
+	uiCursorIndex = ModifyCursorIndex(uiCursorIndex);
 	
 	if (uiCursorIndex == VIDEO_NO_CURSOR)
 	{
@@ -364,12 +366,12 @@ void SetExternMouseCursor(SGPVObject const& vo, UINT16 const region_idx)
 }
 
 // Checks if uiCursorIndex is VIDEO_DEFAULT_TO_NO_CURSOR. If so, we parse it as VIDEO_NO_CURSOR or 0 (generic cursor)
-UINT32 ReturnCursorIndex(UINT32 uiCursorIndex)
+UINT32 ModifyCursorIndex(UINT32 uiCursorIndex)
 {
 	if (uiCursorIndex == VIDEO_DEFAULT_TO_NO_CURSOR)
 	{
 		if (gamepolicy(always_show_cursor_in_tactical))
-			return 0;
+			return CURSOR_NORMAL;
 		else
 			return VIDEO_NO_CURSOR;
 	}

--- a/src/sgp/Cursor_Control.cc
+++ b/src/sgp/Cursor_Control.cc
@@ -5,6 +5,9 @@
 #include "VObject.h"
 #include "Video.h"
 #include "VSurface.h"
+#include "ContentManager.h"
+#include "GameInstance.h"
+#include "policy/GamePolicy.h"
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -189,6 +192,8 @@ void CursorDatabaseClear(void)
 
 BOOLEAN SetCurrentCursorFromDatabase(UINT32 uiCursorIndex)
 {
+	uiCursorIndex = ReturnCursorIndex(uiCursorIndex);
+	
 	if (uiCursorIndex == VIDEO_NO_CURSOR)
 	{
 		SetMouseCursorProperties(0, 0, 0, 0);
@@ -356,4 +361,17 @@ void SetExternMouseCursor(SGPVObject const& vo, UINT16 const region_idx)
 {
 	guiExternVo         = &vo;
 	gusExternVoSubIndex = region_idx;
+}
+
+// Checks if uiCursorIndex is VIDEO_DEFAULT_TO_NO_CURSOR. If so, we parse it as VIDEO_NO_CURSOR or 0 (generic cursor)
+UINT32 ReturnCursorIndex(UINT32 uiCursorIndex)
+{
+	if (uiCursorIndex == VIDEO_DEFAULT_TO_NO_CURSOR)
+	{
+		if (gamepolicy(always_show_cursor_in_tactical))
+			return 0;
+		else
+			return VIDEO_NO_CURSOR;
+	}
+	return uiCursorIndex;
 }

--- a/src/sgp/Cursor_Control.h
+++ b/src/sgp/Cursor_Control.h
@@ -77,6 +77,6 @@ void SetMouseBltHook(MOUSEBLT_HOOK pMouseBltOverride);
 
 void SetExternVOData(UINT32 uiCursorIndex, HVOBJECT hVObject, UINT16 usSubIndex);
 
-UINT32 ReturnCursorIndex(UINT32 uiCursorIndex);
+UINT32 ModifyCursorIndex(UINT32 uiCursorIndex);
 
 #endif

--- a/src/sgp/Cursor_Control.h
+++ b/src/sgp/Cursor_Control.h
@@ -77,4 +77,6 @@ void SetMouseBltHook(MOUSEBLT_HOOK pMouseBltOverride);
 
 void SetExternVOData(UINT32 uiCursorIndex, HVOBJECT hVObject, UINT16 usSubIndex);
 
+UINT32 ReturnCursorIndex(UINT32 uiCursorIndex);
+
 #endif

--- a/src/sgp/Video.h
+++ b/src/sgp/Video.h
@@ -6,6 +6,7 @@
 #include "stracciatella.h"
 
 
+#define VIDEO_DEFAULT_TO_NO_CURSOR 0xFFFE // VIDEO_DEFAULT_TO_NO_CURSOR is equal to VIDEO_NO_CURSOR unless always_show_cursor_in_tactical is true
 #define VIDEO_NO_CURSOR 0xFFFF
 #define GAME_WINDOW g_game_window
 


### PR DESCRIPTION
Under certain circumstances, the mouse cursor is not rendered. Ie, when highlighting a tile for movement in real-time mode or hovering mouse cursor over a mercenary. It still behaves the same behind the scenes, so I feel it's nice to actually see the exact location of it at all times.

This adds a toggle ("always_show_cursor_in_tactical" in game.json) to make mouse cursor always be visible.

Examples of what the change looks like (with default JA2 behaviour, the cursor would be invisible in all of these samples):
![ja2 2021-05-21 18-12-12-683](https://user-images.githubusercontent.com/14843529/119167733-6fc8f600-ba60-11eb-828b-d9f50812edcd.png)
![ja2 2021-05-21 18-12-18-582](https://user-images.githubusercontent.com/14843529/119167739-735c7d00-ba60-11eb-90fc-29aa85566b1e.png)
![ja2 2021-05-21 18-12-23-939](https://user-images.githubusercontent.com/14843529/119167742-748daa00-ba60-11eb-864a-14e14b8b383c.png)
![ja2 2021-05-21 18-12-35-720](https://user-images.githubusercontent.com/14843529/119167744-75bed700-ba60-11eb-951a-6bc7cd378560.png)

I haven't done exhaustive testing of this, but based on the code changes, I think this is unlikely to cause any issues.