### PR TITLE
make sure to expire break lights/smoke when trashing the area

### DIFF
--- a/src/game/TileEngine/Overhead_Map.cc
+++ b/src/game/TileEngine/Overhead_Map.cc
@@ -19,6 +19,7 @@
 #include "Interface_Items.h"
 #include "Interface_Panels.h"
 #include "Isometric_Utils.h"
+#include "LightEffects.h"
 #include "Line.h"
 #include "Map_Information.h"
 #include "MouseSystem.h"
@@ -27,6 +28,7 @@
 #include "Radar_Screen.h"
 #include "Render_Dirty.h"
 #include "RenderWorld.h"
+#include "SmokeEffects.h"
 #include "Soldier_Control.h"
 #include "Soldier_Init_List.h"
 #include "Structure.h"
@@ -271,6 +273,13 @@ void HandleOverheadMap(void)
 	InitNewOverheadDB(giCurrentTilesetID);
 
 	RestoreBackgroundRects();
+
+	// clear for broken saves before TrashWorld took care of this
+	if (!gfEditMode && gfTacticalPlacementGUIActive)
+	{
+		DecaySmokeEffects(GetWorldTotalSeconds());
+		DecayLightEffects(GetWorldTotalSeconds());
+	}
 
 	RenderOverheadMap(0, WORLD_COLS / 2, STD_SCREEN_X, STD_SCREEN_Y, STD_SCREEN_X + 640, STD_SCREEN_Y + 320, FALSE);
 

--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -2554,6 +2554,9 @@ void TrashWorld(void)
 
 	TrashWorldItems();
 	TrashOverheadMap();
+
+	DecaySmokeEffects(0xffffff);
+	DecayLightEffects(0xffffff);
 	ResetSmokeEffects();
 	ResetLightEffects();
 


### PR DESCRIPTION
My guess was right, they didn't get a chance to expire and the Reset* functions just clear some internal state.

fixes #95