### PR TITLE
Read and write to a proper temporary directory

### DIFF
--- a/rust/stracciatella/src/android.rs
+++ b/rust/stracciatella/src/android.rs
@@ -77,13 +77,12 @@ pub fn get_application_context() -> Result<JObject<'static>> {
     })
 }
 
-/// Find ja2 stracciatella configuration directory for android
-pub fn get_android_app_dir() -> Result<PathBuf> {
+fn get_dir_from_application_context(method_name: &'static str) -> Result<PathBuf> {
     let jni_env = crate::android::get_global_jni_env()?;
     let path_obj = jni_env.auto_local(jni_env.with_local_frame(SMALL_JNI_FRAME_SIZE, || {
         let context = crate::android::get_application_context()?;
         let files_dir = jni_env
-            .call_method(context, "getFilesDir", "()Ljava/io/File;", &[])?
+            .call_method(context, method_name, "()Ljava/io/File;", &[])?
             .l()?;
         jni_env
             .call_method(files_dir, "getAbsolutePath", "()Ljava/lang/String;", &[])?
@@ -93,6 +92,16 @@ pub fn get_android_app_dir() -> Result<PathBuf> {
     let path_string: String = path.into();
 
     Ok(PathBuf::from(&path_string))
+}
+
+/// Find ja2 stracciatella configuration directory for android
+pub fn get_android_app_dir() -> Result<PathBuf> {
+    get_dir_from_application_context("getFilesDir")
+}
+
+/// Find cache directory for android
+pub fn get_android_cache_dir() -> Result<PathBuf> {
+    get_dir_from_application_context("getCacheDir")
 }
 
 /// Get asset manager from JNI env

--- a/rust/stracciatella/src/fs.rs
+++ b/rust/stracciatella/src/fs.rs
@@ -27,7 +27,7 @@ pub use std::fs::write;
 pub use std::fs::File;
 pub use std::fs::OpenOptions;
 
-pub use tempfile::TempDir;
+pub use tempfile::{Builder as TempBuilder, NamedTempFile, TempDir};
 
 //--------------
 // replacements

--- a/rust/stracciatella_c_api/Cargo.toml
+++ b/rust/stracciatella_c_api/Cargo.toml
@@ -14,12 +14,10 @@ hex = "0.3.2"
 libc = "0.2"
 log = "0.4"
 stracciatella = { path = "../stracciatella" }
+tempfile = "3.0"
 
 [target.'cfg(target_os = "android")'.dependencies.jni]
 version = "0.14"
-
-[dev-dependencies]
-tempfile = "3.0"
 
 [build-dependencies]
 cbindgen = "0.13, ~0.13.2"

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -197,15 +197,30 @@ public:
 
 	virtual const ST::string& getLandTypeString(size_t index) const = 0;
 
+	/** Does temp file exist. */
+	virtual bool doesTempFileExist(const ST::string& filename) const = 0;
+
 	/** Open temporary file for writing. */
 	virtual SGPFile* openTempFileForWriting(const ST::string& filename, bool truncate) const = 0;
 
 	/** Open temporary file for reading. */
 	virtual SGPFile* openTempFileForReading(const ST::string& filename) const = 0;
 
+	/** Open temporary file for read/write. */
+	virtual SGPFile* openTempFileForReadWrite(const ST::string& filename) const = 0;
+
 	/** Open temporary file for appending. */
 	virtual SGPFile* openTempFileForAppend(const ST::string& filename) const = 0;
 
 	/** Delete temporary file. */
 	virtual void deleteTempFile(const ST::string& filename) const = 0;
+
+	/** Create temporary directory. Does not fail if it exists already. */
+	virtual void createTempDir(const ST::string& dirname) const = 0;
+
+	/** List temporary directory. Pass empty string to list the temp dir itself. */
+	virtual std::vector<ST::string> findAllFilesInTempDir(const ST::string& dirname, bool sortResults = false, bool recursive = false, bool returnOnlyNames = false) const = 0;
+
+	/** Erase all files within temporary directory. */
+	virtual void eraseTempDir(const ST::string& dirname) const = 0;
 };

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -74,11 +74,6 @@
 
 #define DIALOGUESIZE 240
 
-// XXX: Issue #135
-// We need a safe way to create temporary directories - unique and random for every process
-// Boost probably provides this functionality
-#define NEW_TEMP_DIR "temp"
-
 const MercProfileInfo EMPTY_MERC_PROFILE_INFO;
 
 static ST::string LoadEncryptedData(ST::string& err_msg, STRING_ENC_TYPE encType, SGPFile* File, UINT32 seek_chars, UINT32 read_chars)
@@ -203,11 +198,22 @@ DefaultContentManager::DefaultContentManager(RustPointer<EngineOptions> engineOp
 	m_loadingScreenModel = NULL;
 	m_samSitesAirControl = NULL;
 
+	// Initialize temp dir
+	RustPointer<TempDir> tempDir(TempDir_create());
+	if (tempDir.get() == NULL) {
+		RustPointer<char> err{ getRustError() };
+		auto error = ST::format("Failed to create temporary directory: {}", err.get());
+		throw std::runtime_error(error.c_str());
+	}
+	m_tempDir = move(tempDir);
+	RustPointer<char> tempDirPath(TempDir_path(m_tempDir.get()));
+	m_tempDirPath = tempDirPath.get();
+
+	// Initialize VFS
 	auto succeeded = Vfs_init_from_engine_options(m_vfs.get(), m_engineOptions.get());
 	if (!succeeded) {
 		RustPointer<char> err{ getRustError() };
 		auto error = ST::format("Failed to build virtual file system (VFS): {}", err.get());
-		SLOGE(error);
 		throw std::runtime_error(error.c_str());
 	}
 }
@@ -221,6 +227,7 @@ void DefaultContentManager::logConfiguration() const {
 	STLOGI("Extra data directory:          '{}'", assetsDir.get());
 	STLOGI("Data directory:                '{}'", m_dataDir);
 	STLOGI("Saved games directory:         '{}'", getSavedGamesFolder());
+	STLOGI("Temporary directory:           '{}'", m_tempDirPath);
 }
 
 template <class T> 
@@ -245,6 +252,7 @@ void deleteElements(std::map<K, const V*> map)
 
 DefaultContentManager::~DefaultContentManager()
 {
+	SLOGD("Shutting Down Content Manager");
 	for (const ItemModel* item : m_items)
 	{
 		delete item;
@@ -321,6 +329,10 @@ DefaultContentManager::~DefaultContentManager()
 	delete m_cacheSectors;
 	delete m_movementCosts;
 	delete m_samSitesAirControl;
+
+	m_vfs.reset();
+	m_tempDir.reset();
+	m_engineOptions.reset();
 }
 
 const DealerInventory* DefaultContentManager::getBobbyRayNewInventory() const
@@ -450,39 +462,66 @@ std::vector<ST::string> DefaultContentManager::getAllTilecache() const
 	return paths;
 }
 
+/** Does temp file exist. */
+bool DefaultContentManager::doesTempFileExist(const ST::string& filename) const
+{
+	return FileMan::checkFileExistance(m_tempDirPath, filename);
+}
+
 /** Open temporary file for writing. */
 SGPFile* DefaultContentManager::openTempFileForWriting(const ST::string& filename, bool truncate) const
 {
-	ST::string path = FileMan::joinPaths(NEW_TEMP_DIR, filename);
+	ST::string path = FileMan::joinPaths(m_tempDirPath, filename);
 	return FileMan::openForWriting(path, truncate);
-}
-
-/** Open temporary file for appending. */
-SGPFile* DefaultContentManager::openTempFileForAppend(const ST::string& filename) const
-{
-	ST::string path = FileMan::joinPaths(NEW_TEMP_DIR, filename);
-	return FileMan::openForAppend(path);
 }
 
 /* Open temporary file for reading. */
 SGPFile* DefaultContentManager::openTempFileForReading(const ST::string& filename) const
 {
-	ST::string path = FileMan::joinPaths(NEW_TEMP_DIR, filename);
-	RustPointer<File> file(File_open(path.c_str(), FILE_OPEN_READ));
-	if (!file)
-	{
-		RustPointer<char> err(getRustError());
-		ST::string buf = ST::format("DefaultContentManager::openTempFileForReading: {}", err.get());
-		throw std::runtime_error(buf.to_std_string());
-	}
-	return FileMan::getSGPFileFromFile(file.release());
+	ST::string path = FileMan::joinPaths(m_tempDirPath, filename);
+	return FileMan::openForReading(path);
+}
+
+/** Open temporary file for read/write. */
+SGPFile* DefaultContentManager::openTempFileForReadWrite(const ST::string& filename) const
+{
+	ST::string path = FileMan::joinPaths(m_tempDirPath, filename);
+	return FileMan::openForReadWrite(path);
+}
+
+/** Open temporary file for appending. */
+SGPFile* DefaultContentManager::openTempFileForAppend(const ST::string& filename) const
+{
+	ST::string path = FileMan::joinPaths(m_tempDirPath, filename);
+	return FileMan::openForAppend(path);
 }
 
 /** Delete temporary file. */
 void DefaultContentManager::deleteTempFile(const ST::string& filename) const
 {
-	ST::string path = FileMan::joinPaths(NEW_TEMP_DIR, filename);
+	ST::string path = FileMan::joinPaths(m_tempDirPath, filename);
 	FileDelete(path);
+}
+
+/** Create temporary directory. Does not fail if it exists already. */
+void DefaultContentManager::createTempDir(const ST::string& dirname) const
+{
+	ST::string path = FileMan::joinPaths(m_tempDirPath, dirname);
+	FileMan::createDir(path);
+}
+
+/** List temporary directory. Pass empty string to list the temp dir itself. */
+std::vector<ST::string> DefaultContentManager::findAllFilesInTempDir(const ST::string& dirname, bool sortResults, bool recursive, bool returnOnlyNames) const
+{
+	ST::string path = dirname.size() == 0 ? m_tempDirPath : FileMan::joinPaths(m_tempDirPath, dirname);
+	return FindAllFilesInDir(path, sortResults, recursive, returnOnlyNames);
+}
+
+/** Erase all files within temporary directory. */
+void DefaultContentManager::eraseTempDir(const ST::string& dirname) const
+{
+	ST::string path = FileMan::joinPaths(m_tempDirPath, dirname);
+	EraseDirectory(path);
 }
 
 /* Open a game resource file for reading.

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -46,6 +46,9 @@ public:
 	/** Get all available tilecache. */
 	virtual std::vector<ST::string> getAllTilecache() const override;
 
+	/** Does temp file exist. */
+	virtual bool doesTempFileExist(const ST::string& filename) const override;
+
 	/* Open a game resource file for reading. */
 	virtual SGPFile* openGameResForReading(const ST::string& filename) const override;
 
@@ -55,11 +58,23 @@ public:
 	/** Open temporary file for reading. */
 	virtual SGPFile* openTempFileForReading(const ST::string& filename) const override;
 
+	/** Open temporary file for read/write. */
+	virtual SGPFile* openTempFileForReadWrite(const ST::string& filename) const override;
+
 	/** Open temporary file for appending. */
 	virtual SGPFile* openTempFileForAppend(const ST::string& filename) const override;
 
 	/** Delete temporary file. */
 	virtual void deleteTempFile(const ST::string& filename) const override;
+
+	/** Create temporary directory. Does not fail if it exists already. */
+	virtual void createTempDir(const ST::string& dirname) const override;
+
+	/** List temporary directory. Pass empty string to list the temp dir itself. */
+	virtual std::vector<ST::string> findAllFilesInTempDir(const ST::string& dirname, bool sortResults, bool recursive, bool returnOnlyNames) const override;
+
+	/** Erase all files within temporary directory. */
+	virtual void eraseTempDir(const ST::string& dirname) const override;
 
 	/** Open user's private file (e.g. saved game, settings) for reading. */
 	virtual SGPFile* openUserPrivateFileForReading(const ST::string& filename) const override;
@@ -174,6 +189,9 @@ protected:
 	ST::string m_dataDir;
 	ST::string m_userHomeDir;
 	ST::string m_externalizedDataPath;
+
+	RustPointer<TempDir> m_tempDir;
+	ST::string m_tempDirPath;
 
 	GameVersion m_gameVersion;
 

--- a/src/externalized/DefaultContentManager_unittests.cc
+++ b/src/externalized/DefaultContentManager_unittests.cc
@@ -7,34 +7,24 @@
 
 #include "gtest/gtest.h"
 
-
-#define TMPDIR "temp"
-
-#define PS PATH_SEPARATOR_STR
-
 TEST(TempFiles, createFile)
 {
 	DefaultContentManager * cm = DefaultContentManagerUT::createDefaultCMForTesting();
-	Fs_removeDirAll(TMPDIR);
-	FileMan::createDir(TMPDIR);
 
 	{
 		AutoSGPFile file(cm->openTempFileForWriting("foo.txt", true));
 	}
 
-	std::vector<ST::string> results = FindFilesInDir(TMPDIR, "txt", false, false);
+	std::vector<ST::string> results = cm->findAllFilesInTempDir(ST::string(""), false, false, true);
 	ASSERT_EQ(results.size(), 1u);
-	EXPECT_STREQ(results[0].c_str(), TMPDIR PS "foo.txt");
+	EXPECT_STREQ(results[0].c_str(), "foo.txt");
 
-	Fs_removeDirAll(TMPDIR);
 	delete cm;
 }
 
 TEST(TempFiles, writeToFile)
 {
 	DefaultContentManager * cm = DefaultContentManagerUT::createDefaultCMForTesting();
-	Fs_removeDirAll(TMPDIR);
-	FileMan::createDir(TMPDIR);
 
 	{
 		AutoSGPFile file(cm->openTempFileForWriting("foo.txt", true));
@@ -53,17 +43,12 @@ TEST(TempFiles, writeToFile)
 		ASSERT_EQ(FileGetSize(file), 0u);
 	}
 
-	// // void FileRead(SGPFile* const f, void* const pDest, size_t const uiBytesToRead)
-
-	Fs_removeDirAll(TMPDIR);
 	delete cm;
 }
 
 TEST(TempFiles, writeAndRead)
 {
 	DefaultContentManager * cm = DefaultContentManagerUT::createDefaultCMForTesting();
-	Fs_removeDirAll(TMPDIR);
-	FileMan::createDir(TMPDIR);
 
 	{
 		AutoSGPFile file(cm->openTempFileForWriting("foo.txt", true));
@@ -78,15 +63,12 @@ TEST(TempFiles, writeAndRead)
 		ASSERT_STREQ(buf, "hello");
 	}
 
-	Fs_removeDirAll(TMPDIR);
 	delete cm;
 }
 
 TEST(TempFiles, append)
 {
 	DefaultContentManager * cm = DefaultContentManagerUT::createDefaultCMForTesting();
-	Fs_removeDirAll(TMPDIR);
-	FileMan::createDir(TMPDIR);
 
 	{
 		AutoSGPFile file(cm->openTempFileForWriting("foo.txt", true));
@@ -103,29 +85,25 @@ TEST(TempFiles, append)
 		ASSERT_EQ(FileGetSize(file), 10u);
 	}
 
-	Fs_removeDirAll(TMPDIR);
 	delete cm;
 }
 
 TEST(TempFiles, deleteFile)
 {
 	DefaultContentManager * cm = DefaultContentManagerUT::createDefaultCMForTesting();
-	Fs_removeDirAll(TMPDIR);
-	FileMan::createDir(TMPDIR);
 
 	{
 		AutoSGPFile file(cm->openTempFileForWriting("foo.txt", true));
 	}
 
-	std::vector<ST::string> results = FindFilesInDir(TMPDIR, "txt", false, false);
+	std::vector<ST::string> results = cm->findAllFilesInTempDir("", false, false, true);
 	ASSERT_EQ(results.size(), 1u);
 
 	cm->deleteTempFile("foo.txt");
 
-	results = FindFilesInDir(TMPDIR, "txt", false, false);
+	results = cm->findAllFilesInTempDir("", false, false, true);
 	ASSERT_EQ(results.size(), 0u);
 
-	Fs_removeDirAll(TMPDIR);
 	delete cm;
 }
 

--- a/src/game/Directories.h
+++ b/src/game/Directories.h
@@ -21,7 +21,8 @@
 #define SOUNDSDIR      "sounds"
 #define SPEECHDIR      "speech"
 #define STSOUNDSDIR    "stsounds"
-#define TEMPDIR        "temp"
 #define TILECACHEDIR   "tilecache"
+
+#define TACTICAL_SAVE_TEMPDIR  "tactical-save"
 
 #endif

--- a/src/game/Laptop/Files.cc
+++ b/src/game/Laptop/Files.cc
@@ -192,7 +192,7 @@ static void ClearFilesList(void);
 
 void GameInitFiles(void)
 {
-	FileDelete(FILES_DAT_FILE);
+	GCM->deleteTempFile(FILES_DATA_FILE);
 	ClearFilesList( );
 
 	// add background check by RIS
@@ -358,14 +358,13 @@ static void OpenAndReadFilesFile(void)
 {
 	ClearFilesList();
 
-	AutoSGPFile f;
-	try
-	{
-		f = GCM->openGameResForReading(FILES_DAT_FILE);
+	if (!GCM->doesTempFileExist(FILES_DATA_FILE)) {
+		return;
 	}
-	catch (...) { return; /* XXX TODO0019 ignore */ }
 
 	// file exists, read in data, continue until file end
+	AutoSGPFile f(GCM->openTempFileForReading(FILES_DATA_FILE));
+
 	for (UINT i = FileGetSize(f) / FILE_ENTRY_SIZE; i != 0; --i)
 	{
 		BYTE data[FILE_ENTRY_SIZE];
@@ -387,7 +386,7 @@ static void OpenAndReadFilesFile(void)
 
 static void OpenAndWriteFilesFile(void)
 {
-	AutoSGPFile f(FileMan::openForWriting(FILES_DAT_FILE));
+	AutoSGPFile f(GCM->openTempFileForWriting(FILES_DATA_FILE, true));
 
 	for (const FilesUnit* i = pFilesListHead; i; i = i->Next)
 	{

--- a/src/game/Laptop/Files.h
+++ b/src/game/Laptop/Files.h
@@ -1,7 +1,7 @@
 #ifndef __FILES_H
 #define __FILES_H
 
-#define FILES_DAT_FILE TEMPDIR "/files.dat"
+#define FILES_DATA_FILE "files.dat"
 
 void GameInitFiles(void);
 void EnterFiles(void);

--- a/src/game/Laptop/Finances.cc
+++ b/src/game/Laptop/Finances.cc
@@ -254,7 +254,7 @@ INT32 GetProjectedTotalDailyIncome( void )
 void GameInitFinances()
 {
 	// initialize finances on game start up
-	GCM->deleteTempFile(NEWTMP_FINANCES_DATA_FILE);
+	GCM->deleteTempFile(FINANCES_DATA_FILE);
 	GetBalanceFromDisk( );
 }
 
@@ -874,27 +874,20 @@ static void DisplayFinancePageNumberAndDateRange(void)
 static void WriteBalanceToDisk(void)
 {
 	// will write the current balance to disk
-	AutoSGPFile hFileHandle(GCM->openTempFileForWriting(NEWTMP_FINANCES_DATA_FILE, false));
+	AutoSGPFile hFileHandle(GCM->openTempFileForWriting(FINANCES_DATA_FILE, false));
 	FileWrite(hFileHandle, &LaptopSaveInfo.iCurrentBalance, sizeof(INT32));
 }
 
 
+// will grab the current blanace from disk
+// this procedure will open and read in data to the finance list	
 static void GetBalanceFromDisk(void)
 {
-	// will grab the current blanace from disk
-	// assuming file already openned
-	// this procedure will open and read in data to the finance list
-	AutoSGPFile f;
-	try
-	{
-		f = GCM->openTempFileForReading(NEWTMP_FINANCES_DATA_FILE);
-	}
-	catch (...)
-	{
+	if (!GCM->doesTempFileExist(FINANCES_DATA_FILE)) {
 		LaptopSaveInfo.iCurrentBalance = 0;
-		return; /* XXX TODO0019 ignore */
+		return;
 	}
-
+	AutoSGPFile f(GCM->openTempFileForReading(FINANCES_DATA_FILE));
 	// get balance from disk first
 	FileRead(f, &LaptopSaveInfo.iCurrentBalance, sizeof(INT32));
 }
@@ -903,7 +896,7 @@ static void GetBalanceFromDisk(void)
 // will write the current finance to disk
 static void AppendFinanceToEndOfFile(void)
 {
-	AutoSGPFile f(GCM->openTempFileForAppend(NEWTMP_FINANCES_DATA_FILE));
+	AutoSGPFile f(GCM->openTempFileForAppend(FINANCES_DATA_FILE));
 
 	const FinanceUnit* const fu = pFinanceListHead;
 	BYTE  data[FINANCE_RECORD_SIZE];
@@ -922,7 +915,7 @@ static void AppendFinanceToEndOfFile(void)
 // Grabs the size of the file and interprets number of pages it will take up
 static void SetLastPageInRecords(void)
 {
-	AutoSGPFile f(GCM->openTempFileForReading(NEWTMP_FINANCES_DATA_FILE));
+	AutoSGPFile f(GCM->openTempFileForReading(FINANCES_DATA_FILE));
 
 	const UINT32 size = FileGetSize(f);
 
@@ -961,7 +954,7 @@ static void LoadInRecords(UINT32 const page)
 	ClearFinanceList();
 	if (page == 0) return; // check if bad page
 
-	AutoSGPFile f(GCM->openTempFileForReading(NEWTMP_FINANCES_DATA_FILE));
+	AutoSGPFile f(GCM->openTempFileForReading(FINANCES_DATA_FILE));
 
 	UINT32 const size = FileGetSize(f);
 	if (size < FINANCE_HEADER_SIZE) return;
@@ -1039,7 +1032,7 @@ static INT32 GetPreviousDaysBalance(void)
 
 	if (date_in_days < 2) return 0;
 
-	AutoSGPFile f(GCM->openTempFileForReading(NEWTMP_FINANCES_DATA_FILE));
+	AutoSGPFile f(GCM->openTempFileForReading(FINANCES_DATA_FILE));
 
 	INT32 balance = 0;
 	// start at the end, move back until Date / 24 * 60 on the record equals date_in_days - 2
@@ -1080,7 +1073,7 @@ static INT32 GetTodaysBalance(void)
 	const UINT32 date_in_minutes = GetWorldTotalMin();
 	const UINT32 date_in_days    = date_in_minutes / (24 * 60);
 
-	AutoSGPFile f(GCM->openTempFileForReading(NEWTMP_FINANCES_DATA_FILE));
+	AutoSGPFile f(GCM->openTempFileForReading(FINANCES_DATA_FILE));
 
 	INT32 balance = 0;
 	// loop, make sure we don't pass beginning of file, if so, we have an error, and check for condifition above
@@ -1119,7 +1112,7 @@ static INT32 GetPreviousDaysIncome(void)
 	const UINT32 date_in_minutes = GetWorldTotalMin();
 	const UINT32 date_in_days    = date_in_minutes / (24 * 60);
 
-	AutoSGPFile f(GCM->openTempFileForReading(NEWTMP_FINANCES_DATA_FILE));
+	AutoSGPFile f(GCM->openTempFileForReading(FINANCES_DATA_FILE));
 
 	INT32 iTotalPreviousIncome = 0;
 	// start at the end, move back until Date / 24 * 60 on the record is = date_in_days - 2
@@ -1165,7 +1158,7 @@ static INT32 GetTodaysDaysIncome(void)
 	const UINT32 date_in_minutes = GetWorldTotalMin();
 	const UINT32 date_in_days    = date_in_minutes / (24 * 60);
 
-	AutoSGPFile f(GCM->openTempFileForReading(NEWTMP_FINANCES_DATA_FILE));
+	AutoSGPFile f(GCM->openTempFileForReading(FINANCES_DATA_FILE));
 
 	INT32 iTotalIncome = 0;
 	// loop, make sure we don't pass beginning of file, if so, we have an error, and check for condifition above
@@ -1226,7 +1219,7 @@ static INT32 GetTodaysOtherDeposits(void)
 	const UINT32 date_in_minutes = GetWorldTotalMin();
 	const UINT32 date_in_days    = date_in_minutes / (24 * 60);
 
-	AutoSGPFile f(GCM->openTempFileForReading(NEWTMP_FINANCES_DATA_FILE));
+	AutoSGPFile f(GCM->openTempFileForReading(FINANCES_DATA_FILE));
 
 	INT32 iTotalIncome = 0;
 	// loop, make sure we don't pass beginning of file, if so, we have an error, and check for condifition above
@@ -1274,7 +1267,7 @@ static INT32 GetYesterdaysOtherDeposits(void)
 	const UINT32 iDateInMinutes = GetWorldTotalMin();
 	const UINT32 date_in_days   = iDateInMinutes / (24 * 60);
 
-	AutoSGPFile f(GCM->openTempFileForReading(NEWTMP_FINANCES_DATA_FILE));
+	AutoSGPFile f(GCM->openTempFileForReading(FINANCES_DATA_FILE));
 
 	INT32 iTotalPreviousIncome = 0;
 	// start at the end, move back until Date / 24 * 60 on the record is =  date_in_days - 2

--- a/src/game/Laptop/Finances.h
+++ b/src/game/Laptop/Finances.h
@@ -9,7 +9,7 @@ void EnterFinances(void);
 void ExitFinances(void);
 void RenderFinances(void);
 
-#define NEWTMP_FINANCES_DATA_FILE "finances.dat"
+#define FINANCES_DATA_FILE "finances.dat"
 
 enum
 {

--- a/src/game/Laptop/History.cc
+++ b/src/game/Laptop/History.cc
@@ -125,7 +125,7 @@ void AddHistoryToPlayersLog(const UINT8 ubCode, const UINT8 ubSecondCode, const 
 
 void GameInitHistory()
 {
-	FileDelete(HISTORY_DATA_FILE);
+	GCM->deleteTempFile(HISTORY_DATA_FILE);
 }
 
 
@@ -348,7 +348,7 @@ static void OpenAndReadHistoryFile(void)
 {
 	ClearHistoryList();
 
-	AutoSGPFile f(GCM->openGameResForReading(HISTORY_DATA_FILE));
+	AutoSGPFile f(GCM->openTempFileForReading(HISTORY_DATA_FILE));
 
 	UINT entry_count = FileGetSize(f) / SIZE_OF_HISTORY_FILE_RECORD;
 	while (entry_count-- > 0)
@@ -684,7 +684,7 @@ try
 	// check if bad page
 	if (uiPage == 0) return FALSE;
 
-	AutoSGPFile f(GCM->openGameResForReading(HISTORY_DATA_FILE));
+	AutoSGPFile f(GCM->openTempFileForReading(HISTORY_DATA_FILE));
 
 	UINT       entry_count = FileGetSize(f) / SIZE_OF_HISTORY_FILE_RECORD;
 	UINT const skip        = (uiPage - 1) * NUM_RECORDS_PER_PAGE;
@@ -749,7 +749,7 @@ static void LoadPreviousHistoryPage(void)
 
 static void AppendHistoryToEndOfFile(void)
 {
-	AutoSGPFile f(FileMan::openForAppend(HISTORY_DATA_FILE));
+	AutoSGPFile f(GCM->openTempFileForAppend(HISTORY_DATA_FILE));
 
 	const HistoryUnit* const h = pHistoryListHead;
 
@@ -804,7 +804,7 @@ static ST::string GetQuestEndedString(const UINT8 ubQuestValue)
 
 static INT32 GetNumberOfHistoryPages(void)
 {
-	AutoSGPFile f(GCM->openGameResForReading(HISTORY_DATA_FILE));
+	AutoSGPFile f(GCM->openTempFileForReading(HISTORY_DATA_FILE));
 
 	const UINT32 uiFileSize = FileGetSize(f);
 

--- a/src/game/Laptop/History.h
+++ b/src/game/Laptop/History.h
@@ -7,7 +7,7 @@ void ExitHistory(void);
 void RenderHistory(void);
 
 
-#define HISTORY_DATA_FILE TEMPDIR "/history.dat"
+#define HISTORY_DATA_FILE "history.dat"
 
 
 enum{

--- a/src/game/Laptop/Laptop.cc
+++ b/src/game/Laptop/Laptop.cc
@@ -36,10 +36,12 @@
 #include "BobbyRUsed.h"
 #include "BobbyRMailOrder.h"
 #include "CharProfile.h"
+#include "ContentManager.h"
 #include "Florist.h"
 #include "Florist_Cards.h"
 #include "Florist_Gallery.h"
 #include "Florist_Order_Form.h"
+#include "GameInstance.h"
 #include "Insurance.h"
 #include "Insurance_Contract.h"
 #include "Insurance_Info.h"
@@ -3263,10 +3265,9 @@ static void HandleWebBookMarkNotifyTimer(void)
 void ClearOutTempLaptopFiles(void)
 {
 	// clear out all temp files from laptop
-	FileDelete("files.dat");
-	FileDelete("finances.dat");
-	FileDelete("email.dat");
-	FileDelete("history.dat");
+	GCM->deleteTempFile(FILES_DATA_FILE);
+	GCM->deleteTempFile(FINANCES_DATA_FILE);
+	GCM->deleteTempFile(HISTORY_DATA_FILE);
 }
 
 

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -150,9 +150,6 @@ ScreenID guiScreenToGotoAfterLoadingSavedGame = ERROR_SCREEN; // XXX TODO001A wa
 
 extern		UINT32		guiCurrentUniqueSoldierId;
 
-static void SaveTempFileToSavedGame(const char* fileName, HWFILE const hFile);
-static void LoadTempFileFromSavedGame(const char* tempFileName, HWFILE const hFile);
-
 static void ExtractGameOptions(DataReader& d, GAME_OPTIONS& g)
 {
 	size_t start = d.getConsumed();
@@ -350,11 +347,11 @@ BOOLEAN SaveGame(UINT8 ubSaveGameID, const ST::string& gameDesc)
 
 		SaveSoldierStructure(f);
 
-		SaveTempFileToSavedGame(NEWTMP_FINANCES_DATA_FILE, f);
+		SaveFilesToSavedGame(FINANCES_DATA_FILE, f);
 
 		SaveFilesToSavedGame(HISTORY_DATA_FILE, f);
 
-		SaveFilesToSavedGame(FILES_DAT_FILE, f);
+		SaveFilesToSavedGame(FILES_DATA_FILE, f);
 
 		SaveEmailToSavedGame(f);
 
@@ -723,13 +720,13 @@ void LoadSavedGame(UINT8 const save_slot_id)
 	LoadSoldierStructure(f, version, stracLinuxFormat);
 
 	BAR(1, "Finances Data File...");
-	LoadTempFileFromSavedGame(NEWTMP_FINANCES_DATA_FILE, f);
+	LoadFilesFromSavedGame(FINANCES_DATA_FILE, f);
 
 	BAR(1, "History File...");
 	LoadFilesFromSavedGame(HISTORY_DATA_FILE, f);
 
 	BAR(1, "The Laptop FILES file...");
-	LoadFilesFromSavedGame(FILES_DAT_FILE, f);
+	LoadFilesFromSavedGame(FILES_DATA_FILE, f);
 
 	BAR(1, "Email...");
 	LoadEmailFromSavedGame(f);
@@ -1438,15 +1435,9 @@ static void SaveFileToSavedGame(SGPFile* fileToSave, HWFILE const hFile)
 	FileWrite(hFile, pData, uiFileSize);
 }
 
-static void SaveTempFileToSavedGame(const char* fileName, HWFILE const hFile)
-{
-	AutoSGPFile fileToSave(GCM->openTempFileForReading(fileName));
-	SaveFileToSavedGame(fileToSave, hFile);
-}
-
 void SaveFilesToSavedGame(char const* const pSrcFileName, HWFILE const hFile)
 {
-	AutoSGPFile hSrcFile(GCM->openGameResForReading(pSrcFileName));
+	AutoSGPFile hSrcFile(GCM->openTempFileForReading(pSrcFileName));
 	SaveFileToSavedGame(hSrcFile, hFile);
 }
 
@@ -1467,15 +1458,9 @@ static void LoadFileFromSavedGame(SGPFile* fileToWrite, HWFILE const hFile)
 	FileWrite(fileToWrite, pData, uiFileSize);
 }
 
-void LoadTempFileFromSavedGame(const char* tempFileName, HWFILE const hFile)
-{
-	AutoSGPFile fileToWrite(GCM->openTempFileForWriting(tempFileName, true));
-	LoadFileFromSavedGame(fileToWrite, hFile);
-}
-
 void LoadFilesFromSavedGame(char const* const pSrcFileName, HWFILE const hFile)
 {
-	AutoSGPFile hSrcFile(FileMan::openForWriting(pSrcFileName));
+	AutoSGPFile hSrcFile(GCM->openTempFileForWriting(pSrcFileName, true));
 	LoadFileFromSavedGame(hSrcFile, hFile);
 }
 

--- a/src/game/Tactical/Keys.cc
+++ b/src/game/Tactical/Keys.cc
@@ -784,7 +784,7 @@ void UpdateDoorPerceivedValue( DOOR *pDoor )
 
 void SaveDoorTableToDoorTableTempFile(INT16 const x, INT16 const y, INT8 const z)
 {
-	AutoSGPFile f(FileMan::openForWriting(GetMapTempFileName(SF_DOOR_TABLE_TEMP_FILES_EXISTS, x, y, z)));
+	AutoSGPFile f(GCM->openTempFileForWriting(GetMapTempFileName(SF_DOOR_TABLE_TEMP_FILES_EXISTS, x, y, z), true));
 	Assert(DoorTable.size() <= UINT8_MAX);
 	UINT8 numDoors = static_cast<UINT8>(DoorTable.size());
 	FileWriteArray(f, numDoors, DoorTable.data());
@@ -798,12 +798,12 @@ void LoadDoorTableFromDoorTableTempFile()
 	ST::string const zMapName = GetMapTempFileName( SF_DOOR_TABLE_TEMP_FILES_EXISTS, gWorldSectorX, gWorldSectorY, gbWorldSectorZ );
 
 	//If the file doesnt exists, its no problem.
-	if (!GCM->doesGameResExists(zMapName)) return;
+	if (!GCM->doesTempFileExist(zMapName)) return;
 
 	//Get rid of the existing door table
 	TrashDoorTable();
 
-	AutoSGPFile hFile(GCM->openGameResForReading(zMapName));
+	AutoSGPFile hFile(GCM->openTempFileForReading(zMapName));
 
 	//Read in the number of doors
 	UINT8 numDoors = 0;
@@ -1151,7 +1151,7 @@ void SaveDoorStatusArrayToDoorStatusTempFile(INT16 const x, INT16 const y, INT8 
 	// Turn off any door busy flags
 	FOR_EACH_DOOR_STATUS(d) d.ubFlags &= ~DOOR_BUSY;
 
-	AutoSGPFile f(FileMan::openForWriting(GetMapTempFileName(SF_DOOR_STATUS_TEMP_FILE_EXISTS, x, y, z)));
+	AutoSGPFile f(GCM->openTempFileForWriting(GetMapTempFileName(SF_DOOR_STATUS_TEMP_FILE_EXISTS, x, y, z), true));
 	Assert(gpDoorStatus.size() <= UINT8_MAX);
 	UINT8 numDoorStatus = static_cast<UINT8>(gpDoorStatus.size());
 	FileWriteArray(f, numDoorStatus, gpDoorStatus.data());
@@ -1165,7 +1165,7 @@ void LoadDoorStatusArrayFromDoorStatusTempFile()
 {
 	TrashDoorStatusArray();
 
-	AutoSGPFile f(GCM->openGameResForReading(GetMapTempFileName(SF_DOOR_STATUS_TEMP_FILE_EXISTS, gWorldSectorX, gWorldSectorY, gbWorldSectorZ)));
+	AutoSGPFile f(GCM->openTempFileForReading(GetMapTempFileName(SF_DOOR_STATUS_TEMP_FILE_EXISTS, gWorldSectorX, gWorldSectorY, gbWorldSectorZ)));
 
 	// Load the number of elements in the door status array
 	UINT8 numDoorStatus = 0;

--- a/src/game/TileEngine/LightEffects.cc
+++ b/src/game/TileEngine/LightEffects.cc
@@ -203,7 +203,7 @@ void SaveLightEffectsToMapTempFile(INT16 const sMapX, INT16 const sMapY, INT8 co
 	ST::string const zMapName = GetMapTempFileName( SF_LIGHTING_EFFECTS_TEMP_FILE_EXISTS, sMapX, sMapY, bMapZ );
 
 	//delete file the file.
-	FileDelete( zMapName );
+	GCM->deleteTempFile( zMapName );
 
 	//loop through and count the number of Light effects
 	CFOR_EACH_LIGHTEFFECT(l)
@@ -219,7 +219,7 @@ void SaveLightEffectsToMapTempFile(INT16 const sMapX, INT16 const sMapY, INT8 co
 		return;
 	}
 
-	AutoSGPFile hFile(FileMan::openForWriting(zMapName));
+	AutoSGPFile hFile(GCM->openTempFileForWriting(zMapName, true));
 
 	//Save the Number of Light Effects
 	FileWrite(hFile, &uiNumLightEffects, sizeof(UINT32));
@@ -240,7 +240,7 @@ void LoadLightEffectsFromMapTempFile(INT16 const sMapX, INT16 const sMapY, INT8 
 
 	ST::string const zMapName = GetMapTempFileName( SF_LIGHTING_EFFECTS_TEMP_FILE_EXISTS, sMapX, sMapY, bMapZ );
 
-	AutoSGPFile hFile(GCM->openGameResForReading(zMapName));
+	AutoSGPFile hFile(GCM->openTempFileForReading(zMapName));
 
 	//Clear out the old list
 	ResetLightEffects();

--- a/src/game/TileEngine/SmokeEffects.cc
+++ b/src/game/TileEngine/SmokeEffects.cc
@@ -493,7 +493,7 @@ void SaveSmokeEffectsToMapTempFile(INT16 const sMapX, INT16 const sMapY, INT8 co
 	ST::string const zMapName = GetMapTempFileName( SF_SMOKE_EFFECTS_TEMP_FILE_EXISTS, sMapX, sMapY, bMapZ );
 
 	//delete file the file.
-	FileDelete( zMapName );
+	GCM->deleteTempFile( zMapName );
 
 	//loop through and count the number of smoke effects
 	CFOR_EACH_SMOKE_EFFECT(s) ++uiNumSmokeEffects;
@@ -506,7 +506,7 @@ void SaveSmokeEffectsToMapTempFile(INT16 const sMapX, INT16 const sMapY, INT8 co
 		return;
 	}
 
-	AutoSGPFile hFile(FileMan::openForWriting(zMapName));
+	AutoSGPFile hFile(GCM->openTempFileForWriting(zMapName, true));
 
 	//Save the Number of Smoke Effects
 	FileWrite(hFile, &uiNumSmokeEffects, sizeof(UINT32));
@@ -526,7 +526,7 @@ void LoadSmokeEffectsFromMapTempFile(INT16 const sMapX, INT16 const sMapY, INT8 
 
 	ST::string const zMapName = GetMapTempFileName( SF_SMOKE_EFFECTS_TEMP_FILE_EXISTS, sMapX, sMapY, bMapZ );
 
-	AutoSGPFile hFile(GCM->openGameResForReading(zMapName));
+	AutoSGPFile hFile(GCM->openTempFileForReading(zMapName));
 
 	//Clear out the old list
 	ResetSmokeEffects();

--- a/src/game/TileEngine/WorldDef.h
+++ b/src/game/TileEngine/WorldDef.h
@@ -271,9 +271,11 @@ void TrashWorld(void);
 void NewWorld(void);
 
 BOOLEAN SaveWorldAbsolute(const ST::string &absolutePath);
+BOOLEAN SaveWorldToSGPFile(SGPFile* f);
 
 void LoadWorldAbsolute(const ST::string &absolutePath);
 void LoadWorld(const ST::string &name);
+void LoadWorldFromSGPFile(SGPFile* f);
 void CompileWorldMovementCosts(void);
 void RecompileLocalMovementCosts( INT16 sCentreGridNo );
 void RecompileLocalMovementCostsFromRadius( INT16 sCentreGridNo, INT8 bRadius );

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -161,6 +161,10 @@ static void shutdownGame()
 		SLOGD("Shutting Down Game Manager");
 		ShutdownGame();
 	}
+
+	delete GCM;
+	GCM = NULL;
+
 	SLOGD("Shutting Down Button System");
 	ShutdownButtonSystem();
 	MSYS_Shutdown();
@@ -434,6 +438,7 @@ int main(int argc, char* argv[])
 
 		if (EngineOptions_shouldRunUnittests(params.get())) {
 	#ifdef WITH_UNITTESTS
+			Logger_setLevel(LogLevel::Error);
 			testing::InitGoogleTest(&argc, argv);
 			return RUN_ALL_TESTS();
 	#else
@@ -549,7 +554,6 @@ int main(int argc, char* argv[])
 
 		delete cm;
 		GCM = NULL;
-
 	} catch (...) {
         TerminationHandler();
         return EXIT_FAILURE;


### PR DESCRIPTION
Split out of #1275. Closes #1255. Closes #135.

This changes temp file interaction logic to use a "proper" temporary directory in the OS-specified location of the temporary files. The temporary directory is unique per process, so multiple instances of the game can run in parallel. An example on linux would be `/tmp/ja2-stracciatella-hufmWU3N`. Some special handling needed to be introduced for Android where there is no temp dir, only an app specific cache dir, which is then used as temp dir.

All interactions with this temporary directory are now done through `ContentManager`. When the content manager deallocates, the temp directory is automatically removed. Some adaptions were necessary here to ensure that the `ContentManager` is always properly deallocated when exiting the game.

The whole mechanism is using the rust `tempfile` crate which was until now only used by tests.

Temp File Operations are done by:
- Saving/Loading laptop information: History, Finances and Files
- Saving/Loading some information about maps, such as Door States, Rotting Corpses, Civilian States, Map Modifications
- Changing Tileset in Editor

Switching the working directory to the old temp dir still happens on startup, because private files are still acessed using relative paths. This would be the next step that needs to be split out of #1275. After that some final cleanup should be done and the original purpose of #1275, the LRU cache, can be implemented safely.