### PR TITLE
Show chance-to-hit next to mouse cursor

### DIFF
--- a/assets/externalized/game.json
+++ b/assets/externalized/game.json
@@ -117,6 +117,10 @@
 	//  Always show mouse cursor during tactical view (if false, no mourse cursor is shown when moving in real-time mode, selecting a merc, etc)
 	//  vanilla setting: false
 	"always_show_cursor_in_tactical": false,
+	
+	//  Show chance-to-hit next to mouse cursor when preparing an attack
+	//  vanilla setting: false
+	"show_hit_chance": false,
 
     //  IMP creation tweaks
     "imp": {

--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -48,6 +48,7 @@ DefaultGamePolicy::DefaultGamePolicy(rapidjson::Document *json)
 	chance_to_hit_minimum = gp.getOptionalInt("chance_to_hit_minimum", 1);
 
 	always_show_cursor_in_tactical = gp.getOptionalBool("always_show_cursor_in_tactical", false);
+	show_hit_chance = gp.getOptionalBool("show_hit_chance", false);
 
 	JsonObjectReader imp = JsonObjectReader(gp.GetValue("imp"));
 	imp_load_saved_merc_by_nickname = imp.getOptionalBool("load_saved_merc_by_nickname");

--- a/src/externalized/policy/GamePolicy.h
+++ b/src/externalized/policy/GamePolicy.h
@@ -71,6 +71,7 @@ public:
 	int8_t chance_to_hit_maximum;         //Maximum chance to hit (chance_to_hit_minimum - 100) vanilla 99
 
 	bool always_show_cursor_in_tactical;  // Always show mouse cursor during tactical view (if false, no mourse cursor is shown when moving in real-time mode, selecting a merc, etc)
+	bool show_hit_chance;                 // Show chance-to-hit when pressing 'F' and next to mouse cursor when preparing an attack
 
 	/* IMP */
 	int8_t imp_attribute_max;             // IMP character attribute maximum 0 to 100, vanilla 85

--- a/src/game/Tactical/DisplayCover.cc
+++ b/src/game/Tactical/DisplayCover.cc
@@ -24,6 +24,7 @@
 #include "ContentManager.h"
 #include "GameInstance.h"
 #include "WeaponModels.h"
+#include "policy/GamePolicy.h"
 
 #include <algorithm>
 
@@ -415,14 +416,6 @@ void DisplayRangeToTarget(SOLDIERTYPE* s, INT16 const sTargetGridNo)
 		ScreenMsg(FONT_MCOLOR_LTYELLOW, MSG_INTERFACE,
 				st_format_printf(zNewTacticalMessages[TCTL_MSG__RANGE_TO_TARGET_AND_GUN_RANGE],
 				GCM->getWeapon(s->inv[HANDPOS].usItem)->usRange / 10, usRange));
-		// Get the chance to hit
-		UINT32 const uiHitChance = CalcChanceToHitGun(s, sTargetGridNo, s->bAimTime, s->bAimShotLocation, false );
-		// Get the cover modifier chance from a soldier to a grid location
-		UINT8 ubChanceToGetThrough = SoldierToLocationChanceToGetThrough(s, sTargetGridNo, s->bTargetLevel, s->bTargetCubeLevel, 0);
-		//display a string with the weapons range, then range to target
-		ScreenMsg(FONT_MCOLOR_LTYELLOW, MSG_INTERFACE,
-				st_format_printf(zNewTacticalMessages[TCTL_MSG__CHANCE_TO_HIT_TARGET],
-				uiHitChance, uiHitChance*ubChanceToGetThrough/100.0f));
 	}
 	else
 	{

--- a/src/game/Tactical/Handle_UI.cc
+++ b/src/game/Tactical/Handle_UI.cc
@@ -390,6 +390,7 @@ ScreenID HandleTacticalUI(void)
 	SetHitLocationText(ST::null);
 	SetIntTileLocationText(ST::null);
 	SetIntTileLocation2Text(ST::null);
+	SetChanceToHitText(ST::null);
 	//gfUIForceReExamineCursorData = FALSE;
 	gfUINewStateForIntTile = FALSE;
 	gfUIShowExitExitGrid = FALSE;

--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -3296,7 +3296,7 @@ void ShotMiss(const BULLET* const b)
 }
 
 
-static UINT32 CalcChanceHTH(SOLDIERTYPE* pAttacker, SOLDIERTYPE* pDefender, UINT8 ubAimTime, UINT8 ubMode)
+static UINT32 CalcChanceHTH(SOLDIERTYPE* pAttacker, SOLDIERTYPE* pDefender, UINT8 ubAimTime, UINT8 ubMode, bool skipSafetyCheck = false)
 {
 	UINT16 usInHand;
 	UINT8  ubBandaged;
@@ -3311,19 +3311,22 @@ static UINT32 CalcChanceHTH(SOLDIERTYPE* pAttacker, SOLDIERTYPE* pDefender, UINT
 		return( 100 );
 	}
 
-	if (ubMode == HTH_MODE_STAB)
+	if (!skipSafetyCheck) // Added this check so we can get punch calculation without "punch item" equipped
 	{
-		// safety check
-		if (GCM->getWeapon(usInHand)->ubWeaponClass != KNIFECLASS)
+		if (ubMode == HTH_MODE_STAB)
 		{
-			return(0);
+			// safety check
+			if (GCM->getWeapon(usInHand)->ubWeaponClass != KNIFECLASS)
+			{
+				return(0);
+			}
 		}
-	}
-	else
-	{
-		if ( GCM->getItem(usInHand)->getItemClass() != IC_PUNCH )
+		else
 		{
-			return(0);
+			if ( GCM->getItem(usInHand)->getItemClass() != IC_PUNCH )
+			{
+				return(0);
+			}
 		}
 	}
 
@@ -3579,9 +3582,9 @@ UINT32 CalcChanceToStab(SOLDIERTYPE * pAttacker,SOLDIERTYPE *pDefender, UINT8 ub
 	return( CalcChanceHTH( pAttacker, pDefender, ubAimTime, HTH_MODE_STAB ) );
 }
 
-UINT32 CalcChanceToPunch(SOLDIERTYPE *pAttacker, SOLDIERTYPE * pDefender, UINT8 ubAimTime)
+UINT32 CalcChanceToPunch(SOLDIERTYPE *pAttacker, SOLDIERTYPE * pDefender, UINT8 ubAimTime, bool skipSafetyCheck)
 {
-	return( CalcChanceHTH( pAttacker, pDefender, ubAimTime, HTH_MODE_PUNCH ) );
+	return( CalcChanceHTH( pAttacker, pDefender, ubAimTime, HTH_MODE_PUNCH, skipSafetyCheck) );
 }
 
 

--- a/src/game/Tactical/Weapons.h
+++ b/src/game/Tactical/Weapons.h
@@ -175,7 +175,7 @@ BOOLEAN InRange(const SOLDIERTYPE* pSoldier, INT16 sGridNo);
 void ShotMiss(const BULLET* b);
 extern UINT32 CalcChanceToHitGun(SOLDIERTYPE *pSoldier, UINT16 sGridNo, UINT8 ubAimTime, UINT8 ubAimPos, BOOLEAN fModify);
 extern UINT32 AICalcChanceToHitGun(SOLDIERTYPE *pSoldier, UINT16 sGridNo, UINT8 ubAimTime, UINT8 ubAimPos );
-extern UINT32 CalcChanceToPunch(SOLDIERTYPE *pAttacker, SOLDIERTYPE * pDefender, UINT8 ubAimTime);
+extern UINT32 CalcChanceToPunch(SOLDIERTYPE *pAttacker, SOLDIERTYPE * pDefender, UINT8 ubAimTime, bool skipSafetyCheck = false);
 extern UINT32 CalcChanceToStab(SOLDIERTYPE * pAttacker,SOLDIERTYPE *pDefender, UINT8 ubAimTime);
 void ReloadWeapon(SOLDIERTYPE*, UINT8 inv_pos);
 bool IsGunBurstCapable(SOLDIERTYPE const*, UINT8 inv_pos);

--- a/src/game/Utils/Cursors.cc
+++ b/src/game/Utils/Cursors.cc
@@ -1237,6 +1237,7 @@ static void BltJA2CursorData(void)
 static ST::string gzLocation;
 static ST::string gzIntTileLocation;
 static ST::string gzIntTileLocation2;
+static ST::string gzHitChance;
 
 
 void SetHitLocationText(const ST::string& str)
@@ -1268,6 +1269,10 @@ const ST::string& GetIntTileLocation2Text(void)
 	return gzIntTileLocation2;
 }
 
+void SetChanceToHitText(const ST::string& str)
+{
+	gzHitChance = str;
+}
 
 static void DrawMouseText(void)
 {
@@ -1277,6 +1282,8 @@ static void DrawMouseText(void)
 	INT16 sX;
 	INT16 sY;
 
+	gsMouseSizeYModifier = 0;
+
 	if (!gzLocation.empty())
 	{
 		// Set dest for gprintf to be different
@@ -1284,7 +1291,7 @@ static void DrawMouseText(void)
 
 		FindFontCenterCoordinates(0, 0, gsCurMouseWidth, gsCurMouseHeight, gzLocation, TINYFONT1, &sX, &sY);
 		SetFontAttributes(TINYFONT1, FONT_MCOLOR_WHITE);
-		MPrint(sX, sY + 12, gzLocation);
+		MPrint(sX, sY + 12, gzLocation); // Below cursor
 		// reset
 		SetFontDestBuffer(FRAME_BUFFER);
 	}
@@ -1309,6 +1316,24 @@ static void DrawMouseText(void)
 		FindFontCenterCoordinates(0, 0, gsCurMouseWidth, gsCurMouseHeight, gzIntTileLocation2, TINYFONT1, &sX, &sY);
 		SetFontAttributes(TINYFONT1, FONT_MCOLOR_WHITE);
 		MPrint(sX, sY - 2, gzIntTileLocation2);
+		// reset
+		SetFontDestBuffer(FRAME_BUFFER);
+	}
+
+	if (!gzHitChance.empty())
+	{
+		// Set dest for gprintf to be different
+		SetFontDestBuffer(MOUSE_BUFFER);
+		FindFontCenterCoordinates(0, 0, gsCurMouseWidth, gsCurMouseHeight, gzHitChance, TINYFONT1, &sX, &sY);
+		SetFontAttributes(TINYFONT1, FONT_MCOLOR_WHITE);
+		if(gzLocation.empty())
+			MPrint(sX, sY + 12, gzHitChance); // Below cursor
+		else
+		{
+			MPrint(sX, sY + 20, gzHitChance); // Below hit location text
+			gsMouseSizeYModifier = 8 + GetFontHeight(TINYFONT1);
+		}
+
 		// reset
 		SetFontDestBuffer(FRAME_BUFFER);
 	}

--- a/src/game/Utils/Cursors.h
+++ b/src/game/Utils/Cursors.h
@@ -250,6 +250,7 @@ void RemoveCursorFlags(UINT32 uiCursor, UINT8 ubFlags);
 void SetHitLocationText(const ST::string& str);
 void SetIntTileLocationText(const ST::string& str);
 void SetIntTileLocation2Text(const ST::string& str);
+void SetChanceToHitText(const ST::string& str);
 
 const ST::string& GetIntTileLocationText(void);
 const ST::string& GetIntTileLocation2Text(void);

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -47,6 +47,7 @@ static UINT16 gusMouseCursorWidth;
 static UINT16 gusMouseCursorHeight;
 static INT16  gsMouseCursorXOffset;
 static INT16  gsMouseCursorYOffset;
+INT16 gsMouseSizeYModifier = 0; // This can increase the size of gusMouseCursorHeight so image data (ie, text) outside the normal height of the mouse cursor can be copied onto screen buffer
 
 static SDL_Rect MouseBackground = { 0, 0, 0, 0 };
 
@@ -598,7 +599,7 @@ void RefreshScreen(void)
 	src.x = 0;
 	src.y = 0;
 	src.w = gusMouseCursorWidth;
-	src.h = gusMouseCursorHeight;
+	src.h = gusMouseCursorHeight + gsMouseSizeYModifier;
 	SDL_Rect dst;
 	dst.x = MousePos.iX - gsMouseCursorXOffset;
 	dst.y = MousePos.iY - gsMouseCursorYOffset;

--- a/src/sgp/Video.h
+++ b/src/sgp/Video.h
@@ -10,6 +10,7 @@
 #define VIDEO_NO_CURSOR 0xFFFF
 #define GAME_WINDOW g_game_window
 
+extern INT16 gsMouseSizeYModifier;
 extern SDL_Window* g_game_window;
 
 using VideoScaleQuality = ScalingQuality;


### PR DESCRIPTION
Here's my work-in-progress implementation for showing chance-to-hit when aiming (this resolves https://github.com/ja2-stracciatella/ja2-stracciatella/issues/1368).

Some notes:

- I'm using `st_format_printf("%d%%", uiHitChance)` to generate the string with the hit chance. I haven't looked into how st_format_printf works, but I noticed other code did something similar, so I figure and hope this is the way to go.
- gusMouseCursorHeight contains the size of the mouse image data. This isn't big enough to contain body location string and hit chance string. I ended up using a rather hacky solution (whenever the hit chance string is used, then a value gsMouseSizeYModifier is increased so that the mouse rendering routine include the hit chance string). Another solution I'm considering is when SetMouseCursorProperties() is called SetCurrentCursorFromDatabase() is to set gusMouseCursorHeight  to a bigger value if the mouse cursor is a targeting cursor. I think that solution would be cleaner.
- I made it so 'F' only shows hit chance if the new config var is true. I saw someone request that, and then it's also closer to original game behaviour (which never shows the hit chance).
- There's some code I need to remove related to the position of the hit chance string. Once we're completely sure where we want it positioned, then I'll remove the extra code.