### PR TITLE
Fix #1379: Read and reset sector flags when removing temp files

### DIFF
--- a/src/externalized/scripting/STStringHandler.h
+++ b/src/externalized/scripting/STStringHandler.h
@@ -1,5 +1,6 @@
 #pragma once
 #define SOL_ALL_SAFETIES_ON 1
+#include <limits>
 #include <sol/sol.hpp>
 #include <string_theory/string>
 #include <string>

--- a/src/externalized/scripting/ScriptingExtensionsLua.cc
+++ b/src/externalized/scripting/ScriptingExtensionsLua.cc
@@ -3,6 +3,7 @@
 #define SOL_CHECK_ARGUMENTS 1
 #define SOL_PRINT_ERRORS 1
 #define SOL_ALL_SAFETIES_ON 1
+#include <limits>
 #include <sol/sol.hpp>  // this needs to be included first
 #include "STStringHandler.h"
 

--- a/src/game/Tactical/Enemy_Soldier_Save.cc
+++ b/src/game/Tactical/Enemy_Soldier_Save.cc
@@ -28,6 +28,15 @@
 BOOLEAN gfRestoringEnemySoldiersFromTempFile = FALSE;
 BOOLEAN gfRestoringCiviliansFromTempFile = FALSE;
 
+static void RemoveTempFile(SectorFlags const file_flag, INT16 const x, INT16 const y, INT8 const z)
+{
+	if (!GetSectorFlagStatus(x, y, z, file_flag)) return;
+
+	// Delete any temp file that is here and toast the flag that says one exists.
+	ReSetSectorFlag(x, y, z, file_flag);
+	GCM->deleteTempFile(GetMapTempFileName(file_flag, x, y, z));
+}
+
 // OLD SAVE METHOD:  This is the old way of loading the enemies and civilians
 void LoadEnemySoldiersFromTempFile()
 {
@@ -80,7 +89,7 @@ void LoadEnemySoldiersFromTempFile()
 	{
 		// The file has aged.  Use the regular method for adding soldiers.
 		f.Deallocate(); // Close the file before deleting it
-		GCM->deleteTempFile(mapFileName);
+		RemoveTempFile(SF_ENEMY_PRESERVED_TEMP_FILE_EXISTS, x, y, z);
 		gfRestoringEnemySoldiersFromTempFile = FALSE;
 		return;
 	}
@@ -294,7 +303,7 @@ void NewWayOfLoadingEnemySoldiersFromTempFile()
 			ubStrategicAdmins != ubNumAdmins ||
 			ubStrategicCreatures != ubNumCreatures)
 		{
-			GCM->deleteTempFile(mapFileName);
+			RemoveTempFile(SF_ENEMY_PRESERVED_TEMP_FILE_EXISTS, x, y, z);
 			return;
 		}
 	}
@@ -347,7 +356,7 @@ void NewWayOfLoadingEnemySoldiersFromTempFile()
 	{
 		// The file has aged.  Use the regular method for adding soldiers.
 		f.Deallocate(); // Close the file before deleting it
-		GCM->deleteTempFile(mapFileName);
+		RemoveTempFile(SF_ENEMY_PRESERVED_TEMP_FILE_EXISTS, x, y, z);
 		gfRestoringEnemySoldiersFromTempFile = FALSE;
 		return;
 	}
@@ -764,7 +773,7 @@ void NewWayOfSavingEnemyAndCivliansToTempFile(INT16 const sSectorX, INT16 const 
 	if (slots == 0)
 	{
 		// No need to save anything, so return successfully
-		GCM->deleteTempFile(mapFileName);
+		RemoveTempFile(file_flag, sSectorX, sSectorY, bSectorZ);
 		return;
 	}
 

--- a/src/game/Utils/Observable.h
+++ b/src/game/Utils/Observable.h
@@ -66,8 +66,9 @@ public:
 	 */
 	void notify(ARG1 arg1 = ARG1(), ARGS... args) const
 	{
-	    if (listeners.empty())
-	        SLOGD("Observable has no listeners");
+		if (listeners.empty()) {
+			SLOGD("Observable has no listeners");
+		}
 
 		for (auto l : listeners)
 		{


### PR DESCRIPTION
Fixes #1379.

Reinstitutes `RemoveTempFile`, which reads/sets sector flags when removing a map temp file.

Also fixes compilation with GCC 11. Due to header changes within the GCC standard library, some headers are less likely to be included by default. This caused an issue with sol which was missing the `<limits>` include. See "Header dependency changes" section in https://gcc.gnu.org/gcc-11/porting_to.html.

Also fixes a warning in `Observable.h`, which warned about an if that does (and should) not guard:

```
In file included from /home/stefan/workspace/ja2-stracciatella/src/game/Strategic/SAM_Sites.h:3,
                 from /home/stefan/workspace/ja2-stracciatella/src/game/Strategic/StrategicMap.h:6,
                 from /home/stefan/workspace/ja2-stracciatella/src/game/Strategic/Quests.h:6,
                 from /home/stefan/workspace/ja2-stracciatella/src/game/Strategic/Campaign_Init.cc:12:
/home/stefan/workspace/ja2-stracciatella/src/game/Utils/Observable.h: In member function ‘void Observable<ARG1, ARGS>::notify(ARG1, ARGS ...) const’:
/home/stefan/workspace/ja2-stracciatella/src/game/Utils/Observable.h:69:13: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
   69 |             if (listeners.empty())
      |             ^~
/home/stefan/workspace/ja2-stracciatella/src/game/Utils/Observable.h:72:17: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
   72 |                 for (auto l : listeners)

```