### PR TITLE
Do not adjust screen brightness unless requested

### DIFF
--- a/assets/distr-files-linux/ja2_manpage
+++ b/assets/distr-files-linux/ja2_manpage
@@ -21,7 +21,7 @@ Path to the original JA2 game
 Screen resolution, e.g. 800x600. Default value is 640x480
 .TP
 \fB\-brightness GAMMA\fR
-Screen brightness (gamma multiplier) value to set where 0.0 is completely dark and 1.0 is normal brightness. Default value is 1.0
+Screen brightness (gamma multiplier) value to set where 0.0 is completely dark and 1.0 is normal brightness. Set to a negative value to disable brightness adjustment. Default value is -1
 .br
 NOTE: some video drivers do not support setting the gamma value and this option may not have any effect in those cases
 .TP

--- a/rust/stracciatella/src/config/cli.rs
+++ b/rust/stracciatella/src/config/cli.rs
@@ -57,7 +57,7 @@ impl Cli {
         opts.optopt(
             "",
             "brightness",
-            "Screen brightness (gamma multiplier) value to set where 0.0 is completely dark and 1.0 is normal brightness. Default value is 1.0",
+            "Screen brightness (gamma multiplier) value to set where 0.0 is completely dark and 1.0 is normal brightness. Set to a negative value to disable brightness adjustment. Default value is -1",
             "GAMMA_VALUE"
         );
         opts.optopt(

--- a/rust/stracciatella/src/config/engine_options.rs
+++ b/rust/stracciatella/src/config/engine_options.rs
@@ -47,7 +47,7 @@ impl Default for EngineOptions {
             assets_dir: PathBuf::from(""),
             mods: vec![],
             resolution: Resolution::default(),
-            brightness: 1.0,
+            brightness: -1.0,
             resource_version: VanillaVersion::ENGLISH,
             show_help: false,
             run_unittests: false,

--- a/rust/stracciatella_c_api/src/c/config.rs
+++ b/rust/stracciatella_c_api/src/c/config.rs
@@ -353,7 +353,7 @@ mod tests {
   "game_dir": "",
   "mods": [],
   "res": "100x100",
-  "brightness": 1.0,
+  "brightness": -1.0,
   "resversion": "ENGLISH",
   "fullscreen": false,
   "scaling": "PERFECT",

--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -201,6 +201,7 @@ int Launcher::writeJsonFile() {
 	int x = (int)resolutionXInput->value();
 	int y = (int)resolutionYInput->value();
 	EngineOptions_setResolution(this->engine_options.get(), x, y);
+	EngineOptions_setBrightness(this->engine_options.get(), -1.0f);
 
 	int currentResourceVersionIndex = gameVersionInput->value();
 	GameVersion currentResourceVersion = predefinedVersions.at(currentResourceVersionIndex);

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -119,7 +119,12 @@ void VideoToggleFullScreen(void)
 
 void VideoSetBrightness(float brightness)
 {
-	SDL_SetWindowBrightness(g_game_window, brightness);
+	if (brightness >= 0)
+	{
+		// Do not set the brightness unless explicitly requested
+		// On Windows, setting the brightness resets color profile and some other disply options.
+		SDL_SetWindowBrightness(g_game_window, brightness);
+	}
 }
 
 


### PR DESCRIPTION
During the investigation of #1382, I found that the ICC profile is reset when JA2 sets the brightness. 

The [SDL_SetWindowBrightness](https://wiki.libsdl.org/SDL_SetWindowBrightness) function adjusts gamma of the whole screen. On Windows it also resets the system's active color profile and undoes some other display options like those available on the NVIDIA Control Panel.

The launcher does not allow changing the brightness. Users may be better off adjusting the brightness at the device or OS / driver. The EngineOption of brightness defaults to 1.0, meaning no adjustment is requested (since #734):

```
    -brightness GAMMA_VALUE
                        Screen brightness (gamma multiplier) value to set
                        where 0.0 is completely dark and 1.0 is normal
                        brightness. Default value is 1.0
```

Or, should we just remove the `-brightness` option?