### PR TITLE
Externalize vehicles

### DIFF
--- a/assets/externalized/vehicles.json
+++ b/assets/externalized/vehicles.json
@@ -1,0 +1,72 @@
+/**
+ * Definitions of player-controllable transport vehicles.
+ *
+ * The ordering in this list is important, and the game has hard-coded references to the
+ * vehicles. For example, the game expects the HELICOPTER to be the 6th vehicle.
+ *
+ * In base vanilla game, only the Hummer, Ice-cream truck and Helicopter are available.
+ *
+ * Fields:
+ * - enterSound: Sound to play when a soldier enters the vehicle. The value must be a valid SoundID.
+ * - moveSound: Sound to play when the vehicle moves. The value must be a valid SoundID.
+ * - profileID: Profile ID associated to the vehicle.
+ * - movementType: Determines if the vehicle can travel through map sectors and how fast. Must be one of FOOT, CAR, TRUCK, TRACKED or AIR.
+ * - armourType: Determines the vehicle's protection against damage. Use the internal name of any armour items.
+ * - seats: Maximum number of soldiers allowed in the vehicle. Must not be greater than 10.
+ */
+[
+    // Eldorado (unused)
+    {
+        "enterSound": 85, // S_VECH1_INTO
+        "moveSound": 82, // S_VECH1_MOVE
+        "profileID": 161, // PROF_ELDERODO
+        "movementType": "CAR",
+        "armourType": "KEVLAR_VEST",
+        "seats": 6
+    },
+    // Hummer
+    {
+        "enterSound": 85,
+        "moveSound": 82,
+        "profileID": 160, // PROF_HUMMER
+        "movementType": "CAR",
+        "armourType": "SPECTRA_VEST",
+        "seats": 6
+    },
+    // Ice cream truck
+    {
+        "enterSound": 85,
+        "moveSound": 82,
+        "profileID": 162, // PROF_ICECREAM
+        "movementType": "CAR",
+        "armourType": "KEVLAR_VEST",
+        "seats": 6
+    },
+    // Jeep (unused)
+    {
+        "enterSound": 85,
+        "moveSound": 82,
+        "profileID": 164, // NPC_164
+        "movementType": "CAR",
+        "armourType": "KEVLAR_VEST",
+        "seats":  6
+    },
+    // Tank (unused)
+    {
+        "enterSound": 85,
+        "moveSound": 82,
+        "profileID": 164, // NPC_164
+        "movementType": "CAR",
+        "armourType": "SPECTRA_VEST",
+        "seats": 6
+    },
+    // Helicopter
+    {
+        "enterSound": 85,
+        "moveSound": 82,
+        "profileID": 163,  // HELICOPTER
+        "movementType": "AIR",
+        "armourType": "KEVLAR_VEST",
+        "seats":6
+    }
+]

--- a/assets/externalized/vehicles.json
+++ b/assets/externalized/vehicles.json
@@ -7,8 +7,8 @@
  * In base vanilla game, only the Hummer, Ice-cream truck and Helicopter are available.
  *
  * Fields:
- * - enterSound: Sound to play when a soldier enters the vehicle. The value must be a valid SoundID.
- * - moveSound: Sound to play when the vehicle moves. The value must be a valid SoundID.
+ * - enterSound: Sound file to play when a soldier enters the vehicle.
+ * - moveSound: Sound file to play when the vehicle moves.
  * - profileID: Profile ID associated to the vehicle.
  * - movementType: Determines if the vehicle can travel through map sectors and how fast. Must be one of FOOT, CAR, TRUCK, TRACKED or AIR.
  * - armourType: Determines the vehicle's protection against damage. Use the internal name of any armour items.
@@ -17,8 +17,8 @@
 [
     // Eldorado (unused)
     {
-        "enterSound": 85, // S_VECH1_INTO
-        "moveSound": 82, // S_VECH1_MOVE
+        "enterSound": "sounds/into vehicle.wav", // S_VECH1_INTO
+        "moveSound": "sounds/driving 01.wav", // S_VECH1_MOVE
         "profileID": 161, // PROF_ELDERODO
         "movementType": "CAR",
         "armourType": "KEVLAR_VEST",
@@ -26,8 +26,8 @@
     },
     // Hummer
     {
-        "enterSound": 85,
-        "moveSound": 82,
+        "enterSound": "sounds/into vehicle.wav",
+        "moveSound": "sounds/driving 01.wav",
         "profileID": 160, // PROF_HUMMER
         "movementType": "CAR",
         "armourType": "SPECTRA_VEST",
@@ -35,8 +35,8 @@
     },
     // Ice cream truck
     {
-        "enterSound": 85,
-        "moveSound": 82,
+        "enterSound": "sounds/into vehicle.wav",
+        "moveSound": "sounds/driving 01.wav",
         "profileID": 162, // PROF_ICECREAM
         "movementType": "CAR",
         "armourType": "KEVLAR_VEST",
@@ -44,8 +44,8 @@
     },
     // Jeep (unused)
     {
-        "enterSound": 85,
-        "moveSound": 82,
+        "enterSound": "sounds/into vehicle.wav",
+        "moveSound": "sounds/driving 01.wav",
         "profileID": 164, // NPC_164
         "movementType": "CAR",
         "armourType": "KEVLAR_VEST",
@@ -53,8 +53,8 @@
     },
     // Tank (unused)
     {
-        "enterSound": 85,
-        "moveSound": 82,
+        "enterSound": "sounds/into vehicle.wav",
+        "moveSound": "sounds/driving 01.wav",
         "profileID": 164, // NPC_164
         "movementType": "CAR",
         "armourType": "SPECTRA_VEST",
@@ -62,8 +62,8 @@
     },
     // Helicopter
     {
-        "enterSound": 85,
-        "moveSound": 82,
+        "enterSound": "sounds/into vehicle.wav",
+        "moveSound": "sounds/driving 01.wav",
         "profileID": 163,  // HELICOPTER
         "movementType": "AIR",
         "armourType": "KEVLAR_VEST",

--- a/src/externalized/CMakeLists.txt
+++ b/src/externalized/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LOCAL_JA2_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/ModPackContentManager.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/ShippingDestinationModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/Soldier.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/VehicleModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/WeaponModels.cc
 )
 

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -41,6 +41,7 @@ class StrategicAIPolicy;
 class StrategicMapSecretModel;
 class TownModel;
 class UndergroundSectorModel;
+class VehicleModel;
 struct AmmoTypeModel;
 struct CalibreModel;
 struct LoadingScreen;
@@ -186,6 +187,9 @@ public:
 
 	/* Gets eyes and mouths offsets for the RPC small portraits. Returns null if none defined. */
 	virtual const RPCSmallFaceModel* getRPCSmallFaceOffsets(uint8_t profileID) const = 0;
+
+	/* Gets all vehicle types */
+	virtual const VehicleModel* getVehicle(uint8_t vehicleID) const = 0;
 
 	/* Gets loading screen for the sector. Returns NULL if the sector does not have an associated loading screen */
 	virtual const LoadingScreen* getLoadingScreenForSector(uint8_t sectorId, uint8_t sectorLevel, bool isNight) const = 0;

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -27,6 +27,7 @@
 #include "MagazineModel.h"
 #include "RustInterface.h"
 #include "ShippingDestinationModel.h"
+#include "VehicleModel.h"
 #include "WeaponModels.h"
 #include "army/ArmyCompositionModel.h"
 #include "army/GarrisonGroupModel.h"
@@ -323,6 +324,7 @@ DefaultContentManager::~DefaultContentManager()
 	deleteElements(m_MERCListings);
 	deleteElements(m_mercProfileInfo);
 	deleteElements(m_mercProfiles);
+	deleteElements(m_vehicles);
 
 	m_sectorLandTypes.clear();
 
@@ -1075,6 +1077,7 @@ bool DefaultContentManager::loadGameData()
 	loadStrategicLayerData();
 	loadTacticalLayerData();
 	loadMercsData();
+	loadVehicles();
 
 	return result;
 }
@@ -1346,6 +1349,18 @@ bool DefaultContentManager::loadMercsData()
 	return true;
 }
 
+void DefaultContentManager::loadVehicles()
+{
+	auto json = readJsonDataFile("vehicles.json");
+	for (auto& element : json->GetArray())
+	{
+		JsonObjectReader obj(element);
+		auto vehicleTypeInfo = VehicleModel::deserialize(obj, this);
+		m_vehicles.push_back(vehicleTypeInfo);
+	}
+	VehicleModel::validateData(m_vehicles);
+}
+
 const std::vector<const BloodCatPlacementsModel*>& DefaultContentManager::getBloodCatPlacements() const
 {
 	return m_bloodCatPlacements;
@@ -1547,6 +1562,16 @@ const MercProfileInfo* DefaultContentManager::getMercProfileInfo(uint8_t const p
 const std::vector<const MercProfile*>& DefaultContentManager::listMercProfiles() const
 {
 	return m_mercProfiles;
+}
+
+const VehicleModel* DefaultContentManager::getVehicle(uint8_t const vehicleID) const
+{
+	if (vehicleID > m_vehicles.size())
+	{
+		ST::string error = ST::format("Vehicle #{} is not defined", vehicleID);
+		throw std::out_of_range(error.to_std_string());
+	}
+	return m_vehicles[vehicleID];
 }
 
 const LoadingScreen* DefaultContentManager::getLoadingScreenForSector(uint8_t sectorId, uint8_t sectorLevel, bool isNight) const

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -176,11 +176,14 @@ public:
 	virtual int16_t getSectorLandType(uint8_t sectorID, uint8_t sectorLevel) const override;
 	virtual const std::vector<const StrategicMapSecretModel*>& getMapSecrets() const override;
 	virtual const CacheSectorsModel* getCacheSectors() const override;
+
 	virtual const std::map<uint8_t, const NpcPlacementModel*>& listNpcPlacements() const override;
 	virtual const NpcPlacementModel* getNpcPlacement(uint8_t profileId) const override;
 	virtual const RPCSmallFaceModel* getRPCSmallFaceOffsets(uint8_t profileID) const override;
 	virtual const std::vector<const MERCListingModel*>& getMERCListings() const override;
 	virtual const std::vector<const MercProfile*>& listMercProfiles() const override;
+	virtual const VehicleModel* getVehicle(uint8_t vehicleID) const override;
+
 	virtual const LoadingScreen* getLoadingScreenForSector(uint8_t sectorId, uint8_t sectorLevel, bool isNight) const override;
 	virtual const LoadingScreen* getLoadingScreen(uint8_t index) const override;
 
@@ -258,6 +261,7 @@ protected:
 
 	std::map<uint8_t, const RPCSmallFaceModel*> m_rpcSmallFaces;
 	std::vector<const MERCListingModel*> m_MERCListings;
+	std::vector<const VehicleModel*> m_vehicles;
 
 	// List of pre-constructed MercProfile objects; indices of elements are arbitrary (unlike gMercProfiles) and not guaranteed to follow any order
 	std::vector<const MercProfile*> m_mercProfiles;
@@ -285,6 +289,7 @@ protected:
 	bool loadStrategicLayerData();
 	bool loadTacticalLayerData();
 	bool loadMercsData();
+	void loadVehicles();
 
 	std::unique_ptr<rapidjson::Document> readJsonDataFile(const ST::string& fileName) const;
 

--- a/src/externalized/VehicleModel.cc
+++ b/src/externalized/VehicleModel.cc
@@ -5,20 +5,11 @@
 #include "JsonObject.h"
 #include "Vehicles.h"
 
-VehicleModel::VehicleModel(SoundID enterSound, SoundID movementSound,
+VehicleModel::VehicleModel(ST::string enterSound, ST::string movementSound,
                            ProfileID profileID, VehicleMovementType movementType,
                            uint16_t armourType, uint8_t seats_)
     : enter_sound(enterSound), move_sound(movementSound), profile(profileID),
       movement_type(movementType), armour_type(armourType), seats(seats_) {}
-
-static SoundID toSoundID(int soundID)
-{
-	if (soundID < -1 || soundID >= NUM_SAMPLES)
-	{
-		throw DataError(ST::format("{} is not a valid SoundID", soundID));
-	}
-	return static_cast<SoundID>(soundID);
-}
 
 static ProfileID toProfileID(unsigned int profileID)
 {
@@ -57,8 +48,8 @@ const VehicleModel* VehicleModel::deserialize(JsonObjectReader &obj, const ItemS
 	}
 
 	return new VehicleModel(
-		toSoundID(obj.GetInt("enterSound")),
-		toSoundID(obj.GetInt("moveSound")),
+		obj.GetString("enterSound"),
+		obj.GetString("moveSound"),
 		toProfileID(obj.GetUInt("profileID")),
 		toMovementType(obj.GetString("movementType")),
 		armour->getItemIndex(),

--- a/src/externalized/VehicleModel.cc
+++ b/src/externalized/VehicleModel.cc
@@ -1,0 +1,76 @@
+#include "VehicleModel.h"
+#include "Exceptions.h"
+#include "ItemModel.h"
+#include "ItemSystem.h"
+#include "JsonObject.h"
+#include "Vehicles.h"
+
+VehicleModel::VehicleModel(SoundID enterSound, SoundID movementSound,
+                           ProfileID profileID, VehicleMovementType movementType,
+                           uint16_t armourType, uint8_t seats_)
+    : enter_sound(enterSound), move_sound(movementSound), profile(profileID),
+      movement_type(movementType), armour_type(armourType), seats(seats_) {}
+
+static SoundID toSoundID(int soundID)
+{
+	if (soundID < -1 || soundID >= NUM_SAMPLES)
+	{
+		throw DataError(ST::format("{} is not a valid SoundID", soundID));
+	}
+	return static_cast<SoundID>(soundID);
+}
+
+static ProfileID toProfileID(unsigned int profileID)
+{
+	if (profileID >= UINT8_MAX)
+	{
+		throw DataError(ST::format("{} is not a valid ProfileID", profileID));
+	}
+	return static_cast<ProfileID>(profileID);
+}
+
+static VehicleMovementType toMovementType(const std::string& typeName)
+{
+	if (typeName == "FOOT") return FOOT;
+	if (typeName == "CAR") return CAR;
+	if (typeName == "TRUCK") return TRUCK;
+	if (typeName == "TRACKED") return TRACKED;
+	if (typeName == "AIR") return AIR;
+
+	throw DataError(ST::format("'{}' is not a valid vehicle movement type", typeName));
+}
+
+const VehicleModel* VehicleModel::deserialize(JsonObjectReader &obj, const ItemSystem* itemSystem)
+{
+	ST::string armourName = obj.GetString("armourType");
+	const ItemModel* armour = itemSystem->getItemByName(armourName);
+	if (!armour || !(armour->isArmour()))
+	{
+		throw DataError(ST::format("'{}' does not refer to an armour item", armourName));
+	}
+
+	unsigned int numSeats = obj.GetUInt("seats");
+	if (numSeats > MAX_PASSENGERS_IN_VEHICLE)
+	{
+		// limited by struct VEHICLETYPE
+		throw DataError(ST::format("Vehicles cannot have more than {} seats", MAX_PASSENGERS_IN_VEHICLE));
+	}
+
+	return new VehicleModel(
+		toSoundID(obj.GetInt("enterSound")),
+		toSoundID(obj.GetInt("moveSound")),
+		toProfileID(obj.GetUInt("profileID")),
+		toMovementType(obj.GetString("movementType")),
+		armour->getItemIndex(),
+		numSeats
+		);
+}
+
+void VehicleModel::validateData(const std::vector<const VehicleModel*>& vehicles)
+{
+	if (vehicles.size() < NUMBER_OF_TYPES_OF_VEHICLES)
+	{
+		// the code has a lot of references to HELICOPTER(5)
+		throw DataError(ST::format("There must be at least {} vehicle types", NUMBER_OF_TYPES_OF_VEHICLES));
+	}
+}

--- a/src/externalized/VehicleModel.h
+++ b/src/externalized/VehicleModel.h
@@ -10,12 +10,12 @@ class ItemSystem;
 class VehicleModel
 {
 public:
-	VehicleModel(SoundID enterSound, SoundID movementSound, ProfileID profileID, VehicleMovementType movementType, uint16_t armourType, uint8_t seats);
+	VehicleModel(ST::string enterSound, ST::string movementSound, ProfileID profileID, VehicleMovementType movementType, uint16_t armourType, uint8_t seats);
 	static const VehicleModel* deserialize(JsonObjectReader& obj, const ItemSystem* itemSystem);
 	static void validateData(const std::vector<const VehicleModel*>& vehicles);
 
-	const SoundID   enter_sound;
-	const SoundID   move_sound;
+	const ST::string   enter_sound;
+	const ST::string   move_sound;
 	const ProfileID profile;
 	const VehicleMovementType   movement_type;
 	const uint16_t  armour_type;

--- a/src/externalized/VehicleModel.h
+++ b/src/externalized/VehicleModel.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "Campaign_Types.h"
+#include "JA2Types.h"
+#include "Sound_Control.h"
+#include <vector>
+
+class JsonObjectReader;
+class ItemSystem;
+
+class VehicleModel
+{
+public:
+	VehicleModel(SoundID enterSound, SoundID movementSound, ProfileID profileID, VehicleMovementType movementType, uint16_t armourType, uint8_t seats);
+	static const VehicleModel* deserialize(JsonObjectReader& obj, const ItemSystem* itemSystem);
+	static void validateData(const std::vector<const VehicleModel*>& vehicles);
+
+	const SoundID   enter_sound;
+	const SoundID   move_sound;
+	const ProfileID profile;
+	const VehicleMovementType   movement_type;
+	const uint16_t  armour_type;
+	const uint8_t   seats;
+};

--- a/src/game/Strategic/Campaign_Types.h
+++ b/src/game/Strategic/Campaign_Types.h
@@ -135,11 +135,14 @@ enum
 
 
 //Vehicle types
-#define FOOT				0x01 //anywhere
-#define CAR					0x02 //roads
-#define TRUCK				0x04 //roads, plains, sparse
-#define TRACKED			0x08 //roads, plains, sand, sparse
-#define AIR					0x10 //can traverse all terrains at 100%
+enum VehicleMovementType
+{
+	FOOT = 0x01,		//anywhere
+	CAR = 0x02,		//roads
+	TRUCK = 0x04,		//roads, plains, sparse
+	TRACKED = 0x08,		//roads, plains, sand, sparse
+	AIR = 0x10		//can traverse all terrains at 100%
+};
 
 //Traversability ratings
 enum

--- a/src/game/Tactical/Vehicles.cc
+++ b/src/game/Tactical/Vehicles.cc
@@ -40,6 +40,7 @@
 #include "ContentManager.h"
 #include "GameInstance.h"
 #include "ShippingDestinationModel.h"
+#include "VehicleModel.h"
 
 #include <stdexcept>
 #include <vector>
@@ -49,31 +50,6 @@ INT8 gubVehicleMovementGroups[ MAX_VEHICLES ];
 
 // the list of vehicle slots
 std::vector<VEHICLETYPE> pVehicleList;
-
-
-//ATE: These arrays below should all be in a large LUT which contains
-// static info for each vehicle....
-
-
-struct VehicleTypeInfo
-{
-	SoundID   enter_sound;
-	SoundID   move_sound;
-	ProfileID profile;
-	UINT8     movement_type;
-	UINT16    armour_type;
-	UINT8     seats;
-};
-
-static const VehicleTypeInfo g_vehicle_type_info[] =
-{
-	{ S_VECH1_INTO, S_VECH1_MOVE, PROF_ELDERODO,   CAR, KEVLAR_VEST,  6 }, // Eldorado
-	{ S_VECH1_INTO, S_VECH1_MOVE, PROF_HUMMER,     CAR, SPECTRA_VEST, 6 }, // Hummer
-	{ S_VECH1_INTO, S_VECH1_MOVE, PROF_ICECREAM,   CAR, KEVLAR_VEST,  6 }, // Ice cream truck
-	{ S_VECH1_INTO, S_VECH1_MOVE, NPC164,          CAR, KEVLAR_VEST,  6 }, // Jeep
-	{ S_VECH1_INTO, S_VECH1_MOVE, NPC164,          CAR, SPECTRA_VEST, 6 }, // Tank
-	{ S_VECH1_INTO, S_VECH1_MOVE, PROF_HELICOPTER, AIR, KEVLAR_VEST,  6 }  // Helicopter
-};
 
 
 // Loop through and create a few soldier squad ID's for vehicles ( max # 3 )
@@ -94,7 +70,7 @@ void SetVehicleValuesIntoSoldierType(SOLDIERTYPE* const vs)
 {
 	const VEHICLETYPE* const v = &pVehicleList[vs->bVehicleID];
 	vs->name = zVehicleName[v->ubVehicleType];
-	vs->ubProfile           = g_vehicle_type_info[v->ubVehicleType].profile;
+	vs->ubProfile           = GCM->getVehicle(v->ubVehicleType)->profile;
 	vs->sBreathRed          = 10000; // Init fuel
 	vs->bBreath             = 100;
 	vs->ubWhatKindOfMercAmI = MERC_TYPE__VEHICLE;
@@ -136,7 +112,7 @@ INT32 AddVehicleToList(const INT16 sMapX, const INT16 sMapY, const INT16 sGridNo
 	Assert(g);
 
 	// ARM: setup group movement defaults
-	g->ubTransportationMask = g_vehicle_type_info[ubType].movement_type;
+	g->ubTransportationMask = GCM->getVehicle(ubType)->movement_type;
 	g->ubSectorX            = sMapX;
 	g->ubNextX              = sMapX;
 	g->ubSectorY            = sMapY;
@@ -175,7 +151,7 @@ bool IsThisVehicleAccessibleToSoldier(SOLDIERTYPE const& s, VEHICLETYPE const& v
 		s.sSectorX == v.sSectorX &&
 		s.sSectorY == v.sSectorY &&
 		s.bSectorZ == v.sSectorZ &&
-		OKUseVehicle(g_vehicle_type_info[v.ubVehicleType].profile);
+		OKUseVehicle(GCM->getVehicle(v.ubVehicleType)->profile);
 }
 
 
@@ -234,7 +210,7 @@ static bool AddSoldierToVehicle(SOLDIERTYPE& s, VEHICLETYPE& v)
 			SelectSoldier(vs, SELSOLDIER_FORCE_RESELECT);
 		}
 
-		PlayLocationJA2Sample(vs->sGridNo, g_vehicle_type_info[v.ubVehicleType].enter_sound, HIGHVOLUME, 1);
+		PlayLocationJA2Sample(vs->sGridNo, GCM->getVehicle(v.ubVehicleType)->enter_sound, HIGHVOLUME, 1);
 	}
 
 	INT32 const seats = GetVehicleSeats(v);
@@ -621,7 +597,8 @@ BOOLEAN ExitVehicle(SOLDIERTYPE* const s)
 		SelectSoldier(s, SELSOLDIER_FORCE_RESELECT);
 	}
 
-	PlayLocationJA2Sample(vs.sGridNo, g_vehicle_type_info[pVehicleList[vs.bVehicleID].ubVehicleType].enter_sound, HIGHVOLUME, 1);
+	UINT8 ubVehicleType = pVehicleList[vs.bVehicleID].ubVehicleType;
+	PlayLocationJA2Sample(vs.sGridNo, GCM->getVehicle(ubVehicleType)->enter_sound, HIGHVOLUME, 1);
 	return TRUE;
 }
 
@@ -814,7 +791,8 @@ void SetVehicleSectorValues(VEHICLETYPE& v, UINT8 const x, UINT8 const y)
 	v.sSectorX = x;
 	v.sSectorY = y;
 
-	MERCPROFILESTRUCT& p = GetProfile(g_vehicle_type_info[v.ubVehicleType].profile);
+	ProfileID vehicleProfile = GCM->getVehicle(v.ubVehicleType)->profile;
+	MERCPROFILESTRUCT& p = GetProfile(vehicleProfile);
 	p.sSectorX = x;
 	p.sSectorY = y;
 
@@ -1058,7 +1036,7 @@ void HandleVehicleMovementSound(const SOLDIERTYPE* const s, const BOOLEAN fOn)
 	{
 		if (v->uiMovementSoundID == NO_SAMPLE)
 		{
-			v->uiMovementSoundID = PlayLocationJA2Sample(s->sGridNo, g_vehicle_type_info[v->ubVehicleType].move_sound, HIGHVOLUME, 1);
+			v->uiMovementSoundID = PlayLocationJA2Sample(s->sGridNo, GCM->getVehicle(v->ubVehicleType)->move_sound, HIGHVOLUME, 1);
 		}
 	}
 	else
@@ -1074,11 +1052,12 @@ void HandleVehicleMovementSound(const SOLDIERTYPE* const s, const BOOLEAN fOn)
 
 UINT8 GetVehicleArmourType(const UINT8 vehicle_id)
 {
-	return GCM->getItem(g_vehicle_type_info[pVehicleList[vehicle_id].ubVehicleType].armour_type)->getClassIndex();
+	auto armourItemIndex = GCM->getVehicle(pVehicleList[vehicle_id].ubVehicleType)->armour_type;
+	return GCM->getItem(armourItemIndex)->getClassIndex();
 }
 
 
 UINT8 GetVehicleSeats(VEHICLETYPE const& v)
 {
-	return g_vehicle_type_info[v.ubVehicleType].seats;
+	return GCM->getVehicle(v.ubVehicleType)->seats;
 }

--- a/src/game/Tactical/Vehicles.h
+++ b/src/game/Tactical/Vehicles.h
@@ -8,6 +8,7 @@
 
 
 #define MAX_VEHICLES 10
+#define MAX_PASSENGERS_IN_VEHICLE 10
 
 // type of vehicles
 enum{
@@ -32,7 +33,7 @@ struct VEHICLETYPE
 	INT16   sSectorZ;
 	BOOLEAN fBetweenSectors; // between sectors?
 	INT16   sGridNo; // location in tactical
-	SOLDIERTYPE *pPassengers[ 10 ];
+	SOLDIERTYPE *pPassengers[MAX_PASSENGERS_IN_VEHICLE];
 	BOOLEAN fDestroyed;
 	UINT32  uiMovementSoundID;
 	BOOLEAN fValid;


### PR DESCRIPTION
For #665. This externalizes the table data of [g_vehicle_type_info](https://github.com/ja2-stracciatella/ja2-stracciatella/blob/e23678b74af7e7fa2ccaf067eb44993184af0a33/src/game/Tactical/Vehicles.cc#L68) into JSON and model class. 

### Intended use-cases

- Change the number of seats, to fit in more soldiers
- Change the movement type, so the vehicle can traverse more terrains types other than roads (e.g. plains).
- Change the armour type, to make it tougher or easier to destroy

### Notes

- Adding new vehicles or re-ordering elements is likely not to work without code support
- `class VehicleModel` is a direct replacement of the old `struct VehicleTypeInfo`
- The helicopter does not seem to use the `enterSound` or `moveSound`
- Adding the `Eldorado` might work if it is also placed in a sector. I haven't tried.