### PR TITLE
Use require function instead of custom require

### DIFF
--- a/assets/mods/generous-rebels/data/scripts/main.lua
+++ b/assets/mods/generous-rebels/data/scripts/main.lua
@@ -1,4 +1,4 @@
-JA2Require("enums.lua")
+require("enums.lua")
 RegisterListener("BeforePrepareSector", "add_items_to_sector")
 
 --[[

--- a/src/externalized/scripting/FunctionsLibrary.h
+++ b/src/externalized/scripting/FunctionsLibrary.h
@@ -84,14 +84,6 @@ extern Observable<> BeforeGameSaved;
  */
 extern Observable<> OnGameLoaded;
 
-/**
- * Loads the specified script file into Lua space. The file is loaded via the VFS sub-system.
- * This function can only be used during initialization.
- * @param scriptFileName the name to the lua script file, e.g. enums.lua
- * @ingroup funclib-general
- */
-void JA2Require(std::string scriptFileName);
-
 /** @defgroup funclib-sectors Map sectors
  *  @brief Access and alter sectors' stratgic-level data
  */

--- a/src/externalized/scripting/ScriptingExtensions.h
+++ b/src/externalized/scripting/ScriptingExtensions.h
@@ -13,7 +13,7 @@
  * ```lua
  * -- Imports the enums.lua provided by the base game
  * -- This gives you access to predefined enum values such as Items or MercsProfiles
- * JA2Require("enums.lua")
+ * require("enums.lua")
  *
  * -- Register a listener with an observable so your code gets called by the game
  * RegisterListener("BeforePrepareSector", "HandlePrepareSector")


### PR DESCRIPTION
A bit of cleanup in the scripting area:

- Require the use of `require` function instead of custom `JA2Require`
- Errors that happen when `main.lua` is executed are catched correctly