### PR TITLE
Dynamic tactical bottom bar

### DIFF
--- a/src/game/Tactical/Interface_Panels.h
+++ b/src/game/Tactical/Interface_Panels.h
@@ -38,7 +38,7 @@ enum
 
 #define NEW_ITEM_CYCLE_COUNT			19
 #define NEW_ITEM_CYCLES			4
-#define NUM_TEAM_SLOTS				6
+#define NUM_TEAM_SLOTS				(g_ui.m_teamPanelNumSlots)
 
 
 #define PASSING_ITEM_DISTANCE_OKLIFE		3
@@ -49,25 +49,25 @@ enum
 
 void CreateSMPanelButtons(void);
 void RemoveSMPanelButtons(void);
-void InitializeSMPanel(void);
-void ShutdownSMPanel(void);
+void InitializeSMPanel();
+void ShutdownSMPanel();
 void RenderSMPanel(DirtyLevel*);
 void EnableSMPanelButtons(BOOLEAN fEnable, BOOLEAN fFromItemPickup);
 
 
 void CreateTEAMPanelButtons(void);
 void RemoveTEAMPanelButtons(void);
-void InitializeTEAMPanel(void);
-void ShutdownTEAMPanel(void);
+void InitializeTEAMPanel();
+void ShutdownTEAMPanel();
 void RenderTEAMPanel(DirtyLevel);
 
 
 void SetSMPanelCurrentMerc(SOLDIERTYPE* s);
 void SetTEAMPanelCurrentMerc(void);
 
-void         InitTEAMSlots(void);
+void         InitTEAMSlots();
 SOLDIERTYPE* GetPlayerFromInterfaceTeamSlot(UINT8 ubPanelSlot);
-void    RemoveAllPlayersFromSlot(void);
+void    RemoveAllPlayersFromSlot();
 BOOLEAN      RemovePlayerFromTeamSlot(const SOLDIERTYPE* s);
 void    CheckForAndAddMercToTeamPanel(SOLDIERTYPE* s);
 

--- a/src/game/UILayout.cc
+++ b/src/game/UILayout.cc
@@ -50,13 +50,16 @@ UINT16 UILayout::get_CLOCK_X() const               { return fInMapMode ? (STD_SC
 UINT16 UILayout::get_CLOCK_Y() const               { return currentHeight() - 23;                                  }
 UINT16 UILayout::get_RADAR_WINDOW_X() const        { return fInMapMode ? (STD_SCREEN_X + 543) : m_teamPanelPosition.iX + m_teamPanelSlotsTotalWidth + 45; }
 UINT16 UILayout::get_RADAR_WINDOW_TM_Y() const     { return currentHeight() - 107;                                 }
-UINT16 UILayout::get_INV_INTERFACE_START_Y() const { return m_screenHeight - 140;                                  }
+UINT16 UILayout::get_INV_INTERFACE_START_Y() const { return m_screenHeight - INV_INTERFACE_HEIGHT;                                  }
 
 
 /** Recalculate UI elements' positions after changing screen size. */
 void UILayout::recalculatePositions()
 {
-	m_teamPanelSlotsTotalWidth = NUMBER_OF_SOLDIERS_PER_SQUAD * TEAMPANEL_SLOT_WIDTH;
+	m_teamPanelNumSlots = std::min({NUMBER_OF_SOLDIERS_PER_SQUAD, (m_screenWidth - TEAMPANEL_BUTTONSBOX_WIDTH) / TEAMPANEL_SLOT_WIDTH, 12});
+	m_teamPanelNumSlots = std::max((int)m_teamPanelNumSlots, 6);
+
+	m_teamPanelSlotsTotalWidth = m_teamPanelNumSlots * TEAMPANEL_SLOT_WIDTH;
 	UINT16 tpXOffset = (m_screenWidth - m_teamPanelSlotsTotalWidth - TEAMPANEL_BUTTONSBOX_WIDTH) / 2;
 	UINT16 tpYOffset = m_screenHeight - 120;
 	m_teamPanelPosition.set(tpXOffset, tpYOffset);

--- a/src/game/UILayout.cc
+++ b/src/game/UILayout.cc
@@ -39,18 +39,18 @@ bool UILayout::setScreenSize(UINT16 width, UINT16 height)
 
 
 /** Check if the screen is bigger than original 640x480. */
-bool UILayout::isBigScreen()
+bool UILayout::isBigScreen() const
 {
 	return (m_screenWidth > 640) || (m_screenHeight > 480);
 }
 
 
-UINT16 UILayout::currentHeight()             { return fInMapMode ? (STD_SCREEN_Y + m_mapScreenHeight) : m_screenHeight; }
-UINT16 UILayout::get_CLOCK_X()               { return fInMapMode ? (STD_SCREEN_X + 554) : m_teamPanelPosition.iX + m_teamPanelSlotsTotalWidth + 56; }
-UINT16 UILayout::get_CLOCK_Y()               { return currentHeight() - 23;                                  }
-UINT16 UILayout::get_RADAR_WINDOW_X()        { return fInMapMode ? (STD_SCREEN_X + 543) : m_teamPanelPosition.iX + m_teamPanelSlotsTotalWidth + 45; }
-UINT16 UILayout::get_RADAR_WINDOW_TM_Y()     { return currentHeight() - 107;                                 }
-UINT16 UILayout::get_INV_INTERFACE_START_Y() { return m_screenHeight - 140;                                  }
+UINT16 UILayout::currentHeight() const             { return fInMapMode ? (STD_SCREEN_Y + m_mapScreenHeight) : m_screenHeight; }
+UINT16 UILayout::get_CLOCK_X() const               { return fInMapMode ? (STD_SCREEN_X + 554) : m_teamPanelPosition.iX + m_teamPanelSlotsTotalWidth + 56; }
+UINT16 UILayout::get_CLOCK_Y() const               { return currentHeight() - 23;                                  }
+UINT16 UILayout::get_RADAR_WINDOW_X() const        { return fInMapMode ? (STD_SCREEN_X + 543) : m_teamPanelPosition.iX + m_teamPanelSlotsTotalWidth + 45; }
+UINT16 UILayout::get_RADAR_WINDOW_TM_Y() const     { return currentHeight() - 107;                                 }
+UINT16 UILayout::get_INV_INTERFACE_START_Y() const { return m_screenHeight - 140;                                  }
 
 
 /** Recalculate UI elements' positions after changing screen size. */
@@ -138,7 +138,7 @@ void UILayout::recalculatePositions()
 }
 
 /** Get X position of tactical textbox. */
-UINT16 UILayout::getTacticalTextBoxX()
+UINT16 UILayout::getTacticalTextBoxX() const
 {
 
 	if ( guiCurrentScreen == MAP_SCREEN )
@@ -152,7 +152,7 @@ UINT16 UILayout::getTacticalTextBoxX()
 }
 
 /** Get Y position of tactical textbox. */
-UINT16 UILayout::getTacticalTextBoxY()
+UINT16 UILayout::getTacticalTextBoxY() const
 {
 	if ( guiCurrentScreen == MAP_SCREEN )
 	{

--- a/src/game/UILayout.h
+++ b/src/game/UILayout.h
@@ -133,20 +133,20 @@ public:
 	bool setScreenSize(UINT16 width, UINT16 height);
 
 	/** Check if the screen is bigger than original 640x480. */
-	bool isBigScreen();
+	bool isBigScreen() const;
 
-	UINT16 currentHeight();
-	UINT16 get_CLOCK_X();
-	UINT16 get_CLOCK_Y();
-	UINT16 get_INV_INTERFACE_START_Y();
-	UINT16 get_RADAR_WINDOW_X();
-	UINT16 get_RADAR_WINDOW_TM_Y();
+	UINT16 currentHeight() const;
+	UINT16 get_CLOCK_X() const;
+	UINT16 get_CLOCK_Y() const;
+	UINT16 get_INV_INTERFACE_START_Y() const;
+	UINT16 get_RADAR_WINDOW_X() const;
+	UINT16 get_RADAR_WINDOW_TM_Y() const;
 
 	/** Get X position of tactical textbox. */
-	UINT16 getTacticalTextBoxX();
+	UINT16 getTacticalTextBoxX() const;
 
 	/** Get Y position of tactical textbox. */
-	UINT16 getTacticalTextBoxY();
+	UINT16 getTacticalTextBoxY() const;
 
 protected:
 	/** Recalculate UI elements' positions after changing screen size. */

--- a/src/game/UILayout.h
+++ b/src/game/UILayout.h
@@ -15,6 +15,7 @@
 #define SCREEN_HEIGHT                   (g_ui.m_screenHeight)
 #define SCREEN_WIDTH                    (g_ui.m_screenWidth)
 #define INV_INTERFACE_START_Y           (g_ui.get_INV_INTERFACE_START_Y())
+#define INV_INTERFACE_HEIGHT            (140)                                 // height of the bottom bar single-merc inventory panel
 #define INTERFACE_START_X               (g_ui.m_teamPanelPosition.iX)
 #define INTERFACE_START_Y               (g_ui.m_teamPanelPosition.iY)
 #define gsVIEWPORT_START_X              (g_ui.m_VIEWPORT_START_X)
@@ -30,6 +31,7 @@
 
 #define SM_BODYINV_X                    (INTERFACE_START_X + 244)
 #define SM_BODYINV_Y                    (INV_INTERFACE_START_Y + 6)
+#define SM_INVINTERFACE_WIDTH           (532)    // width of the single-merc inventory panel excluding the right-side buttons and minimap
 
 #define EDITOR_TASKBAR_HEIGHT           (120)
 #define EDITOR_TASKBAR_POS_Y            (UINT16)(SCREEN_HEIGHT - EDITOR_TASKBAR_HEIGHT)
@@ -39,6 +41,8 @@
 
 #define TEAMPANEL_SLOT_WIDTH            (83)     // width of one slot in the bottom team panel
 #define TEAMPANEL_BUTTONSBOX_WIDTH      (142)    // width of the container of the buttons on the right of team panel
+#define TEAMPANEL_HEIGHT                (120)    // height of the bottom bar team panel
+
 
 /////////////////////////////////////////////////////////////
 // type definitions
@@ -119,6 +123,7 @@ public:
 	SGPPoint              m_teamPanelPosition;              // offset position of the bottom bar
 	UINT16                m_teamPanelSlotsTotalWidth;       // total width of all team slots in the bottom team panel
 	UINT16                m_teamPanelWidth;                 // width of the entire team panel including slots and buttons
+	UINT8                 m_teamPanelNumSlots;              // number of soldier slots to show on team panel
 
 	UINT16                m_stdScreenOffsetX;             /** Offset of the standard (640x480) window */
 	UINT16                m_stdScreenOffsetY;             /** Offset of the standard (640x480) window */


### PR DESCRIPTION
To dynamically draw the bottom bar panels, to support different squad sizes.

# Summary

When squad size is 6 or below it is same as before. When the squad size is 7 or above, we will "assemble" the panel with multiple blits at init. Below shows the panels for squads of 8:

![Screenshot from 2021-09-24 11-12-39](https://user-images.githubusercontent.com/63151803/134672199-a1b0ee4a-1f07-49fd-9637-2055e954f9ae.png)

![Screenshot from 2021-09-24 11-16-59](https://user-images.githubusercontent.com/63151803/134672208-2bfe0424-8172-4075-bf2a-a84b240222ef.png)


# Caveats

Squad size externalization is yet to be implemented. For now you can only do it with a custom build from source with a changed `NUMBER_OF_SOLDIERS_PER_SQUAD` (and that will break save game too).

Squad size of `n` requires horizontal resolution of `640 + (n - 6) * 83`. Squad size of 8 requires screen width of at least 806 px.

If the screen is not wide enough to show all squad slots, the last few mercs will not have a slot in the team panel. The merc can only be selected with mouse click in tactical, but works otherwise normally. The game warns about this at start up.


