### PR TITLE
Allow more than 1 dead mercs on squad

### DIFF
--- a/src/game/Tactical/Squads.cc
+++ b/src/game/Tactical/Squads.cc
@@ -778,6 +778,7 @@ static BOOLEAN AddDeadCharacterToSquadDeadGuys(SOLDIERTYPE* pSoldier, INT32 iSqu
 		if (dead_id == -1 || FindSoldierByProfileIDOnPlayerTeam(dead_id) == NULL)
 		{
 			sDeadMercs[iSquadValue][iCounter] = pSoldier->ubProfile;
+			return TRUE;
 		}
 	}
 

--- a/src/game/Tactical/Squads.cc
+++ b/src/game/Tactical/Squads.cc
@@ -764,15 +764,13 @@ static BOOLEAN IsDeadGuyOnAnySquad(SOLDIERTYPE* pSoldier);
 
 static BOOLEAN AddDeadCharacterToSquadDeadGuys(SOLDIERTYPE* pSoldier, INT32 iSquadValue)
 {
-	INT32 iCounter = 0;
-
 	// is dead guy in any squad
 	if (IsDeadGuyOnAnySquad(pSoldier)) return TRUE;
 
 	if (IsDeadGuyOnSquad(pSoldier->ubProfile, iSquadValue)) return TRUE;
 
 	// now insert the guy
-	for( iCounter = 0; iCounter < NUMBER_OF_SOLDIERS_PER_SQUAD; iCounter++ )
+	for (int iCounter = 0; iCounter < NUMBER_OF_SOLDIERS_PER_SQUAD; iCounter++)
 	{
 		const INT16 dead_id = sDeadMercs[iSquadValue][iCounter];
 		if (dead_id == -1 || FindSoldierByProfileIDOnPlayerTeam(dead_id) == NULL)
@@ -783,7 +781,7 @@ static BOOLEAN AddDeadCharacterToSquadDeadGuys(SOLDIERTYPE* pSoldier, INT32 iSqu
 	}
 
 	// no go
-	return( FALSE );
+	return FALSE;
 }
 
 


### PR DESCRIPTION
Found a bug with the `sDeadMercs` logic when I was experimenting with squad sizes. This should be a minor regression from vanilla.

The bug was introduced in https://github.com/ja2-stracciatella/ja2-stracciatella/commit/71c563428ea8ebb19053faa52ee38ffe6caccfeb. When someone on squad is killed, the same profile ID is added to all of the slots in the `sDeadMercs` list, so the subsequent deaths on squad cannot be added to the `sDeadMercs` list. 

Most of the soldier death logic is not affected. The skull animation is triggered. But after the death sequence is finished, leaving the tactical screen (switching to strategic or saving), the later-dead soldiers would be silently removed from squad.