### PR TITLE
Change the squad save format

### DIFF
--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -130,7 +130,7 @@ static const ST::string g_savegame_ext   = "sav";
 //Global variable used
 
 extern		INT32					giSortStateForMapScreenList;
-extern		INT16					sDeadMercs[ NUMBER_OF_SQUADS ][ NUMBER_OF_SOLDIERS_PER_SQUAD ];
+extern		INT16					sDeadMercs[ NUMBER_OF_SQUADS ][ NUMBER_OF_DEAD_SOLDIERS_ON_SQUAD ];
 extern		INT32					giRTAILastUpdateTime;
 extern		BOOLEAN				gfRedrawSaveLoadScreen;
 extern		UINT8					gubScreenCount;
@@ -1800,7 +1800,7 @@ static void SaveGeneralInfo(HWFILE const f)
 	INJ_BOOL( d, gfMeanwhileTryingToStart)
 	INJ_BOOL( d, gfInMeanwhile)
 	INJ_SKIP( d, 1)
-	for (INT16 (* i)[NUMBER_OF_SOLDIERS_PER_SQUAD] = sDeadMercs; i != endof(sDeadMercs); ++i)
+	for (INT16 (* i)[NUMBER_OF_DEAD_SOLDIERS_ON_SQUAD] = sDeadMercs; i != endof(sDeadMercs); ++i)
 	{
 		INJ_I16A(d, *i, lengthof(*i))
 	}
@@ -1949,7 +1949,7 @@ static void LoadGeneralInfo(HWFILE const f, UINT32 const savegame_version)
 	// Preventing the value to be saved in the first place leads to odd behaviour during the commencing cutscene
 	if (gGameOptions.ubGameSaveMode == DIF_DEAD_IS_DEAD) gfInMeanwhile = FALSE;
 	EXTR_SKIP( d, 1)
-	for (INT16 (* i)[NUMBER_OF_SOLDIERS_PER_SQUAD] = sDeadMercs; i != endof(sDeadMercs); ++i)
+	for (INT16 (* i)[NUMBER_OF_DEAD_SOLDIERS_ON_SQUAD] = sDeadMercs; i != endof(sDeadMercs); ++i)
 	{
 		EXTR_I16A(d, *i, lengthof(*i))
 	}

--- a/src/game/Tactical/Squads.cc
+++ b/src/game/Tactical/Squads.cc
@@ -25,7 +25,7 @@
 SOLDIERTYPE *Squad[ NUMBER_OF_SQUADS ][ NUMBER_OF_SOLDIERS_PER_SQUAD ];
 
 // list of dead guys for squads...in id values -> -1 means no one home
-INT16 sDeadMercs[ NUMBER_OF_SQUADS ][ NUMBER_OF_SOLDIERS_PER_SQUAD ];
+INT16 sDeadMercs[ NUMBER_OF_SQUADS ][ NUMBER_OF_DEAD_SOLDIERS_ON_SQUAD ];
 
 // the movement group ids
 INT8 SquadMovementGroups[ NUMBER_OF_SQUADS ];
@@ -56,7 +56,7 @@ void InitSquads( void )
 
 	for (int i = 0; i < NUMBER_OF_SQUADS; ++i)
 	{
-		std::fill_n(sDeadMercs[i], NUMBER_OF_SOLDIERS_PER_SQUAD, -1);
+		std::fill_n(sDeadMercs[i], NUMBER_OF_DEAD_SOLDIERS_ON_SQUAD, -1);
 	}
 }
 
@@ -549,7 +549,7 @@ void RebuildCurrentSquad( void )
 			CheckForAndAddMercToTeamPanel(*i);
 		}
 
-		for (INT32 iCounter = 0; iCounter < NUMBER_OF_SOLDIERS_PER_SQUAD; ++iCounter)
+		for (INT32 iCounter = 0; iCounter < NUMBER_OF_DEAD_SOLDIERS_ON_SQUAD; ++iCounter)
 		{
 			const INT16 dead_id = sDeadMercs[iCurrentTacticalSquad][iCounter];
 			if (dead_id == -1) continue;
@@ -751,7 +751,7 @@ static void UpdateCurrentlySelectedMerc(SOLDIERTYPE* pSoldier, INT8 bSquadValue)
 
 static BOOLEAN IsDeadGuyOnSquad(const ProfileID pid, const INT8 squad)
 {
-	for (INT32 i = 0; i < NUMBER_OF_SOLDIERS_PER_SQUAD; ++i)
+	for (INT32 i = 0; i < NUMBER_OF_DEAD_SOLDIERS_ON_SQUAD; ++i)
 	{
 		if (sDeadMercs[squad][i] == pid) return TRUE;
 	}
@@ -770,7 +770,7 @@ static BOOLEAN AddDeadCharacterToSquadDeadGuys(SOLDIERTYPE* pSoldier, INT32 iSqu
 	if (IsDeadGuyOnSquad(pSoldier->ubProfile, iSquadValue)) return TRUE;
 
 	// now insert the guy
-	for (int iCounter = 0; iCounter < NUMBER_OF_SOLDIERS_PER_SQUAD; iCounter++)
+	for (int iCounter = 0; iCounter < NUMBER_OF_DEAD_SOLDIERS_ON_SQUAD; iCounter++)
 	{
 		const INT16 dead_id = sDeadMercs[iSquadValue][iCounter];
 		if (dead_id == -1 || FindSoldierByProfileIDOnPlayerTeam(dead_id) == NULL)
@@ -807,7 +807,7 @@ BOOLEAN SoldierIsDeadAndWasOnSquad( SOLDIERTYPE *pSoldier, INT8 bSquadValue )
 
 void ResetDeadSquadMemberList(INT32 const iSquadValue)
 {
-	std::fill_n(sDeadMercs[ iSquadValue ], NUMBER_OF_SOLDIERS_PER_SQUAD, -1);
+	std::fill_n(sDeadMercs[ iSquadValue ], NUMBER_OF_DEAD_SOLDIERS_ON_SQUAD, -1);
 }
 
 

--- a/src/game/Tactical/Squads.h
+++ b/src/game/Tactical/Squads.h
@@ -6,6 +6,8 @@
 
 // header for squad management system
 #define NUMBER_OF_SOLDIERS_PER_SQUAD		6
+#define NUMBER_OF_DEAD_SOLDIERS_ON_SQUAD	6
+
 
 // enums for squads
 enum{

--- a/src/game/Tactical/Squads.h
+++ b/src/game/Tactical/Squads.h
@@ -7,6 +7,8 @@
 // header for squad management system
 #define NUMBER_OF_SOLDIERS_PER_SQUAD		6
 #define NUMBER_OF_DEAD_SOLDIERS_ON_SQUAD	6
+#define SQUAD_INFO_FORMAT_VERSION		(1)                    // extending the Squad save format for dynamic squad sizes
+#define SQUAD_INFO_NUM_RECORDS			(NUMBER_OF_SQUADS * 6)
 
 
 // enums for squads


### PR DESCRIPTION
This is a proposal to update the Squad save format, to allow squad sizes other than 6 in the save and to allow loading saves done with different squad sizes. It retains some compatibility to all old versions down to 1.12 vanilla.

In the current (old) save format, squad size is always 6. The full squads list is a simple list of 120 (20 squads * 6) slots, each containing one `pSoldier->ubID` followed by 10 bytes of unused space.

# New squad data format

To support dynamic squad sizes, we store also the squad ID with each slot in the unused space, instead of assuming fixed-size lists.

At squad size of 6 or lower, the data layout is unchanged, and so it is fully compatible with all previous versions; At higher squad sizes, there are not enough space in the data region to store all unused the squad slots.

For backwards compatability, we keep the data to 120 (6 soldiers * 20 squads) records and pad each squad to multiples of 6. The 120 slots is more than enough for the max number (18) of soldiers, with any squad sizes including padding.


## Examples

Below are some illustrations when the squad size is different.

At squad size of 7 or higher, not all squads will be saved. The data layout is different are illustrated below - `S` and `s` are soldiers in different squads and `.` are empty slots in squads.

Saving squads of size 8, in the new format:

```
Squad 1 | S S S S S S
Squad 1 | S S . . . .
Squad 2 | s s . . . .
        | . . . . . .
```

In all old game versions, it is interpreted as:
```
Squad 1 | S S S S S S
Squad 2 | s s . . . .
Squad 3 | S S . . . .
Squad 4 | . . . . . .
```

When we open the save with squad size 4 in new game version, then it is re-interpreted as:
```
Squad 1 (S) | S S S S s s
Squad 2 (s) | s s . . . .
Squad 3     | S S . . . .
            | . . . . . .
```
## Problems

There are problems only when a new save with big squads is loaded in old versions. There are no problems when the saves are loaded in the same JA2:S version, no matter how the squad size has changed.

The save version is already incremented for the next release in #1282, so players will get the generic save version warning popup.

### When loading big squads in old versions

When squad size is higher than 6 and the squads are not in continuous numbering, in the new save format:
```
Squad 3 | S S S . . .
Squad 5 | s s . . . .
        | . . . . . .
```

Old versions interprets as Squads 1 and 2:

```
Squad 1 | S S S . . .
Squad 2 | s s . . . .
Squad 3 | . . . . . .
```

Once loaded, the soldiers will still have `bAssignment` of Squads 3 and 5. It doesn't affect much other than display. The player can re-assign the squads to fix.

### Dead mercs

There is an `sDeadMercs` array storing dead soldiers on each squad. The list is kept at size 6. In case of a squad wipe, that more than 6 mercs on squad are killed, only the first 6 are kept in the team panel slot. The rest will still "die normally" but get dropped from the squad right after.


