### PR TITLE
Refund the correct amount of medical deposit

### DIFF
--- a/src/game/Strategic/Merc_Contract.cc
+++ b/src/game/Strategic/Merc_Contract.cc
@@ -737,7 +737,7 @@ static void CalculateMedicalDepositRefund(SOLDIERTYPE const& s)
 	}
 	else if (s.bLife > 0)
 	{ // The merc is injured, refund a partial amount
-		refund = (2 * refund * s.bLifeMax / s.bLifeMax + 1) / 2;
+		refund = (2 * refund * s.bLife / s.bLifeMax + 1) / 2;
 		AddTransactionToPlayersBook(PARTIAL_MEDICAL_REFUND, pid, now, refund);
 		msg_offset = AIM_MEDICAL_DEPOSIT_PARTIAL_REFUND;
 		msg_length = AIM_MEDICAL_DEPOSIT_PARTIAL_REFUND_LENGTH;


### PR DESCRIPTION
Broken since 1cd87b6770df7ef318be19ac293e150629306e73. I got full refund even Gus has lost half his health. Feels like cheating.

The formula should give a partial amount depending on the health left when the merc leaves.

The original formula: 
```c++
iRefundAmount = (INT32) ( ( pSoldier->bLife / ( FLOAT ) pSoldier->bLifeMax ) * pSoldier->usMedicalDeposit + 0.5 );
```