### PR TITLE
Fix UI locking up when item is spotted during movement

### DIFF
--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -7461,7 +7461,7 @@ void HaultSoldierFromSighting( SOLDIERTYPE *pSoldier, BOOLEAN fFromSightingEnemy
 	}
 
 	// Unset UI!
-	if ( fFromSightingEnemy || ( fIsThrowing && !pSoldier->fTurningToShoot ) )
+	if ( fFromSightingEnemy || ( !fIsThrowing && !pSoldier->fTurningToShoot ) )
 	{
 		UnSetUIBusy(pSoldier);
 	}


### PR DESCRIPTION
Fixes #1367. 

This is a logic error introduced in #1325([diff](https://github.com/ja2-stracciatella/ja2-stracciatella/pull/1325/files#diff-5c7a7fd92593a4c65764acb3fec8e25342b7d717db783924d012b1761cf8f9baR7464)), the original condition to unlock the UI (`UnSetUIBusy`) checks for:
```c++
pSoldier->pTempObject == NULL
```
And `fIsThrowing` is defined as:

https://github.com/ja2-stracciatella/ja2-stracciatella/blob/c75a2773eb1905c82111b9bb294ca7ecf5fb5bb0/src/game/Tactical/Soldier_Control.cc#L7383

