### PR TITLE
Add NULL check when counting shots hit

### DIFF
--- a/src/game/Tactical/LOS.cc
+++ b/src/game/Tactical/LOS.cc
@@ -1996,10 +1996,10 @@ static BOOLEAN BulletHitMerc(BULLET* pBullet, STRUCTURE* pStructure, BOOLEAN fIn
 		}
 		iDamage = BulletImpact(pFirer, &tgt, ubHitLocation, iImpact, sHitBy, &ubSpecial);
 		// handle hit here...
-		if( pFirer->bTeam == 0 )
+		if (pFirer->bTeam == 0)
 		{
 			// issue #1140 : sync usShotsFired with usShotsHit and so that merc statistic <= 100%
-			if (pFirer->target->bLife > 0) gMercProfiles[ pFirer->ubProfile ].usShotsHit++;
+			if (pFirer->target && pFirer->target->bLife > 0) gMercProfiles[ pFirer->ubProfile ].usShotsHit++;
 		}
 
 		// intentionally shot


### PR DESCRIPTION
Fixes #1365. 

Adds a NULL check, and skips the `usShotsHit++` if the current `pFirer` does not have a target. In this case the firing soldier is not aiming at people but at grids, and the `tgt` just happens to be standing there.