### PR TITLE
Use UINT32 to handle GetJA2Clock time

### DIFF
--- a/src/game/Editor/LoadScreen.cc
+++ b/src/game/Editor/LoadScreen.cc
@@ -96,7 +96,7 @@ static GUIButtonRef iFileDlgButtons[NUM_FILEDIALOG_BUTTONS];
 static INT32 iTopFileShown;
 static INT32 iCurrFileShown;
 static INT32 iLastFileClicked;
-static INT32 iLastClickTime;
+static UINT32 uiLastClickTime;
 
 static std::vector<FileDialogEntry> gFileList;
 
@@ -141,7 +141,7 @@ static void ChangeDirectory(const ST::string directory, bool resetState) {
 	gFileList.clear();
 
 	if (resetState) {
-		iTopFileShown = iLastClickTime = 0;
+		iTopFileShown = uiLastClickTime = 0;
 		iCurrFileShown = iLastFileClicked = -1;
 	}
 
@@ -191,7 +191,7 @@ static void LoadSaveScreenEntry(void)
 	}
 
 	iLastFileClicked = -1;
-	iLastClickTime = 0;
+	uiLastClickTime = 0;
 }
 
 
@@ -641,7 +641,7 @@ static void SelectFileDialogYPos(UINT16 usRelativeYPos)
 	{
 		if( (INT32)sSelName == (x-iTopFileShown) )
 		{
-			INT32 iCurrClickTime;
+			UINT32 uiCurrClickTime;
 			iCurrFileShown = x;
 			gCurrentFilename = ST::format("{}", curr->filename);
 			SetInputFieldString(0, gCurrentFilename);
@@ -649,12 +649,12 @@ static void SelectFileDialogYPos(UINT16 usRelativeYPos)
 			RenderInactiveTextField( 0 );
 
 			//Calculate and process any double clicking...
-			iCurrClickTime = GetJA2Clock();
-			if( iCurrClickTime - iLastClickTime < 400 && x == iLastFileClicked )
+			uiCurrClickTime = GetJA2Clock();
+			if (uiCurrClickTime - uiLastClickTime < 400 && x == iLastFileClicked)
 			{ //Considered a double click, so activate load/save this filename.
 				iFDlgState = iCurrentAction == ACTION_SAVE_MAP ? DIALOG_SAVE : DIALOG_LOAD;
 			}
-			iLastClickTime = iCurrClickTime;
+			uiLastClickTime = uiCurrClickTime;
 			iLastFileClicked = x;
 		}
 		curr++;

--- a/src/game/Editor/Sector_Summary.cc
+++ b/src/game/Editor/Sector_Summary.cc
@@ -185,7 +185,7 @@ static INT16 gsSelSectorY;
 
 //Used to determine how long the F5 key has been held down for to determine whether or not the
 //summary is going to be persistant or not.
-static UINT32 giInitTimer;
+static UINT32 guiInitTimer;
 
 static ST::string gszFilename;
 static ST::string gszTempFilename;
@@ -268,7 +268,7 @@ void CreateSummaryWindow()
 	gsSelSectorY = gWorldSectorY;
 	gfSummaryWindowActive = TRUE;
 	gfPersistantSummary = FALSE;
-	giInitTimer = GetJA2Clock();
+	guiInitTimer = GetJA2Clock();
 	gfDeniedSummaryCreation = FALSE;
 	gfRenderSummary = TRUE;
 	//Create all of the buttons here
@@ -371,7 +371,7 @@ static void ReleaseSummaryWindow(void)
 	if( !gfSummaryWindowActive || gfPersistantSummary )
 		return;
 	uiCurrTimer = GetJA2Clock();
-	if( !gfWorldLoaded || uiCurrTimer - giInitTimer < 400 )
+	if( !gfWorldLoaded || uiCurrTimer - guiInitTimer < 400 )
 	{ //make window persistant
 		for( i = 1; i < NUM_SUMMARY_BUTTONS; i++ )
 			ShowButton( iSummaryButton[ i ] );

--- a/src/game/JAScreens.cc
+++ b/src/game/JAScreens.cc
@@ -100,7 +100,7 @@ void DisplayFrameRate( )
 		SetVideoOverlayText(g_fps_overlay, ST::format("FPS: {}", __min(uiFPS, 1000)));
 
 		// TIMER COUNTER
-		SetVideoOverlayText(g_counter_period_overlay, ST::format("Game Loop Time: {}", __min(giTimerDiag, 1000)));
+		SetVideoOverlayText(g_counter_period_overlay, ST::format("Game Loop Time: {}", __min(guiTimerDiag, 1000)));
 	}
 }
 

--- a/src/game/Laptop/Laptop.cc
+++ b/src/game/Laptop/Laptop.cc
@@ -2436,21 +2436,21 @@ static void ShowLights(void)
 
 static void FlickerHDLight(void)
 {
-	static INT32 iBaseTime        = 0;
-	static INT32 iTotalDifference = 0;
+	static UINT32 uiBaseTime       = 0;
+	static INT32  iTotalDifference = 0;
 
 	if (fLoadPendingFlag) fFlickerHD = TRUE;
 	if (!fFlickerHD) return;
 
-	if (iBaseTime == 0) iBaseTime = GetJA2Clock();
+	if (uiBaseTime == 0) uiBaseTime = GetJA2Clock();
 
-	const INT32 iDifference = GetJA2Clock() - iBaseTime;
+	const INT32 iDifference = GetJA2Clock() - uiBaseTime;
 
 	if (iTotalDifference > HD_FLICKER_TIME && !fLoadPendingFlag)
 	{
-		iBaseTime         = GetJA2Clock();
+		uiBaseTime         = GetJA2Clock();
 		fHardDriveLightOn = FALSE;
-		iBaseTime         = 0;
+		uiBaseTime         = 0;
 		iTotalDifference  = 0;
 		fFlickerHD        = FALSE;
 		InvalidateRegion(88, 466, 102, 477);
@@ -2473,24 +2473,24 @@ static BOOLEAN ExitLaptopDone(void)
 {
 	// check if this is the first time, to reset counter
 	static BOOLEAN fOldLeaveLaptopState = FALSE;
-	static INT32 iBaseTime              = 0;
+	static UINT32  uiBaseTime            = 0;
 
 	if (!fOldLeaveLaptopState)
 	{
 		fOldLeaveLaptopState = TRUE;
-		iBaseTime = GetJA2Clock();
+		uiBaseTime = GetJA2Clock();
 	}
 
 	fPowerLightOn = FALSE;
 
 	InvalidateRegion(44, 466, 58, 477);
 	// get the current difference
-	const INT32 iDifference = GetJA2Clock() - iBaseTime;
+	const INT32 iDifference = GetJA2Clock() - uiBaseTime;
 
 	// did we wait long enough?
 	if (iDifference > EXIT_LAPTOP_DELAY_TIME)
 	{
-		iBaseTime = 0;
+		uiBaseTime = 0;
 		fOldLeaveLaptopState = FALSE;
 		return TRUE;
 	}
@@ -3215,7 +3215,7 @@ static void DisplayWebBookMarkNotify(void)
 // handle timer for bookmark notify
 static void HandleWebBookMarkNotifyTimer(void)
 {
-	static INT32 iBaseTime              = 0;
+	static UINT32  uiBaseTime            = 0;
 	static BOOLEAN fOldShowBookMarkInfo = FALSE;
 
 	// check if maxing or mining?
@@ -3244,25 +3244,25 @@ static void HandleWebBookMarkNotifyTimer(void)
 	// check if flag false, is so, leave
 	if (!fShowBookmarkInfo)
 	{
-		iBaseTime = 0;
+		uiBaseTime = 0;
 		return;
 	}
 
 	// check if this is the first time in here
-	if (iBaseTime == 0)
+	if (uiBaseTime == 0)
 	{
-		iBaseTime = GetJA2Clock();
+		uiBaseTime = GetJA2Clock();
 		return;
 	}
 
-	const INT32 iDifference = GetJA2Clock() - iBaseTime;
+	const INT32 iDifference = GetJA2Clock() - uiBaseTime;
 
 	fReDrawBookMarkInfo = TRUE;
 
 	if (iDifference > DISPLAY_TIME_FOR_WEB_BOOKMARK_NOTIFY)
 	{
 		// waited long enough, stop showing
-		iBaseTime = 0;
+		uiBaseTime = 0;
 		fShowBookmarkInfo = FALSE;
 	}
 }

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -131,7 +131,7 @@ static const ST::string g_savegame_ext   = "sav";
 
 extern		INT32					giSortStateForMapScreenList;
 extern		INT16					sDeadMercs[ NUMBER_OF_SQUADS ][ NUMBER_OF_DEAD_SOLDIERS_ON_SQUAD ];
-extern		INT32					giRTAILastUpdateTime;
+extern		UINT32					guiRTAILastUpdateTime;
 extern		BOOLEAN				gfRedrawSaveLoadScreen;
 extern		UINT8					gubScreenCount;
 extern		INT16					sWorldSectorLocationOfFirstBattle;
@@ -1021,7 +1021,7 @@ void LoadSavedGame(UINT8 const save_slot_id)
 	BAR(1, "Final Checks...");
 
 	// Reset the AI Timer clock
-	giRTAILastUpdateTime = 0;
+	guiRTAILastUpdateTime = 0;
 
 	// If we are in tactical
 	if (guiScreenToGotoAfterLoadingSavedGame == GAME_SCREEN)

--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -332,11 +332,11 @@ GUIButtonRef giMapContractButton;
 
 INT32 giSortStateForMapScreenList = 0;
 
-INT32 giCommonGlowBaseTime = 0;
-INT32 giFlashAssignBaseTime = 0;
-INT32 giFlashContractBaseTime = 0;
+UINT32 guiCommonGlowBaseTime = 0;
+UINT32 guiFlashAssignBaseTime = 0;
+UINT32 guiFlashContractBaseTime = 0;
 UINT32 guiFlashCursorBaseTime = 0;
-INT32 giPotCharPathBaseTime = 0;
+UINT32 guiPotCharPathBaseTime = 0;
 
 static SGPVObject* guiCHARLIST;
 static SGPVObject* guiCHARINFO;
@@ -4127,7 +4127,7 @@ static void DisplayThePotentialPathForCurrentDestinationCharacterForMapScreenInt
 	if( bOldDestChar != bSelectedDestChar )
 	{
 		bOldDestChar = bSelectedDestChar;
-		giPotCharPathBaseTime = GetJA2Clock( );
+		guiPotCharPathBaseTime = GetJA2Clock( );
 
 		sPrevMapX = sMapX;
 		sPrevMapY = sMapY;
@@ -4138,7 +4138,7 @@ static void DisplayThePotentialPathForCurrentDestinationCharacterForMapScreenInt
 
 	if( ( sMapX != sPrevMapX) || ( sMapY != sPrevMapY ) )
 	{
-		giPotCharPathBaseTime = GetJA2Clock( );
+		guiPotCharPathBaseTime = GetJA2Clock( );
 
 		sPrevMapX = sMapX;
 		sPrevMapY = sMapY;
@@ -4150,14 +4150,14 @@ static void DisplayThePotentialPathForCurrentDestinationCharacterForMapScreenInt
 		fDrawTempPath = FALSE;
 	}
 
-	iDifference = GetJA2Clock( ) - giPotCharPathBaseTime ;
+	iDifference = GetJA2Clock( ) - guiPotCharPathBaseTime ;
 
 	if (fTempPathAlreadyDrawn) return;
 
 	if( iDifference > MIN_WAIT_TIME_FOR_TEMP_PATH )
 	{
 		fDrawTempPath = TRUE;
-		giPotCharPathBaseTime = GetJA2Clock( );
+		guiPotCharPathBaseTime = GetJA2Clock( );
 		fTempPathAlreadyDrawn = TRUE;
 	}
 }
@@ -6261,16 +6261,14 @@ static bool AnyMercsLeavingRealSoon();
 
 static void HandleContractTimeFlashForMercThatIsAboutLeave(void)
 {
-	INT32 iCurrentTime;
-
 	// grab the current time
-	iCurrentTime = GetJA2Clock();
+	UINT32 uiCurrentTime = GetJA2Clock();
 
 	// only bother checking once flash interval has elapsed
-	if( ( iCurrentTime - giFlashContractBaseTime ) >= DELAY_PER_FLASH_FOR_DEPARTING_PERSONNEL )
+	if( ( uiCurrentTime - guiFlashContractBaseTime ) >= DELAY_PER_FLASH_FOR_DEPARTING_PERSONNEL )
 	{
 		// update timer so that we only run check so often
-		giFlashContractBaseTime = iCurrentTime;
+		guiFlashContractBaseTime = uiCurrentTime;
 		fFlashContractFlag = !fFlashContractFlag;
 
 		// don't redraw unless we have to!
@@ -6762,16 +6760,14 @@ static void RemoveTeamPanelSortButtonsForMapScreen()
 
 static void HandleCommonGlowTimer(void)
 {
-	INT32 iCurrentTime = 0;
-
 	// grab the current time
-	iCurrentTime = GetJA2Clock();
+	UINT32 uiCurrentTime = GetJA2Clock();
 
 	// only bother checking once flash interval has elapsed
-	if( ( iCurrentTime - giCommonGlowBaseTime ) >= GLOW_DELAY )
+	if( ( uiCurrentTime - guiCommonGlowBaseTime ) >= GLOW_DELAY )
 	{
 		// update timer so that we only run check so often
-		giCommonGlowBaseTime = iCurrentTime;
+		guiCommonGlowBaseTime = uiCurrentTime;
 
 		// set flag to trigger glow higlight updates
 		gfGlowTimerExpired = TRUE;
@@ -6793,13 +6789,13 @@ static void HandleAssignmentsDoneAndAwaitingFurtherOrders(void)
 	}
 
 	// grab the current time
-	const INT32 iCurrentTime = GetJA2Clock();
+	const UINT32 uiCurrentTime = GetJA2Clock();
 
 	// only bother checking once flash interval has elapsed
-	if( ( iCurrentTime - giFlashAssignBaseTime ) >= ASSIGNMENT_DONE_FLASH_TIME )
+	if( ( uiCurrentTime - guiFlashAssignBaseTime ) >= ASSIGNMENT_DONE_FLASH_TIME )
 	{
 		// update timer so that we only run check so often
-		giFlashAssignBaseTime = iCurrentTime;
+		guiFlashAssignBaseTime = uiCurrentTime;
 
 		CFOR_EACH_IN_CHAR_LIST(c)
 		{

--- a/src/game/Strategic/Map_Screen_Interface.cc
+++ b/src/game/Strategic/Map_Screen_Interface.cc
@@ -233,7 +233,7 @@ static MERC_LEAVE_ITEM* gpLeaveListHead[NUM_LEAVE_LIST_SLOTS];
 static UINT32 guiLeaveListOwnerProfileId[NUM_LEAVE_LIST_SLOTS];
 
 // timers for double click
-static INT32 giDblClickTimersForMoveBoxMouseRegions[MAX_POPUP_BOX_STRING_COUNT];
+static UINT32 guiDblClickTimersForMoveBoxMouseRegions[MAX_POPUP_BOX_STRING_COUNT];
 
 UINT32 guiSectorLocatorBaseTime = 0;
 
@@ -2575,18 +2575,19 @@ static void SelectAllOtherSoldiersInList(void);
 static void MoveMenuBtnCallback(MOUSE_REGION* pRegion, INT32 iReason)
 {
 	// btn callback handler for move box line regions
-	INT32 iMoveBoxLine = -1, iRegionType = -1, iListIndex = -1, iClickTime = 0;
+	INT32 iMoveBoxLine = -1, iRegionType = -1, iListIndex = -1;
+	UINT32 uiClickTime = 0;
 	SOLDIERTYPE *pSoldier = NULL;
 
 
 	iMoveBoxLine = MSYS_GetRegionUserData( pRegion, 0 );
 	iRegionType  = MSYS_GetRegionUserData( pRegion, 1 );
 	iListIndex   = MSYS_GetRegionUserData( pRegion, 2 );
-	iClickTime   = GetJA2Clock();
+	uiClickTime   = GetJA2Clock();
 
 	if( ( iReason & MSYS_CALLBACK_REASON_LBUTTON_UP )  )
 	{
-		if( iClickTime - giDblClickTimersForMoveBoxMouseRegions[ iMoveBoxLine ] < DBL_CLICK_DELAY_FOR_MOVE_MENU  )
+		if( uiClickTime - guiDblClickTimersForMoveBoxMouseRegions[ iMoveBoxLine ] < DBL_CLICK_DELAY_FOR_MOVE_MENU  )
 		{
 			// dbl click, and something is selected?
 			if ( IsAnythingSelectedForMoving() )
@@ -2598,7 +2599,7 @@ static void MoveMenuBtnCallback(MOUSE_REGION* pRegion, INT32 iReason)
 		}
 		else
 		{
-			giDblClickTimersForMoveBoxMouseRegions[ iMoveBoxLine ] = iClickTime;
+			guiDblClickTimersForMoveBoxMouseRegions[ iMoveBoxLine ] = uiClickTime;
 
 			if( iRegionType == SQUAD_REGION )
 			{
@@ -3614,7 +3615,7 @@ void EndUpdateBox( BOOLEAN fContinueTimeCompression )
 
 void InitTimersForMoveMenuMouseRegions()
 {
-	FOR_EACH(INT32, i, giDblClickTimersForMoveBoxMouseRegions) *i = 0;
+	FOR_EACH(UINT32, i, guiDblClickTimersForMoveBoxMouseRegions) *i = 0;
 }
 
 

--- a/src/game/Strategic/Map_Screen_Interface_Bottom.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Bottom.cc
@@ -429,13 +429,13 @@ static void BtnTimeCompressLessMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 
 static void BtnMessageDownMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 {
-	static INT32 iLastRepeatScrollTime = 0;
+	static UINT32 uiLastRepeatScrollTime = 0;
 
 	if (reason & MSYS_CALLBACK_REASON_LBUTTON_DWN)
 	{
 		// redraw region
 		if (btn->uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
-		iLastRepeatScrollTime = 0;
+		uiLastRepeatScrollTime = 0;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
@@ -445,17 +445,17 @@ static void BtnMessageDownMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_REPEAT)
 	{
-		if (GetJA2Clock() - iLastRepeatScrollTime >= MESSAGE_BTN_SCROLL_TIME)
+		if (GetJA2Clock() - uiLastRepeatScrollTime >= MESSAGE_BTN_SCROLL_TIME)
 		{
 			MapScreenMsgScrollDown(1);
-			iLastRepeatScrollTime = GetJA2Clock();
+			uiLastRepeatScrollTime = GetJA2Clock();
 		}
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_DWN)
 	{
 		// redraw region
 		if (btn->uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
-		iLastRepeatScrollTime = 0;
+		uiLastRepeatScrollTime = 0;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_UP)
 	{
@@ -465,10 +465,10 @@ static void BtnMessageDownMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_REPEAT)
 	{
-		if (GetJA2Clock() - iLastRepeatScrollTime >= MESSAGE_BTN_SCROLL_TIME)
+		if (GetJA2Clock() - uiLastRepeatScrollTime >= MESSAGE_BTN_SCROLL_TIME)
 		{
 			MapScreenMsgScrollDown(MAX_MESSAGES_ON_MAP_BOTTOM);
-			iLastRepeatScrollTime = GetJA2Clock();
+			uiLastRepeatScrollTime = GetJA2Clock();
 		}
 	}
 }
@@ -476,13 +476,13 @@ static void BtnMessageDownMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 
 static void BtnMessageUpMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 {
-	static INT32 iLastRepeatScrollTime = 0;
+	static UINT32 uiLastRepeatScrollTime = 0;
 
 	if (reason & MSYS_CALLBACK_REASON_LBUTTON_DWN)
 	{
 		// redraw region
 		if (btn->Area.uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
-		iLastRepeatScrollTime = 0;
+		uiLastRepeatScrollTime = 0;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
@@ -492,17 +492,17 @@ static void BtnMessageUpMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_REPEAT)
 	{
-		if (GetJA2Clock() - iLastRepeatScrollTime >= MESSAGE_BTN_SCROLL_TIME)
+		if (GetJA2Clock() - uiLastRepeatScrollTime >= MESSAGE_BTN_SCROLL_TIME)
 		{
 			MapScreenMsgScrollUp(1);
-			iLastRepeatScrollTime = GetJA2Clock();
+			uiLastRepeatScrollTime = GetJA2Clock();
 		}
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_DWN)
 	{
 		// redraw region
 		if (btn->uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
-		iLastRepeatScrollTime = 0;
+		uiLastRepeatScrollTime = 0;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_UP)
 	{
@@ -512,10 +512,10 @@ static void BtnMessageUpMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_REPEAT)
 	{
-		if (GetJA2Clock() - iLastRepeatScrollTime >= MESSAGE_BTN_SCROLL_TIME)
+		if (GetJA2Clock() - uiLastRepeatScrollTime >= MESSAGE_BTN_SCROLL_TIME)
 		{
 			MapScreenMsgScrollUp(MAX_MESSAGES_ON_MAP_BOTTOM);
-			iLastRepeatScrollTime = GetJA2Clock();
+			uiLastRepeatScrollTime = GetJA2Clock();
 		}
 	}
 }

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -394,8 +394,8 @@ static UINT16 gusUndergroundNearBlack;
 
 BOOLEAN gfMilitiaPopupCreated = FALSE;
 
-INT32 giAnimateRouteBaseTime = 0;
-INT32 giPotHeliPathBaseTime = 0;
+UINT32 guiAnimateRouteBaseTime = 0;
+UINT32 guiPotHeliPathBaseTime = 0;
 
 // sam and mine icons
 static SGPVObject* guiSAMICON;
@@ -1529,14 +1529,14 @@ static BOOLEAN TraceCharAnimatedRoute(PathSt* const pPath, const BOOLEAN fForceU
 	}
 
 	// Check Timer
-	if (giAnimateRouteBaseTime==0)
+	if (guiAnimateRouteBaseTime==0)
 	{
-		giAnimateRouteBaseTime=GetJA2Clock();
+		guiAnimateRouteBaseTime=GetJA2Clock();
 		return FALSE;
 	}
 
 	// check difference in time
-	iDifference=GetJA2Clock()-giAnimateRouteBaseTime;
+	iDifference=GetJA2Clock()-guiAnimateRouteBaseTime;
 
 	// if pause flag, check time, if time passed, reset, continue on, else return
 	if(fPauseFlag)
@@ -1548,7 +1548,7 @@ static BOOLEAN TraceCharAnimatedRoute(PathSt* const pPath, const BOOLEAN fForceU
 		else
 		{
 			fPauseFlag=FALSE;
-		giAnimateRouteBaseTime=GetJA2Clock();
+		guiAnimateRouteBaseTime=GetJA2Clock();
 		}
 	}
 
@@ -1564,7 +1564,7 @@ static BOOLEAN TraceCharAnimatedRoute(PathSt* const pPath, const BOOLEAN fForceU
 		else
 		{
 			// sufficient time, update base time
-			giAnimateRouteBaseTime=GetJA2Clock();
+			guiAnimateRouteBaseTime=GetJA2Clock();
 			fUpDateFlag=!fUpDateFlag;
 
 			fNextNode=TRUE;
@@ -2020,7 +2020,7 @@ void DisplayThePotentialPathForHelicopter(INT16 sMapX, INT16 sMapY )
 	if( fOldShowAirCraft != fShowAircraftFlag )
 	{
 		fOldShowAirCraft = fShowAircraftFlag;
-		giPotHeliPathBaseTime = GetJA2Clock( );
+		guiPotHeliPathBaseTime = GetJA2Clock( );
 
 		sOldMapX = sMapX;
 		sOldMapY = sMapY;
@@ -2031,7 +2031,7 @@ void DisplayThePotentialPathForHelicopter(INT16 sMapX, INT16 sMapY )
 
 	if( ( sMapX != sOldMapX) || ( sMapY != sOldMapY ) )
 	{
-		giPotHeliPathBaseTime = GetJA2Clock( );
+		guiPotHeliPathBaseTime = GetJA2Clock( );
 
 		sOldMapX = sMapX;
 		sOldMapY = sMapY;
@@ -2046,7 +2046,7 @@ void DisplayThePotentialPathForHelicopter(INT16 sMapX, INT16 sMapY )
 		fDrawTempHeliPath = FALSE;
 	}
 
-	iDifference = GetJA2Clock( ) - giPotHeliPathBaseTime ;
+	iDifference = GetJA2Clock( ) - guiPotHeliPathBaseTime ;
 
 	if( fTempPathAlreadyDrawn )
 	{
@@ -2056,7 +2056,7 @@ void DisplayThePotentialPathForHelicopter(INT16 sMapX, INT16 sMapY )
 	if( iDifference > MIN_WAIT_TIME_FOR_TEMP_PATH )
 	{
 		fDrawTempHeliPath = TRUE;
-		giPotHeliPathBaseTime = GetJA2Clock( );
+		guiPotHeliPathBaseTime = GetJA2Clock( );
 		fTempPathAlreadyDrawn = TRUE;
 	}
 }

--- a/src/game/Strategic/Map_Screen_Interface_Map_Inventory.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map_Inventory.cc
@@ -106,8 +106,8 @@ static BOOLEAN      fChangedInventorySlots = FALSE;
 // the unseen items list...have to save this
 static std::vector<WORLDITEM> pUnSeenItems;
 
-INT32 giFlashHighlightedItemBaseTime = 0;
-INT32 giCompatibleItemBaseTime = 0;
+UINT32 guiFlashHighlightedItemBaseTime = 0;
+UINT32 guiCompatibleItemBaseTime = 0;
 
 static GUIButtonRef guiMapInvenButton[3];
 
@@ -1171,7 +1171,7 @@ static void DrawTextOnSectorInventory(void)
 
 void HandleFlashForHighLightedItem( void )
 {
-	INT32 iCurrentTime = 0;
+	UINT32 uiCurrentTime = 0;
 	INT32 iDifference = 0;
 
 
@@ -1179,25 +1179,25 @@ void HandleFlashForHighLightedItem( void )
 	if( iCurrentlyHighLightedItem == -1 )
 	{
 		fFlashHighLightInventoryItemOnradarMap = FALSE;
-		giFlashHighlightedItemBaseTime = 0;
+		guiFlashHighlightedItemBaseTime = 0;
 	}
 
 	// get the current time
-	iCurrentTime = GetJA2Clock();
+	uiCurrentTime = GetJA2Clock();
 
 	// if there basetime is uninit
-	if( giFlashHighlightedItemBaseTime == 0 )
+	if( guiFlashHighlightedItemBaseTime == 0 )
 	{
-		giFlashHighlightedItemBaseTime = iCurrentTime;
+		guiFlashHighlightedItemBaseTime = uiCurrentTime;
 	}
 
 
-	iDifference = iCurrentTime - giFlashHighlightedItemBaseTime;
+	iDifference = uiCurrentTime - guiFlashHighlightedItemBaseTime;
 
 	if( iDifference > DELAY_FOR_HIGHLIGHT_ITEM_FLASH )
 	{
 		// reset timer
-		giFlashHighlightedItemBaseTime = iCurrentTime;
+		guiFlashHighlightedItemBaseTime = uiCurrentTime;
 
 		// flip flag
 		fFlashHighLightInventoryItemOnradarMap = !fFlashHighLightInventoryItemOnradarMap;
@@ -1219,19 +1219,19 @@ static void HandleMouseInCompatableItemForMapSectorInventory(INT32 iCurrentSlot)
 
 	if( iCurrentSlot == -1 )
 	{
-		giCompatibleItemBaseTime = 0;
+		guiCompatibleItemBaseTime = 0;
 	}
 
 	if (fChangedInventorySlots)
 	{
-		giCompatibleItemBaseTime = 0;
+		guiCompatibleItemBaseTime = 0;
 		fChangedInventorySlots = FALSE;
 	}
 
 	// reset the base time to the current game clock
-	if( giCompatibleItemBaseTime == 0 )
+	if( guiCompatibleItemBaseTime == 0 )
 	{
-		giCompatibleItemBaseTime = GetJA2Clock( );
+		guiCompatibleItemBaseTime = GetJA2Clock( );
 
 		if (fItemWasHighLighted)
 		{
@@ -1260,7 +1260,7 @@ static void HandleMouseInCompatableItemForMapSectorInventory(INT32 iCurrentSlot)
 			{
 				if( HandleCompatibleAmmoUIForMapScreen( pSoldier, iCurrentSlot + ( iCurrentInventoryPoolPage * MAP_INVENTORY_POOL_SLOT_COUNT ), TRUE, FALSE ) )
 				{
-					if( GetJA2Clock( ) - giCompatibleItemBaseTime > 100 )
+					if( GetJA2Clock( ) - guiCompatibleItemBaseTime > 100 )
 					{
 						if (!fItemWasHighLighted)
 						{
@@ -1273,7 +1273,7 @@ static void HandleMouseInCompatableItemForMapSectorInventory(INT32 iCurrentSlot)
 		}
 		else
 		{
-			giCompatibleItemBaseTime = 0;
+			guiCompatibleItemBaseTime = 0;
 		}
 	}
 
@@ -1286,7 +1286,7 @@ static void HandleMouseInCompatableItemForMapSectorInventory(INT32 iCurrentSlot)
 		{
 			if( HandleCompatibleAmmoUIForMapInventory( pSoldier, iCurrentSlot, ( iCurrentInventoryPoolPage * MAP_INVENTORY_POOL_SLOT_COUNT ) , TRUE, FALSE ) )
 			{
-				if( GetJA2Clock( ) - giCompatibleItemBaseTime > 100 )
+				if( GetJA2Clock( ) - guiCompatibleItemBaseTime > 100 )
 				{
 					if (!fItemWasHighLighted)
 					{
@@ -1298,7 +1298,7 @@ static void HandleMouseInCompatableItemForMapSectorInventory(INT32 iCurrentSlot)
 		}
 		else
 		{
-			giCompatibleItemBaseTime = 0;
+			guiCompatibleItemBaseTime = 0;
 		}
 	}
 }

--- a/src/game/Tactical/Overhead.cc
+++ b/src/game/Tactical/Overhead.cc
@@ -112,7 +112,7 @@
 #define RT_DELAY_BETWEEN_AI_HANDLING	50
 #define RT_AI_TIMESLICE			10
 
-INT32         giRTAILastUpdateTime = 0;
+UINT32        guiRTAILastUpdateTime = 0;
 static UINT32 guiAISlotToHandle    = 0;
 #define HANDLE_OFF_MAP_MERC		0xFFFF
 #define RESET_HANDLE_OF_OFF_MAP_MERCS	0xFFFF
@@ -121,7 +121,7 @@ static UINT32 guiAIAwaySlotToHandle = RESET_HANDLE_OF_OFF_MAP_MERCS;
 #define PAUSE_ALL_AI_DELAY		1500
 
 static BOOLEAN gfPauseAllAI      = FALSE;
-static INT32   giPauseAllAITimer = 0;
+static UINT32  guiPauseAllAITimer = 0;
 
 
 BOOLEAN gfSurrendered = FALSE;
@@ -529,14 +529,14 @@ static BOOLEAN NextAIToHandle(UINT32 uiCurrAISlot)
 void PauseAITemporarily(void)
 {
 	gfPauseAllAI      = TRUE;
-	giPauseAllAITimer = GetJA2Clock();
+	guiPauseAllAITimer = GetJA2Clock();
 }
 
 
 void PauseAIUntilManuallyUnpaused(void)
 {
 	gfPauseAllAI      = TRUE;
-	giPauseAllAITimer = 0;
+	guiPauseAllAITimer = 0;
 }
 
 
@@ -544,7 +544,7 @@ void UnPauseAI(void)
 {
 	// overrides any timer too
 	gfPauseAllAI      = FALSE;
-	giPauseAllAITimer = 0;
+	guiPauseAllAITimer = 0;
 }
 
 
@@ -565,9 +565,9 @@ void ExecuteOverhead(void)
 		RESETCOUNTER(TOVERHEAD);
 
 		// Diagnostic Stuff
-		INT32 iTimerVal = GetJA2Clock();
-		giTimerDiag = iTimerVal - iTimerTest;
-		iTimerTest  = iTimerVal;
+		UINT32 uiTimerVal = GetJA2Clock();
+		guiTimerDiag = uiTimerVal - iTimerTest;
+		iTimerTest  = uiTimerVal;
 
 		// ANIMATED TILE STUFF
 		UpdateAniTiles();
@@ -579,7 +579,7 @@ void ExecuteOverhead(void)
 
 		CheckHostileOrSayQuoteList();
 
-		if (gfPauseAllAI && giPauseAllAITimer && iTimerVal - giPauseAllAITimer > PAUSE_ALL_AI_DELAY)
+		if (gfPauseAllAI && guiPauseAllAITimer && uiTimerVal - guiPauseAllAITimer > PAUSE_ALL_AI_DELAY)
 		{
 			// ok, stop pausing the AI!
 			gfPauseAllAI = FALSE;
@@ -591,9 +591,9 @@ void ExecuteOverhead(void)
 			// AI limiting crap
 			if (!(gTacticalStatus.uiFlags & INCOMBAT))
 			{
-				if (iTimerVal - giRTAILastUpdateTime > RT_DELAY_BETWEEN_AI_HANDLING)
+				if (uiTimerVal - guiRTAILastUpdateTime > RT_DELAY_BETWEEN_AI_HANDLING)
 				{
-					giRTAILastUpdateTime = iTimerVal;
+					guiRTAILastUpdateTime = uiTimerVal;
 					// figure out which AI guy to handle this time around,
 					// starting with the slot AFTER the current AI guy
 					fHandleAI = NextAIToHandle(guiAISlotToHandle);
@@ -1137,7 +1137,7 @@ void ExecuteOverhead(void)
 					HandleSoldierAI(pSoldier);
 					if (!(gTacticalStatus.uiFlags & INCOMBAT))
 					{
-						if (GetJA2Clock() - iTimerVal > RT_AI_TIMESLICE)
+						if (GetJA2Clock() - uiTimerVal > RT_AI_TIMESLICE)
 						{
 							// don't do any more AI this time!
 							fHandleAI = FALSE;
@@ -6134,7 +6134,7 @@ static void HandleCreatureTenseQuote(void)
 	if (!(gTacticalStatus.uiFlags & IN_CREATURE_LAIR)) return;
 	if (gTacticalStatus.uiFlags & INCOMBAT) return;
 
-	INT32 uiTime = GetJA2Clock();
+	UINT32 uiTime = GetJA2Clock();
 	if (uiTime - gTacticalStatus.uiCreatureTenseQuoteLastUpdate > (UINT32)(gTacticalStatus.sCreatureTenseQuoteDelay * 1000))
 	{
 		gTacticalStatus.uiCreatureTenseQuoteLastUpdate = uiTime;

--- a/src/game/Utils/Timer_Control.cc
+++ b/src/game/Utils/Timer_Control.cc
@@ -14,8 +14,8 @@
 #include <stdexcept>
 
 
-INT32	giClockTimer = -1;
-INT32	giTimerDiag  =  0;
+UINT32	guiClockTimer = UINT32_MAX;
+UINT32	guiTimerDiag  =  0;
 
 UINT32 guiBaseJA2Clock = 0;
 
@@ -59,16 +59,16 @@ static SDL_TimerID g_timer;
 
 
 extern UINT32 guiCompressionStringBaseTime;
-extern INT32  giFlashHighlightedItemBaseTime;
-extern INT32  giCompatibleItemBaseTime;
-extern INT32  giAnimateRouteBaseTime;
-extern INT32  giPotHeliPathBaseTime;
+extern UINT32 guiFlashHighlightedItemBaseTime;
+extern UINT32 guiCompatibleItemBaseTime;
+extern UINT32 guiAnimateRouteBaseTime;
+extern UINT32 guiPotHeliPathBaseTime;
 extern UINT32 guiSectorLocatorBaseTime;
-extern INT32  giCommonGlowBaseTime;
-extern INT32  giFlashAssignBaseTime;
-extern INT32  giFlashContractBaseTime;
+extern UINT32 guiCommonGlowBaseTime;
+extern UINT32 guiFlashAssignBaseTime;
+extern UINT32 guiFlashContractBaseTime;
 extern UINT32 guiFlashCursorBaseTime;
-extern INT32  giPotCharPathBaseTime;
+extern UINT32 guiPotCharPathBaseTime;
 
 
 static UINT32 TimeProc(UINT32 const interval, void*)
@@ -185,16 +185,16 @@ void ResetJA2ClockGlobalTimers(void)
 {
 	UINT32 const now = GetJA2Clock();
 
-	guiCompressionStringBaseTime   = now;
-	giFlashHighlightedItemBaseTime = now;
-	giCompatibleItemBaseTime       = now;
-	giAnimateRouteBaseTime         = now;
-	giPotHeliPathBaseTime          = now;
-	guiSectorLocatorBaseTime       = now;
+	guiCompressionStringBaseTime    = now;
+	guiFlashHighlightedItemBaseTime = now;
+	guiCompatibleItemBaseTime       = now;
+	guiAnimateRouteBaseTime         = now;
+	guiPotHeliPathBaseTime          = now;
+	guiSectorLocatorBaseTime        = now;
 
-	giCommonGlowBaseTime           = now;
-	giFlashAssignBaseTime          = now;
-	giFlashContractBaseTime        = now;
-	guiFlashCursorBaseTime         = now;
-	giPotCharPathBaseTime          = now;
+	guiCommonGlowBaseTime           = now;
+	guiFlashAssignBaseTime          = now;
+	guiFlashContractBaseTime        = now;
+	guiFlashCursorBaseTime          = now;
+	guiPotCharPathBaseTime          = now;
 }

--- a/src/game/Utils/Timer_Control.h
+++ b/src/game/Utils/Timer_Control.h
@@ -39,9 +39,9 @@ extern const INT32 giTimerIntervals[NUMTIMERS];
 extern INT32       giTimerCounters[NUMTIMERS];
 
 // GLOBAL SYNC TEMP TIME
-extern INT32 giClockTimer;
+extern UINT32 guiClockTimer;
 
-extern INT32 giTimerDiag;
+extern UINT32 guiTimerDiag;
 
 extern INT32 giTimerTeamTurnUpdate;
 


### PR DESCRIPTION
This is a find-and-replace update to ensure we use `UINT32` variables to handle clock time. I searched for keywords including `GetJA2Clock` and `timer`, and replaced the usage of `INT32` if it is not appropriate.

None of the variables are persisted in saves, so it is safe to change the variable type.

Related to #1386.
