### PR TITLE
Option to refill totally defeated patrol groups

### DIFF
--- a/assets/externalized/strategic-ai-policy.json
+++ b/assets/externalized/strategic-ai-policy.json
@@ -1,7 +1,7 @@
 /**
  * Game policies governing Strategic AI behaviour.
  *
- * Most of the settings here are set at the start of a  campaign. Changes will only take 
+ * Most of the settings here are set at the start of a campaign. Changes will only take
  * effect in a new game.
  */
 {
@@ -73,6 +73,12 @@
     "grace_period_in_hours_easy": 144,  // 6 days
     "grace_period_in_hours_medium": 96, // 4 days
     "grace_period_in_hours_hard": 48,   // 2 days
+
+    //  Whether or not the queen would send new groups of army to replace defeated patrols. By
+    //  default, the queen only reinforces active patrol groups.
+    //
+    //  vanilla value: false
+    "refill_defeated_patrol_groups": false,
 
     //  Defines how many days must pass before the queen is willing to refill a defeated patrol
     //  group.

--- a/src/externalized/policy/DefaultStrategicAIPolicy.cc
+++ b/src/externalized/policy/DefaultStrategicAIPolicy.cc
@@ -28,5 +28,8 @@ DefaultStrategicAIPolicy::DefaultStrategicAIPolicy(rapidjson::Document* json)
 	grace_period_in_hours        = ReadSAIPolicy<unsigned int>(*json, "grace_period_in_hours");
 	patrol_grace_period_in_days  = ReadSAIPolicy<unsigned int>(*json, "patrol_grace_period_in_days");
 	num_aware_battles            = ReadSAIPolicy<unsigned int>(*json, "num_aware_battles");
+
+	JsonObjectReader r(*json);
+	refill_defeated_patrol_groups = r.getOptionalBool("refill_defeated_patrol_groups", false);
 }
 

--- a/src/externalized/policy/StrategicAIPolicy.h
+++ b/src/externalized/policy/StrategicAIPolicy.h
@@ -7,7 +7,8 @@
 #include <string_theory/string>
 
 // gets the Strategic AI policy value for the current game difficulty
-#define saipolicy(element) ( GCM->getStrategicAIPolicy()->element[gGameOptions.ubDifficultyLevel - 1] )
+#define saipolicy(element) ( GCM->getStrategicAIPolicy()->element )
+#define saipolicy_by_diff(element) ( saipolicy(element)[gGameOptions.ubDifficultyLevel - 1] )
 
 // Refer to strategic-ai-policy.json for the definition of each value
 class StrategicAIPolicy
@@ -23,4 +24,6 @@ public:
 	std::array<unsigned int, NUM_DIF_LEVELS>    grace_period_in_hours;
 	std::array<unsigned int, NUM_DIF_LEVELS>    patrol_grace_period_in_days;
 	std::array<unsigned int, NUM_DIF_LEVELS>    num_aware_battles;
+
+	bool refill_defeated_patrol_groups;
 };

--- a/src/game/Strategic/Strategic_AI.cc
+++ b/src/game/Strategic/Strategic_AI.cc
@@ -3279,6 +3279,10 @@ static BOOLEAN PatrolRequestingMinimumReinforcements(INT32 iPatrolID)
 			return TRUE;
 		}
 	}
+	else if (saipolicy(refill_defeated_patrol_groups))
+	{ // we want to refill totally defeated patrols too
+		return TRUE;
+	}
 	return FALSE;
 }
 

--- a/src/game/Strategic/Strategic_AI.cc
+++ b/src/game/Strategic/Strategic_AI.cc
@@ -335,13 +335,13 @@ void InitStrategicAI()
 	UINT32      evaluate_time = 475;
 	UINT8 const difficulty    = gGameOptions.ubDifficultyLevel;
 
-	giReinforcementPool   = saipolicy(queens_pool_of_troops);
-	giForcePercentage     = saipolicy(initial_garrison_percentages);
-	giArmyAlertness       = saipolicy(enemy_starting_alert_level);
-	giArmyAlertnessDecay  = saipolicy(enemy_starting_alert_decay);
-	gubMinEnemyGroupSize  = saipolicy(min_enemy_group_size);
-	gubHoursGracePeriod   = saipolicy(grace_period_in_hours);
-	evaluate_time        += saipolicy(time_evaluate_in_minutes) + Random(saipolicy(time_evaluate_variance));
+	giReinforcementPool   = saipolicy_by_diff(queens_pool_of_troops);
+	giForcePercentage     = saipolicy_by_diff(initial_garrison_percentages);
+	giArmyAlertness       = saipolicy_by_diff(enemy_starting_alert_level);
+	giArmyAlertnessDecay  = saipolicy_by_diff(enemy_starting_alert_decay);
+	gubMinEnemyGroupSize  = saipolicy_by_diff(min_enemy_group_size);
+	gubHoursGracePeriod   = saipolicy_by_diff(grace_period_in_hours);
+	evaluate_time        += saipolicy_by_diff(time_evaluate_in_minutes) + Random(saipolicy_by_diff(time_evaluate_variance));
 	
 	AddStrategicEvent(EVENT_EVALUATE_QUEEN_SITUATION, evaluate_time, 0);
 
@@ -2012,7 +2012,7 @@ void EvaluateQueenSituation()
 	// This can increase the decision intervals by up to 500 extra minutes (> 8 hrs)
 	uiOffset = MAX( 100 - giRequestPoints, 0);
 	uiOffset = uiOffset + Random( uiOffset * 4 );
-	uiOffset += saipolicy(time_evaluate_in_minutes) + Random(saipolicy(time_evaluate_variance));
+	uiOffset += saipolicy_by_diff(time_evaluate_in_minutes) + Random(saipolicy_by_diff(time_evaluate_variance));
 
 	if( !giReinforcementPool )
 	{ //Queen has run out of reinforcements.  Simulate recruiting and training new troops
@@ -2922,7 +2922,7 @@ void ExecuteStrategicAIAction( UINT16 usActionCode, INT16 sSectorX, INT16 sSecto
 			break;
 		case NPC_ACTION_GIVE_KNOWLEDGE_OF_ALL_MERCS:
 			//temporarily make the queen's forces more aware (high alert)
-			gubNumAwareBattles = saipolicy(num_aware_battles);
+			gubNumAwareBattles = saipolicy_by_diff(num_aware_battles);
 			break;
 		default:
 			SLOGD("QueenAI failed to handle action code %d.", usActionCode );
@@ -3667,7 +3667,7 @@ static void TagSAIGroupWithGracePeriod(GROUP const& g)
 	size_t const patrol_id = FindPatrolGroupIndexForGroupID(g.ubGroupID);
 	if (patrol_id == (size_t)-1) return;
 
-	UINT32 grace_period = saipolicy(patrol_grace_period_in_days);
+	UINT32 grace_period = saipolicy_by_diff(patrol_grace_period_in_days);
 	gPatrolGroup[patrol_id].bFillPermittedAfterDayMod100 = (GetWorldDay() + grace_period) % 100;
 }
 


### PR DESCRIPTION
The second issue in #1419.

The vanilla Strategic AI seems not replacing a totally defeated patrol group. It is able to reinforce if the group has some of the soldiers killed but the group is still active. But if the group is destroyed, it will never get replaced.

Here we have a new option `refill_defeated_patrol_groups` in the Strategic AI policy. I set it to disabled by default for consistency with vanilla, though I would personally always play with it enabled.