### PR TITLE
Fix UI overlay glitches in tactical UI

### DIFF
--- a/src/game/Tactical/Interface_Control.cc
+++ b/src/game/Tactical/Interface_Control.cc
@@ -534,13 +534,13 @@ static void StartViewportOverlays(void)
 	gOldDirtyClippingRect = ClippingRect;
 
 	// Set bottom clipping value for blitter clipping rect
-	ClippingRect.iLeft   = INTERFACE_START_X;
+	ClippingRect.iLeft   = gsVIEWPORT_START_X;
 	ClippingRect.iTop    = gsVIEWPORT_WINDOW_START_Y;
 	ClippingRect.iRight  = SCREEN_WIDTH;
 	ClippingRect.iBottom = gsVIEWPORT_WINDOW_END_Y;
 
 	// Set values for dirty rect clipping rect
-	gDirtyClipRect.iLeft   = INTERFACE_START_X;
+	gDirtyClipRect.iLeft   = gsVIEWPORT_START_X;
 	gDirtyClipRect.iTop    = gsVIEWPORT_WINDOW_START_Y;
 	gDirtyClipRect.iRight  = SCREEN_WIDTH;
 	gDirtyClipRect.iBottom = gsVIEWPORT_WINDOW_END_Y;


### PR DESCRIPTION
Bug since #1404, reported on Discord. 

Using widescreen resolution, in the far-left side in the tactical UI, the UI overlay elements (cursors, soldier names, etc) are not properly drawn and cleaned, causing artifacts on screen.

The problem is in Interface_Control.cc, which handles the UI overlay elements. It uses clipping to prevent drawing elements over of the bottom bar. The bottom bar was moved to the center, but the clipping rectangle uses `INTERFACE_START_X` which I think is wrong.

`INTERFACE_START_X` is now used as the "leftmost X-position of the tactical bottom bar". It used to be zero as everything had been aligned to the left. 

`gsVIEWPORT_START_X` is the correct one to use. The value is currently always zero, because the tactical viewport takes the entire screen width.