### PR TITLE
Fix crash when giving NPC items

### DIFF
--- a/src/game/Tactical/Interface_Dialogue.cc
+++ b/src/game/Tactical/Interface_Dialogue.cc
@@ -244,8 +244,9 @@ void HandlePendingInitConv( )
 	if ( gfConversationPending )
 	{
 		// OK, if pending, remove and now call........
+		OBJECTTYPE* pPendingObject = (g_pending_approach_object.usItem != NONE) ? &g_pending_approach_object : NULL;
 		InternalInitiateConversation(gpPendingDestSoldier, gpPendingSrcSoldier, gbPendingApproach,
-						g_pending_approach_record, &g_pending_approach_object);
+						g_pending_approach_record, pPendingObject);
 	}
 }
 


### PR DESCRIPTION
Changing the temporary global variable `g_pending_approach_object` from `OBJECTTYPE*` to `OBJECTTYPE`.

This makes sense because, in the current code, the `TempObject` variable is a local copy of the object being used:

https://github.com/ja2-stracciatella/ja2-stracciatella/blob/e23678b74af7e7fa2ccaf067eb44993184af0a33/src/game/Tactical/Handle_Items.cc#L2353-L2355

Which is then passed by pointer to `InitiateConversationFull`:

https://github.com/ja2-stracciatella/ja2-stracciatella/blob/e23678b74af7e7fa2ccaf067eb44993184af0a33/src/game/Tactical/Handle_Items.cc#L2523-L2524

If we are blocked by another conversation, the pointer to `TempObject` is saved for later use (and crash):

https://github.com/ja2-stracciatella/ja2-stracciatella/blob/e23678b74af7e7fa2ccaf067eb44993184af0a33/src/game/Tactical/Interface_Dialogue.cc#L216-L217

These are the only places `g_pending_approach_object` is used. It is not persisted in saves.  This fixes #1378.