### PR TITLE
Fix chance-to-hit preview for rooftop targets

### DIFF
--- a/src/game/Tactical/UI_Cursors.cc
+++ b/src/game/Tactical/UI_Cursors.cc
@@ -252,7 +252,7 @@ static UICursorID HandleActivatedTargetCursor(SOLDIERTYPE* const s, GridNo const
 			GridNo targetTile = gUIFullTarget ? gUIFullTarget->sGridNo : map_pos;
 			giHitChance = is_throwing_knife ? CalcThrownChanceToHit(s, targetTile, s->bShownAimTime / 2, s->bAimShotLocation) :
 				CalcChanceToHitGun(s, targetTile, s->bShownAimTime / 2, s->bAimShotLocation, false);
-			giHitChance *= SoldierToLocationChanceToGetThrough(s, targetTile, s->bTargetLevel, s->bTargetCubeLevel, 0) / 100.0f;
+			giHitChance *= SoldierToLocationChanceToGetThrough(s, targetTile, gsInterfaceLevel, s->bTargetCubeLevel, 0) / 100.0f;
 		}
 	
 		// Attach chance-to-hit to mouse cursor


### PR DESCRIPTION
First reported on Discord. The CTH display (`show_hit_chance` since #1375) shows only `0%` when you target from the ground to an enemy on a rooftop.

This is because `pSoldier->bTargetLevel` is not set until the shot is [actually fired](https://github.com/ja2-stracciatella/ja2-stracciatella/blob/e23678b74af7e7fa2ccaf067eb44993184af0a33/src/game/Tactical/Handle_Items.cc#L398-L399), so the CTH preview never worked on the first shot to a target on a rooftop.
