### PR TITLE
Bullet should never hit when the hit-chance is zero

### DIFF
--- a/src/game/Tactical/LOS.cc
+++ b/src/game/Tactical/LOS.cc
@@ -3388,7 +3388,7 @@ INT8 FireBulletGivenTarget(SOLDIERTYPE* const pFirer, const FLOAT dEndX, const F
 			ddVerticAngle = ddOrigVerticAngle;
 
 			// first bullet, roll to hit...
-			if ( sHitBy >= 0 )
+			if (sHitBy > 0)
 			{
 				// calculate by hand (well, without angles) to match LOS
 				pBullet->qIncrX = FloatToFixed( dDeltaX / (FLOAT)iDistance );
@@ -3440,7 +3440,7 @@ INT8 FireBulletGivenTarget(SOLDIERTYPE* const pFirer, const FLOAT dEndX, const F
 
 		// NB we can only apply correction for leftovers if the bullet is going to hit
 		// because otherwise the increments are not right for the calculations!
-		if ( pBullet->sHitBy >= 0 )
+		if (pBullet->sHitBy > 0)
 		{
 			pBullet->qCurrX += ( FloatToFixed( dDeltaX ) - pBullet->qIncrX * iDistance ) / 2;
 			pBullet->qCurrY += ( FloatToFixed( dDeltaY ) - pBullet->qIncrY * iDistance ) / 2;

--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -951,7 +951,7 @@ static BOOLEAN UseGun(SOLDIERTYPE* pSoldier, INT16 sTargetGridNo)
 	}
 
 	FireBulletGivenTarget(pSoldier, dTargetX, dTargetY, dTargetZ, pSoldier->usAttackingWeapon,
-				(UINT16) (uiHitChance - uiDiceRoll), fBuckshot, FALSE);
+				(INT16) (uiHitChance - uiDiceRoll), fBuckshot, FALSE);
 
 	ubVolume = GCM->getWeapon( pSoldier->usAttackingWeapon )->ubAttackVolume;
 


### PR DESCRIPTION
Resolves #1393.

Details are already mentioned in the issue. This changes `>=` checks to `>`, so 0% chance should not result in a hit. 

Also a change in the type-casting, that we now use the expected type of signed `INT16`, instead of first casting to `UINT16` and then implicitly casted to `INT16`.