### PR TITLE
Use play as default launcher tab instead of mods

### DIFF
--- a/src/launcher/StracciatellaLauncher.cc
+++ b/src/launcher/StracciatellaLauncher.cc
@@ -10,7 +10,6 @@ StracciatellaLauncher::StracciatellaLauncher() {
       { Fl_Group* o = new Fl_Group(0, 50, 520, 300, "@> Play  ");
         o->labelsize(16);
         o->labelcolor((Fl_Color)24);
-        o->hide();
         { editorButton = new Fl_Button(160, 150, 200, 25, "Start Map Editor");
         } // Fl_Button* editorButton
         { playButton = new Fl_Button(160, 185, 200, 55, "Play Ja2 Stracciatella");
@@ -51,6 +50,7 @@ StracciatellaLauncher::StracciatellaLauncher() {
       } // Fl_Group* o
       { Fl_Group* o = new Fl_Group(0, 50, 520, 300, "@-> Mods ");
         o->labelcolor((Fl_Color)24);
+        o->hide();
         { Fl_Group* o = new Fl_Group(10, 60, 500, 165);
           { enabledModsBrowser = new Fl_Browser(20, 75, 215, 150, "Enabled Mods:");
             enabledModsBrowser->type(3);

--- a/src/launcher/StracciatellaLauncher.fl
+++ b/src/launcher/StracciatellaLauncher.fl
@@ -14,8 +14,8 @@ class StracciatellaLauncher {open
         xywh {0 0 520 350} align 9 resizable
       } {
         Fl_Group {} {
-          label {@> Play  }
-          xywh {0 50 520 300} labelsize 16 labelcolor 24 hide
+          label {@> Play  } selected
+          xywh {0 50 520 300} labelsize 16 labelcolor 24
         } {
           Fl_Button editorButton {
             label {Start Map Editor}
@@ -61,7 +61,7 @@ class StracciatellaLauncher {open
         }
         Fl_Group {} {
           label {@-> Mods } open
-          xywh {0 50 520 300} labelcolor 24
+          xywh {0 50 520 300} labelcolor 24 hide
         } {
           Fl_Group {} {open
             xywh {10 60 500 165}
@@ -75,7 +75,7 @@ class StracciatellaLauncher {open
               tooltip {Enable one or multiple mods.} xywh {245 75 30 30} deactivate
             }
             Fl_Button disableModsButton {
-              label {@>} selected
+              label {@>}
               tooltip {Disable one or multiple mods.} xywh {245 115 30 30} deactivate
             }
             Fl_Button moveUpModsButton {


### PR DESCRIPTION
I accidentially changed it in #1429 to be the mods tab.