### PR TITLE
Fixing AppImageLint on CI

### DIFF
--- a/.ci/ci-functions.sh
+++ b/.ci/ci-functions.sh
@@ -34,7 +34,16 @@ linux-install-appimage-build-tools () {
     sudo curl -sSfL -o /usr/bin/appimagelint https://github.com/TheAssassin/appimagelint/releases/download/continuous/appimagelint-x86_64.AppImage
     sudo chmod +x /usr/bin/appimagelint
 
+    ###
+    ### See #1431. This whole block can be removed when CI runners use Ubuntu 21.04 or newer
     linux-install-via-apt-get zstd
+    curl -sL -o "tar-1.34.tar.gz" https://ftp.gnu.org/gnu/tar/tar-1.34.tar.gz
+    tar zxf "tar-1.34.tar.gz"
+    cd tar-1.34 && ./configure && make && sudo make install
+    sudo cp /usr/local/bin/tar /usr/bin/tar
+    which tar
+    tar --version
+    ###
 }
 
 linux-install-via-android-sdkmanager () {


### PR DESCRIPTION
Quick summary, I may tidy up this later:

Ubuntu Impish uses `.tar.zst` in the package. AppImageLint needs to extract package contents to inspect the glibcxx version. `zstd` support was added to `tar` in version 1.31 (released in 2019)

Our runners are on Ubuntu 18.04 (with tar 1.29), so it fails to get package information for Ubuntu "Impish" or later.

EDIT: Issue opened on appimagelint upstream - https://github.com/TheAssassin/appimagelint/issues/24