### PR TITLE
Fix truncated error message

### DIFF
--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -44,6 +44,9 @@ cmake path/to/source
 make
 ```
 
+If you want to be able to install the resulting binary on your system, please ensure that `CMAKE_INSTALL_PREFIX` matches
+with `EXTRA_DATA_DIR`. Example: `cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DEXTRA_DATA_DIR=/usr/local/share/ja2 path/to/source`
+
 ## Build for Windows on Linux using MinGW (cross build)
 
 Additional requirements: MinGW compiler

--- a/rust/stracciatella_c_api/src/c/vfs.rs
+++ b/rust/stracciatella_c_api/src/c/vfs.rs
@@ -39,10 +39,7 @@ pub extern "C" fn Vfs_init(
     let engine_options = unsafe_ref(engine_options);
     let mod_manager = unsafe_ref(mod_manager);
     if let Err(err) = vfs.init(engine_options, mod_manager) {
-        remember_rust_error(format!(
-            "Vfs_init_from_engine_options {:?}: {}",
-            engine_options, err
-        ));
+        remember_rust_error(format!("Vfs_init_from_engine_options: {}", err));
     }
     no_rust_error()
 }

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -566,7 +566,7 @@ void TerminationHandler()
 		{
 		}
 	}
-	SLOGE(errorMessage.c_str());
+	STLOGE("{}", errorMessage);
 	#ifdef __ANDROID__
 	jniEnv->CallVoidMethod(exceptionContainerSingleton, setAndroidExceptionMethodId,
                                    jniEnv->NewStringUTF(errorMessage.c_str()));

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -566,7 +566,7 @@ void TerminationHandler()
 		{
 		}
 	}
-	STLOGE("{}", errorMessage);
+	STLOGE(errorMessage.c_str());
 	#ifdef __ANDROID__
 	jniEnv->CallVoidMethod(exceptionContainerSingleton, setAndroidExceptionMethodId,
                                    jniEnv->NewStringUTF(errorMessage.c_str()));


### PR DESCRIPTION
Closes #1433.

Fixes error message being truncated on unhandled exception (`SLOGE` truncates to 256 characters).

Also makes the specific error message in #1433 shorter (does not include the whole EngineOptions struct anymore, the error message itself is specific enough: `Error initializing VFS for "/data/data_gold2/data": No such file or directory (os error 2) (St13runtime_error)`).

Adds a line about creating an installable linux build to `COMPILATION.md`