### PR TITLE
Fix graphical glitching during scrolling when merc lights are enabled

### DIFF
--- a/src/game/GameScreen.cc
+++ b/src/game/GameScreen.cc
@@ -61,6 +61,7 @@
 #include "GameMode.h"
 #include "EditScreen.h"
 #include "Logger.h"
+#include "GameSettings.h"
 
 #define ARE_IN_FADE_IN( )		( gfFadeIn || gfFadeInitialized )
 
@@ -525,6 +526,10 @@ ScreenID MainGameScreenHandle(void)
 		// Handle Interface Stuff
 		SetUpInterface( );
 		HandleTacticalPanelSwitch( );
+	} else {
+		if( gGameSettings.fOptions[TOPTION_MERC_CASTS_LIGHT] && NightTime()) {
+			SetRenderFlags( RENDER_FLAG_FULL );
+		}
 	}
 
 	// Handle Scroll Of World

--- a/src/game/TileEngine/RenderWorld.cc
+++ b/src/game/TileEngine/RenderWorld.cc
@@ -2010,7 +2010,10 @@ static BOOLEAN HandleScrollDirections(UINT32 ScrollFlags, INT16 sScrollXStep, IN
 	}
 
 	const BOOLEAN fAGoodMove = (scroll_x != 0 || scroll_y != 0);
-	if (fAGoodMove && !fCheckOnly) ScrollBackground(scroll_x, scroll_y);
+
+	if( fAGoodMove && !fCheckOnly && !( gRenderFlags & RENDER_FLAG_FULL )) {
+		ScrollBackground( scroll_x, scroll_y );
+	}
 
 	return fAGoodMove;
 }


### PR DESCRIPTION
This seems to fix the bad glitches during camera scrolling while mercs are moving and the "merc lights during movement" option is enabled.

It's kind of a workaround-y way to do it i guess, until a better fix comes along.

Related issues : #551