### PR TITLE
Fix camera focus when clicking on overhead map

### DIFF
--- a/src/game/TileEngine/Overhead_Map.cc
+++ b/src/game/TileEngine/Overhead_Map.cc
@@ -848,8 +848,6 @@ static void RenderOverheadOverlays(void)
 
 static void ClickOverheadRegionCallback(MOUSE_REGION* reg, INT32 reason)
 {
-	INT16  sWorldScreenX, sWorldScreenY;
-
 	if( gfTacticalPlacementGUIActive )
 	{
 		HandleTacticalPlacementClicksInOverheadMap(reason);
@@ -858,11 +856,8 @@ static void ClickOverheadRegionCallback(MOUSE_REGION* reg, INT32 reason)
 
 	if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
-		sWorldScreenX = ( gusMouseXPos - gsStartRestrictedX ) * 5;
-		sWorldScreenY = ( gusMouseYPos - gsStartRestrictedY ) * 5;
-
 		// Get new proposed center location.
-		const GridNo pos = GetMapPosFromAbsoluteScreenXY(sWorldScreenX, sWorldScreenY);
+		const GridNo pos = GetOverheadMouseGridNo();
 		INT16 cell_x;
 		INT16 cell_y;
 		ConvertGridNoToCenterCellXY(pos, &cell_x, &cell_y);


### PR DESCRIPTION
Clicking the overhead map was broken and often ended up in strange places. This should fix it.