### PR TITLE
Highlight compatible items in sector inventory

### DIFF
--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -3722,6 +3722,13 @@ static void HandleCursorOverRifleAmmo(void)
 {
 	if (!fShowInventoryFlag) return;
 
+	// make sure sector inventory is updated if visible
+	if( fShowMapInventoryPool )	{
+		if(( GetJA2Clock() - guiMouseOverItemTime ) > 100 ) {
+			fMapPanelDirty = TRUE;
+		}
+	}
+
 	if( gbCheckForMouseOverItemPos == -1 )
 	{
 		return;
@@ -3735,6 +3742,11 @@ static void HandleCursorOverRifleAmmo(void)
 			{
 				fTeamPanelDirty = TRUE;
 			}
+		}
+
+		// also highlight in sector inventory
+		if( fShowMapInventoryPool )	{
+			HandleCompatibleAmmoUIForMapInventory( GetSelectedInfoChar(), gbCheckForMouseOverItemPos, ( iCurrentInventoryPoolPage * MAP_INVENTORY_POOL_SLOT_COUNT ), TRUE, TRUE );
 		}
 	}
 }


### PR DESCRIPTION
Normally the map inventory screen only highlights compatibles when hovering on an item that is in the map inventory, showing compatibles in the map and on the current merc.

This patch makes it so that hovering over a merc item shows compatibles in the map inventory as well.