### PR TITLE
Update google sdk on AppVeyor for Python 3.10 compatibility

### DIFF
--- a/.ci/ci-functions.sh
+++ b/.ci/ci-functions.sh
@@ -81,9 +81,10 @@ windows-install-rustup () {
 
 windows-install-google-cloud-sdk () {
     export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+    export CLOUDSDK_PYTHON="C:\\Python39\\python.exe"
     local ARCHIVE_PATH="$HOMEPATH\google-cloud.zip"
     local UNZIP_PATH="$USERPROFILE"
-    curl -sSf -o "$ARCHIVE_PATH" https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-299.0.0-windows-x86.zip
+    curl -sSf -o "$ARCHIVE_PATH" https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-366.0.0-windows-x86.zip
     unzip -q "$ARCHIVE_PATH" -d $UNZIP_PATH
     export PATH="$PATH;$UNZIP_PATH\google-cloud-sdk\bin"
 }

--- a/.ci/upload-artifact.sh
+++ b/.ci/upload-artifact.sh
@@ -24,6 +24,11 @@ if [[ "$PUBLISH_DIR" == "" ]]; then
   exit 1
 fi
 
+if [[ "$CI_TARGET" == windows-msvc-* ]]; then
+  # Fix used python version for google cloud sdk
+  export CLOUDSDK_PYTHON="C:\\Python39\\python.exe"
+fi
+
 
 # Bucket Name to upload to
 BUCKET_NAME=ja2-builds


### PR DESCRIPTION
This should fix google-cloud-sdk on AppVeyor, where Python 3.10 is now installed, which is not supported by the google cloud SDK version we use.

See: https://issuetracker.google.com/issues/202172882

Edit: Well it seems that the latest version does not support Python 3.10 either. So I pinned the version to 3.9...

NB: The MingGW issue seems to be caused by updated CMake (3.22.0).