### PR TITLE
Bugfix for Launcher build format-security error

### DIFF
--- a/src/launcher/Launcher.cc
+++ b/src/launcher/Launcher.cc
@@ -330,7 +330,7 @@ void Launcher::startExecutable(bool asEditor) {
 		}
 
 		fl_message_title("Invalid mods");
-		fl_alert(message.c_str());
+		fl_alert("%s", message.c_str());
 		return;
 	}
 


### PR DESCRIPTION
Fix for the below build error:
```
Consolidate compiler generated dependencies of target ja2-launcher
Building CXX object CMakeFiles/ja2-launcher.dir/src/launcher/Launcher.cc.o
/home/aleh/downloads/build/ja2-stracciatella-git/src/ja2-stracciatella/src/launcher/Launcher.cc: In member function ‘void Launcher::startExecutable(bool)’:
/home/aleh/downloads/build/ja2-stracciatella-git/src/ja2-stracciatella/src/launcher/Launcher.cc:333:25: error: format not a string literal and no format arguments [-Werror=format-security]
  333 |                 fl_alert(message.c_str());
      |                 ~~~~~~~~^~~~~~~~~~~~~~~~~
cc1plus: some warnings being treated as errors
make[2]: *** [CMakeFiles/ja2-launcher.dir/build.make:146: CMakeFiles/ja2-launcher.dir/src/launcher/Launcher.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:643: CMakeFiles/ja2-launcher.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
==> ERROR: A failure occurred in build().
    Aborting...
```
