### PR TITLE
Bugfix: training militia in a city already full of militia

### DIFF
--- a/src/game/Strategic/Town_Militia.cc
+++ b/src/game/Strategic/Town_Militia.cc
@@ -397,7 +397,7 @@ static void InitFriendlyTownSectorServer(UINT8 ubTownId, INT16 sSkipSectorX, INT
  * MUST CALL InitFriendlyTownSectorServer() before using! */
 static bool ServeNextFriendlySectorInTown(INT16* const neighbour_x, INT16* const neighbour_y)
 {
-	while (g_town_sectors[gubTownSectorServerIndex].town != BLANK_SECTOR)
+	while (gubTownSectorServerIndex < g_town_sectors.size() && g_town_sectors[gubTownSectorServerIndex].town != BLANK_SECTOR)
 	{
 		INT32 const sector = g_town_sectors[gubTownSectorServerIndex++].sector;
 


### PR DESCRIPTION
Training militia in a city that is already full of green militia in every sector causes a crash. Fixed by an extra check on the index value.

```
2022-01-09T13:27:29 [INFO] game/GameLoop.cc: Version Label: Stracciatella v0.19.0-git+72eeb77c7
2022-01-09T13:27:29 [INFO] game/GameLoop.cc: Version #:     Build 04.12.02
2022-01-09T13:27:51 [WARN] game/Tactical/Tactical_Save.cc: SynchronizeItemTempFile() Reported 0, should be 24
/usr/include/c++/11.1.0/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = TownSectorInfo; _Alloc = std::allocator<TownSectorInfo>; std::vector<_Tp, _Alloc>::reference = TownSectorInfo&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__n < this->size()' failed.
Aborted (core dumped)
```
