### PR TITLE
AllTeamsLookForAll: skip misplaced soldiers, #1387

### DIFF
--- a/src/game/Tactical/OppList.cc
+++ b/src/game/Tactical/OppList.cc
@@ -1194,6 +1194,7 @@ void AllTeamsLookForAll(UINT8 ubAllowInterrupts)
 	FOR_EACH_MERC(i)
 	{
 		SOLDIERTYPE& s = **i;
+		if (s.sGridNo == NOWHERE) continue;
 		if (s.bLife >= OKLIFE) HandleSight(s, SIGHT_LOOK); // no radio or interrupts yet
 	}
 


### PR DESCRIPTION
I think this code path got introduced when fixing the non-expiring breaklights and gasses.