### PR TITLE
Fix german translation on saveload screen

### DIFF
--- a/src/game/Utils/_GermanText.cc
+++ b/src/game/Utils/_GermanText.cc
@@ -2550,7 +2550,7 @@ static const ST::string s_ger_zSaveLoadText[zSaveLoadText_SIZE] =
 	"Achtung:",
 	"Versuche, älteren Spielstand zu laden. Das Laden wird den Spielstand automatisch aktualisieren.",
 	"Der Spielstand wurde mit anderen Mods geschrieben as aktuell aktiviert sind.",
-	"Möchten Sie fortfahren?"
+	"Möchten Sie fortfahren?",
 
 	"Spielstand mit Namen \"%s\" wirklich überschreiben?",
 


### PR DESCRIPTION
![Screenshot from 2022-04-11 19-08-29](https://user-images.githubusercontent.com/848854/163019288-45c77f09-3ed0-47d6-8d72-3b3fd5ba4215.png)

This concatenated the two translation strings instead of defining them separately. Fixes bug mentioned in https://github.com/ja2-stracciatella/ja2-stracciatella/issues/1356