### PR TITLE
Fix save load screen issues

### DIFF
--- a/src/game/SaveLoadScreen.cc
+++ b/src/game/SaveLoadScreen.cc
@@ -1055,25 +1055,32 @@ static void RedrawSaveLoadScreenAfterMessageBox(MessageBoxReturnValue);
 
 static void SelectedSaveRegionCallBack(MOUSE_REGION* pRegion, INT32 iReason)
 {
+	INT32	bSelected = gCurrentScrollTop + MSYS_GetRegionUserData( pRegion, 0 );
+	if (bSelected >= INT32(gSavedGamesList.size())) {
+		bSelected = -1;
+	}
+
 	if (iReason & MSYS_CALLBACK_REASON_LBUTTON_DOUBLECLICK) {
-		INT32	bSelected = gCurrentScrollTop + MSYS_GetRegionUserData( pRegion, 0 );
-		if (gbSelectedSaveLocation == bSelected && !gfUserInTextInputMode) {
+		if (bSelected == -1) {
+			DisableButton(guiSlgSaveLoadBtn);
+		} else if (gbSelectedSaveLocation == bSelected && !gfUserInTextInputMode) {
 			SaveLoadSelectedSave();
 		}
 	}
 	else if (iReason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
-		INT32	bSelected = gCurrentScrollTop + MSYS_GetRegionUserData( pRegion, 0 );
-
-		if( gbSelectedSaveLocation != bSelected ) {
+		if(gbSelectedSaveLocation != bSelected ) {
 			gbSelectedSaveLocation = bSelected;
 
-			EnableButton(guiSlgSaveLoadBtn);
-
 			DestroySaveLoadTextInputBoxes();
-			if (gfSaveGame && gbSelectedSaveLocation == 0) {
-				// If the first entry is selected we need to input a new name
-				InitSaveLoadScreenTextInputBoxes();
+			if (bSelected != -1) {
+				EnableButton(guiSlgSaveLoadBtn);
+				if (gfSaveGame && gbSelectedSaveLocation == 0) {
+					// If the first entry is selected we need to input a new name
+					InitSaveLoadScreenTextInputBoxes();
+				}
+			} else {
+				DisableButton(guiSlgSaveLoadBtn);
 			}
 
 			gfRedrawSaveLoadScreen = TRUE;

--- a/src/game/SaveLoadScreen.cc
+++ b/src/game/SaveLoadScreen.cc
@@ -1039,7 +1039,7 @@ static void BtnSlgSaveLoadCallback(GUI_BUTTON* btn, INT32 reason)
 {
 	if(reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
-		if (gfSaveGame && gbSelectedSaveLocation && gfUserInTextInputMode) {
+		if (gfSaveGame && gbSelectedSaveLocation == 0 && gfUserInTextInputMode) {
 			SaveNewSave();
 		} else {
 			SaveLoadSelectedSave();


### PR DESCRIPTION
This should address the issues in the save load screen mentioned in #1508.

- No crashes anymore when deleting / saving without having a save game slot selected
- Make save button work while entering text in new save game