### PR TITLE
Do not check for empty squad if none is selected

### DIFF
--- a/src/game/Tactical/Squads.cc
+++ b/src/game/Tactical/Squads.cc
@@ -197,7 +197,8 @@ BOOLEAN AddCharacterToSquad(SOLDIERTYPE* const s, INT8 const bSquadValue)
 		// set squad value
 		ChangeSoldiersAssignment(s, bSquadValue);
 
-		if (SquadIsEmpty(iCurrentTacticalSquad)) SetCurrentSquad(bSquadValue, TRUE);
+		// update selected squad if the old one is emptied
+		if (iCurrentTacticalSquad == NO_CURRENT_SQUAD || SquadIsEmpty(iCurrentTacticalSquad)) SetCurrentSquad(bSquadValue, TRUE);
 
 		if (bSquadValue == iCurrentTacticalSquad) CheckForAndAddMercToTeamPanel(s);
 
@@ -265,8 +266,13 @@ INT8 AddCharacterToUniqueSquad(SOLDIERTYPE* const s)
 }
 
 
-BOOLEAN SquadIsEmpty( INT8 bSquadValue )
+BOOLEAN SquadIsEmpty(INT8 bSquadValue)
 {
+	if (bSquadValue < 0 || bSquadValue >= NUMBER_OF_SQUADS)
+	{
+		throw std::logic_error("invalid squad number");
+	}
+
 	// run through this squad's slots and find if they ALL are empty
 	FOR_EACH_IN_SQUAD(i, bSquadValue)
 	{


### PR DESCRIPTION
Fixes #1512 and #1476.

The game crashes during squad assignment, when `iCurrentTacticalSquad` has the value of `NO_CURRENT_SQUAD (20)`. The code attempts to check the squad slots of `Squad[20]`, which is out of bounds. Debug build seems to be protected from this crash.

At the crash, there is a squad selected in the UI (the red arrow(s) next to mercs). But other than this crash, I see no issues in squad assignment. The `AddCharacterToSquad` function has not be changed for more than 10 years, but the crash was never reported in previous releases. It might be a side-effect of #1415.

Adding an assertion in the squad empty check, so should there are similar crashes the logs would have more information.
