### PR TITLE
Build signed release APKs instead of debug APKs for Android

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -59,7 +59,7 @@ elif [[ "$CI_TARGET" == "mac" ]]; then
 elif [[ "$CI_TARGET" == "android" ]]; then
   export CONFIGURE_CMD="true"
   export BUILD_CMD="../android/gradlew"
-  export BUILD_TOOL_ARGS="-p ../android assembleDebug -PbuildDir=$(pwd)/ci-build"
+  export BUILD_TOOL_ARGS="-p ../android assembleRelease -PbuildDir=$(pwd)/ci-build"
   export RUN_TESTS=false
   export PACKAGE_NAME="ja2-stracciatella_$(./android/gradlew -q -p ./android projectVersion)-$VERSION_TAG+$(git rev-parse --short HEAD)_android.apk"
 else
@@ -105,7 +105,7 @@ fi
 if [[ "$CI_TARGET" == "linux" ]]; then
   $BUILD_CMD --target package-appimage
 elif [[ "$CI_TARGET" == "android" ]]; then
-  cp ./outputs/apk/debug/app-debug.apk "./$PACKAGE_NAME"
+  cp ./outputs/apk/release/app-release.apk "./$PACKAGE_NAME"
 else
   $BUILD_CMD --target package
 fi

--- a/.ci/ci-functions.sh
+++ b/.ci/ci-functions.sh
@@ -60,6 +60,12 @@ linux-set-gcc-version () {
     sudo update-alternatives --set g++ "/usr/bin/g++-$1"
 }
 
+linux-setup-android-signing-keys () {
+    mkdir $HOME/.stracciatella-android-signing-keys
+
+    echo -n "$ANDROID_KEYSTORE_FILE" | base64 -d > $HOME/.stracciatella-android-signing-keys/keystore.jks
+}
+
 macOS-install-via-brew () {
     brew install $@
 }

--- a/.ci/ci-setup.sh
+++ b/.ci/ci-setup.sh
@@ -47,13 +47,13 @@ elif [[ "$CI_TARGET" == "linux-mingw64" ]]; then
 
     # Google Cloud SDK for Artifact Upload
     linux-install-google-cloud-sdk
-    
+
     # Rust via Rustup
     unix-install-rustup x86_64-pc-windows-gnu
 elif [[ "$CI_TARGET" == "mac" ]]; then
     # sccache for compilation caching
     macOS-install-via-brew sccache
-    
+
     # Google Cloud SDK for Artifact Upload
     macOS-install-via-brew-cask google-cloud-sdk
     source "$(brew --prefix)/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.bash.inc"
@@ -91,6 +91,8 @@ elif [[ "$CI_TARGET" == "android" ]]; then
 
     # Specific version of Android NDK
     linux-install-via-android-sdkmanager "ndk;21.0.6113669"
+
+    linux-setup-android-signing-keys
 else
     echo "unexpected target ${CI_TARGET}"
     exit 1
@@ -98,7 +100,6 @@ fi
 
 # print build environment info
 rustup show
-env
 which rustc
 rustc -V
 which cargo

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -88,6 +88,7 @@ jobs:
         echo "PATH=$PATH" >> $GITHUB_ENV
       env:
         CI_TARGET: ${{ matrix.cfg.target }}
+        ANDROID_KEYSTORE_FILE: ${{ secrets.ANDROID_KEYSTORE_FILE }}
 
     - name: Build and run tests
       shell: bash
@@ -98,6 +99,7 @@ jobs:
         CI_TARGET: ${{ matrix.cfg.target }}
         CI_REF: ${{ github.ref }}
         GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
 
     - name: Publish packages
       shell: bash

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -12,7 +12,6 @@ android {
         disable 'NewApi'
     }
 
-
     defaultConfig {
         applicationId "io.github.ja2stracciatella"
         minSdkVersion 19
@@ -52,18 +51,30 @@ android {
         }
     }
 
+    signingConfigs {
+        release {
+            storeFile file("${System.getenv("HOME")}/.stracciatella-android-signing-keys/keystore.jks")
+            storePassword System.getenv("ANDROID_KEYSTORE_PASSWORD")
+            keyAlias "stracciatella-signing-key"
+            keyPassword System.getenv("ANDROID_KEYSTORE_PASSWORD")
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.release
         }
     }
+
     externalNativeBuild {
         cmake {
             path "../../CMakeLists.txt"
             version "3.10.2"
         }
     }
+
     sourceSets {
         main {
             assets {


### PR DESCRIPTION
I added some secrets to the CI to provide a keystore for Android builds, so they always have the same signature. Should close #1503.

I also switched to release builds in the CI, as it seemed simpler to use different signing mechanisms for debug/release so local development with debug builds is still easily possible.

I still have to test the resulting builds.