### PR TITLE
Get rid of ndk fork in rust dependencies

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -122,6 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
 name = "caseless"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +216,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b727aacc797f9fc28e355d21f34709ac4fc9adecfe470ad07b8f4464f53062"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,17 +268,6 @@ checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",
-]
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -442,10 +447,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1981310da491a4f0f815238097d0d43d8072732b5ae5f8bd0d8eadf5bf245402"
 dependencies = [
  "cesu8",
- "combine",
+ "combine 3.8.1",
  "error-chain",
  "jni-sys",
  "log",
+ "walkdir",
+]
+
+[[package]]
+name = "jni"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24967112a1e4301ca5342ea339763613a37592b8a6ce6cf2e4494537c7a42faf"
+dependencies = [
+ "cesu8",
+ "combine 4.6.3",
+ "jni-sys",
+ "log",
+ "thiserror",
  "walkdir",
 ]
 
@@ -535,9 +554,11 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.2.0"
-source = "git+https://github.com/selaux/android-ndk-rs#11199e44b555e6fa4cfb8e54f873ebbc50f76d5b"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2032c77e030ddee34a6787a64166008da93f6a352b629261d0fee232b8742dd4"
 dependencies = [
+ "bitflags",
  "jni-sys",
  "ndk-sys",
  "num_enum",
@@ -546,8 +567,12 @@ dependencies = [
 
 [[package]]
 name = "ndk-sys"
-version = "0.2.0"
-source = "git+https://github.com/selaux/android-ndk-rs#11199e44b555e6fa4cfb8e54f873ebbc50f76d5b"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5a6ae77c8ee183dcbbba6150e2e6b9f3f4196a7666c02a715a95692ec1fa97"
+dependencies = [
+ "jni-sys",
+]
 
 [[package]]
 name = "num-integer"
@@ -580,19 +605,18 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.4.3"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca565a7df06f3d4b485494f25ba05da1435950f4dc263440eda7a6fa9b8e36e4"
+checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
 dependencies = [
- "derivative",
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.4.3"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
+checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -623,10 +647,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "proc-macro-crate"
-version = "0.1.5"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
+ "thiserror",
  "toml",
 ]
 
@@ -841,7 +866,8 @@ dependencies = [
  "dunce",
  "getopts",
  "hex",
- "jni",
+ "jni 0.18.0",
+ "jni-sys",
  "json_comments",
  "lazy_static",
  "libc",
@@ -881,7 +907,7 @@ dependencies = [
  "byteorder",
  "cbindgen",
  "hex",
- "jni",
+ "jni 0.14.0",
  "libc",
  "log",
  "stracciatella",

--- a/rust/stracciatella/Cargo.toml
+++ b/rust/stracciatella/Cargo.toml
@@ -48,11 +48,13 @@ version = "0.10"
 [target.'cfg(target_os = "android")'.dependencies.lazy_static]
 version = "1.4"
 [target.'cfg(target_os = "android")'.dependencies.jni]
-version = "0.14"
+version = "0.18"
+[target.'cfg(target_os = "android")'.dependencies.jni-sys]
+version = "0.3"
 [target.'cfg(target_os = "android")'.dependencies.ndk]
-git = "https://github.com/selaux/android-ndk-rs"
+version = "0.6"
 [target.'cfg(target_os = "android")'.dependencies.ndk-sys]
-git = "https://github.com/selaux/android-ndk-rs"
+version = "0.3"
 
 [build-dependencies]
 serde = "1.0"


### PR DESCRIPTION
The SDL2 update seems to allow this now. Last part of https://github.com/ja2-stracciatella/ja2-stracciatella/issues/1248.

Closes #1248.