### PR TITLE
cmake: rewrite the contributor tracking target

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,15 @@
+Czcibór <foo@foo.com>
+Derek Chan <63151803+ja2-derek@users.noreply.github.com>
+Derek Chan <63151803+ja2-derek@users.noreply.github.com> <ja2-derek@github>
+Derek Chan <63151803+ja2-derek@users.noreply.github.com> <ja2-derek>
+Derek Chan <63151803+ja2-derek@users.noreply.github.com> ja2-derek <you@example.com>
+Derek Chan <63151803+ja2-derek@users.noreply.github.com> <sfod_csy@hotmail.com>
+Gennady Trafimenkov <gennady.trafimenkov@gmail.com> <gennady@aspire.(none)>
+Gregor Zorc <ketchupy@gmail.com>
+Nils Reuße <ml@hxgn.net>
+Richard Fröhning <misanthropos@gmx.de> Misanthropos <misanthropos@gmx.net>
+Richard Fröhning <misanthropos@gmx.de> Misanthropos <misanthropos@gmx.de>
+RinneT <thomas.rinsch@arcor.de>
+Stephan Bauroth <der_steffi@gmx.de>
+vxx <no@e.mail> wvx
+vxx <no@e.mail> wvx <ardor-ja2s-wvxx-zkfu-eka83>

--- a/cmake/target-rebuild-contributors-list.cmake.in
+++ b/cmake/target-rebuild-contributors-list.cmake.in
@@ -1,5 +1,9 @@
 find_package(Git)
 
+if(NOT GIT_FOUND)
+    message(FATAL_ERROR "No git executable found, aborting.")
+endif()
+
 function(get_contributors OUTPUT_VARIABLE)
     execute_process(
             COMMAND ${GIT_EXECUTABLE} "shortlog" "--summary" "--group=author" "--group=trailer:co-authored-by"
@@ -12,46 +16,42 @@ function(get_contributors OUTPUT_VARIABLE)
     set(${OUTPUT_VARIABLE} ${GIT_CONTRIBUTORS} PARENT_SCOPE)
 endfunction(get_contributors)
 
-if(GIT_FOUND)
-    get_contributors(UNIQUE_CONTRIBUTORS)
+get_contributors(UNIQUE_CONTRIBUTORS)
 
-    # and add some non-git contributors
-    list(APPEND UNIQUE_CONTRIBUTORS
-        "Oliver Jankowski"
-        "mgl from The Bear's Pit Forum"
-        "sunshine from The Bear's Pit Forum"
-        "Rebekka Bais (Logo Design)"
-        "Agatae (https://bitbucket.org/Agatae)"
-    )
+# and add some non-git contributors
+list(APPEND UNIQUE_CONTRIBUTORS
+    "Oliver Jankowski"
+    "mgl from The Bear's Pit Forum"
+    "sunshine from The Bear's Pit Forum"
+    "Rebekka Bais (Logo Design)"
+    "Agatae (https://bitbucket.org/Agatae)"
+)
 
-    # Cmake can only do case-sensitive sorting
-    foreach(CONTRIBUTOR ${UNIQUE_CONTRIBUTORS})
-        string(TOLOWER ${CONTRIBUTOR} LOWER)
-        list(APPEND UNIQUE_CONTRIBUTORS_LOWERCASE ${LOWER})
+# Cmake can only do case-sensitive sorting
+foreach(CONTRIBUTOR ${UNIQUE_CONTRIBUTORS})
+    string(TOLOWER ${CONTRIBUTOR} LOWER)
+    list(APPEND UNIQUE_CONTRIBUTORS_LOWERCASE ${LOWER})
+endforeach()
+list(SORT UNIQUE_CONTRIBUTORS_LOWERCASE)
+foreach(CONTRIBUTOR ${UNIQUE_CONTRIBUTORS_LOWERCASE})
+    foreach(CANDIDATE ${UNIQUE_CONTRIBUTORS})
+        string(TOLOWER ${CANDIDATE} LOWER)
+        string(REGEX REPLACE " <[^>]+>" "" CANDIDATE ${CANDIDATE})
+        if(CONTRIBUTOR STREQUAL LOWER)
+            list(APPEND SORTED_CONTRIBUTORS ${CANDIDATE})
+            break()
+        endif()
     endforeach()
-    list(SORT UNIQUE_CONTRIBUTORS_LOWERCASE)
-    foreach(CONTRIBUTOR ${UNIQUE_CONTRIBUTORS_LOWERCASE})
-        foreach(CANDIDATE ${UNIQUE_CONTRIBUTORS})
-            string(TOLOWER ${CANDIDATE} LOWER)
-            string(REGEX REPLACE " <[^>]+>" "" CANDIDATE ${CANDIDATE})
-            if(CONTRIBUTOR STREQUAL LOWER)
-                list(APPEND SORTED_CONTRIBUTORS ${CANDIDATE})
-                break()
-            endif()
-        endforeach()
-    endforeach()
+endforeach()
 
-    set(filename "@CMAKE_SOURCE_DIR@/contributors.txt")
-    file(WRITE ${filename} "Founder of the project\n" )
-    file(APPEND ${filename} "----------------------\n\n")
-    file(APPEND ${filename} "Tron\n\n")
-    file(APPEND ${filename} "Contributors (sorted alphabetically)\n")
-    file(APPEND ${filename} "------------------------------------\n\n")
-    foreach(CONTRIBUTOR ${SORTED_CONTRIBUTORS})
-        file(APPEND ${filename} "${CONTRIBUTOR}\n")
-    endforeach()
+set(filename "@CMAKE_SOURCE_DIR@/contributors.txt")
+file(WRITE ${filename} "Founder of the project\n" )
+file(APPEND ${filename} "----------------------\n\n")
+file(APPEND ${filename} "Tron\n\n")
+file(APPEND ${filename} "Contributors (sorted alphabetically)\n")
+file(APPEND ${filename} "------------------------------------\n\n")
+foreach(CONTRIBUTOR ${SORTED_CONTRIBUTORS})
+    file(APPEND ${filename} "${CONTRIBUTOR}\n")
+endforeach()
 
-    message("Contributors updated in ${filename}")
-else()
-    message(FATAL_ERROR "No git executable found, aborting.")
-endif()
+message("Contributors updated in ${filename}")

--- a/cmake/target-rebuild-contributors-list.cmake.in
+++ b/cmake/target-rebuild-contributors-list.cmake.in
@@ -1,76 +1,28 @@
 find_package(Git)
 
-function(get_contributors WITH_EMAIL OUTPUT_VARIABLE)
-    set(FORMAT "%an")
-    if (WITH_EMAIL)
-        set(FORMAT "${FORMAT} <%ae>")
-    endif()
-
+function(get_contributors OUTPUT_VARIABLE)
     execute_process(
-            COMMAND ${GIT_EXECUTABLE} "log" "--pretty=format:${FORMAT}"
+            COMMAND ${GIT_EXECUTABLE} "shortlog" "--summary" "--group=author" "--group=trailer:co-authored-by"
             WORKING_DIRECTORY "@CMAKE_SOURCE_DIR@"
             OUTPUT_VARIABLE GIT_CONTRIBUTORS
     )
-    string(REPLACE "\n" ";" GIT_CONTRIBUTORS ${GIT_CONTRIBUTORS})
-    list(REMOVE_DUPLICATES GIT_CONTRIBUTORS)
+    # cmake has very basic regex support, so we need two steps to remove the commit count
+    string(REPLACE "\n" "@" GIT_CONTRIBUTORS ${GIT_CONTRIBUTORS})
+    string(REGEX REPLACE "[\t ]+[0-9]+[\t ]+([^@]*)@" "\\1;" GIT_CONTRIBUTORS ${GIT_CONTRIBUTORS})
     set(${OUTPUT_VARIABLE} ${GIT_CONTRIBUTORS} PARENT_SCOPE)
 endfunction(get_contributors)
 
 if(GIT_FOUND)
-    get_contributors(ON GIT_CONTRIBUTORS_WITH_EMAIL)
-    get_contributors(OFF GIT_CONTRIBUTORS_WITHOUT_EMAIL)
+    get_contributors(UNIQUE_CONTRIBUTORS)
 
-    foreach(CONTRIBUTOR ${GIT_CONTRIBUTORS_WITHOUT_EMAIL})
-        foreach(CANDIDATE ${GIT_CONTRIBUTORS_WITH_EMAIL})
-            if("${CANDIDATE}" MATCHES "^${CONTRIBUTOR} <")
-                list(APPEND CONTRIBUTORS_WITH_UNIQUE_NAMES ${CANDIDATE})
-                break()
-            endif()
-        endforeach()
-    endforeach()
-
-    foreach(CONTRIBUTOR ${CONTRIBUTORS_WITH_UNIQUE_NAMES})
-        string(REGEX REPLACE "^(.*) <(.*)>$" "\\1" CONTRIBUTOR_EMAIL ${CONTRIBUTOR})
-
-        foreach(CANDIDATE ${GIT_CONTRIBUTORS_WITH_EMAIL})
-            string(REGEX REPLACE "^(.*) <(.*)>$" "\\1" CANDIDATE_EMAIL ${CANDIDATE})
-            if(CANDIDATE_EMAIL STREQUAL CONTRIBUTOR_EMAIL)
-                list(APPEND UNIQUE_CONTRIBUTORS ${CANDIDATE})
-                break()
-            endif()
-        endforeach()
-    endforeach()
-
-
-    # Remove some duplicates and svn references and add some non-git contributors
-    list(REMOVE_ITEM UNIQUE_CONTRIBUTORS
-        "stefan <stefan@stefan.wg>"
-        "Gennady <gennady@aspire.(none)>"
-        "Nils R <ml@hxgn.net>"
-        "wolf <wolf@5e31c081-6ce3-0310-bb30-f584a8092234>"
-        "tron <tron@5e31c081-6ce3-0310-bb30-f584a8092234>"
-        "Czcibor <foo@foo.com>"
-        "vxx <no@e.mail>"
-        "Gregor Z <ketchupy@gmail.com>"
-        "Misanthropos <misanthropos@gmx.de>"
-        "RinneT <thomas.rinsch@arcor.de>"
-        "derSteFfi <der_steffi@gmx.de>"
-        "ja2-derek <sfod_csy@hotmail.com>"
-        "Stefan Lau <selaux@users.noreply.github.com>"
-        "Peinthor Rene <rp@regalis.localdomain>"
-    )
+    # and add some non-git contributors
     list(APPEND UNIQUE_CONTRIBUTORS
         "Oliver Jankowski"
         "mgl from The Bear's Pit Forum"
         "sunshine from The Bear's Pit Forum"
         "Rebekka Bais (Logo Design)"
-        "wolf (committer to the original Tron's svn repository)"
         "Agatae (https://bitbucket.org/Agatae)"
-        "Richard Fröhning <misanthropos@gmx.de>"
-        "Stefan Lau <github@stefanlau.com>"
-        "Peinthor Rene <peinthor@gmail.com>"
     )
-    list(REMOVE_DUPLICATES UNIQUE_CONTRIBUTORS)
 
     # Cmake can only do case-sensitive sorting
     foreach(CONTRIBUTOR ${UNIQUE_CONTRIBUTORS})

--- a/cmake/target-rebuild-contributors-list.cmake.in
+++ b/cmake/target-rebuild-contributors-list.cmake.in
@@ -4,19 +4,14 @@ if(NOT GIT_FOUND)
     message(FATAL_ERROR "No git executable found, aborting.")
 endif()
 
-function(get_contributors OUTPUT_VARIABLE)
-    execute_process(
-            COMMAND ${GIT_EXECUTABLE} "shortlog" "--summary" "--group=author" "--group=trailer:co-authored-by"
-            WORKING_DIRECTORY "@CMAKE_SOURCE_DIR@"
-            OUTPUT_VARIABLE GIT_CONTRIBUTORS
-    )
-    # cmake has very basic regex support, so we need two steps to remove the commit count
-    string(REPLACE "\n" "@" GIT_CONTRIBUTORS ${GIT_CONTRIBUTORS})
-    string(REGEX REPLACE "[\t ]+[0-9]+[\t ]+([^@]*)@" "\\1;" GIT_CONTRIBUTORS ${GIT_CONTRIBUTORS})
-    set(${OUTPUT_VARIABLE} ${GIT_CONTRIBUTORS} PARENT_SCOPE)
-endfunction(get_contributors)
-
-get_contributors(UNIQUE_CONTRIBUTORS)
+execute_process(
+    COMMAND ${GIT_EXECUTABLE} "shortlog" "--summary" "--group=author" "--group=trailer:co-authored-by"
+    WORKING_DIRECTORY "@CMAKE_SOURCE_DIR@"
+    OUTPUT_VARIABLE UNIQUE_CONTRIBUTORS
+)
+# cmake has very basic regex support, so we need two steps to remove the commit count
+string(REPLACE "\n" "@" UNIQUE_CONTRIBUTORS ${UNIQUE_CONTRIBUTORS})
+string(REGEX REPLACE "[\t ]+[0-9]+[\t ]+([^@]*)@" "\\1;" UNIQUE_CONTRIBUTORS ${UNIQUE_CONTRIBUTORS})
 
 # and add some non-git contributors
 list(APPEND UNIQUE_CONTRIBUTORS

--- a/cmake/target-rebuild-contributors-list.cmake.in
+++ b/cmake/target-rebuild-contributors-list.cmake.in
@@ -13,15 +13,6 @@ execute_process(
 string(REPLACE "\n" "@" UNIQUE_CONTRIBUTORS ${UNIQUE_CONTRIBUTORS})
 string(REGEX REPLACE "[\t ]+[0-9]+[\t ]+([^@]*)@" "\\1;" UNIQUE_CONTRIBUTORS ${UNIQUE_CONTRIBUTORS})
 
-# and add some non-git contributors
-list(APPEND UNIQUE_CONTRIBUTORS
-    "Oliver Jankowski"
-    "mgl from The Bear's Pit Forum"
-    "sunshine from The Bear's Pit Forum"
-    "Rebekka Bais (Logo Design)"
-    "Agatae (https://bitbucket.org/Agatae)"
-)
-
 # Cmake can only do case-sensitive sorting
 foreach(CONTRIBUTOR ${UNIQUE_CONTRIBUTORS})
     string(TOLOWER ${CONTRIBUTOR} LOWER)

--- a/contributors.txt
+++ b/contributors.txt
@@ -13,6 +13,7 @@ Alex Ellwein
 Alexander 'z33ky' Hirsch
 Alexander Gordeev
 Alexander von Gernler
+Alexandru Pinca
 Czcibór
 Darius Kazemi
 David Krawiec
@@ -45,14 +46,17 @@ Poncho
 rebb
 Rebekka Bais (Logo Design)
 Richard Fröhning
-Rinne
+RinneT
 rk
 RoddyAtHat
 sam
+Seven
 Simon Bitschnau
+stefan
 Stefan Lau
 Stephan Bauroth
 sunshine from The Bear's Pit Forum
+tron
 vancv
-wolf (committer to the original Tron's svn repository)
-wvx
+vxx
+wolf


### PR DESCRIPTION
- simplifies the code by letting git deduplicate and removing legacy logic
- handles coauthorship (why Seven was uncaught in 0.19)
- minor cleanup afterwards