### PR TITLE
Add read/write functionality for STCI to rust

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -87,9 +87,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.64"
+version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
 dependencies = [
  "addr2line",
  "cc",
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b727aacc797f9fc28e355d21f34709ac4fc9adecfe470ad07b8f4464f53062"
+checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
 dependencies = [
  "bytes",
  "memchr",
@@ -461,7 +461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24967112a1e4301ca5342ea339763613a37592b8a6ce6cf2e4494537c7a42faf"
 dependencies = [
  "cesu8",
- "combine 4.6.3",
+ "combine 4.6.4",
  "jni-sys",
  "log",
  "thiserror",
@@ -488,9 +488,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
 
 [[package]]
 name = "linked-hash-map"
@@ -544,12 +544,11 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
 dependencies = [
  "adler",
- "autocfg",
 ]
 
 [[package]]
@@ -626,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
 dependencies = [
  "memchr",
 ]
@@ -666,18 +665,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -687,14 +686,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
@@ -859,6 +857,7 @@ name = "stracciatella"
 version = "0.1.0"
 dependencies = [
  "android_logger",
+ "bitflags",
  "byteorder",
  "caseless",
  "digest",
@@ -995,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1010,9 +1009,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]

--- a/rust/stracciatella/Cargo.toml
+++ b/rust/stracciatella/Cargo.toml
@@ -11,6 +11,7 @@ name = "stracciatella"
 path = "src/stracciatella.rs"
 
 [dependencies]
+bitflags = "1.3"
 getopts = "0.2"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }

--- a/rust/stracciatella/src/file_formats/mod.rs
+++ b/rust/stracciatella/src/file_formats/mod.rs
@@ -4,6 +4,7 @@ use std::io::ErrorKind::{InvalidData, InvalidInput};
 use std::io::{Error, Read, Result, Write};
 
 pub mod slf;
+pub mod stci;
 
 /// Trait that adds extra functions to Read.
 pub trait StracciatellaReadExt: Read {

--- a/rust/stracciatella/src/file_formats/stci/color.rs
+++ b/rust/stracciatella/src/file_formats/stci/color.rs
@@ -1,0 +1,104 @@
+//! This module contains color related functionality for the STCI image format
+
+use byteorder::{ReadBytesExt, WriteBytesExt, LE};
+use std::io::{Read, Result, Write};
+
+/// Mask used to get red bits from Rgb565 color
+pub const STCI_RGB565_RED_MASK: u32 = 0xF800;
+/// Mask used to get green bits from Rgb565 color
+pub const STCI_RGB565_GREEN_MASK: u32 = 0x7E0;
+/// Mask used to get blue bits from Rgb565 color
+pub const STCI_RGB565_BLUE_MASK: u32 = 0x1F;
+
+/// Rgb color representation with 8 bit per color
+///
+/// This is used in indexed STCI images as the palette colors
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct StciRgb888(pub u8, pub u8, pub u8);
+
+impl StciRgb888 {
+    /// Read a single Rgb888 pixel from input
+    #[allow(dead_code)]
+    pub fn from_input<T>(input: &mut T) -> Result<Self>
+    where
+        T: Read,
+    {
+        let red = input.read_u8()?;
+        let green = input.read_u8()?;
+        let blue = input.read_u8()?;
+
+        Ok(Self(red, green, blue))
+    }
+
+    /// Write a single Rgb888 pixel to output
+    #[allow(dead_code)]
+    pub fn to_output<T>(self, output: &mut T) -> Result<()>
+    where
+        T: Write,
+    {
+        output.write_u8(self.0)?;
+        output.write_u8(self.1)?;
+        output.write_u8(self.2)?;
+        Ok(())
+    }
+}
+
+const fn max_value_565_shift_right(mask: u32, shift: u32) -> u32 {
+    std::u32::MAX & mask >> shift
+}
+
+const fn max_value_565_shift_left(mask: u32, shift: u32) -> u32 {
+    std::u32::MAX & mask << shift
+}
+
+impl From<StciRgb565> for StciRgb888 {
+    /// This conversion is slightly different from the one used in the original source code
+    /// It ensures that the whole 0..255 range of colors is used.
+    fn from(value16: StciRgb565) -> Self {
+        let r: u32 = (u32::from(value16.0) & STCI_RGB565_RED_MASK) >> 8;
+        let g: u32 = (u32::from(value16.0) & STCI_RGB565_GREEN_MASK) >> 3;
+        let b: u32 = (u32::from(value16.0) & STCI_RGB565_BLUE_MASK) << 3;
+        let r = (255 * r) / max_value_565_shift_right(STCI_RGB565_RED_MASK, 8);
+        let g = (255 * g) / max_value_565_shift_right(STCI_RGB565_GREEN_MASK, 3);
+        let b = (255 * b) / max_value_565_shift_left(STCI_RGB565_BLUE_MASK, 3);
+        StciRgb888(r as u8, g as u8, b as u8)
+    }
+}
+
+/// Rgb color representation with 5 bits red, 6 bits green, 5 bits blue
+///
+/// This is used in rgb STCI images as pixel data
+///
+/// ```
+/// use stracciatella::file_formats::stci::{StciRgb565, StciRgb888};
+///
+/// // White should be white
+/// assert_eq!(StciRgb888::from(StciRgb565(std::u16::MAX)), StciRgb888(255, 255, 255));
+/// // Black should be black
+/// assert_eq!(StciRgb888::from(StciRgb565(0)), StciRgb888(0, 0, 0));
+/// ```
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct StciRgb565(pub u16);
+
+impl StciRgb565 {
+    /// Read a single Rgb565 pixel from input
+    #[allow(dead_code)]
+    pub fn from_input<T>(input: &mut T) -> Result<Self>
+    where
+        T: Read,
+    {
+        let v = input.read_u16::<LE>()?;
+
+        Ok(Self(v))
+    }
+
+    /// Write a single Rgb565 pixel to output
+    #[allow(dead_code)]
+    pub fn to_output<T>(self, output: &mut T) -> Result<()>
+    where
+        T: Write,
+    {
+        output.write_u16::<LE>(self.0)?;
+        Ok(())
+    }
+}

--- a/rust/stracciatella/src/file_formats/stci/etrle.rs
+++ b/rust/stracciatella/src/file_formats/stci/etrle.rs
@@ -1,0 +1,222 @@
+//! This module contains functionality around the ETRLE compression used in indexed STCI images
+//!
+//! ETRLE compression can compress an arbitrary byte array and is optimized to compress consecutive
+//! bytes of the same value. This value is chosen beforehand and called `val` in further description.
+//! ETRLE compressed data consists of control bytes and data bytes.
+//!
+//! A control byte consists of the following bits:
+//! - 1 Bit (called `com` in further description) to indicate whether this control byte indicates a compressed (1)
+//!   sequence of bytes or a non-compressed (0) sequence of bytes
+//! - 7 Bit (called `len` in further description) to indicate the length of the current sequence
+//!
+//! The algorithm works as follows:
+//! - Read next control byte
+//!   - If `com == 1`, decompress it by writing `val` `len` times to the output
+//!   - If not read the next `len` bytes and copy them to the output
+//!   - Goto read next control byte
+
+use byteorder::{ReadBytesExt, WriteBytesExt};
+use std::io::{Error, ErrorKind, Read, Result, Write};
+
+/// Predetermined value that is compressed
+pub const INDEXED_ALPHA_VALUE: u8 = 0;
+
+/// Bit mask to determine whether the current control byte indicates a compressed or non-compressed sequence of bytes
+#[allow(dead_code)]
+const IS_COMPRESSED_BIT_MASK: u8 = 0x80;
+
+/// Bit mask to determine the length of the current sequence
+#[allow(dead_code)]
+const COMPRESSED_SEQUENCE_LENGTH_MASK: u8 = 0x7F;
+
+/// Maximum sequence length
+#[allow(dead_code)]
+const MAX_SEQUENCE_LENGTH: u8 = 127;
+
+/// This function reads ETRLE compressed data from input and writes the decompressed data to output
+///
+/// This function reads input until the end.
+///
+/// ```rust
+/// use stracciatella::file_formats::stci::etrle::etrle_decompress;
+///
+/// let mut input: &[u8] = &[0x85];
+/// let mut output: Vec<u8> = vec![];
+///
+/// etrle_decompress(&mut input, &mut output).unwrap();
+/// assert_eq!(output, vec![0, 0, 0, 0, 0])
+/// ```
+#[allow(dead_code)]
+pub fn etrle_decompress<R, W>(input: &mut R, output: &mut W) -> Result<()>
+where
+    R: Read,
+    W: Write,
+{
+    let next_control_byte = input.read_u8();
+    match next_control_byte {
+        Ok(next_control_byte) => {
+            let is_compressed = ((next_control_byte & IS_COMPRESSED_BIT_MASK) >> 7) == 1;
+            let length_of_subsequence = next_control_byte & COMPRESSED_SEQUENCE_LENGTH_MASK;
+
+            for _ in 0..length_of_subsequence {
+                if is_compressed {
+                    output.write_u8(INDEXED_ALPHA_VALUE)?;
+                } else {
+                    output.write_u8(input.read_u8()?)?;
+                }
+            }
+
+            etrle_decompress(input, output)
+        }
+        Err(ref e) if e.kind() == ErrorKind::UnexpectedEof => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// Writes a sequence to the output
+///
+/// A sequence in this case consists of only zero bytes or only non-zero bytes
+/// and is shorter or equal 127 bytes
+fn write_sequence<W>(sequence: &[u8], output: &mut W) -> Result<()>
+where
+    W: Write,
+{
+    let sequence_length = sequence.len();
+    if sequence_length == 0 {
+        return Ok(());
+    }
+    if sequence_length > usize::from(MAX_SEQUENCE_LENGTH) {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!("expected sequence length <= 127, got {}", sequence.len()),
+        ));
+    }
+    let sequence_length = sequence_length as u8;
+
+    if sequence[0] == INDEXED_ALPHA_VALUE {
+        output.write_u8(sequence_length | IS_COMPRESSED_BIT_MASK)?;
+    } else {
+        output.write_u8(sequence_length)?;
+        output.write_all(&sequence)?;
+    }
+
+    Ok(())
+}
+
+/// This function reads data from input and writes the ETRLE compressed data to output
+///
+/// This function reads input until the end.
+///
+/// ```rust
+/// use stracciatella::file_formats::stci::etrle::etrle_compress;
+///
+/// let mut input: &[u8] = &[0, 0, 0, 0, 0];
+/// let mut output: Vec<u8> = vec![];
+///
+/// etrle_compress(&mut input, &mut output).unwrap();
+/// assert_eq!(output, vec![0x85])
+/// ```
+#[allow(dead_code)]
+pub fn etrle_compress<R, W>(input: &mut R, output: &mut W) -> Result<()>
+where
+    R: Read,
+    W: Write,
+{
+    let mut current_sequence = vec![];
+    loop {
+        let next_byte = input.read_u8();
+
+        match next_byte {
+            Ok(next_byte) => {
+                if current_sequence.len() == usize::from(MAX_SEQUENCE_LENGTH) {
+                    write_sequence(&current_sequence, output)?;
+                    current_sequence = vec![];
+                }
+                match (current_sequence.get(0), next_byte) {
+                    (None, next_byte) => {
+                        current_sequence.push(next_byte);
+                    }
+                    (Some(&INDEXED_ALPHA_VALUE), INDEXED_ALPHA_VALUE) => {
+                        current_sequence.push(INDEXED_ALPHA_VALUE);
+                    }
+                    (Some(_), INDEXED_ALPHA_VALUE) => {
+                        write_sequence(&current_sequence, output)?;
+                        current_sequence = vec![INDEXED_ALPHA_VALUE];
+                    }
+                    (Some(&INDEXED_ALPHA_VALUE), v) => {
+                        write_sequence(&current_sequence, output)?;
+                        current_sequence = vec![v];
+                    }
+                    (Some(_), v) => {
+                        current_sequence.push(v);
+                    }
+                }
+            }
+            Err(ref e) if e.kind() == ErrorKind::UnexpectedEof => {
+                write_sequence(&current_sequence, output)?;
+                break;
+            }
+            Err(e) => {
+                return Err(e);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode() {
+        let mut input: &[u8] = &[];
+        let mut output: Vec<u8> = vec![];
+        etrle_decompress(&mut input, &mut output).unwrap();
+        assert_eq!(output.len(), 0);
+
+        let mut input: &[u8] = &[0x02, 2, 3, 0x03, 4, 5, 6];
+        let mut output: Vec<u8> = vec![];
+        etrle_decompress(&mut input, &mut output).unwrap();
+        assert_eq!(output, vec![2, 3, 4, 5, 6]);
+
+        let mut input: &[u8] = &[0x85];
+        let mut output: Vec<u8> = vec![];
+        etrle_decompress(&mut input, &mut output).unwrap();
+        assert_eq!(output, vec![0, 0, 0, 0, 0]);
+
+        let mut input: &[u8] = &[0x82, 0x02, 2, 3, 0x83, 0x03, 4, 5, 6];
+        let mut output: Vec<u8> = vec![];
+        etrle_decompress(&mut input, &mut output).unwrap();
+        assert_eq!(output, vec![0, 0, 2, 3, 0, 0, 0, 4, 5, 6]);
+    }
+
+    #[test]
+    fn encode() {
+        let mut input: &[u8] = &[];
+        let mut output: Vec<u8> = vec![];
+        etrle_compress(&mut input, &mut output).unwrap();
+        assert_eq!(output.len(), 0);
+
+        let mut input: &[u8] = &[2, 3, 4, 5, 6];
+        let mut output: Vec<u8> = vec![];
+        etrle_compress(&mut input, &mut output).unwrap();
+        assert_eq!(output, vec![0x05, 2, 3, 4, 5, 6]);
+
+        let mut input: &[u8] = &[0, 0, 0, 0, 0];
+        let mut output: Vec<u8> = vec![];
+        etrle_compress(&mut input, &mut output).unwrap();
+        assert_eq!(output, vec![0x85]);
+
+        let mut input: &[u8] = &[0, 0, 2, 3, 0, 0, 0, 4, 5, 6];
+        let mut output: Vec<u8> = vec![];
+        etrle_compress(&mut input, &mut output).unwrap();
+        assert_eq!(output, vec![0x82, 0x02, 2, 3, 0x83, 0x03, 4, 5, 6]);
+
+        let mut input: &[u8] = &[0; 128];
+        let mut output: Vec<u8> = vec![];
+        etrle_compress(&mut input, &mut output).unwrap();
+        assert_eq!(output, vec![0xFF, 0x81]);
+    }
+}

--- a/rust/stracciatella/src/file_formats/stci/indexed.rs
+++ b/rust/stracciatella/src/file_formats/stci/indexed.rs
@@ -1,0 +1,464 @@
+//! This module contains functionality around indexed STCI images
+
+use super::super::{StracciatellaReadExt, StracciatellaWriteExt};
+use super::color::StciRgb888;
+use byteorder::{ReadBytesExt, WriteBytesExt, LE};
+use std::fmt;
+use std::io::{
+    Error,
+    ErrorKind::{InvalidData, InvalidInput},
+    Read, Result, Write,
+};
+
+/// Represents the color depth defined within the STCI indexed format specific header
+///
+/// We currently only support RGB888 color depth for palettes, all other color depths in STCI
+/// images will result in an error.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StciColorDepthIndexed(pub u8, pub u8, pub u8);
+
+impl StciColorDepthIndexed {
+    /// Read the color depth part from input.
+    #[allow(dead_code)]
+    pub fn from_input<T>(input: &mut T) -> Result<Self>
+    where
+        T: Read,
+    {
+        let red = input.read_u8()?;
+        let green = input.read_u8()?;
+        let blue = input.read_u8()?;
+
+        if red != 8 || green != 8 || blue != 8 {
+            return Err(Error::new(
+                InvalidData,
+                format!(
+                    "expected RGB888 palette in indexed STCI, go RGB{}{}{} in header",
+                    red, green, blue
+                ),
+            ));
+        }
+
+        Ok(Self(red, green, blue))
+    }
+
+    /// Write the color depth part to output.
+    #[allow(dead_code)]
+    pub fn to_output<T>(&self, output: &mut T) -> Result<()>
+    where
+        T: Write,
+    {
+        if self.0 != 8 || self.1 != 8 || self.2 != 8 {
+            return Err(Error::new(
+                InvalidInput,
+                format!(
+                    "only supporting RGB888 palettes in indexed STCI, got RGB{}{}{}",
+                    self.0, self.1, self.2
+                ),
+            ));
+        }
+        output.write_u8(self.0)?;
+        output.write_u8(self.1)?;
+        output.write_u8(self.2)?;
+        Ok(())
+    }
+}
+
+impl Default for StciColorDepthIndexed {
+    fn default() -> Self {
+        StciColorDepthIndexed(8, 8, 8)
+    }
+}
+
+/// Represents the indexed format specific part of the STCI header
+///
+/// We currently only support 256 palette colors, all other numbers of colors
+/// will result in an error.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StciHeaderIndexed {
+    pub number_of_palette_colors: u32,
+    pub number_of_images: u16,
+    pub color_depth: StciColorDepthIndexed,
+}
+
+impl StciHeaderIndexed {
+    /// Read format specific part from input.
+    #[allow(dead_code)]
+    pub fn from_input<T>(input: &mut T) -> Result<Self>
+    where
+        T: Read,
+    {
+        let number_of_palette_colors = input.read_u32::<LE>()?;
+        let number_of_images = input.read_u16::<LE>()?;
+
+        if number_of_palette_colors != 256 {
+            return Err(Error::new(
+                InvalidData,
+                format!(
+                    "expected 256 palette colors in indexed STCI, got {} in header",
+                    number_of_palette_colors,
+                ),
+            ));
+        }
+        if number_of_images == 0 {
+            return Err(Error::new(
+                InvalidData,
+                "expected at least one sub image in indexed STCI",
+            ));
+        }
+
+        let color_depth = StciColorDepthIndexed::from_input(input)?;
+        input.read_unused(11)?;
+
+        Ok(Self {
+            number_of_palette_colors,
+            number_of_images,
+            color_depth,
+        })
+    }
+
+    /// Write format specific part to output.
+    #[allow(dead_code)]
+    pub fn to_output<T>(&self, output: &mut T) -> Result<()>
+    where
+        T: Write,
+    {
+        if self.number_of_palette_colors != 256 {
+            return Err(Error::new(
+                InvalidInput,
+                format!(
+                    "expected 256 palette colors in indexed STCI, got {}",
+                    self.number_of_palette_colors,
+                ),
+            ));
+        }
+        if self.number_of_images == 0 {
+            return Err(Error::new(
+                InvalidData,
+                "expected at least one sub image in indexed STCI",
+            ));
+        }
+        output.write_u32::<LE>(self.number_of_palette_colors)?;
+        output.write_u16::<LE>(self.number_of_images)?;
+        self.color_depth.to_output(output)?;
+        output.write_unused(11)?;
+
+        Ok(())
+    }
+}
+
+impl Default for StciHeaderIndexed {
+    fn default() -> Self {
+        Self {
+            number_of_palette_colors: 256,
+            number_of_images: 0,
+            color_depth: StciColorDepthIndexed::default(),
+        }
+    }
+}
+
+/// Represents the palette within a STCI image
+///
+/// The palette of STCI images consists of 256 RGB888 color values.
+#[derive(Clone)]
+pub struct StciPalette {
+    pub colors: [StciRgb888; 256],
+}
+
+impl Default for StciPalette {
+    fn default() -> Self {
+        Self {
+            colors: [StciRgb888(0, 0, 0); 256],
+        }
+    }
+}
+
+impl fmt::Debug for StciPalette {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        self.colors[..].fmt(formatter)
+    }
+}
+
+impl PartialEq for StciPalette {
+    fn eq(&self, other: &StciPalette) -> bool {
+        self.colors[..].eq(&other.colors[..])
+    }
+}
+
+impl StciPalette {
+    /// Read the palette from input.
+    #[allow(dead_code)]
+    pub fn from_input<T>(input: &mut T, number_of_colors: usize) -> Result<Self>
+    where
+        T: Read,
+    {
+        if number_of_colors != 256 {
+            return Err(Error::new(
+                InvalidData,
+                format!("expected 256 colors for palette, got {}", number_of_colors),
+            ));
+        }
+        let mut colors = [StciRgb888(0, 0, 0); 256];
+        for color in colors.iter_mut() {
+            *color = StciRgb888::from_input(input)?;
+        }
+        Ok(Self { colors })
+    }
+
+    /// Write the palette to output.
+    #[allow(dead_code)]
+    pub fn to_output<T>(&self, output: &mut T) -> Result<()>
+    where
+        T: Write,
+    {
+        for color in &self.colors[..] {
+            color.to_output(output)?;
+        }
+        Ok(())
+    }
+}
+
+/// Size of a single sub image header in STCI files in bytes
+#[allow(dead_code)]
+pub const STCI_SUB_IMAGE_HEADER_SIZE: usize = 16;
+
+/// This represents a sub image header within an indexed STCI image
+///
+/// Sub image headers determine where the data of a specific sub image
+/// is located and it's dimensions and offset when rendered.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StciSubImageHeader {
+    pub data_offset: u32,
+    pub data_length: u32,
+    pub offset: (i16, i16),
+    pub dimensions: (u16, u16),
+}
+
+impl StciSubImageHeader {
+    /// Read the sub image header from input.
+    #[allow(dead_code)]
+    pub fn from_input<T>(input: &mut T) -> Result<Self>
+    where
+        T: Read,
+    {
+        let data_offset = input.read_u32::<LE>()?;
+        let data_length = input.read_u32::<LE>()?;
+        let offset_x = input.read_i16::<LE>()?;
+        let offset_y = input.read_i16::<LE>()?;
+        let dimensions_y = input.read_u16::<LE>()?;
+        let dimensions_x = input.read_u16::<LE>()?;
+
+        Ok(Self {
+            data_offset,
+            data_length,
+            offset: (offset_x, offset_y),
+            dimensions: (dimensions_x, dimensions_y),
+        })
+    }
+
+    /// Write the sub image header to output.
+    #[allow(dead_code)]
+    pub fn to_output<T>(&self, output: &mut T) -> Result<()>
+    where
+        T: Write,
+    {
+        output.write_u32::<LE>(self.data_offset)?;
+        output.write_u32::<LE>(self.data_length)?;
+        output.write_i16::<LE>(self.offset.0)?;
+        output.write_i16::<LE>(self.offset.1)?;
+        output.write_u16::<LE>(self.dimensions.1)?;
+        output.write_u16::<LE>(self.dimensions.0)?;
+        Ok(())
+    }
+}
+
+bitflags::bitflags! {
+    /// Some tile-specific flags within the app data in an indexed STCI image
+    pub struct StciAppDataFlags: u8 {
+        const FULL_TILE = 0x01;
+        const ANIMATED_TILE = 0x02;
+        const DYNAMIC_TILE = 0x04;
+        const INTERACTIVE_TILE = 0x08;
+        const IGNORES_HEIGHT = 0x10;
+        const USES_LAND_Z = 0x20;
+    }
+}
+
+/// Ja2 specific metadata that might exist for each sub image in an indexed STCI image
+#[derive(Debug, Clone, PartialEq)]
+pub struct StciAppData {
+    pub wall_orientation: u8,
+    pub number_of_tiles: u8,
+    pub tile_location_index: u16,
+    pub current_frame: u8,
+    pub number_of_frames: u8,
+    pub flags: StciAppDataFlags,
+}
+
+/// Size of a single app data stuct in STCI files in bytes
+#[allow(dead_code)]
+pub const STCI_APP_DATA_SIZE: usize = 16;
+
+impl StciAppData {
+    /// Read the app data from input.
+    #[allow(dead_code)]
+    pub fn from_input<T>(input: &mut T) -> Result<Self>
+    where
+        T: Read,
+    {
+        let wall_orientation = input.read_u8()?;
+        let number_of_tiles = input.read_u8()?;
+        let tile_location_index = input.read_u16::<LE>()?;
+        input.read_unused(3)?;
+        let current_frame = input.read_u8()?;
+        let number_of_frames = input.read_u8()?;
+        let flags = input.read_u8()?;
+        let flags = StciAppDataFlags::from_bits(flags)
+            .ok_or_else(|| Error::new(InvalidData, "expected valid app data flags"))?;
+        input.read_unused(6)?;
+
+        Ok(Self {
+            wall_orientation,
+            number_of_tiles,
+            tile_location_index,
+            current_frame,
+            number_of_frames,
+            flags,
+        })
+    }
+
+    /// Write the app data to output.
+    #[allow(dead_code)]
+    pub fn to_output<T>(&self, output: &mut T) -> Result<()>
+    where
+        T: Write,
+    {
+        output.write_u8(self.wall_orientation)?;
+        output.write_u8(self.number_of_tiles)?;
+        output.write_u16::<LE>(self.tile_location_index)?;
+        output.write_unused(3)?;
+        output.write_u8(self.current_frame)?;
+        output.write_u8(self.number_of_frames)?;
+        output.write_u8(self.flags.bits())?;
+        output.write_unused(6)?;
+        Ok(())
+    }
+}
+
+/// Final representation of a sub image within a indexed STCI image.
+///
+/// This already holds decompressed ETRLE data, so no need to further decompress anything.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StciSubImage {
+    pub offset: (i16, i16),
+    pub dimensions: (u16, u16),
+    pub app_data: Option<StciAppData>,
+    pub data: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_indexed_format_specific_header() {
+        let format_specific_header = StciHeaderIndexed {
+            number_of_palette_colors: 256,
+            number_of_images: 1,
+            color_depth: StciColorDepthIndexed(8, 8, 8),
+        };
+        let mut v = vec![0u8; 16];
+        let mut c = Cursor::new(&mut v);
+
+        format_specific_header
+            .to_output(&mut c)
+            .expect("should be possible to write header");
+        assert_eq!(
+            c.position(),
+            20,
+            "format specific header should have 20 bytes in size when writing"
+        );
+
+        c.set_position(0);
+        let read_header =
+            StciHeaderIndexed::from_input(&mut c).expect("should be possible to read header");
+        assert_eq!(
+            c.position(),
+            20,
+            "format specific header should have 20 bytes in size when reading"
+        );
+        assert_eq!(read_header, format_specific_header)
+    }
+
+    #[test]
+    fn test_stci_sub_image_header() {
+        let header = StciSubImageHeader {
+            data_offset: 256,
+            data_length: 300,
+            offset: (1, -1),
+            dimensions: (20, 30),
+        };
+        let mut v = vec![0u8; STCI_SUB_IMAGE_HEADER_SIZE];
+        let mut c = Cursor::new(&mut v);
+
+        header
+            .to_output(&mut c)
+            .expect("should be possible to write header");
+        assert_eq!(
+            c.position(),
+            STCI_SUB_IMAGE_HEADER_SIZE as u64,
+            "app data should have size {} when writing, got {}",
+            STCI_SUB_IMAGE_HEADER_SIZE,
+            c.position()
+        );
+
+        c.set_position(0);
+        let read_header =
+            StciSubImageHeader::from_input(&mut c).expect("should be possible to read header");
+        assert_eq!(
+            c.position(),
+            STCI_SUB_IMAGE_HEADER_SIZE as u64,
+            "app data should have size {} when reading, got {}",
+            STCI_SUB_IMAGE_HEADER_SIZE,
+            c.position()
+        );
+        assert_eq!(read_header, header)
+    }
+
+    #[test]
+    fn test_stci_app_data() {
+        let header = StciAppData {
+            wall_orientation: 0,
+            number_of_tiles: 0,
+            tile_location_index: 0,
+            current_frame: 0,
+            number_of_frames: 0,
+            flags: StciAppDataFlags::empty(),
+        };
+        let mut v = vec![0u8; STCI_APP_DATA_SIZE];
+        let mut c = Cursor::new(&mut v);
+
+        header
+            .to_output(&mut c)
+            .expect("should be possible to write header");
+        assert_eq!(
+            c.position(),
+            STCI_APP_DATA_SIZE as u64,
+            "app data should have size {} when writing, got {}",
+            STCI_APP_DATA_SIZE,
+            c.position()
+        );
+
+        c.set_position(0);
+        let read_header =
+            StciAppData::from_input(&mut c).expect("should be possible to read header");
+        assert_eq!(
+            c.position(),
+            STCI_APP_DATA_SIZE as u64,
+            "app data should have size {} when reading, got {}",
+            STCI_APP_DATA_SIZE,
+            c.position()
+        );
+        assert_eq!(read_header, header)
+    }
+}

--- a/rust/stracciatella/src/file_formats/stci/mod.rs
+++ b/rust/stracciatella/src/file_formats/stci/mod.rs
@@ -1,0 +1,911 @@
+//! This module contains code to read and write Sir-Tech's Crazy Image (STCI) file format.
+//!
+//! STCI is a file format that holds information about one or multiple images in Jagged Alliance 2.
+//!
+//! There are two variants: Indexed and RGB.
+//!
+//! Indexed STCI images store their colors in a palette and the data as ETRLE compressed indices into
+//! this palette. It also can contain multiple sub images, so it can encode e.g. one or multiple images,
+//! animations or tiles. Those sub images can have additional metadata associated such as offsets or
+//! animation or tile metadata.
+//!
+//! RGB STCI images store their colors as RGB565 colors in the data section. They cannot have additional
+//! metadata and only a single image can be stored in a RGB STCI image.
+//!
+//! # File Structure
+//!
+//! Based on `src/sgp/ImgFmt.h`
+//!
+//! Each file is composed of:
+//!
+//! - STCI prefix: 4 bytes of value `b"STCI"`
+//! - Header (60 bytes)
+//! - Palette (only for indexed images, 768 bytes, stored as RGB triplets)
+//! - SubImageHeaders (only for indexed images, 16 bytes each)
+//! - Data Section
+//! - App Data (only for indexed images, even then it is optional, 16 bytes each)
+//!
+//! # Header Structure
+//!
+//! - 4 byte unsigned int with the uncompressed size of the included image(s) pixels
+//! - 4 byte unsigned int with the compressed size of the included image(s) pixels
+//! - 4 byte unsigned int with the value that is transparent in the image. Is always 0 for Jagged Alliance 2 assets.
+//! - 4 byte unsigned into with flags for the stci image. Flags determine whether it is the indexed or RGB variant of STCI
+//! - 2 byte unsigned int with the height of the image. Ignored for indexed images, as their size is defined in the sub image headers.
+//! - 2 byte unsigned int with the width of the image. Ignored for indexed images, as their size is defined in the sub image headers.
+//! - 20 bytes with a format specific header. This header part is different for indexed and RGB images
+//! - 1 byte unsigned int with color_depth of the image. This is always 8 for indexed and 16 for RGB images for Jagged Alliance 2 assets.
+//! - 3 bytes unused. NOTE: This is different from original source code where no unused bytes are defined after the color depth, but
+//!   it seems to be required
+//! - 4 bytes unsigned int with the size of the app data included in the STCI image. Always 0 for RGB images.
+//!
+//! # Indexed Format Specific Header Structure
+//!
+//! - 4 bytes unsigned int with the number of palette colors. Always 256 for Jagged Alliance 2 assets.
+//! - 2 bytes unsigned int with the number of sub images in the indexed STCI image
+//! - 1 byte unsigned int with the red color depth for the STCI image. Always 8 for Jagged Alliance 2 assets.
+//! - 1 byte unsigned int with the green color depth for the STCI image. Always 8 for Jagged Alliance 2 assets.
+//! - 1 byte unsigned int with the blue color depth for the STCI image. Always 8 for Jagged Alliance 2 assets.
+//! - 11 bytes of unused data
+//!
+//! # RGB Format Specific Header Structure
+//!
+//! - 4 bytes unsigned int with the red color mask for the RGB image. Always `0xF800` for Jagged Alliance 2 assets.
+//! - 4 bytes unsigned int with the green color mask for the RGB image. Always `0x7E0` for Jagged Alliance 2 assets.
+//! - 4 bytes unsigned int with the blue color mask for the RGB image. Always `0x1F` for Jagged Alliance 2 assets.
+//! - 4 bytes unsigned int with the alpha color mask for the RGB image. Always `0` for Jagged Alliance 2 assets.
+//! - 1 bytes unsigned int with the red color depth for the RGB image. Always `5` for Jagged Alliance 2 assets.
+//! - 1 bytes unsigned int with the green color depth for the RGB image. Always `6` for Jagged Alliance 2 assets.
+//! - 1 bytes unsigned int with the blue color depth for the RGB image. Always `5` for Jagged Alliance 2 assets.
+//! - 1 bytes unsigned int with the alpha color depth for the RGB image. Always `0` for Jagged Alliance 2 assets.
+//!
+//! # Sub Image Header Stucture
+//!
+//! - 4 bytes unsigned int with the data offset from data section start
+//! - 4 bytes unsigned int with the compressed data length for this sub image
+//! - 2 bytes signed int with the x offset for this sub image
+//! - 2 bytes signed int with the y offset for this sub image
+//! - 2 bytes unsigned int with the height of this sub image
+//! - 2 bytes unsigned int with the width of this sub image
+//!
+//! # Indexed Data Section Structure
+//!
+//! The data section for indexed images contains all pixel data for each sub image in consecutive order.
+//! The data is ETRLE compressed for each sub image. When decompressed it can be used to index into the
+//! palette of the STCI image.
+//!
+//! # RGB Data Section Structure
+//!
+//! The data section for RGB images contains all pixel data for the RGB image in RGB565 color (which is represented
+//! as an 2 byte unsigned int).
+//!
+//! # App Data Structure
+//!
+//! App Data is optionally there for indexed STCI images. It contains additional information for the tile and/or
+//! animation system. It is only read when the app data size field in the header is > 0.
+//!
+//! - 1 byte unsigned int for wall orientation
+//! - 1 byte unsigned int for number of tiles
+//! - 2 byte unsigned int for tile location index
+//! - 3 unused bytes
+//! - 1 byte unsigned int for current animation keyframe. Seems to be `0` for Jagged Alliance 2 assets.
+//! - 1 byte unsigned int for the number of frames for animation
+//! - 1 byte unsigned int for flags on the sub image
+//! - 6 unused bytes
+
+use super::{StracciatellaReadExt, StracciatellaWriteExt};
+use bitflags::bitflags;
+use byteorder::{ReadBytesExt, WriteBytesExt, LE};
+use std::io::{
+    Cursor, Error,
+    ErrorKind::{InvalidData, InvalidInput, UnexpectedEof},
+    Read, Result, Seek, SeekFrom, Write,
+};
+
+mod color;
+pub mod etrle;
+pub mod indexed;
+pub mod rgb;
+
+pub use color::*;
+use indexed::*;
+use rgb::*;
+
+pub use indexed::{StciAppData, StciPalette, StciSubImage};
+
+/// Representation of the size part of the STCI header.
+///
+/// - For indexed images:
+///   - `original`: Accumulated uncompressed size of the data of all sub images
+///   - `stored`: Accumulated compressed size of the data of all sub images
+/// - For rgb images:
+///   - `original` == `stored`: Uncompressed size of the data in the STCI image
+#[derive(Debug, Default, Clone, PartialEq)]
+struct StciSize {
+    original: u32,
+    stored: u32,
+}
+
+impl StciSize {
+    /// Read the sizes from input.
+    #[allow(dead_code)]
+    pub fn from_input<T>(input: &mut T) -> Result<Self>
+    where
+        T: Read,
+    {
+        let original = input.read_u32::<LE>()?;
+        let stored = input.read_u32::<LE>()?;
+
+        Ok(Self { original, stored })
+    }
+
+    /// Write the sizes to output.
+    #[allow(dead_code)]
+    pub fn to_output<T>(&self, output: &mut T) -> Result<()>
+    where
+        T: Write,
+    {
+        output.write_u32::<LE>(self.original)?;
+        output.write_u32::<LE>(self.stored)?;
+        Ok(())
+    }
+}
+
+bitflags! {
+    /// Flags that can be set on an STCI image
+    pub struct StciFlags: u32 {
+        /// Sets the STCI to be ETRLE compressed. Needs to be set for indexed STCI images.
+        const ETRLE_COMPRESSED = 0x0020;
+        /// Sets the STCI to be zlib compressed. Not supported. Setting this flag will result in an error.
+        const ZLIB_COMPRESSED = 0x0010;
+        /// Sets the STCI to be an indexed STCI.
+        const INDEXED = 0x0008;
+        /// Sets the STCI to be a rgb STCI.
+        const RGB = 0x0004;
+        /// Seems to be unused.
+        const ALPHA = 0x0002;
+        /// Seems to be unused.
+        const TRANSPARENT = 0x0001;
+    }
+}
+
+impl StciFlags {
+    /// Returns proper flags for indexed image
+    #[allow(dead_code)]
+    fn indexed() -> Self {
+        let mut flags = StciFlags::empty();
+        flags.insert(StciFlags::INDEXED);
+        flags.insert(StciFlags::ETRLE_COMPRESSED);
+        flags
+    }
+
+    /// Returns proper flags for rgb image
+    #[allow(dead_code)]
+    fn rgb() -> Self {
+        let mut flags = StciFlags::empty();
+        flags.insert(StciFlags::RGB);
+        flags
+    }
+}
+
+/// Representation of header parts that are common to indexed and rgb STCI.
+///
+/// In the original data structure there are rgb/indexed specific header parts
+/// between `width` and `color_depth`.
+#[derive(Debug, Clone, PartialEq)]
+struct StciCommonHeader {
+    size: StciSize,
+    transparent_value: u32,
+    flags: StciFlags,
+    height: u16,
+    width: u16,
+    color_depth: u8,
+    app_data_size: u32,
+}
+
+impl StciCommonHeader {
+    /// Returns proper common header for indexed images
+    ///
+    /// Unknown values (e.g. sizes are set to 0)
+    #[allow(dead_code)]
+    fn indexed() -> Self {
+        StciCommonHeader {
+            size: StciSize::default(),
+            transparent_value: etrle::INDEXED_ALPHA_VALUE.into(),
+            flags: StciFlags::indexed(),
+            height: 0,
+            width: 0,
+            color_depth: 8,
+            app_data_size: 0,
+        }
+    }
+
+    /// Returns proper common header for rgb images
+    ///
+    /// Unknown values (e.g. sizes are set to 0)
+    #[allow(dead_code)]
+    fn rgb() -> Self {
+        StciCommonHeader {
+            size: StciSize::default(),
+            transparent_value: 0,
+            flags: StciFlags::rgb(),
+            height: 0,
+            width: 0,
+            color_depth: 16,
+            app_data_size: 0,
+        }
+    }
+}
+
+/// Complete representation of the STCI header including common and format specific parts
+#[derive(Debug, Clone, PartialEq)]
+enum StciHeader {
+    Indexed {
+        header: StciCommonHeader,
+        format_specific_header: StciHeaderIndexed,
+    },
+    Rgb {
+        header: StciCommonHeader,
+        format_specific_header: StciHeaderRgb,
+    },
+}
+
+impl StciHeader {
+    /// Read the header from input.
+    #[allow(dead_code)]
+    pub fn from_input<T>(input: &mut T) -> Result<Self>
+    where
+        T: Read,
+    {
+        let size = StciSize::from_input(input)?;
+        let transparent_value = input.read_u32::<LE>()?;
+        let flags = input.read_u32::<LE>()?;
+        let flags = StciFlags::from_bits(flags)
+            .ok_or_else(|| Error::new(InvalidData, "could not parse StciFlags"))?;
+        let height = input.read_u16::<LE>()?;
+        let width = input.read_u16::<LE>()?;
+        let is_indexed = flags.intersects(StciFlags::INDEXED);
+        let is_rgb = flags.intersects(StciFlags::RGB);
+
+        if flags.intersects(StciFlags::ZLIB_COMPRESSED) {
+            return Err(Error::new(
+                InvalidData,
+                "zlib compressed stci not supported",
+            ));
+        }
+
+        match (is_indexed, is_rgb) {
+            (true, false) => {
+                let format_specific_header = StciHeaderIndexed::from_input(input)?;
+                let color_depth = input.read_u8()?;
+                input.read_unused(3)?;
+                let app_data_size = input.read_u32::<LE>()?;
+                input.read_unused(12)?;
+
+                if color_depth != 8 {
+                    return Err(Error::new(
+                        InvalidData,
+                        "only supporting 8 bit indexed images",
+                    ));
+                }
+                if transparent_value != u32::from(etrle::INDEXED_ALPHA_VALUE) {
+                    return Err(Error::new(
+                        InvalidData,
+                        "only supporting 0 as transparent value",
+                    ));
+                }
+                if !flags.intersects(StciFlags::ETRLE_COMPRESSED) {
+                    return Err(Error::new(
+                        InvalidData,
+                        "only supporting etrle compressed indexed images",
+                    ));
+                }
+
+                Ok(StciHeader::Indexed {
+                    header: StciCommonHeader {
+                        size,
+                        transparent_value,
+                        flags,
+                        width,
+                        height,
+                        color_depth,
+                        app_data_size,
+                    },
+                    format_specific_header,
+                })
+            }
+            (false, true) => {
+                let format_specific_header = StciHeaderRgb::from_input(input)?;
+                let color_depth = input.read_u8()?;
+                input.read_unused(3)?;
+                let app_data_size = input.read_u32::<LE>()?;
+                input.read_unused(12)?;
+
+                if color_depth != 16 {
+                    return Err(Error::new(InvalidData, "only supporting 16 bit RGB images"));
+                }
+                if flags.intersects(StciFlags::ETRLE_COMPRESSED) {
+                    return Err(Error::new(
+                        InvalidData,
+                        "not supporting etrle encoded rgb images",
+                    ));
+                }
+
+                Ok(StciHeader::Rgb {
+                    header: StciCommonHeader {
+                        size,
+                        transparent_value,
+                        flags,
+                        width,
+                        height,
+                        color_depth,
+                        app_data_size,
+                    },
+                    format_specific_header,
+                })
+            }
+            (true, true) => Err(Error::new(
+                InvalidInput,
+                "both INDEXED and RGB flags are set",
+            )),
+            (false, false) => Err(Error::new(
+                InvalidInput,
+                "neither INDEXED nor RGB flag is set",
+            )),
+        }
+    }
+
+    /// Write the header to output.
+    #[allow(dead_code)]
+    pub fn to_output<T>(&self, output: &mut T) -> Result<()>
+    where
+        T: Write,
+    {
+        match self {
+            StciHeader::Indexed { header, .. } | StciHeader::Rgb { header, .. } => {
+                header.size.to_output(output)?;
+                output.write_u32::<LE>(header.transparent_value)?;
+                output.write_u32::<LE>(header.flags.bits())?;
+                output.write_u16::<LE>(header.height)?;
+                output.write_u16::<LE>(header.width)?;
+            }
+        }
+        match self {
+            StciHeader::Indexed {
+                format_specific_header,
+                ..
+            } => format_specific_header.to_output(output)?,
+            StciHeader::Rgb {
+                format_specific_header,
+                ..
+            } => format_specific_header.to_output(output)?,
+        }
+        match self {
+            StciHeader::Indexed { header, .. } | StciHeader::Rgb { header, .. } => {
+                output.write_u8(header.color_depth)?;
+                output.write_unused(3)?;
+                output.write_u32::<LE>(header.app_data_size)?;
+                output.write_unused(12)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Complete representation of an STCI image
+#[derive(Debug, PartialEq)]
+pub enum Stci {
+    /// Indexed variant
+    Indexed {
+        palette: Box<StciPalette>,
+        sub_images: Vec<StciSubImage>,
+    },
+    /// Rgb variant
+    Rgb {
+        width: u16,
+        height: u16,
+        data: Vec<StciRgb565>,
+    },
+}
+
+fn decode_sub_image_headers<T>(
+    input: &mut T,
+    number_of_sub_images: usize,
+) -> Result<Vec<StciSubImageHeader>>
+where
+    T: Read,
+{
+    let mut subimage_headers = Vec::with_capacity(number_of_sub_images);
+    for _ in 0..number_of_sub_images {
+        subimage_headers.push(StciSubImageHeader::from_input(input)?);
+    }
+    Ok(subimage_headers)
+}
+
+fn decode_sub_images<T>(
+    subimage_headers: Vec<StciSubImageHeader>,
+    decode_app_data: bool,
+    input: &mut T,
+) -> Result<Vec<StciSubImage>>
+where
+    T: Read,
+{
+    let number_of_subimages = subimage_headers.len();
+    let mut sub_images = Vec::with_capacity(number_of_subimages);
+    let mut current_index: u32 = 0;
+    for header in subimage_headers.iter() {
+        // We expect the images to be stored in the same order as the headers.
+        // This seems to be true for all STCI shipped with Jagged Alliance 2
+        if header.data_offset != current_index {
+            return Err(Error::new(
+                InvalidInput,
+                "only supporting continoous offsets",
+            ));
+        }
+
+        let data_length = header.data_length as usize;
+        let expected_decompressed_length =
+            header.dimensions.0 as usize * header.dimensions.1 as usize;
+        let mut data = Vec::with_capacity(expected_decompressed_length);
+        let mut output = Cursor::new(&mut data);
+        let mut input = input.take(data_length as u64);
+        etrle::etrle_decompress(&mut input, &mut output)?;
+
+        // Check whether we decompressed exactly the number of bytes we need
+        if data.len() != expected_decompressed_length {
+            return Err(Error::new(
+                UnexpectedEof,
+                format!(
+                    "expected to read {} bytes for sub image data, got {}",
+                    expected_decompressed_length,
+                    data.len(),
+                ),
+            ));
+        }
+        sub_images.push(StciSubImage {
+            offset: header.offset,
+            dimensions: header.dimensions,
+            app_data: None,
+            data,
+        });
+
+        current_index += header.data_length;
+    }
+    // App data is optional
+    if decode_app_data {
+        for sub_image in sub_images.iter_mut() {
+            let app_data = StciAppData::from_input(input)?;
+            sub_image.app_data = Some(app_data);
+        }
+    }
+    Ok(sub_images)
+}
+
+impl Stci {
+    /// Check if an input is actually an STCI image.
+    ///
+    /// This is done by reading the first 4 bytes and checking them against `b"STCI"`.
+    /// After reading it seeks back 4 bytes, so we are at the same position as before.
+    #[allow(dead_code)]
+    pub fn peek_is_stci<T>(input: &mut T) -> Result<bool>
+    where
+        T: Read + Seek,
+    {
+        let mut tag = [0u8; 4];
+        let e = input.read_exact(&mut tag);
+        match e {
+            Ok(_) => {}
+            Err(ref e) if e.kind() == UnexpectedEof => {
+                // We cannot read enough bytes for the tag, so its not an STCI file
+                return Ok(false);
+            }
+            Err(e) => {
+                // Forward any other error
+                return Err(e);
+            }
+        }
+        input.seek(SeekFrom::Current(-4))?;
+        Ok(&tag == b"STCI")
+    }
+
+    /// Read an STCI image from input.
+    #[allow(dead_code)]
+    pub fn from_input<T>(input: &mut T) -> Result<Self>
+    where
+        T: Read,
+    {
+        let mut tag = [0u8; 4];
+        input.read_exact(&mut tag)?;
+        if &tag != b"STCI" {
+            return Err(Error::new(InvalidInput, "does not seem to be a stci file"));
+        }
+        let header = StciHeader::from_input(input)?;
+        Ok(match header {
+            StciHeader::Rgb { header, .. } => {
+                let pixels = header.width as usize * header.height as usize;
+                let mut data = Vec::with_capacity(pixels);
+                for _ in 0..pixels {
+                    data.push(StciRgb565::from_input(input)?)
+                }
+                Stci::Rgb {
+                    width: header.width,
+                    height: header.height,
+                    data,
+                }
+            }
+            StciHeader::Indexed {
+                header,
+                format_specific_header,
+            } => {
+                let palette = StciPalette::from_input(
+                    input,
+                    format_specific_header.number_of_palette_colors as usize,
+                )?;
+                let sub_image_headers = decode_sub_image_headers(
+                    input,
+                    format_specific_header.number_of_images as usize,
+                )?;
+                let sub_images =
+                    decode_sub_images(sub_image_headers, header.app_data_size > 0, input)?;
+                Stci::Indexed {
+                    palette: Box::new(palette),
+                    sub_images,
+                }
+            }
+        })
+    }
+
+    /// Write a STCI image to output.
+    #[allow(dead_code)]
+    pub fn to_output<T>(&self, output: &mut T) -> Result<()>
+    where
+        T: Write,
+    {
+        output.write_all(b"STCI")?;
+        match self {
+            Stci::Rgb {
+                width,
+                height,
+                data,
+            } => {
+                let byte_size: usize = std::mem::size_of::<u16>();
+                let header = StciHeader::Rgb {
+                    header: StciCommonHeader {
+                        size: StciSize {
+                            original: (data.len() * byte_size) as u32,
+                            stored: (data.len() * byte_size) as u32,
+                        },
+                        width: *width,
+                        height: *height,
+                        ..StciCommonHeader::rgb()
+                    },
+                    format_specific_header: StciHeaderRgb::default(),
+                };
+                header.to_output(output)?;
+
+                for color in data {
+                    color.to_output(output)?;
+                }
+            }
+            Stci::Indexed {
+                palette,
+                sub_images,
+            } => {
+                let number_of_images = sub_images.len();
+                let app_data_size: u32 = sub_images
+                    .iter()
+                    .map(|sub_image| {
+                        if sub_image.app_data.is_some() {
+                            STCI_APP_DATA_SIZE as u32
+                        } else {
+                            0
+                        }
+                    })
+                    .sum();
+                let compressed_sub_image_bytes: Result<Vec<Vec<u8>>> = sub_images
+                    .iter()
+                    .map(|sub_image| {
+                        let mut data = Vec::<u8>::new();
+                        let mut input = sub_image.data.as_slice();
+                        let mut output = Cursor::new(&mut data);
+
+                        etrle::etrle_compress(&mut input, &mut output)?;
+
+                        Ok(data)
+                    })
+                    .collect();
+                let compressed_sub_image_bytes = compressed_sub_image_bytes?;
+                let original_size: u32 = sub_images
+                    .iter()
+                    .map(|sub_image| {
+                        u32::from(sub_image.dimensions.0) * u32::from(sub_image.dimensions.1)
+                    })
+                    .sum();
+                let stored_size: u32 = compressed_sub_image_bytes
+                    .iter()
+                    .map(|v| v.len() as u32)
+                    .sum();
+                let header = StciHeader::Indexed {
+                    header: StciCommonHeader {
+                        size: StciSize {
+                            original: original_size,
+                            stored: stored_size,
+                        },
+                        app_data_size,
+                        ..StciCommonHeader::indexed()
+                    },
+                    format_specific_header: StciHeaderIndexed {
+                        number_of_images: number_of_images as u16,
+                        ..StciHeaderIndexed::default()
+                    },
+                };
+                header.to_output(output)?;
+                palette.to_output(output)?;
+
+                let mut current_offset: u32 = 0;
+                for (index, sub_image) in sub_images.iter().enumerate() {
+                    let compressed_data = &compressed_sub_image_bytes[index];
+                    let compressed_data_len = compressed_data.len() as u32;
+                    let sub_image_header = StciSubImageHeader {
+                        data_offset: current_offset,
+                        data_length: compressed_data_len,
+                        dimensions: sub_image.dimensions,
+                        offset: sub_image.offset,
+                    };
+
+                    sub_image_header.to_output(output)?;
+
+                    current_offset += compressed_data_len;
+                }
+
+                for sub_image_bytes in compressed_sub_image_bytes {
+                    output.write_all(&sub_image_bytes)?;
+                }
+
+                if app_data_size > 0 {
+                    for sub_image in sub_images {
+                        if let Some(app_data) = &sub_image.app_data {
+                            app_data.to_output(output)?;
+                        } else {
+                            return Err(Error::new(
+                                InvalidInput,
+                                "either all or no sub images should have app data",
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn parse_sti_rgb() {
+        let mut sti_rgb: &[u8] = b"STCI\x06\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x03\x00\x00\xF8\x00\x00\xe0\x07\x00\x00\x1f\x00\x00\x00\x00\x00\x00\x00\x05\x06\x05\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xF8\x00\xF8\x00\xF8";
+        Stci::from_input(&mut sti_rgb).expect("rgb sti should parse");
+    }
+
+    #[test]
+    fn test_stci_header_indexed() {
+        let header = StciHeader::Indexed {
+            header: StciCommonHeader::indexed(),
+            format_specific_header: StciHeaderIndexed {
+                number_of_images: 1,
+                ..StciHeaderIndexed::default()
+            },
+        };
+        let expected_size: usize = 60;
+        let mut v = vec![0u8; expected_size];
+        let mut c = Cursor::new(&mut v);
+
+        // We dont include the STCI tag in our header so it needs to be 60 instead of 64 bytes
+        header
+            .to_output(&mut c)
+            .expect("should be possible to write header");
+        assert_eq!(
+            c.position(),
+            expected_size as u64,
+            "header should have {} bytes in size when writing, got {}",
+            expected_size,
+            c.position(),
+        );
+
+        c.set_position(0);
+        let read_header =
+            StciHeader::from_input(&mut c).expect("should be possible to read header");
+        assert_eq!(
+            c.position(),
+            expected_size as u64,
+            "header should have {} bytes in size when reading, got {}",
+            expected_size,
+            c.position(),
+        );
+        assert_eq!(read_header, header)
+    }
+
+    #[test]
+    fn test_stci_header_rgb() {
+        let header = StciHeader::Rgb {
+            header: StciCommonHeader {
+                height: 1,
+                width: 3,
+                ..StciCommonHeader::rgb()
+            },
+            format_specific_header: StciHeaderRgb::default(),
+        };
+        let expected_size: usize = 60;
+        let mut v = vec![0u8; expected_size];
+        let mut c = Cursor::new(&mut v);
+
+        // We dont include the STCI tag in our header so it needs to be 60 instead of 64 bytes
+        header
+            .to_output(&mut c)
+            .expect("should be possible to write header");
+        assert_eq!(
+            c.position(),
+            expected_size as u64,
+            "header should have {} bytes in size when writing, got {}",
+            expected_size,
+            c.position(),
+        );
+
+        c.set_position(0);
+        let read_header =
+            StciHeader::from_input(&mut c).expect("should be possible to read header");
+        assert_eq!(
+            c.position(),
+            expected_size as u64,
+            "header should have {} bytes in size when reading, got {}",
+            expected_size,
+            c.position(),
+        );
+        assert_eq!(read_header, header)
+    }
+
+    #[test]
+    fn test_stci_rgb() {
+        let stci = Stci::Rgb {
+            height: 1,
+            width: 1,
+            data: vec![StciRgb565(0)],
+        };
+        // expected size is 4 byte STCI tag + 60 byte header + 2 byte data
+        let expected_size: usize = 66;
+        let mut v = vec![0u8; expected_size];
+        let mut c = Cursor::new(&mut v);
+
+        stci.to_output(&mut c)
+            .expect("should be possible to write header");
+        assert_eq!(
+            c.position(),
+            expected_size as u64,
+            "stci should have {} bytes in size when writing, got {}",
+            expected_size,
+            c.position()
+        );
+
+        c.set_position(0);
+        let read_stci = Stci::from_input(&mut c).expect("should be possible to read header");
+        assert_eq!(
+            c.position(),
+            expected_size as u64,
+            "stci should have {} bytes in size when reading, got {}",
+            expected_size,
+            c.position(),
+        );
+        assert_eq!(read_stci, stci)
+    }
+
+    #[test]
+    fn test_stci_indexed_no_app_data() {
+        let stci = Stci::Indexed {
+            palette: Box::new(StciPalette::default()),
+            sub_images: vec![
+                StciSubImage {
+                    offset: (0, 0),
+                    dimensions: (1, 1),
+                    data: vec![0],
+                    app_data: None,
+                },
+                StciSubImage {
+                    offset: (1, -1),
+                    dimensions: (1, 1),
+                    data: vec![0],
+                    app_data: None,
+                },
+            ],
+        };
+        // expected size is 4 byte STCI tag + 60 byte header + 3 * 256 bytes palette +  2 * 16 byte sub image header + 2 * 1 byte data
+        let expected_size: usize = 866;
+        let mut v = vec![0u8; expected_size];
+        let mut c = Cursor::new(&mut v);
+
+        stci.to_output(&mut c)
+            .expect("should be possible to write header");
+        assert_eq!(
+            c.position(),
+            expected_size as u64,
+            "stci should have {} bytes in size when writing, got {}",
+            expected_size,
+            c.position()
+        );
+
+        c.set_position(0);
+        let read_stci = Stci::from_input(&mut c).expect("should be possible to read header");
+        assert_eq!(
+            c.position(),
+            expected_size as u64,
+            "stci should have {} bytes in size when reading, got {}",
+            expected_size,
+            c.position(),
+        );
+        assert_eq!(read_stci, stci)
+    }
+
+    #[test]
+    fn test_stci_indexed_with_app_data() {
+        let stci = Stci::Indexed {
+            palette: Box::new(StciPalette::default()),
+            sub_images: vec![
+                StciSubImage {
+                    offset: (0, 0),
+                    dimensions: (1, 1),
+                    data: vec![0],
+                    app_data: Some(StciAppData {
+                        wall_orientation: 0,
+                        number_of_tiles: 0,
+                        tile_location_index: 0,
+                        current_frame: 0,
+                        number_of_frames: 2,
+                        flags: StciAppDataFlags::empty(),
+                    }),
+                },
+                StciSubImage {
+                    offset: (1, -1),
+                    dimensions: (1, 1),
+                    data: vec![0],
+                    app_data: Some(StciAppData {
+                        wall_orientation: 0,
+                        number_of_tiles: 0,
+                        tile_location_index: 0,
+                        current_frame: 0,
+                        number_of_frames: 0,
+                        flags: StciAppDataFlags::empty(),
+                    }),
+                },
+            ],
+        };
+        // expected size is
+        // 4 byte STCI tag + 60 byte header + 3 * 256 bytes palette +  2 * 16 byte sub image header + 2 * 1 byte data + 2 * 16 byte app data
+        let expected_size: usize = 898;
+        let mut v = vec![0u8; expected_size];
+        let mut c = Cursor::new(&mut v);
+
+        stci.to_output(&mut c)
+            .expect("should be possible to write header");
+        assert_eq!(
+            c.position(),
+            expected_size as u64,
+            "stci should have {} bytes in size when writing, got {}",
+            expected_size,
+            c.position()
+        );
+
+        c.set_position(0);
+        let read_stci = Stci::from_input(&mut c).expect("should be possible to read header");
+        assert_eq!(
+            c.position(),
+            expected_size as u64,
+            "stci should have {} bytes in size when reading, got {}",
+            expected_size,
+            c.position(),
+        );
+        assert_eq!(read_stci, stci)
+    }
+}

--- a/rust/stracciatella/src/file_formats/stci/rgb.rs
+++ b/rust/stracciatella/src/file_formats/stci/rgb.rs
@@ -1,0 +1,168 @@
+//! This module contains functionality around RGB STCI images
+
+use super::{STCI_RGB565_BLUE_MASK, STCI_RGB565_GREEN_MASK, STCI_RGB565_RED_MASK};
+use std::io::{
+    Error,
+    ErrorKind::{InvalidData, InvalidInput},
+    Read, Result, Write,
+};
+
+use byteorder::{ReadBytesExt, WriteBytesExt, LE};
+
+/// Mask part of the rgb STCI header
+///
+/// The mask includes masks for all RGBA channels.
+///
+/// We only support RGB565 without alpha channel right now. All other masks will result
+/// in an error.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StciMaskRgb(pub u32, pub u32, pub u32, pub u32);
+
+impl StciMaskRgb {
+    /// Read the mask part from input.
+    #[allow(dead_code)]
+    pub fn from_input<T>(input: &mut T) -> Result<Self>
+    where
+        T: Read,
+    {
+        let red = input.read_u32::<LE>()?;
+        let green = input.read_u32::<LE>()?;
+        let blue = input.read_u32::<LE>()?;
+        let alpha = input.read_u32::<LE>()?;
+
+        if red != STCI_RGB565_RED_MASK
+            || green != STCI_RGB565_GREEN_MASK
+            || blue != STCI_RGB565_BLUE_MASK && alpha != 0
+        {
+            return Err(Error::new(InvalidData, "expected RGB565 mask values"));
+        }
+
+        Ok(Self(red, green, blue, alpha))
+    }
+
+    /// Write the mask part to output.
+    #[allow(dead_code)]
+    pub fn to_output<T>(&self, output: &mut T) -> Result<()>
+    where
+        T: Write,
+    {
+        if self.0 != STCI_RGB565_RED_MASK
+            || self.1 != STCI_RGB565_GREEN_MASK
+            || self.2 != STCI_RGB565_BLUE_MASK && self.3 != 0
+        {
+            return Err(Error::new(InvalidInput, "expected RGB565 mask values"));
+        }
+
+        output.write_u32::<LE>(self.0)?;
+        output.write_u32::<LE>(self.1)?;
+        output.write_u32::<LE>(self.2)?;
+        output.write_u32::<LE>(self.3)?;
+        Ok(())
+    }
+}
+
+impl Default for StciMaskRgb {
+    fn default() -> Self {
+        Self(
+            STCI_RGB565_RED_MASK,
+            STCI_RGB565_GREEN_MASK,
+            STCI_RGB565_BLUE_MASK,
+            0,
+        )
+    }
+}
+
+/// Color depth part of the rgb STCI header
+///
+/// The mask includes color depths for all RGBA channels.
+///
+/// We only support RGB565 without alpha channel right now. All other color depths will result
+/// in an error.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StciColorDepthRgb(pub u8, pub u8, pub u8, pub u8);
+
+impl StciColorDepthRgb {
+    /// Read the color depth part from input.
+    #[allow(dead_code)]
+    pub fn from_input<T>(input: &mut T) -> Result<Self>
+    where
+        T: Read,
+    {
+        let red = input.read_u8()?;
+        let green = input.read_u8()?;
+        let blue = input.read_u8()?;
+        let alpha = input.read_u8()?;
+
+        if red != 5 || green != 6 || blue != 5 || alpha != 0 {
+            return Err(Error::new(
+                InvalidData,
+                format!(
+                    "only supporting RGB5650 color depth in rgb stci images, got RGB{}{}{}{} in header",
+                    red, green, blue, alpha
+                ),
+            ));
+        }
+
+        Ok(Self(red, green, blue, alpha))
+    }
+
+    /// Write the color depth part to output.
+    #[allow(dead_code)]
+    pub fn to_output<T>(&self, output: &mut T) -> Result<()>
+    where
+        T: Write,
+    {
+        if self.0 != 5 || self.1 != 6 || self.2 != 5 || self.3 != 0 {
+            return Err(Error::new(
+                InvalidInput,
+                format!(
+                    "only supporting RGB5650 color depth in rgb stci images, got RGB{}{}{}{}",
+                    self.0, self.1, self.2, self.3
+                ),
+            ));
+        }
+
+        output.write_u8(self.0)?;
+        output.write_u8(self.1)?;
+        output.write_u8(self.2)?;
+        output.write_u8(self.3)?;
+        Ok(())
+    }
+}
+
+impl Default for StciColorDepthRgb {
+    fn default() -> Self {
+        Self(5, 6, 5, 0)
+    }
+}
+
+/// Rgb specific part of the STCI header
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct StciHeaderRgb {
+    pub mask: StciMaskRgb,
+    pub color_depth: StciColorDepthRgb,
+}
+
+impl StciHeaderRgb {
+    /// Read the rgb specific part from input.
+    #[allow(dead_code)]
+    pub fn from_input<T>(input: &mut T) -> Result<Self>
+    where
+        T: Read,
+    {
+        let mask = StciMaskRgb::from_input(input)?;
+        let color_depth = StciColorDepthRgb::from_input(input)?;
+        Ok(Self { mask, color_depth })
+    }
+
+    /// Write the rgb specific part to output.
+    #[allow(dead_code)]
+    pub fn to_output<T>(&self, output: &mut T) -> Result<()>
+    where
+        T: Write,
+    {
+        self.mask.to_output(output)?;
+        self.color_depth.to_output(output)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
I've had this code lying around a bit and don't want to let it go to waste. It adds support for reading and writing STCI files in Rust.

If you have concerns regarding compile times (as the code is currently not used by the engine) let me know. I can adapt it to not compile by default, only if explicitly enabled.