### PR TITLE
Add 0.19.x to branch filter for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ branches:
   only:
     - master
     - nightly
+    - /\d+\.\d+\.[\dx]+/
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
It seems like otherwise the builds for `0.19.1` are not triggered on AppVeyor. I hope this fixes it. We can remove it once `0.20.0` is released.