### PR TITLE
Handle the EXDEV error on all OS's where it can happen

### DIFF
--- a/rust/stracciatella/src/fs.rs
+++ b/rust/stracciatella/src/fs.rs
@@ -59,7 +59,7 @@ pub fn remove_file<P: AsRef<Path>>(path: P) -> Result<(), io::Error> {
 pub fn rename<P: AsRef<Path>>(from: P, to: P) -> Result<(), io::Error> {
     match std::fs::rename(&from, &to) {
         Ok(()) => Ok(()),
-        #[cfg(target_os = "linux")]
+        #[cfg(target_family = "unix")]
         Err(e) if e.raw_os_error() == Some(libc::EXDEV) => {
             std::fs::copy(&from, &to).and_then(|_| remove_file(&from))
         }


### PR DESCRIPTION
This EXDEV error can happen on all Unix-like OS's that have a rename(2) that
conform to POSIX.1. So, go with the more inclusive "target_family"
instead of target_os.

Makes JA2 work with FreeBSD (and likely all the other OS's that may have their
tmp on another file system).

This is the more general fix to #1478.