### PR TITLE
Upgrade miniaudio dependency to latest version in 0.10.x branch

### DIFF
--- a/dependencies/lib-miniaudio/getter/CMakeLists.txt.in
+++ b/dependencies/lib-miniaudio/getter/CMakeLists.txt.in
@@ -12,9 +12,10 @@ project(getter NONE)
 
 include(ExternalProject)
 externalproject_add(get-miniaudio
-    # This is version 0.10.20
-    URL "https://github.com/mackron/miniaudio/archive/634cdb028f340075ae8e8a1126620695688d2ac3.zip"
-    URL_MD5 "b30045e95cec65bfe1d9fe3639f480a2"
+    # Need miniaudio>=0.10.36<0.11
+    # This is version 0.10.43
+    URL "https://github.com/mackron/miniaudio/archive/8686f52e6625e562f4756b946696692c016324ab.zip"
+    URL_MD5 "7e682c814564dd64ee05dc34130a0e15"
     CMAKE_ARGS
         "-G@CMAKE_GENERATOR@"
         SOURCE_DIR          "@SRC_DIR@"

--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -693,7 +693,7 @@ size_t MiniaudioReadProc(ma_decoder* pDecoder, void* pBufferOut, size_t bytesToR
 	return SDL_RWread(rwOps, pBufferOut, sizeof(UINT8), bytesToRead);
 }
 
-ma_bool32 MiniaudioSeekProc(ma_decoder* pDecoder, int byteOffset, ma_seek_origin origin) {
+ma_bool32 MiniaudioSeekProc(ma_decoder* pDecoder, ma_int64 byteOffset, ma_seek_origin origin) {
 	auto rwOps = (SDL_RWops*)pDecoder->pUserData;
 	auto sdlOrigin = RW_SEEK_SET;
 	if (origin == ma_seek_origin::ma_seek_origin_current) {


### PR DESCRIPTION
In general I'd like to have an ability to pick up miniaudio dependency from the system during ja2 build process.
See also https://github.com/ja2-stracciatella/ja2-stracciatella/issues/1377

And the first step I'd like to be done is to update the needed miniaudio version to latest in 0.10.x branch (0.11.x has broken a lot of APIs).
Besides that provide a comment in the cmake file telling what miniaudio version ja2 needs now.
Also provide small patch to make ja2 compatible with miniaudio 0.10.36+