### PR TITLE
Run game without blocking the launcher and add logs as a launcher tab

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,11 +287,6 @@ if (ANDROID)
     LIST(APPEND JA2_LIBRARIES android log)
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    LIST(APPEND JA2_LIBRARIES stdc++fs)
-    LIST(APPEND LAUNCHER_LIBRARIES stdc++fs)
-endif()
-
 if(ANDROID)
     add_library(${JA2_BINARY} SHARED ${JA2_SOURCES})
 else()

--- a/rust/stracciatella_c_api/cbindgen.toml
+++ b/rust/stracciatella_c_api/cbindgen.toml
@@ -30,6 +30,7 @@ struct RustDelete
 	void operator()(ModManager* ptr) const { ModManager_destroy(ptr); }
 	void operator()(Mod* ptr) const { Mod_destroy(ptr); }
 	void operator()(SchemaManager* ptr) const { SchemaManager_destroy(ptr); }
+	void operator()(SubProcess* ptr) const { SubProcess_destroy(ptr); }
 };
 
 /// Alias to a std::unique_ptr that deletes with RustDelete.

--- a/rust/stracciatella_c_api/src/c/logger.rs
+++ b/rust/stracciatella_c_api/src/c/logger.rs
@@ -9,9 +9,17 @@ use crate::c::common::*;
 
 /// Initializes the logger
 #[no_mangle]
-pub extern "C" fn Logger_initialize(log_file: *const c_char) {
-    let log_file = path_buf_from_c_str_or_panic(unsafe_c_str(log_file));
+pub extern "C" fn Logger_initialize(log_file_name: *const c_char) {
+    let log_file = str_from_c_str_or_panic(unsafe_c_str(log_file_name));
     Logger::init(&log_file)
+}
+
+/// Returns the path to the log file specified by `log_file_name`
+#[no_mangle]
+pub extern "C" fn Logger_getFilePath(log_file_name: *const c_char) -> *mut c_char {
+    let log_file = str_from_c_str_or_panic(unsafe_c_str(log_file_name));
+    let file_name = c_string_from_path_or_panic(&Logger::get_log_file_path(&log_file));
+    file_name.into_raw()
 }
 
 /// Set log level

--- a/rust/stracciatella_c_api/src/c/mod.rs
+++ b/rust/stracciatella_c_api/src/c/mod.rs
@@ -10,6 +10,7 @@ pub mod misc;
 pub mod mod_manager;
 pub mod path;
 pub mod schema_manager;
+pub mod subprocess;
 pub mod vec;
 pub mod vfs;
 

--- a/rust/stracciatella_c_api/src/c/subprocess.rs
+++ b/rust/stracciatella_c_api/src/c/subprocess.rs
@@ -1,0 +1,193 @@
+//! This module and it's submodules contains threadsafe C bindings to std::process.
+
+use libc::c_char;
+use std::path::PathBuf;
+use std::process::{Child, Command, Output};
+use std::sync::{Arc, Mutex};
+
+use crate::c::common::*;
+use crate::c::vec::*;
+
+pub enum SubProcessState {
+    /// The subprocess is still running
+    Running(Option<Child>),
+    /// The subprocess has finished with status code
+    Finished(Arc<Output>),
+    /// Communication with the process has failed
+    Error(Arc<std::io::Error>),
+}
+
+impl SubProcessState {
+    /// Run subprocess with arguments
+    pub fn new(cmd: std::path::PathBuf, args: Vec<PathBuf>) -> std::io::Result<Self> {
+        let cmd = Command::new(cmd).args(args).spawn()?;
+        Ok(cmd.into())
+    }
+
+    /// Check if process finished or failed
+    pub fn is_done(&self) -> bool {
+        matches!(self, Self::Finished(_) | Self::Error(_))
+    }
+
+    /// Check if process has finished and update state
+    pub fn process(&mut self) {
+        if let Self::Running(ref mut c) = self {
+            let mut c = std::mem::take(c).expect("SubProcess::Running child should always be some");
+            *self = match c.try_wait() {
+                Ok(Some(_)) => match c.wait_with_output() {
+                    Ok(o) => o.into(),
+                    Err(e) => Self::Error(Arc::new(e)),
+                },
+                Ok(None) => Self::Running(Some(c)),
+                Err(e) => Self::Error(Arc::new(e)),
+            }
+        }
+    }
+
+    /// Get subprocess output
+    pub fn output(&self) -> Result<Option<Arc<Output>>, Arc<std::io::Error>> {
+        match self {
+            Self::Finished(o) => Ok(Some(o.clone())),
+            Self::Error(e) => Err(e.clone()),
+            Self::Running(_) => Ok(None),
+        }
+    }
+}
+
+impl From<Child> for SubProcessState {
+    fn from(c: Child) -> Self {
+        Self::Running(Some(c))
+    }
+}
+
+impl From<Output> for SubProcessState {
+    fn from(o: Output) -> Self {
+        Self::Finished(Arc::new(o))
+    }
+}
+
+pub struct SubProcess {
+    inner: Arc<Mutex<SubProcessState>>,
+}
+
+impl SubProcess {
+    /// Run subprocess with arguments
+    pub fn new(cmd: std::path::PathBuf, args: Vec<PathBuf>) -> std::io::Result<Self> {
+        let cmd = Command::new(cmd).args(args).spawn()?;
+        Ok(Self {
+            inner: Arc::new(Mutex::new(cmd.into())),
+        })
+    }
+
+    /// Check if process finished or failed
+    pub fn is_done(&self) -> bool {
+        let inner = self.inner.lock().expect("subprocess mutex poisoned");
+        inner.is_done()
+    }
+
+    /// Check if process has finished and update state
+    pub fn process(&mut self) {
+        let mut inner = self.inner.lock().expect("subprocess mutex poisoned");
+        inner.process()
+    }
+
+    /// Get subprocess output.
+    pub fn output(&self) -> Result<Option<Arc<Output>>, Arc<std::io::Error>> {
+        let inner = self.inner.lock().expect("subprocess mutex poisoned");
+        inner.output()
+    }
+}
+
+/// Starts a subprocess and collects stdin/stderr in the process
+///
+/// Returns null on error
+#[no_mangle]
+pub extern "C" fn Subprocess_new(program: *const c_char, args: *mut VecCString) -> *mut SubProcess {
+    forget_rust_error();
+
+    let program = path_buf_from_c_str_or_panic(unsafe_c_str(program));
+    let args: Vec<_> = unsafe_ref(args)
+        .inner
+        .iter()
+        .map(|x| path_buf_from_c_str_or_panic(x))
+        .collect();
+    let cmd = SubProcess::new(program, args);
+
+    match cmd {
+        Ok(cmd) => into_ptr(cmd),
+        Err(e) => {
+            remember_rust_error(format!("{}", e));
+            std::ptr::null_mut()
+        }
+    }
+}
+
+/// Checks whether the subprocess is done running
+///
+/// Also considers the subprocess as finished when a communication error occurs
+#[no_mangle]
+pub extern "C" fn Subprocess_isDone(ptr: *mut SubProcess) -> bool {
+    let ptr = unsafe_mut(ptr);
+    ptr.is_done()
+}
+
+/// Maintains internal subprocess state. Will mark it as done when subprocess has finished
+#[no_mangle]
+pub extern "C" fn Subprocess_process(ptr: *mut SubProcess) {
+    let ptr = unsafe_mut(ptr);
+    ptr.process()
+}
+
+/// Gets the subprocesses exit code. Throws an error if the process has not finished yet.
+///
+/// Also throws an error when a communication error with the subprocess occured
+///
+/// # Safety
+///
+/// We use `libc::strsignal` to create a signal string for the error message. If the result is not valid utf8 the function will crash.
+#[no_mangle]
+pub unsafe extern "C" fn Subprocess_getExitCode(ptr: *mut SubProcess) -> i32 {
+    forget_rust_error();
+
+    let ptr = unsafe_mut(ptr);
+    match ptr.output() {
+        Ok(Some(output)) => {
+            let exit_code = output.status.code();
+            if let Some(exit_code) = exit_code {
+                exit_code
+            } else {
+                let mut error = "Subprocess terminated by a signal.".to_owned();
+                #[cfg(target_family = "unix")]
+                {
+                    // Include signal details on unix systems
+                    use std::os::unix::process::ExitStatusExt;
+
+                    if let Some(signal) = output.status.signal() {
+                        let signal_ptr = libc::strsignal(signal);
+                        if !signal_ptr.is_null() {
+                            let signal_str = str_from_c_str_or_panic(unsafe_c_str(signal_ptr));
+                            error = format!("Subprocess terminated by signal: {}", signal_str);
+                        }
+                    }
+                }
+                remember_rust_error(error);
+                i32::MIN
+            }
+        }
+        Ok(None) => {
+            remember_rust_error("Subprocess has not finished yet.");
+            i32::MIN
+        }
+        Err(e) => {
+            remember_rust_error(format!("Error communicating with subprocess: {}", e));
+            i32::MIN
+        }
+    }
+}
+
+/// Destroys the SubProcess instance.
+/// coverity[+free : arg-0]
+#[no_mangle]
+pub extern "C" fn SubProcess_destroy(ptr: *mut SubProcess) {
+    let _drop_me = from_ptr(ptr);
+}

--- a/src/launcher/Launcher.h
+++ b/src/launcher/Launcher.h
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <iterator>
 #include <set>
+#include <optional>
 
 struct sortMods {
     bool operator() (ST::string a, ST::string b) const {
@@ -32,11 +33,15 @@ private:
 	char** argv;
 	RustPointer<EngineOptions> engineOptions;
 	RustPointer<ModManager> modManager;
+	std::optional<RustPointer<SubProcess>> subProcess;
+	Fl_Text_Buffer logsBuffer;
 
 	void populateChoices();
 	void startExecutable(bool asEditor);
 	bool resolutionIsInvalid();
-	void update(bool changed, Fl_Widget *widget);
+	bool gameIsRunning();
+	void update(bool changed);
+	void updateLogs();
 	void showModDetails(const ST::string& modName);
 	void hideModDetails();
 	static void openGameDirectorySelector(Fl_Widget *btn, void *userdata);
@@ -55,6 +60,7 @@ private:
 	static void moveUpMods(Fl_Widget* widget, void* userdata);
 	static void moveDownMods(Fl_Widget* widget, void* userdata);
 	static void selectGameVersion(Fl_Widget* widget, void* userdata);
+	static void maintainSubProcessState(void*);
 };
 
 #endif //JA2_LAUNCHER_H_H

--- a/src/launcher/StracciatellaLauncher.cc
+++ b/src/launcher/StracciatellaLauncher.cc
@@ -5,8 +5,8 @@
 StracciatellaLauncher::StracciatellaLauncher() {
   { stracciatellaLauncher = new Fl_Double_Window(520, 380, "JA2 Stracciatella Launcher");
     stracciatellaLauncher->user_data((void*)(this));
-    { Fl_Tabs* o = new Fl_Tabs(0, 0, 520, 350);
-      o->align(Fl_Align(FL_ALIGN_TOP_RIGHT));
+    { tabs = new Fl_Tabs(0, 0, 520, 350);
+      tabs->align(Fl_Align(FL_ALIGN_TOP_RIGHT));
       { Fl_Group* o = new Fl_Group(0, 50, 520, 300, "@> Play  ");
         o->labelsize(16);
         o->labelcolor((Fl_Color)24);
@@ -170,9 +170,20 @@ le from the mod with the highest priority is used.");
         } // Fl_Group* o
         o->end();
       } // Fl_Group* o
-      o->end();
-      Fl_Group::current()->resizable(o);
-    } // Fl_Tabs* o
+      { logsTab = new Fl_Group(0, 50, 520, 300, "@square Logs");
+        logsTab->labelcolor((Fl_Color)24);
+        logsTab->hide();
+        { logsDisplay = new Fl_Text_Display(20, 95, 480, 250, "You can view the logs of the latest JA2 Stracciatella execution here. If you \
+want to report a bug, please include them in your bug report.");
+          logsDisplay->box(FL_DOWN_BOX);
+          logsDisplay->align(Fl_Align(133));
+          Fl_Group::current()->resizable(logsDisplay);
+        } // Fl_Text_Display* logsDisplay
+        logsTab->end();
+      } // Fl_Group* logsTab
+      tabs->end();
+      Fl_Group::current()->resizable(tabs);
+    } // Fl_Tabs* tabs
     { Fl_Group* o = new Fl_Group(0, 350, 465520, 30);
       { ja2JsonPathOutput = new Fl_Output(0, 350, 460, 30);
         ja2JsonPathOutput->tooltip("Path to stracciatella engine options");

--- a/src/launcher/StracciatellaLauncher.fl
+++ b/src/launcher/StracciatellaLauncher.fl
@@ -8,9 +8,9 @@ class StracciatellaLauncher {open
   } {
     Fl_Window stracciatellaLauncher {
       label {JA2 Stracciatella Launcher} open
-      xywh {659 182 520 380} type Double resizable size_range {520 390 0 0} visible
+      xywh {555 168 520 380} type Double resizable size_range {520 390 0 0} visible
     } {
-      Fl_Tabs {} {open
+      Fl_Tabs tabs {open
         xywh {0 0 520 350} align 9 resizable
       } {
         Fl_Group {} {
@@ -27,7 +27,7 @@ class StracciatellaLauncher {open
           }
         }
         Fl_Group {} {
-          label {@filenew Data } open
+          label {@filenew Data }
           xywh {0 50 520 300} labelcolor 24 hide
         } {
           Fl_Group {} {
@@ -72,7 +72,7 @@ class StracciatellaLauncher {open
           }
         }
         Fl_Group {} {
-          label {@-> Mods } open
+          label {@-> Mods }
           xywh {0 50 520 300} labelcolor 24 hide
         } {
           Fl_Group {} {
@@ -108,7 +108,7 @@ class StracciatellaLauncher {open
           }
         }
         Fl_Group {} {
-          label {@menu Settings } open
+          label {@menu Settings }
           xywh {0 50 520 300} labelcolor 24 hide
         } {
           Fl_Group {} {open
@@ -175,8 +175,17 @@ class StracciatellaLauncher {open
             xywh {10 285 445 30} labeltype NO_LABEL align 17 resizable
           } {}
         }
+        Fl_Group logsTab {
+          label {@square Logs} open
+          xywh {0 50 520 300} labelcolor 24 hide
+        } {
+          Fl_Text_Display logsDisplay {
+            label {You can view the logs of the latest JA2 Stracciatella execution here. If you want to report a bug, please include them in your bug report.}
+            xywh {20 95 480 250} box DOWN_BOX align 133 resizable
+          }
+        }
       }
-      Fl_Group {} {
+      Fl_Group {} {open
         xywh {0 350 465520 30}
       } {
         Fl_Output ja2JsonPathOutput {

--- a/src/launcher/StracciatellaLauncher.h
+++ b/src/launcher/StracciatellaLauncher.h
@@ -21,6 +21,7 @@ class StracciatellaLauncher {
 public:
   StracciatellaLauncher();
   Fl_Double_Window *stracciatellaLauncher;
+  Fl_Tabs *tabs;
   Fl_Button *editorButton;
   Fl_Button *playButton;
   Fl_Input *gameDirectoryInput;
@@ -44,6 +45,8 @@ public:
   Fl_Box *invalidResolutionLabel;
   Fl_Check_Button *fullscreenCheckbox;
   Fl_Check_Button *playSoundsCheckbox;
+  Fl_Group *logsTab;
+  Fl_Text_Display *logsDisplay;
   Fl_Output *ja2JsonPathOutput;
   Fl_Button *ja2JsonReloadBtn;
   Fl_Button *ja2JsonSaveBtn;

--- a/src/launcher/main.cc
+++ b/src/launcher/main.cc
@@ -3,18 +3,9 @@
 #include <FL/Fl.H>
 #include <string_theory/string>
 
-#if defined(__GNUC__) && __GNUC__ < 8
-	#include <experimental/filesystem>
-	namespace fs = std::experimental::filesystem;
-#else
-	#include <filesystem>
-	namespace fs = std::filesystem;
-#endif
-
-int main(int argc, char* argv[]) 
+int main(int argc, char* argv[])
 {
-	ST::string logPath { fs::temp_directory_path().append("ja2-launcher.log") };
-	Logger_initialize(logPath.c_str());
+	Logger_initialize("ja2-launcher.log");
 
 #ifdef _WIN32
 	// Ensure quick-edit mode is off, or else it will block execution

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -58,26 +58,6 @@
 #include <new>
 #include <utility>
 
-#ifdef __ANDROID__
-	static inline ST::string get_temp_filename(void)
-	{
-		return "ja2.log";
-	}
-#else
-	#if defined(__GNUC__) && __GNUC__ < 8
-	#include <experimental/filesystem>
-	namespace fs = std::experimental::filesystem;
-	#else
-	#include <filesystem>
-	namespace fs = std::filesystem;
-	#endif
-
-	static inline ST::string get_temp_filename(void)
-	{
-		return ST::string{fs::temp_directory_path().append("ja2.log")};
-	}
-#endif
-
 extern BOOLEAN gfPauseDueToPlayerGamePause;
 
 ////////////////////////////////////////////////////////////////////////////
@@ -370,8 +350,7 @@ int main(int argc, char* argv[])
 		// init locale and logging
 		{
 			std::vector<ST::string> problems = InitGlobalLocale();
-			ST::string const tempFilename{get_temp_filename()};
-			Logger_initialize(tempFilename.c_str());
+			Logger_initialize("ja2.log");
 			for (const ST::string& msg : problems)
 			{
 				SLOGW("%s", msg.c_str());
@@ -842,19 +821,5 @@ TEST(cpp_language, sizeof_type)
 	EXPECT_EQ(sizeof(char16_t), 2);
 	EXPECT_EQ(sizeof(char32_t), 4);
 }
-
-#ifndef __ANDROID__
-TEST(cpp_language, filesystem)
-{
-	EXPECT_FALSE(fs::temp_directory_path().empty());
-	EXPECT_TRUE(fs::temp_directory_path().is_absolute());
-
-	auto const tmpFilename{fs::temp_directory_path().append("ja2.log")};
-	EXPECT_EQ(tmpFilename, fs::temp_directory_path() / "ja2.log");
-	EXPECT_EQ(tmpFilename.filename(), "ja2.log");
-	EXPECT_EQ(tmpFilename.extension(), ".log");
-	EXPECT_EQ(tmpFilename.stem(), "ja2");
-}
-#endif
 
 #endif // WITH_UNITTESTS


### PR DESCRIPTION
This PR changes the way the launcher runs the game itself.

Previously it was blocking the whole time while the game was running.

With this PR the game subprocess is started in a non-blocking way and is polled each second to determine whether it has finished. When the game subprocess has finished, the resulting logs are displayed in a new tab in the launcher. If an error occured the active tab is automatically switched to the "Logs" tab, so the user might be able to determine the reason for the crash. While the game is running the reachable buttons/tabs in the launcher are disabled.

Closes #1507 

New Logs Tab:
![Screenshot from 2022-04-30 18-00-36](https://user-images.githubusercontent.com/848854/166113227-9fea48f0-015f-4332-8dad-b5ea1b48a87f.png)

Disabled state while game is running:
![Screenshot from 2022-04-30 18-02-11](https://user-images.githubusercontent.com/848854/166113248-a1c7dc6b-483f-42e5-9b19-caef55064e68.png)

New error message after running game:
![Screenshot from 2022-04-30 18-00-30](https://user-images.githubusercontent.com/848854/166113263-1673b7e2-c5a2-4455-9f99-d500485c39ba.png)



