### PR TITLE
Fix Android CI build for external contributors

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -59,7 +59,12 @@ elif [[ "$CI_TARGET" == "mac" ]]; then
 elif [[ "$CI_TARGET" == "android" ]]; then
   export CONFIGURE_CMD="true"
   export BUILD_CMD="../android/gradlew"
-  export BUILD_TOOL_ARGS="-p ../android assembleRelease -PbuildDir=$(pwd)/ci-build"
+  export ANDROID_BUILD_TYPE="Release"
+  # If we dont have a keystore password we need to build the debug package, as the keys for release will not be present
+  if [[ "$ANDROID_KEYSTORE_PASSWORD" == "" ]]; then
+    export ANDROID_BUILD_TYPE="Debug"
+  fi
+  export BUILD_TOOL_ARGS="-p ../android assemble$ANDROID_BUILD_TYPE -PbuildDir=$(pwd)/ci-build"
   export RUN_TESTS=false
   export PACKAGE_NAME="ja2-stracciatella_$(./android/gradlew -q -p ./android projectVersion)-$VERSION_TAG+$(git rev-parse --short HEAD)_android.apk"
 else
@@ -105,7 +110,7 @@ fi
 if [[ "$CI_TARGET" == "linux" ]]; then
   $BUILD_CMD --target package-appimage
 elif [[ "$CI_TARGET" == "android" ]]; then
-  cp ./outputs/apk/release/app-release.apk "./$PACKAGE_NAME"
+  cp ./outputs/apk/${ANDROID_BUILD_TYPE,,}/app-${ANDROID_BUILD_TYPE,,}.apk "./$PACKAGE_NAME"
 else
   $BUILD_CMD --target package
 fi


### PR DESCRIPTION
External contibutors CI runs dont have access to secrets, so we need to build a debug android build for those cases, as the signing keys will not be present for release builds.