### PR TITLE
Fix error messages when commiting read pointer in sound system

### DIFF
--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -941,12 +941,12 @@ static void SoundCallback(void* userdata, Uint8* stream, int len)
 					gMixBuffer[2 * i + 1] += src[2 * i + 1] * vol_r >> 7;
 				}
 
-				if (samples < want_samples) {
+				rbResult = ma_pcm_rb_commit_read(Sound->pRingBuffer, samples, (void**)src);
+				if (samples < want_samples || rbResult == MA_AT_END) {
 					Sound->State = CHANNEL_DEAD;
 				}
 
-				rbResult = ma_pcm_rb_commit_read(Sound->pRingBuffer, samples, (void**)src);
-				if (rbResult != MA_SUCCESS) {
+				if (rbResult != MA_SUCCESS && rbResult != MA_AT_END) {
 					SLOGE("Could not commit read pointer for channel {}: {}", Sound - pSoundList, ma_result_description(rbResult));
 				} else {
 					ringBuffersNeedService |= DoesChannelRingBufferNeedService(Sound);


### PR DESCRIPTION
The newer version of miniaudio we introduced seems to [return MA_AT_END](https://github.com/mackron/miniaudio/commit/9be681b84829d0247ea00dd23db22c95d71b56aa) when the ringbuffer is fully read. This PR fixes the annoying log when a sound has finished:

> 2022-05-20T09:44:25 [ERROR] sgp/SoundMan.cc: Could not commit read pointer for channel 1: At end

Functionally there should be no differences.