### PR TITLE
Fix bPercentCoverForGridno values going out of 0-100 bound

### DIFF
--- a/src/game/Tactical/DisplayCover.cc
+++ b/src/game/Tactical/DisplayCover.cc
@@ -329,7 +329,7 @@ static INT8 CalcCoverForGridNoBasedOnTeamKnownEnemies(SOLDIERTYPE const* const p
 	{
 		bPercentCoverForGridno = iTotalCoverPoints / bNumEnemies;
 		INT32 const iTemp = bPercentCoverForGridno - (iHighestValue / bNumEnemies) + iHighestValue;
-		bPercentCoverForGridno = std::min(0, 100 - iTemp);
+		bPercentCoverForGridno = std::min(0, std::clamp(100 - iTemp, 0, 100));
 	}
 	return bPercentCoverForGridno;
 }

--- a/src/game/Tactical/DisplayCover.cc
+++ b/src/game/Tactical/DisplayCover.cc
@@ -329,7 +329,7 @@ static INT8 CalcCoverForGridNoBasedOnTeamKnownEnemies(SOLDIERTYPE const* const p
 	{
 		bPercentCoverForGridno = iTotalCoverPoints / bNumEnemies;
 		INT32 const iTemp = bPercentCoverForGridno - (iHighestValue / bNumEnemies) + iHighestValue;
-		bPercentCoverForGridno = std::min(0, std::clamp(100 - iTemp, 0, 100));
+		bPercentCoverForGridno = std::clamp(100 - iTemp, 0, 100);
 	}
 	return bPercentCoverForGridno;
 }


### PR DESCRIPTION
bPercentCoverForGridno was set up in such a way that the minimum between 0 and 100 - iTemp could be a negative number, causing the assertion errors mentioned in #1548 