### PR TITLE
Small cleanups

### DIFF
--- a/src/game/Editor/SelectWin.cc
+++ b/src/game/Editor/SelectWin.cc
@@ -81,7 +81,7 @@ static INT16 iEndClickY;
 #define DOWN_ICON		2
 #define OK_ICON		3
 
-static INT32 iButtonIcons[4];
+static INT16 iButtonIcons[4];
 static GUIButtonRef iSelectWin;
 static GUIButtonRef iCancelWin;
 static GUIButtonRef iScrollUp;
@@ -226,7 +226,7 @@ static void UpClkCallback(GUI_BUTTON* button, INT32 reason);
 
 static GUIButtonRef MakeButton(UINT idx, const char* gfx, INT16 y, INT16 h, GUI_CALLBACK click, const ST::string& help)
 {
-	INT32 img = LoadGenericButtonIcon(gfx);
+	INT16 const img = LoadGenericButtonIcon(gfx);
 	iButtonIcons[idx] = img;
 	GUIButtonRef const btn = CreateIconButton(img, 0, SCREEN_WIDTH - 40, y, 40, h, MSYS_PRIORITY_HIGH, click);
 	btn->SetFastHelpText(help);
@@ -601,10 +601,8 @@ static DisplayList* TrashList(DisplayList* pNode);
 //
 void ShutdownJA2SelectionWindow( void )
 {
-	INT16 x;
-
-	for (x = 0; x < 4; x++)
-		UnloadGenericButtonIcon( (INT16)iButtonIcons[x] );
+	for (INT16 const icon : iButtonIcons)
+		UnloadGenericButtonIcon(icon);
 
 	if (pDispList != NULL)
 	{

--- a/src/game/Strategic/Meanwhile.cc
+++ b/src/game/Strategic/Meanwhile.cc
@@ -357,7 +357,6 @@ static void StartMeanwhile(void)
 
 
 static void DoneFadeInMeanwhile(void);
-static void LocateMeanWhileGrid(void);
 
 
 static void DoneFadeOutMeanwhile(void)
@@ -365,8 +364,8 @@ static void DoneFadeOutMeanwhile(void)
 	// OK, insertion data found, enter sector!
 	SetCurrentWorldSector(gCurrentMeanwhileDef.sSector);
 
-	//LocateToMeanwhileCharacter( );
-	LocateMeanWhileGrid( );
+	// go to the approp. gridno
+	InternalLocateGridNo(gusMeanWhileGridNo[ubCurrentMeanWhileId], TRUE);
 
 	gFadeInDoneCallback = DoneFadeInMeanwhile;
 
@@ -620,17 +619,6 @@ static void DoneFadeOutMeanwhileOnceDone(void)
 static void DoneFadeInMeanwhileOnceDone(void)
 {
 
-}
-
-
-static void LocateMeanWhileGrid(void)
-{
-	INT16 sGridNo = 0;
-
-	// go to the approp. gridno
-	sGridNo = gusMeanWhileGridNo[ ubCurrentMeanWhileId ];
-
-	InternalLocateGridNo( sGridNo, TRUE );
 }
 
 void LocateToMeanwhileCharacter( )

--- a/src/game/Utils/WordWrap.cc
+++ b/src/game/Utils/WordWrap.cc
@@ -497,9 +497,8 @@ UINT16 IanWrappedStringHeight(UINT16 max_w, UINT8 gap, SGPFont font, const ST::u
 			default:
 				// get the length (in pixels) of this word
 				UINT16 word_w = 0;
-				// each character goes towards building a new word
-				const char32_t* word_start = i;
 
+				// each character goes towards building a new word
 				do
 				{
 					word_w += GetCharWidth(cur_font, *i);


### PR DESCRIPTION
The unused variable in WordWrap.cc is currently one of two warnings I get while building apart from the deprecated declarations. The other one is in miniaudio.

SelectWin.cc stores 16-bit values in an array of 32-bit integers for no good reason.

LocateMeanWhileGrid is used just once and does nothing but call another function.