### PR TITLE
Fix #1538 Possible INT8 overflow in bLockDamage

### DIFF
--- a/src/game/Tactical/Keys.cc
+++ b/src/game/Tactical/Keys.cc
@@ -646,12 +646,9 @@ BOOLEAN AttemptToBlowUpLock( SOLDIERTYPE * pSoldier, DOOR * pDoor )
 
 		// Not sure if this makes sense, but the explosive is small.
 		// Double the damage here as we are damaging a lock rather than a person
-		pDoor->bLockDamage += Explosive[GCM->getItem(SHAPED_CHARGE)->getClassIndex()].ubDamage * 2;
-		if (pDoor->bLockDamage > LockTable[ pDoor->ubLockID ].ubSmashDifficulty )
+		if (pDoor->damageLock(Explosive[GCM->getItem(SHAPED_CHARGE)->getClassIndex()].ubDamage * 2))
 		{
-			// succeeded! door can never be locked again, so remove from door list...
-			RemoveDoorInfoFromTable( pDoor->sGridNo );
-			// award experience points?
+			// Lock destroyed, award experience points?
 			return( TRUE );
 		}
 	}
@@ -668,6 +665,21 @@ BOOLEAN AttemptToBlowUpLock( SOLDIERTYPE * pSoldier, DOOR * pDoor )
 		IgniteExplosionXY(NULL, pSoldier->sX, pSoldier->sY, gpWorldLevelData[pSoldier->sGridNo].sHeight, pSoldier->sGridNo, SHAPED_CHARGE, 0);
 	}
 	return( FALSE );
+}
+
+bool DOOR::damageLock(int const additionalDamage)
+{
+	bLockDamage = std::min<int>(INT8_MAX, bLockDamage + additionalDamage);
+	if (bLockDamage > LockTable[ubLockID].ubSmashDifficulty)
+	{
+		// Display message!
+		ScreenMsg(FONT_MCOLOR_LTYELLOW, MSG_INTERFACE, TacticalStr[LOCK_HAS_BEEN_DESTROYED]);
+
+		// succeeded! door can never be locked again, so remove from door list...
+		RemoveDoorInfoFromTable(sGridNo);
+		return true;
+	}
+	return false;
 }
 
 //File I/O for loading the door information from the map.  This automatically allocates

--- a/src/game/Tactical/Keys.h
+++ b/src/game/Tactical/Keys.h
@@ -61,6 +61,11 @@ struct DOOR
 	INT8    bPerceivedTrapped; // See above, but with respect to traps rather than locked status
 	INT8    bLockDamage; // Damage to the lock
 	INT8    bPadding[4]; // extra bytes // XXX HACK000B
+
+	// Damage the door's lock by the given amount. Removes the door from the door table
+	// and displays a message if the lock was destroyed.
+	// Returns true if the lock was destroyed, false otherwise.
+	bool damageLock(int const additionalDamage);
 };
 
 

--- a/src/game/Tactical/LOS.cc
+++ b/src/game/Tactical/LOS.cc
@@ -2300,17 +2300,9 @@ static INT32 HandleBulletStructureInteraction(BULLET* pBullet, STRUCTURE* pStruc
 
 				ScreenMsg( FONT_MCOLOR_LTYELLOW, MSG_INTERFACE, TacticalStr[ LOCK_HAS_BEEN_HIT ] );
 
-				pDoor->bLockDamage+= sLockDamage;
-
 				// Check if it has been shot!
-				if ( pDoor->bLockDamage > LockTable[ pDoor->ubLockID ].ubSmashDifficulty )
+				if (pDoor->damageLock(sLockDamage))
 				{
-					// Display message!
-					ScreenMsg( FONT_MCOLOR_LTYELLOW, MSG_INTERFACE, TacticalStr[ LOCK_HAS_BEEN_DESTROYED ] );
-
-					// succeeded! door can never be locked again, so remove from door list...
-					RemoveDoorInfoFromTable( pDoor->sGridNo );
-
 					// MARKSMANSHIP GAIN (marksPts): Opened/Damaged a door
 					StatChange(*pBullet->pFirer, MARKAMT, 10, FROM_SUCCESS);
 				}


### PR DESCRIPTION
Small behaviour change, previously you got the 'Lock destroyed' message only when you shot the lock. Now it's displayed when you blow the lock with an explosive, too.