### PR TITLE
Cleanup KEY_ON_RING related code

### DIFF
--- a/src/game/Tactical/Interface_Items.cc
+++ b/src/game/Tactical/Interface_Items.cc
@@ -2862,30 +2862,20 @@ void BeginItemPointer( SOLDIERTYPE *pSoldier, UINT8 ubHandPos )
 
 void BeginKeyRingItemPointer( SOLDIERTYPE *pSoldier, UINT8 ubKeyRingPosition )
 {
-	BOOLEAN fOk;
-
 	// If not null return
 	if ( gpItemPointer != NULL )
 	{
 		return;
 	}
 
-	if (_KeyDown( SHIFT ))
-	{
-		// Remove all from soldier's slot
-		fOk = RemoveKeysFromSlot( pSoldier, ubKeyRingPosition, pSoldier->pKeyRing[ ubKeyRingPosition ].ubNumber, &gItemPointer );
-	}
-	else
-	{
-		RemoveKeysFromSlot( pSoldier, ubKeyRingPosition, 1, &gItemPointer );
-		fOk = (gItemPointer.ubNumberOfObjects == 1);
-	}
-
+	// With shift down, remove all keys from this slot
+	// With shift up, remove only one key
+	BOOLEAN const fOk = RemoveKeysFromSlot( pSoldier, ubKeyRingPosition,
+		_KeyDown( SHIFT ) ? pSoldier->pKeyRing[ ubKeyRingPosition ].ubNumber : 1,
+		&gItemPointer );
 
 	if (fOk)
 	{
-		// ATE: Look if we are a BLOODIED KNIFE, and change if so, making guy scream...
-
 		// Dirty interface
 		fInterfacePanelDirty = DIRTYLEVEL2;
 		SetItemPointer(&gItemPointer, pSoldier);
@@ -2893,12 +2883,6 @@ void BeginKeyRingItemPointer( SOLDIERTYPE *pSoldier, UINT8 ubKeyRingPosition )
 
 		if (fInMapMode) SetMapCursorItem();
 	}
-	else
-	{
-		//Debug mesg
-	}
-
-
 
 	gfItemPointerDifferentThanDefault = FALSE;
 }

--- a/src/game/Tactical/Interface_Items.cc
+++ b/src/game/Tactical/Interface_Items.cc
@@ -2877,7 +2877,7 @@ void BeginKeyRingItemPointer( SOLDIERTYPE *pSoldier, UINT8 ubKeyRingPosition )
 	}
 	else
 	{
-		RemoveKeyFromSlot( pSoldier, ubKeyRingPosition, &gItemPointer );
+		RemoveKeysFromSlot( pSoldier, ubKeyRingPosition, 1, &gItemPointer );
 		fOk = (gItemPointer.ubNumberOfObjects == 1);
 	}
 
@@ -4081,12 +4081,12 @@ void RenderKeyRingPopup(const BOOLEAN fFullRender)
 
 		BltVideoObject(FRAME_BUFFER, guiItemPopupBoxes, 0, x, y);
 
-		const KEY_ON_RING* const key = &key_ring[i];
-		if (key->ubKeyID == INVALID_KEY_NUMBER || key->ubNumber == 0) continue;
+		const KEY_ON_RING& key = key_ring[i];
+		if (!key.isValid()) continue;
 
-		o.ubNumberOfObjects = key->ubNumber;
+		o.ubNumberOfObjects = key.ubNumber;
 
-		auto keyId = LockTable[key->ubKeyID].usKeyItem;
+		auto keyId = LockTable[key.ubKeyID].usKeyItem;
 		auto item = GCM->getKeyItemForKeyId(keyId);
 		if (item == NULL) {
 			throw std::runtime_error(ST::format("Could not find key item for key id `{}` when rendering key popup", keyId).to_std_string());

--- a/src/game/Tactical/Interface_Panels.cc
+++ b/src/game/Tactical/Interface_Panels.cc
@@ -3435,7 +3435,7 @@ void KeyRingSlotInvClickCallback( MOUSE_REGION * pRegion, INT32 iReason )
 		if ( gpItemPointer == NULL )
 		{
 			// Return if empty
-			if( ( gpItemPopupSoldier->pKeyRing[ uiKeyRing ].ubKeyID == INVALID_KEY_NUMBER ) || ( gpItemPopupSoldier->pKeyRing[ uiKeyRing ].ubNumber == 0 ) )
+			if (!gpItemPopupSoldier->pKeyRing[uiKeyRing].isValid())
 				return;
 
 			// If our flags are set to do this, gofoit!
@@ -3588,7 +3588,7 @@ void KeyRingSlotInvClickCallback( MOUSE_REGION * pRegion, INT32 iReason )
 		fRightDown = FALSE;
 
 		// Return if empty
-		if( ( gpItemPopupSoldier->pKeyRing[ uiKeyRing ].ubKeyID == INVALID_KEY_NUMBER ) || ( gpItemPopupSoldier->pKeyRing[ uiKeyRing ].ubNumber == 0 ) )
+		if (!gpItemPopupSoldier->pKeyRing[uiKeyRing].isValid())
 		{
 			DeleteKeyRingPopup( );
 			fTeamPanelDirty = TRUE;

--- a/src/game/Tactical/Items.cc
+++ b/src/game/Tactical/Items.cc
@@ -2342,65 +2342,22 @@ BOOLEAN RemoveObjectFromSlot( SOLDIERTYPE * pSoldier, INT8 bPos, OBJECTTYPE * pO
 	}
 }
 
-BOOLEAN RemoveKeyFromSlot( SOLDIERTYPE * pSoldier, INT8 bKeyRingPosition, OBJECTTYPE * pObj )
-{
-	UINT8 ubItem = 0;
-
-	CHECKF( pObj );
-
-	if( ( pSoldier->pKeyRing[ bKeyRingPosition ].ubNumber == 0 ) || ( pSoldier->pKeyRing[ bKeyRingPosition ].ubKeyID == INVALID_KEY_NUMBER ) )
-	{
-		return( FALSE );
-	}
-	else
-	{
-		//*pObj = pSoldier->inv[bPos];
-
-		// create an object
-		ubItem = pSoldier->pKeyRing[ bKeyRingPosition ].ubKeyID;
-
-		if( pSoldier->pKeyRing[ bKeyRingPosition ].ubNumber > 1 )
-		{
-			pSoldier->pKeyRing[ bKeyRingPosition ].ubNumber--;
-		}
-		else
-		{
-
-			pSoldier->pKeyRing[ bKeyRingPosition ].ubNumber = 0;
-			pSoldier->pKeyRing[ bKeyRingPosition ].ubKeyID = INVALID_KEY_NUMBER;
-		}
-
-		CreateKeyObject(pObj, 1, ubItem);
-		return TRUE;
-	}
-}
-
-
 BOOLEAN RemoveKeysFromSlot( SOLDIERTYPE * pSoldier, INT8 bKeyRingPosition, UINT8 ubNumberOfKeys ,OBJECTTYPE * pObj )
 {
-	UINT8 ubItems = 0;
-
 	CHECKF( pObj );
 
-
-	if( ( pSoldier->pKeyRing[ bKeyRingPosition ].ubNumber == 0 ) || ( pSoldier->pKeyRing[ bKeyRingPosition ].ubKeyID == INVALID_KEY_NUMBER ) )
+	if (pSoldier->pKeyRing[bKeyRingPosition].isValid())
 	{
-		return( FALSE );
-	}
-	else
-	{
-		//*pObj = pSoldier->inv[bPos];
-
 		if( pSoldier->pKeyRing[ bKeyRingPosition ].ubNumber < ubNumberOfKeys )
 		{
 			ubNumberOfKeys = pSoldier->pKeyRing[ bKeyRingPosition ].ubNumber;
 		}
 
 
-		ubItems = pSoldier->pKeyRing[ bKeyRingPosition ].ubKeyID;
+		UINT8 const ubItems = pSoldier->pKeyRing[ bKeyRingPosition ].ubKeyID;
 		if( pSoldier->pKeyRing[ bKeyRingPosition ].ubNumber - ubNumberOfKeys > 0 )
 		{
-			pSoldier->pKeyRing[ bKeyRingPosition ].ubNumber--;
+			pSoldier->pKeyRing[ bKeyRingPosition ].ubNumber -= ubNumberOfKeys;
 		}
 		else
 		{
@@ -2411,6 +2368,7 @@ BOOLEAN RemoveKeysFromSlot( SOLDIERTYPE * pSoldier, INT8 bKeyRingPosition, UINT8
 		CreateKeyObject(pObj, ubNumberOfKeys, ubItems);
 		return TRUE;
 	}
+	return FALSE;
 }
 
 

--- a/src/game/Tactical/Items.h
+++ b/src/game/Tactical/Items.h
@@ -88,10 +88,7 @@ void CreateKeyObject(OBJECTTYPE*, UINT8 ubNumberOfKeys, UINT8 ubKeyIdValue);
 BOOLEAN DeleteKeyObject( OBJECTTYPE * pObj );
 void    AllocateObject(OBJECTTYPE** pObj);
 
-// removes a key from a *KEYRING* slot
-BOOLEAN RemoveKeyFromSlot( SOLDIERTYPE * pSoldier, INT8 bKeyRingPosition, OBJECTTYPE * pObj );
-
-// take several
+// remove one or more keys from a *KEYRING* slot
 BOOLEAN RemoveKeysFromSlot( SOLDIERTYPE * pSoldier, INT8 bKeyRingPosition, UINT8 ubNumberOfKeys ,OBJECTTYPE * pObj );
 
 // add the keys to an inventory slot

--- a/src/game/Tactical/Keys.cc
+++ b/src/game/Tactical/Keys.cc
@@ -127,7 +127,7 @@ bool SoldierHasKey(SOLDIERTYPE const& s, UINT8 const key_id)
 
 bool KeyExistsInKeyRing(SOLDIERTYPE const& s, UINT8 const key_id)
 {
-	if (!s.pKeyRing) return FALSE; // No key ring
+	if (!s.pKeyRing) return false; // No key ring
 
 	KEY_ON_RING const* const end = s.pKeyRing + NUM_KEYS;
 	for (KEY_ON_RING const* i = s.pKeyRing; i != end; ++i)

--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -601,10 +601,6 @@ try
 	if (IsOnOurTeam(s))
 	{
 		s.pKeyRing = new KEY_ON_RING[NUM_KEYS]{};
-		for (UINT32 i = 0; i < NUM_KEYS; ++i)
-		{
-			s.pKeyRing[i].ubKeyID = INVALID_KEY_NUMBER;
-		}
 	}
 	else
 	{
@@ -2252,9 +2248,6 @@ void EVENT_FireSoldierWeapon( SOLDIERTYPE *pSoldier, INT16 sTargetGridNo )
 		}
 	}
 }
-
-//gAnimControl[ pSoldier->usAnimState ].ubEndHeight
-//					ChangeSoldierState( pSoldier, SHOOT_RIFLE_STAND, 0 , FALSE );
 
 
 static UINT16 SelectFireAnimation(SOLDIERTYPE* pSoldier, UINT8 ubHeight)

--- a/src/game/Tactical/Soldier_Control.h
+++ b/src/game/Tactical/Soldier_Control.h
@@ -8,6 +8,7 @@
 
 #include "Animation_Cache.h"
 #include "JA2Types.h"
+#include "Keys.h"
 #include "Overhead_Types.h"
 #include "Item_Types.h"
 
@@ -269,8 +270,10 @@ enum SoldierClass
 
 struct KEY_ON_RING
 {
-	UINT8 ubKeyID;
-	UINT8 ubNumber;
+	UINT8 ubKeyID{INVALID_KEY_NUMBER};
+	UINT8 ubNumber{0};
+
+	bool isValid() const { return ubKeyID != INVALID_KEY_NUMBER && ubNumber != 0; }
 };
 
 


### PR DESCRIPTION
Cleans up a bit of copy & paste coding, removes the function `RemoveKeyFromSlot` and uses the generic `RemoveKeysFromSlot` instead. 

Adds a simple method to make the key ring slot checks easier to read.