### PR TITLE
Restore the save game validity condition from before sector refactoring

### DIFF
--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -571,7 +571,7 @@ void ParseSavedGameHeader(const BYTE *data, SAVED_GAME_HEADER& h, bool stracLinu
  * This function does only a basic check.  It might not detect all problems. */
 bool isValidSavedGameHeader(SAVED_GAME_HEADER& h)
 {
-	if (!h.sSector.IsValid())
+	if((h.sSector.x == 0) && (h.sSector.y == 0) && (h.sSector.z == -1))
 	{
 		// Special case: sector N/A at the game start
 		if((h.uiDay == 0)


### PR DESCRIPTION
This should fix the locally failing unittest. The condition didn't simply check if the sector is invalid before, but compared it to the values that should be set when no sector has been visited yet. Still not sure why it does not fail in CI though...