### PR TITLE
Overhaul Animation_Cache

### DIFF
--- a/src/game/Tactical/Animation_Cache.h
+++ b/src/game/Tactical/Animation_Cache.h
@@ -1,21 +1,24 @@
 #ifndef __ANIMATION_CACHE_H
 #define __ANIMATION_CACHE_H
 
-#include "Types.h"
+#include "JA2Types.h"
 
-#define DEFAULT_ANIM_CACHE_SIZE	3
+constexpr int ANIM_CACHE_SIZE = 3;
 
 
-struct AnimationSurfaceCacheType
+class AnimationSurfaceCacheType
 {
-	UINT16 *usCachedSurfaces;
-	INT16  *sCacheHits;
-	UINT8  ubCacheSize;
-};
+	UINT16    usCachedSurfaces[ANIM_CACHE_SIZE];
+	INT16     sCacheHits[ANIM_CACHE_SIZE];
+	ProfileID mPid;
 
-void GetCachedAnimationSurface(UINT16 usSoldierID, AnimationSurfaceCacheType* pAnimCache, UINT16 usSurfaceIndex, UINT16 usCurrentAnimation);
-void InitAnimationCache(UINT16 usSoldierID, AnimationSurfaceCacheType*);
-void DeleteAnimationCache( UINT16 usSoldierID, AnimationSurfaceCacheType *pAnimCache );
-void UnLoadCachedAnimationSurfaces( UINT16 usSoldierID, AnimationSurfaceCacheType *pAnimCache );
+public:
+	// Load an animation surface if it is not already cached.
+	void cache(UINT16 usSurfaceIndex, UINT16 usCurrentAnimation);
+	// Init the animation cache for the specified soldier.
+	void init(ProfileID usSoldierID);
+	// Unload all cached animation surfaces.
+	void free();
+};
 
 #endif

--- a/src/game/Tactical/Animation_Control.cc
+++ b/src/game/Tactical/Animation_Control.cc
@@ -2576,7 +2576,7 @@ UINT16 LoadSoldierAnimationSurface(SOLDIERTYPE& s, UINT16 const anim_state)
 	try
 	{
 		// Ensure that it's been loaded
-		GetCachedAnimationSurface(s.ubID, &s.AnimCache, anim_surface, s.usAnimState);
+		s.AnimCache.cache(anim_surface, s.usAnimState);
 		return anim_surface;
 	}
 	catch (...)

--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -608,7 +608,7 @@ try
 	}
 
 	// Create frame cache
-	InitAnimationCache(s.ubID, &s.AnimCache);
+	s.AnimCache.init(s.ubID);
 
 	UINT16 ani_state = s.usAnimState;
 	if (!(gTacticalStatus.uiFlags & LOADING_SAVED_GAME))
@@ -696,8 +696,7 @@ void DeleteSoldier(SOLDIERTYPE& s)
 	}
 
 	// Free any animations we may have locked...
-	UnLoadCachedAnimationSurfaces(s.ubID, &s.AnimCache);
-	DeleteAnimationCache(s.ubID, &s.AnimCache);
+	s.AnimCache.free();
 
 	DeleteSoldierLight(&s);
 	UnMarkMovementReserved(s);


### PR DESCRIPTION
• Do not dynamically allocated 6 byte arrays and then use an 8 byte pointer
  to store their addresses.
• Convert the free functions to class methods.
• Don't let functions other than init pass in the soldier's profile id
  because the AnimCache and the profile id must come from the same soldier.
• The cache size was not helpful