### PR TITLE
Fix some remaining invalid format strings for sectors

### DIFF
--- a/src/externalized/strategic/UndergroundSectorModel.cc
+++ b/src/externalized/strategic/UndergroundSectorModel.cc
@@ -95,7 +95,7 @@ void UndergroundSectorModel::validateData(const std::vector<const UndergroundSec
 		auto iter = std::find_if(ugSectors.begin(), ugSectors.end(), [sectorId, sectorZ](const UndergroundSectorModel* s) { return (s->sectorId == sectorId && s->sectorZ == sectorZ); });
 		if (iter == ugSectors.end())
 		{
-			ST::string err = ST::format("An underground sector is expected at ({}), but is not defined.", basement.AsLongString());
+			ST::string err = ST::format("An underground sector is expected at ({}), but is not defined.", basement);
 			throw std::runtime_error(err.to_std_string());
 		}
 	}

--- a/src/game/Strategic/Auto_Resolve.cc
+++ b/src/game/Strategic/Auto_Resolve.cc
@@ -1808,7 +1808,7 @@ static void RemoveAutoResolveInterface(bool const delete_for_good)
 			 * 32. We basically cheat by eliminating the rest of them. */
 			if (NumEnemiesInSector(arSector))
 			{
-				SLOGI("Eliminating remaining enemies after Autoresolve in ({})", arSector.AsShortString());
+				SLOGI("Eliminating remaining enemies after Autoresolve in ({})", arSector);
 				EliminateAllEnemies(arSector);
 			}
 		}

--- a/src/game/Strategic/Creature_Spreading.cc
+++ b/src/game/Strategic/Creature_Spreading.cc
@@ -131,8 +131,7 @@ static CREATURE_DIRECTIVE* NewDirective(UINT8 ubSectorID, UINT8 ubSectorZ, UINT8
 	curr->pLevel = FindUnderGroundSector(ubSector);
 	if( !curr->pLevel )
 	{
-		SLOGA("Could not find underground sector node ({}) that should exist.",
-			ubSector.AsLongString());
+		SLOGA("Could not find underground sector node ({}) that should exist.", ubSector);
 		delete curr;
 		return 0;
 	}

--- a/src/game/Strategic/Game_Init.cc
+++ b/src/game/Strategic/Game_Init.cc
@@ -83,13 +83,13 @@ static void InitNPCs()
 		if (placement->useAlternateMap)
 		{
 			SectorInfo[sMap.AsByte()].uiFlags |= SF_USE_ALTERNATE_MAP;
-			SLOGD("Alternate map in {}", sMap.AsShortString());
+			SLOGD("Alternate map in {}", sMap);
 		}
 		if (placement->isPlacedAtStart)
 		{
 			MERCPROFILESTRUCT& merc = GetProfile(placement->profileId);
 			merc.sSector = sMap;
-			SLOGD("{} in {}", merc.zNickname, sMap.AsShortString());
+			SLOGD("{} in {}", merc.zNickname, sMap);
 		}
 	}
 

--- a/src/game/Strategic/Map_Screen_Interface.cc
+++ b/src/game/Strategic/Map_Screen_Interface.cc
@@ -1043,11 +1043,11 @@ static void HandleEquipmentLeft(UINT32 const slot_idx, INT const sector, GridNo 
 		ProfileID      const id   = guiLeaveListOwnerProfileId[slot_idx];
 		if (id != NO_PROFILE)
 		{
-			sString = st_format_printf(str_left_equipment, GetProfile(id).zNickname, town, sMap.AsShortString());
+			sString = st_format_printf(str_left_equipment, GetProfile(id).zNickname, town, sMap);
 		}
 		else
 		{
-			sString = ST::format("A departing merc has left their equipment in {} ({}).", town, sMap.AsShortString());
+			sString = ST::format("A departing merc has left their equipment in {} ({}).", town, sMap);
 		}
 		ScreenMsg(FONT_MCOLOR_LTYELLOW, MSG_INTERFACE, sString);
 

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -2386,8 +2386,8 @@ static void DisplayDestinationOfHelicopter(void)
 		UINT32 x = MAP_VIEW_START_X + ( MAP_GRID_X * sMap.x ) + 1;
 		UINT32 y = MAP_VIEW_START_Y + ( MAP_GRID_Y * sMap.y ) + 3;
 
-		AssertMsg(x < SCREEN_WIDTH, ST::format("DisplayDestinationOfHelicopter: Invalid x = {}.  Dest {}", x, sMap.AsShortString()));
-		AssertMsg(y < SCREEN_HEIGHT, ST::format("DisplayDestinationOfHelicopter: Invalid y = {}.  Dest {}", y, sMap.AsShortString()));
+		AssertMsg(x < SCREEN_WIDTH, ST::format("DisplayDestinationOfHelicopter: Invalid x = {}.  Dest {}", x, sMap));
+		AssertMsg(y < SCREEN_HEIGHT, ST::format("DisplayDestinationOfHelicopter: Invalid y = {}.  Dest {}", y, sMap));
 
 		// clip blits to mapscreen region
 		ClipBlitsToMapViewRegion( );

--- a/src/game/Strategic/Queen_Command.cc
+++ b/src/game/Strategic/Queen_Command.cc
@@ -390,7 +390,7 @@ void PrepareEnemyForSectorBattle()
 	if (n_stationary_enemies > 32)
 	{
 		SLOGE("The total stationary enemy forces in sector {} is {}. (max {})",
-			  gWorldSector.AsShortString(), total_admins + total_troops + total_elites, 32);
+			  gWorldSector, total_admins + total_troops + total_elites, 32);
 		total_admins = std::min(total_admins, 32);
 		total_troops = std::min(total_troops, 32 - total_admins);
 		total_elites = std::min(total_elites, 32 - total_admins + total_troops);

--- a/src/game/Strategic/SAM_Sites.cc
+++ b/src/game/Strategic/SAM_Sites.cc
@@ -41,7 +41,7 @@ void UpdateSAMDoneRepair(const SGPSector& sec)
 	auto samSite = GCM->findSamSiteBySector(sector);
 	if (samSite == NULL)
 	{
-		SLOGW("There is no SAM site at sector {}", sec.AsShortString());
+		SLOGW("There is no SAM site at sector {}", sec);
 		return;
 	}
 

--- a/src/game/Strategic/StrategicMap.cc
+++ b/src/game/Strategic/StrategicMap.cc
@@ -1187,7 +1187,7 @@ check_entry:
 	// If no insertion direction exists, this is bad!
 	if (gridno == -1)
 	{
-		SLOGW("Insertion gridno for direction {} not added to map sector {}", s.ubStrategicInsertionCode, sSector.AsShortString());
+		SLOGW("Insertion gridno for direction {} not added to map sector {}", s.ubStrategicInsertionCode, sSector);
 place_in_center:
 		gridno = WORLD_ROWS / 2 * WORLD_COLS + WORLD_COLS / 2;
 	}

--- a/src/game/Strategic/Strategic_AI.cc
+++ b/src/game/Strategic/Strategic_AI.cc
@@ -236,7 +236,7 @@ static void RequestAttackOnSector(UINT8 ubSectorID, UINT16 usDefencePoints)
 	{
 		if( gGarrisonGroup[ i ].ubSectorID == ubSectorID && !gGarrisonGroup[ i ].ubPendingGroupID )
 		{
-			SLOGD("An attack has been requested in sector {}.", sMap.AsShortString());
+			SLOGD("An attack has been requested in sector {}.", sMap);
 			SendReinforcementsForGarrison( i, usDefencePoints, NULL );
 			return;
 		}
@@ -274,7 +274,7 @@ static void ValidateGroup(GROUP* pGroup)
 		if( gTacticalStatus.uiFlags & LOADING_SAVED_GAME )
 		{
 			SLOGE("Internal error (invalid enemy group #{} location at {}, destination {}).  Please send PRIOR save file and Debug Log.",
-				pGroup->ubGroupID, pGroup->ubSector.AsShortString(), pGroup->ubNext.AsShortString());
+				pGroup->ubGroupID, pGroup->ubSector, pGroup->ubNext);
 			RemoveGroupFromStrategicAILists(*pGroup);
 			RemoveGroup(*pGroup);
 			return;
@@ -310,7 +310,7 @@ static void ValidateLargeGroup(GROUP* pGroup)
 				({} admins, {} troops, {} elites) in sector {}.  This message is a temporary test message\n\
 				to evaluate a potential problems with very large enemy groups.",
 				pGroup->ubGroupSize, pGroup->pEnemyGroup->ubNumAdmins, pGroup->pEnemyGroup->ubNumTroops, pGroup->pEnemyGroup->ubNumElites,
-				pGroup->ubSector.AsShortString());
+				pGroup->ubSector);
 		}
 }
 
@@ -560,7 +560,7 @@ void InitStrategicAI()
 		SECTORINFO &si = SectorInfo[sSectorID];
 		si.uiFlags |= SF_USE_ALTERNATE_MAP;
 		si.ubNumTroops = model->getNumTroops(difficulty);
-		SLOGD("Weapon cache is at {}", SGPSector(sSectorID).AsShortString());
+		SLOGD("Weapon cache is at {}", SGPSector(sSectorID));
 	}
 }
 
@@ -707,17 +707,17 @@ static BOOLEAN HandlePlayerGroupNoticedByPatrolGroup(const GROUP* const pPlayerG
 		MoveSAIGroupToSector( &pEnemyGroup, playerSector, DIRECT, PURSUIT );
 
 		SLOGD("Enemy group at {} detected player group at {} and is moving to intercept them at {}.",
-			pEnemyGroup->ubSector.AsShortString(), pPlayerGroup->ubSector.AsShortString(),
-			pPlayerGroup->ubNext.AsShortString());
+			pEnemyGroup->ubSector, pPlayerGroup->ubSector,
+			pPlayerGroup->ubNext);
 	}
 	else
 	{
 		MoveSAIGroupToSector( &pEnemyGroup, playerSector, DIRECT, PURSUIT );
 
 		SLOGD("Enemy group at {} detected player group at {} and is moving to intercept them at {}.",
-					pEnemyGroup->ubSector.AsShortString(),
-					pPlayerGroup->ubSector.AsShortString(),
-					pPlayerGroup->ubSector.AsShortString());
+					pEnemyGroup->ubSector,
+					pPlayerGroup->ubSector,
+					pPlayerGroup->ubSector);
 	}
 	return TRUE;
 }
@@ -767,13 +767,13 @@ static void HandlePlayerGroupNoticedByGarrison(const GROUP* const pPlayerGroup, 
 			if( pSector->ubNumTroops + pSector->ubNumElites + pSector->ubNumAdmins > MAX_STRATEGIC_TEAM_SIZE )
 			{
 				SLOGE("Sector {} now has {} enemies (max {}).",
-					SGPSector::FromSectorID(gGarrisonGroup[pSector->ubGarrisonID].ubSectorID, 0).AsShortString(),
+					SGPSector::FromSectorID(gGarrisonGroup[pSector->ubGarrisonID].ubSectorID, 0),
 					pSector->ubNumTroops + pSector->ubNumElites + pSector->ubNumAdmins, MAX_STRATEGIC_TEAM_SIZE);
 			}
 
-			SLOGD("Enemy garrison at {}{} detected stopped player group at {} and is sending {} troops to attack.",
-					gGarrisonGroup[ pSector->ubGarrisonID ].ubSectorID / 16 + 'A' , gGarrisonGroup[ pSector->ubGarrisonID ].ubSectorID % 16,
-					pPlayerGroup->ubSector.AsShortString(),
+			SLOGD("Enemy garrison at {} detected stopped player group at {} and is sending {} troops to attack.",
+					SGPSector(gGarrisonGroup[ pSector->ubGarrisonID ].ubSectorID),
+					pPlayerGroup->ubSector,
 					pGroup->pEnemyGroup->ubNumElites + pGroup->pEnemyGroup->ubNumTroops );
 		}
 	}
@@ -796,8 +796,7 @@ static BOOLEAN HandleMilitiaNoticedByPatrolGroup(UINT8 ubSectorID, GROUP* pEnemy
 	}
 
 	MoveSAIGroupToSector(&pEnemyGroup, sSector.AsByte(), DIRECT, REINFORCEMENTS);
-	SLOGD("Enemy group at {} detected militia at {}{} and is moving to attack them.",
-			pEnemyGroup->ubSector.AsShortString(), sSector.AsShortString());
+	SLOGD("Enemy group at {} detected militia at {} and is moving to attack them.", pEnemyGroup->ubSector, sSector);
 	return FALSE;
 }
 
@@ -895,8 +894,8 @@ static BOOLEAN HandleEmptySectorNoticedByPatrolGroup(GROUP* pGroup, UINT8 ubEmpt
 
 	gGarrisonGroup[ ubGarrisonID ].ubPendingGroupID = pGroup->ubGroupID;
 	MoveSAIGroupToSector(&pGroup, sSector.AsByte(), DIRECT, REINFORCEMENTS);
-	SLOGD("Enemy group at {} detected undefended sector at {}{} and is moving to retake it.",
-			pGroup->ubSector.AsShortString(), sSector.AsShortString());
+	SLOGD("Enemy group at {} detected undefended sector at {} and is moving to retake it.",
+			pGroup->ubSector, sSector);
 	return TRUE;
 }
 
@@ -965,7 +964,7 @@ static BOOLEAN ReinforcementsApproved(INT32 iGarrisonID, UINT16* pusDefencePoint
 	if( gubGarrisonReinforcementsDenied[ iGarrisonID ] + usOffensePoints > *pusDefencePoints )
 	{
 		SLOGD("Sector {} will now recieve an {} extra troops due to multiple denials for reinforcements in the past for strong player presence.",
-				sSector.AsShortString(), gubGarrisonReinforcementsDenied[iGarrisonID] / 3);
+				sSector, gubGarrisonReinforcementsDenied[iGarrisonID] / 3);
 		return TRUE;
 	}
 	//Reinforcements will have to wait.  For now, increase the reinforcements denied.  The amount increase is 20 percent
@@ -1022,7 +1021,7 @@ static BOOLEAN EvaluateGroupSituation(GROUP* pGroup)
 
 					SLOGD("{} reinforcements have arrived to garrison sector {}",
 							pGroup->pEnemyGroup->ubNumAdmins + pGroup->pEnemyGroup->ubNumTroops +
-							pGroup->pEnemyGroup->ubNumElites, sec.AsShortString());
+							pGroup->pEnemyGroup->ubNumElites, sec);
 					if (IsThisSectorASAMSector(sec))
 					{
 						StrategicMap[sec.AsStrategicIndex()].bSAMCondition = 100;
@@ -1047,14 +1046,14 @@ static BOOLEAN EvaluateGroupSituation(GROUP* pGroup)
 						{ //Add all the troops to the queen's guard.
 							pSector->ubNumElites += pGroup->ubGroupSize;
 							SLOGD("{} reinforcements have arrived to garrison queen's sector ({}).",
-									pGroup->ubGroupSize, sec.AsShortString());
+									pGroup->ubGroupSize, sec);
 						}
 					}
 					else
 					{ //Add all the troops to the reinforcement pool as the queen's guard is at full strength.
 						giReinforcementPool += pGroup->ubGroupSize;
 						SLOGD("{} reinforcements have arrived at queen's sector ({}) and have been added to the reinforcement pool.",
-								pGroup->ubGroupSize, sec.AsShortString());
+								pGroup->ubGroupSize, sec);
 					}
 				}
 
@@ -1082,14 +1081,14 @@ static BOOLEAN EvaluateGroupSituation(GROUP* pGroup)
 					pPatrolGroup->ubGroupSize += (UINT8)(pGroup->pEnemyGroup->ubNumTroops + pGroup->pEnemyGroup->ubNumElites + pGroup->pEnemyGroup->ubNumAdmins );
 					SLOGD("{} reinforcements have joined patrol group at sector {} (new size: {})",
 							pGroup->pEnemyGroup->ubNumTroops + pGroup->pEnemyGroup->ubNumElites + pGroup->pEnemyGroup->ubNumAdmins,
-							pPatrolGroup->ubSector.AsShortString(), pPatrolGroup->ubGroupSize);
+							pPatrolGroup->ubSector, pPatrolGroup->ubGroupSize);
 					if( pPatrolGroup->ubGroupSize > MAX_STRATEGIC_TEAM_SIZE )
 					{
 						UINT8 ubCut;
 						SLOGE("Patrol group #{} in {} received too many reinforcements from group #{} that was created in {}.  Size truncated from {} to {}.\n\
 							Please send Strategic Decisions.txt and PRIOR save.",
-							pPatrolGroup->ubGroupID, sec.AsShortString(),
-							pGroup->ubGroupID, cSector.AsShortString(),
+							pPatrolGroup->ubGroupID, sec,
+							pGroup->ubGroupID, cSector,
 							pPatrolGroup->ubGroupSize, MAX_STRATEGIC_TEAM_SIZE);
 						//truncate the group size.
 						ubCut = pPatrolGroup->ubGroupSize - MAX_STRATEGIC_TEAM_SIZE;
@@ -1135,7 +1134,7 @@ static BOOLEAN EvaluateGroupSituation(GROUP* pGroup)
 							AddWaypointIDToPGroup( pGroup, gPatrolGroup[ i ].ubSectorID[ 3 ] );
 					}
 					SLOGD("{} soldiers have arrived to patrol area near sector {}",
-							pGroup->pEnemyGroup->ubNumTroops + pGroup->pEnemyGroup->ubNumElites + pGroup->pEnemyGroup->ubNumAdmins, sec.AsShortString());
+							pGroup->pEnemyGroup->ubNumTroops + pGroup->pEnemyGroup->ubNumElites + pGroup->pEnemyGroup->ubNumAdmins, sec);
 					RecalculatePatrolWeight(gPatrolGroup[i]);
 				}
 				return TRUE;
@@ -1699,8 +1698,8 @@ static void SendReinforcementsForGarrison(INT32 iDstGarrisonID, UINT16 usDefence
 
 		SLOGD("{} troops have been reassigned from {} to garrison sector {}",
 				pGroup->pEnemyGroup->ubNumTroops + pGroup->pEnemyGroup->ubNumElites + pGroup->pEnemyGroup->ubNumAdmins,
-				pGroup->ubSector.AsShortString(),
-				dstSector.AsShortString());
+				pGroup->ubSector,
+				dstSector);
 
 		gGarrisonGroup[ iDstGarrisonID ].ubPendingGroupID = pGroup->ubGroupID;
 		ConvertGroupTroopsToComposition( pGroup, gGarrisonGroup[ iDstGarrisonID ].ubComposition );
@@ -1762,13 +1761,13 @@ static void SendReinforcementsForGarrison(INT32 iDstGarrisonID, UINT16 usDefence
 		if( ubNumExtraReinforcements )
 		{
 			SLOGD("{} troops have been sent from palace to stage assault near sector {}",
-				  ubGroupSize, dstSector.AsShortString());
+				  ubGroupSize, dstSector);
 			MoveSAIGroupToSector( &pGroup, gGarrisonGroup[ iDstGarrisonID ].ubSectorID, STAGE, STAGING );
 		}
 		else
 		{
 			SLOGD("{} troops have been sent from palace to garrison sector {}",
-					ubGroupSize, dstSector.AsShortString());
+					ubGroupSize, dstSector);
 			MoveSAIGroupToSector( &pGroup, gGarrisonGroup[ iDstGarrisonID ].ubSectorID, STAGE, REINFORCEMENTS );
 		}
 		return;
@@ -1831,19 +1830,19 @@ static void SendReinforcementsForGarrison(INT32 iDstGarrisonID, UINT16 usDefence
 			{
 				pGroup->pEnemyGroup->ubPendingReinforcements = ubNumExtraReinforcements;
 				SLOGD("{} troops have been sent from sector {} to stage assault near sector {}",
-						ubGroupSize, pGroup->ubSector.AsShortString(), dstSector.AsShortString());
+						ubGroupSize, pGroup->ubSector, dstSector);
 
 				MoveSAIGroupToSector( &pGroup, gGarrisonGroup[ iDstGarrisonID ].ubSectorID, STAGE, STAGING );
 			}
 			else
 			{
 				SLOGD("{} troops have been sent from sector {} to garrison sector {}",
-						ubGroupSize, pGroup->ubSector.AsShortString(), dstSector.AsShortString());
+						ubGroupSize, pGroup->ubSector, dstSector);
 
 				MoveSAIGroupToSector( &pGroup, gGarrisonGroup[ iDstGarrisonID ].ubSectorID, STAGE, REINFORCEMENTS );
 			}
 			SLOGD("{} troops have been sent from garrison sector {} to patrol area near sector {}",
-					ubGroupSize, srcSector.AsShortString(), dstSector.AsShortString());
+					ubGroupSize, srcSector, dstSector);
 
 			return;
 		}
@@ -1874,7 +1873,7 @@ static void SendReinforcementsForPatrol(INT32 iPatrolID, GROUP** pOptionalGroup)
 
 		SLOGD("{} troops have been reassigned from {} to reinforce patrol group covering sector {}",
 				pGroup->pEnemyGroup->ubNumTroops + pGroup->pEnemyGroup->ubNumElites + pGroup->pEnemyGroup->ubNumAdmins,
-				pGroup->ubSector.AsShortString(), dstSector.AsShortString());
+				pGroup->ubSector, dstSector);
 
 		MoveSAIGroupToSector(pOptionalGroup, pg->ubSectorID[1], EVASIVE, REINFORCEMENTS);
 		return;
@@ -1894,7 +1893,7 @@ static void SendReinforcementsForPatrol(INT32 iPatrolID, GROUP** pOptionalGroup)
 		pg->ubPendingGroupID = pGroup->ubGroupID;
 
 		SLOGD("{} troops have been sent from palace to patrol area near sector {}",
-				pGroup->pEnemyGroup->ubNumTroops + pGroup->pEnemyGroup->ubNumElites + pGroup->pEnemyGroup->ubNumAdmins, dstSector.AsShortString());
+				pGroup->pEnemyGroup->ubNumTroops + pGroup->pEnemyGroup->ubNumElites + pGroup->pEnemyGroup->ubNumAdmins, dstSector);
 
 		MoveSAIGroupToSector(&pGroup, pg->ubSectorID[1], EVASIVE, REINFORCEMENTS);
 		return;
@@ -1924,7 +1923,7 @@ static void SendReinforcementsForPatrol(INT32 iPatrolID, GROUP** pOptionalGroup)
 
 						SLOGD("{} troops have been sent from garrison sector {} to patrol area near sector {}",
 								pGroup->pEnemyGroup->ubNumTroops + pGroup->pEnemyGroup->ubNumElites + pGroup->pEnemyGroup->ubNumAdmins,
-								srcSector.AsShortString(), dstSector.AsShortString());
+								srcSector, dstSector);
 
 						MoveSAIGroupToSector(&pGroup, pg->ubSectorID[1], EVASIVE, REINFORCEMENTS);
 						return;
@@ -2013,8 +2012,7 @@ void EvaluateQueenSituation()
 				else
 				{
 					SGPSector sMap(gGarrisonGroup[i].ubSectorID);
-					SLOGD("Reinforcements were denied to go to {} because player forces too strong.",
-							sMap.AsShortString());
+					SLOGD("Reinforcements were denied to go to {} because player forces too strong.", sMap);
 				}
 				return;
 			}
@@ -3806,7 +3804,7 @@ static UINT8 RedirectEnemyGroupsMovingThroughSector(const SGPSector& sSector)
 	if( ubNumGroupsRedirected )
 	{
 		SLOGD("Test message for new feature: {} enemy groups were redirected away from moving through sector {}.  Please don't report unless this number is greater than 5.",
-			ubNumGroupsRedirected, sSector.AsShortString());
+			ubNumGroupsRedirected, sSector);
 	}
 	return ubNumGroupsRedirected;
 }

--- a/src/game/Strategic/Strategic_Movement.cc
+++ b/src/game/Strategic/Strategic_Movement.cc
@@ -107,7 +107,7 @@ static UINT8 AddGroupToList(GROUP* pGroup);
 //step before adding waypoints and members to the player group.
 GROUP* CreateNewPlayerGroupDepartingFromSector(const SGPSector& sMap)
 {
-	AssertMsg(sMap.IsValid(), ST::format("CreateNewPlayerGroup with out of range sector values of {}", sMap.AsShortString()));
+	AssertMsg(sMap.IsValid(), ST::format("CreateNewPlayerGroup with out of range sector values of {}", sMap));
 	GROUP* const pNew = new GROUP{};
 	pNew->pPlayerList = NULL;
 	pNew->pWaypoints = NULL;
@@ -128,7 +128,7 @@ GROUP* CreateNewPlayerGroupDepartingFromSector(const SGPSector& sMap)
 
 GROUP* CreateNewVehicleGroupDepartingFromSector(const SGPSector& sMap)
 {
-	AssertMsg(sMap.IsValid(), ST::format("CreateNewVehicleGroupDepartingFromSector with out of range sector values of {}", sMap.AsShortString()));
+	AssertMsg(sMap.IsValid(), ST::format("CreateNewVehicleGroupDepartingFromSector with out of range sector values of {}", sMap));
 	GROUP* const pNew = new GROUP{};
 	pNew->pWaypoints = NULL;
 	pNew->ubSector = pNew->ubNext = sMap;
@@ -353,7 +353,7 @@ static void InitiateGroupMovementToNextSector(GROUP* pGroup);
  * horizontal or vertical level as the last waypoint added. */
 BOOLEAN AddWaypointToPGroup(GROUP *g, const SGPSector& sMap)
 {
-	AssertMsg(sMap.IsValid(), ST::format("AddWaypointToPGroup with out of range sector values of {}", sMap.AsShortString()));
+	AssertMsg(sMap.IsValid(), ST::format("AddWaypointToPGroup with out of range sector values of {}", sMap));
 	if (!g) return FALSE;
 
 	/* At this point, we have the group, and a valid coordinate. Now we must
@@ -1582,7 +1582,7 @@ static BOOLEAN PossibleToCoordinateSimultaneousGroupArrivals(GROUP* const first_
 	/* header, sector, singular/plural str, confirmation string.
 	 * Ex:  Enemies have been detected in sector J9 and another squad is about to
 	 *      arrive.  Do you wish to coordinate a simultaneous arrival? */
-	ST::string str = st_format_printf(pStr, enemy_type, first_group->ubSector.AsShortString());
+	ST::string str = st_format_printf(pStr, enemy_type, first_group->ubSector);
 	str += ST::format(" {}", gpStrategicString[STR_COORDINATE]);
 	DoMapMessageBox(MSG_BOX_BASIC_STYLE, str, guiCurrentScreen, MSG_BOX_FLAG_YESNO, PlanSimultaneousGroupArrivalCallback);
 	gfWaitingForInput = TRUE;
@@ -1715,7 +1715,7 @@ static void InitiateGroupMovementToNextSector(GROUP* pGroup)
 
 	AssertMsg(pGroup->uiTraverseTime != TRAVERSE_TIME_IMPOSSIBLE, ST::format("Group {} ({}) attempting illegal move from {} to {} ({}).",
 			pGroup->ubGroupID, ( pGroup->fPlayer ) ? "Player" : "AI",
-			pGroup->ubSector.AsShortString(), pGroup->ubNext.AsShortString(),
+			pGroup->ubSector, pGroup->ubNext,
 			gszTerrain[SectorInfo[ubSector].ubTraversability[ubDirection]] ) );
 
 	// add sleep, if any
@@ -2702,7 +2702,7 @@ void CalculateGroupRetreatSector( GROUP *pGroup )
 	}
 	else
 	{
-		SLOGA("Player group cannot retreat from sector {} ", pGroup->ubSector.AsShortString());
+		SLOGA("Player group cannot retreat from sector {} ", pGroup->ubSector);
 		return;
 	}
 	if( pGroup->fPlayer )
@@ -2733,7 +2733,7 @@ void RetreatGroupToPreviousSector(GROUP& g)
 		else if (delta.x == -1 && delta.y ==  0) direction = WEST_STRATEGIC_MOVE;
 		else
 		{
-			throw std::runtime_error(ST::format("Player group attempting illegal retreat from {} to {}.", g.ubSector.AsShortString(), g.ubNext.AsShortString()).to_std_string());
+			throw std::runtime_error(ST::format("Player group attempting illegal retreat from {} to {}.", g.ubSector, g.ubNext).to_std_string());
 		}
 	}
 	else
@@ -2746,7 +2746,7 @@ void RetreatGroupToPreviousSector(GROUP& g)
 	// Calc time to get to next waypoint
 	UINT8 const sector = g.ubSector.AsByte();
 	g.uiTraverseTime = GetSectorMvtTimeForGroup(sector, direction, &g);
-	AssertMsg(g.uiTraverseTime != TRAVERSE_TIME_IMPOSSIBLE, ST::format("Group {} ({}) attempting illegal move from {} to {} ({}).", g.ubGroupID, g.fPlayer ? "Player" : "AI", g.ubSector.AsShortString(), g.ubNext.AsShortString(), gszTerrain[SectorInfo[sector].ubTraversability[direction]]));
+	AssertMsg(g.uiTraverseTime != TRAVERSE_TIME_IMPOSSIBLE, ST::format("Group {} ({}) attempting illegal move from {} to {} ({}).", g.ubGroupID, g.fPlayer ? "Player" : "AI", g.ubSector, g.ubNext, gszTerrain[SectorInfo[sector].ubTraversability[direction]]));
 
 	// Because we are in the strategic layer, don't make the arrival instantaneous (towns)
 	if (g.uiTraverseTime == 0) g.uiTraverseTime = 5;
@@ -2983,7 +2983,7 @@ BOOLEAN GroupWillMoveThroughSector(GROUP *pGroup, const SGPSector& sSector)
 	if (pGroup->ubMoveType != ONE_WAY)
 	{
 		SLOGA("GroupWillMoveThroughSector() -- Attempting to test group with an invalid move type.  ubGroupID: {}, ubMoveType: {}, sector: {} -- KM:0",
-			pGroup->ubGroupID, pGroup->ubMoveType, pGroup->ubSector.AsShortString());
+			pGroup->ubGroupID, pGroup->ubMoveType, pGroup->ubSector);
 	}
 
 	//Preserve the original sector values, as we will be temporarily modifying the group's ubSectorX/Y values
@@ -3015,14 +3015,13 @@ BOOLEAN GroupWillMoveThroughSector(GROUP *pGroup, const SGPSector& sSector)
 			if (delta.x && delta.y)
 			{ //Can't move diagonally!
 				SLOGA("GroupWillMoveThroughSector() -- Attempting to process waypoint in a diagonal direction from sector {} to sector {} for group at sector {}",
-					   pGroup->ubSector.AsShortString(), wp->sSector.AsShortString(), ubOrig.AsShortString());
+					   pGroup->ubSector, wp->sSector, ubOrig);
 				pGroup->ubSector = ubOrig;
 				return TRUE;
 			}
 			if (!delta.x && !delta.y) //Can't move to position currently at!
 			{
-				SLOGA("GroupWillMoveThroughSector() -- Attempting to process same waypoint at {} for group at {}",
-					wp->sSector.AsShortString(), ubOrig.AsShortString());
+				SLOGA("GroupWillMoveThroughSector() -- Attempting to process same waypoint at {} for group at {}", wp->sSector, ubOrig);
 				pGroup->ubSector = ubOrig;
 				return TRUE;
 			}

--- a/src/game/Tactical/Morale.cc
+++ b/src/game/Tactical/Morale.cc
@@ -406,11 +406,11 @@ void HandleMoraleEvent(SOLDIERTYPE *pSoldier, INT8 bMoraleEvent, const SGPSector
 	// Those that do need it have Asserts on a case by case basis below
 	if (pSoldier == NULL)
 	{
-		SLOGD("Handling morale event {} at {}", bMoraleEvent, sMap.AsLongString());
+		SLOGD("Handling morale event {} at {}", bMoraleEvent, sMap);
 	}
 	else
 	{
-		SLOGD("Handling morale event {} for {} at {}", bMoraleEvent, pSoldier->name, sMap.AsLongString());
+		SLOGD("Handling morale event {} for {} at {}", bMoraleEvent, pSoldier->name, sMap);
 	}
 
 

--- a/src/game/Tactical/Tactical_Save.cc
+++ b/src/game/Tactical/Tactical_Save.cc
@@ -340,7 +340,7 @@ void HandleAllReachAbleItemsInTheSector(const SGPSector& sector)
 	if (grid_no == -1) grid_no = m.sEastGridNo;
 	if (grid_no == -1) grid_no = m.sSouthGridNo;
 	if (grid_no == -1) grid_no = m.sWestGridNo;
-	AssertMsg(grid_no != -1, ST::format("Map {} does not have any entry points!", sector.AsLongString()));
+	AssertMsg(grid_no != -1, ST::format("Map {} does not have any entry points!", sector));
 	if (grid_no == -1) return;
 
 	GridNo       grid_no2 = NOWHERE;

--- a/src/game/TacticalAI/Knowledge.cc
+++ b/src/game/TacticalAI/Knowledge.cc
@@ -52,7 +52,7 @@ void CallAvailableTeamEnemiesToAmbush(GridNo const grid_no){
 		}
 		else
 		{
-			SLOGE("Ambush aborted in sector {} -- no center point in map.", gWorldSector.AsShortString());
+			SLOGE("Ambush aborted in sector {} -- no center point in map.", gWorldSector);
 		}
 	}
 }

--- a/src/game/TileEngine/Map_Edgepoints.cc
+++ b/src/game/TileEngine/Map_Edgepoints.cc
@@ -998,19 +998,19 @@ INT16 SearchForClosestPrimaryMapEdgepoint( INT16 sGridNo, UINT8 ubInsertionCode 
 	{
 		case INSERTION_CODE_NORTH:
 			pEdgepoints = &gps1stNorthEdgepointArray;
-			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any north mapedgepoints. LC:1", gWorldSector.AsLongString()));
+			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any north mapedgepoints. LC:1", gWorldSector));
 			break;
 		case INSERTION_CODE_EAST:
 			pEdgepoints = &gps1stEastEdgepointArray;
-			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any east mapedgepoints. LC:1", gWorldSector.AsLongString()));
+			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any east mapedgepoints. LC:1", gWorldSector));
 			break;
 		case INSERTION_CODE_SOUTH:
 			pEdgepoints = &gps1stSouthEdgepointArray;
-			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any south mapedgepoints. LC:1", gWorldSector.AsLongString()));
+			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any south mapedgepoints. LC:1", gWorldSector));
 			break;
 		case INSERTION_CODE_WEST:
 			pEdgepoints = &gps1stWestEdgepointArray;
-			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any west mapedgepoints. LC:1", gWorldSector.AsLongString()));
+			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any west mapedgepoints. LC:1", gWorldSector));
 			break;
 	}
 	if (!pEdgepoints || pEdgepoints->size() == 0)
@@ -1112,19 +1112,19 @@ INT16 SearchForClosestSecondaryMapEdgepoint( INT16 sGridNo, UINT8 ubInsertionCod
 	{
 		case INSERTION_CODE_NORTH:
 			pEdgepoints = &gps2ndNorthEdgepointArray;
-			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any isolated north mapedgepoints. KM:1", gWorldSector.AsLongString()));
+			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any isolated north mapedgepoints. KM:1", gWorldSector));
 			break;
 		case INSERTION_CODE_EAST:
 			pEdgepoints = &gps2ndEastEdgepointArray;
-			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any isolated east mapedgepoints. KM:1", gWorldSector.AsLongString()));
+			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any isolated east mapedgepoints. KM:1", gWorldSector));
 			break;
 		case INSERTION_CODE_SOUTH:
 			pEdgepoints = &gps2ndSouthEdgepointArray;
-			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any isolated south mapedgepoints. KM:1", gWorldSector.AsLongString()));
+			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any isolated south mapedgepoints. KM:1", gWorldSector));
 			break;
 		case INSERTION_CODE_WEST:
 			pEdgepoints = &gps2ndWestEdgepointArray;
-			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any isolated west mapedgepoints. KM:1", gWorldSector.AsLongString()));
+			AssertMsg(pEdgepoints->size() != 0, ST::format("Sector {} doesn't have any isolated west mapedgepoints. KM:1", gWorldSector));
 			break;
 	}
 	if (!pEdgepoints || pEdgepoints->size() == 0)

--- a/src/game/Utils/_ChineseText.cc
+++ b/src/game/Utils/_ChineseText.cc
@@ -610,8 +610,8 @@ static const ST::string s_cn_pDirectionStr[pDirectionStr_SIZE] =
 
 static const ST::string s_cn_gpStrategicString[gpStrategicString_SIZE] =
 {
-	"%s在%c%d区域被发现了, 另一小队即将到达.",	//STR_DETECTED_SINGULAR
-	"%s在%c%d区域被发现了, 其它几个小队即将到达.",	//STR_DETECTED_PLURAL
+	"%s在%s区域被发现了, 另一小队即将到达.",	//STR_DETECTED_SINGULAR
+	"%s在%s区域被发现了, 其它几个小队即将到达.",	//STR_DETECTED_PLURAL
 	"您想调整为同时到达吗?",												//STR_COORDINATE
 
 	//Dialog strings for enemies.
@@ -726,11 +726,11 @@ static const ST::string s_cn_gpStrategicString[gpStrategicString_SIZE] =
 
 	//various popup messages for battle conditions.
 
-	//%c%d is the sector -- ex:  A9
-	"敌军向您在%c%d区域的民兵发起了攻击.",
-	//%c%d is the sector -- ex:  A9
-	"异形向您在%c%d区域的民兵发起了攻击.",
-	//1st %d refers to the number of civilians eaten by monsters,  %c%d is the sector -- ex:  A9
+	//%s -- ex:  A9
+	"敌军向您在%s区域的民兵发起了攻击.",
+	//%s -- ex:  A9
+	"异形向您在%s区域的民兵发起了攻击.",
+	//1st %d refers to the number of civilians eaten by monsters,  %s -- ex:  A9
 	//Note:  the minimum number of civilians eaten will be two.
 	"异形攻击了区域%s, 吃掉了%d名平民.",
 	//%s is the sector location -- ex:  A9: Omerta

--- a/src/game/Utils/_DutchText.cc
+++ b/src/game/Utils/_DutchText.cc
@@ -624,8 +624,8 @@ static const ST::string s_dut_pDirectionStr[pDirectionStr_SIZE] =
 
 static const ST::string s_dut_gpStrategicString[gpStrategicString_SIZE] =
 {
-	"%s zijn ontdekt in sector %c%d en een ander team arriveert binnenkort.",	//STR_DETECTED_SINGULAR
-	"%s zijn ontdekt in sector %c%d en andere teams arriveren binnenkort.",	//STR_DETECTED_PLURAL
+	"%s zijn ontdekt in sector %s en een ander team arriveert binnenkort.",	//STR_DETECTED_SINGULAR
+	"%s zijn ontdekt in sector %s en andere teams arriveren binnenkort.",	//STR_DETECTED_PLURAL
 	"Wil je een gezamenlijke aankomst coördineren?",					//STR_COORDINATE
 
 	//Dialog strings for enemies.
@@ -740,11 +740,11 @@ static const ST::string s_dut_gpStrategicString[gpStrategicString_SIZE] =
 
 	//various popup messages for battle conditions.
 
-	//%c%d is the sector -- ex:  A9
-	"Vijanden vallen je militie aan in sector %c%d.",
-	//%c%d is the sector -- ex:  A9
-	"Beesten vallen je militie aan in sector %c%d.",
-	//1st %d refers to the number of civilians eaten by monsters,  %c%d is the sector -- ex:  A9
+	//%s -- ex:  A9
+	"Vijanden vallen je militie aan in sector %s.",
+	//%s -- ex:  A9
+	"Beesten vallen je militie aan in sector %s.",
+	//1st %d refers to the number of civilians eaten by monsters,  %s -- ex:  A9
 	//Note:  the minimum number of civilians eaten will be two.
 	"Beesten vallen aan en doden %d burgers in sector %s.",
 	//%s is the sector location -- ex:  A9: Omerta

--- a/src/game/Utils/_EnglishText.cc
+++ b/src/game/Utils/_EnglishText.cc
@@ -610,8 +610,8 @@ static const ST::string s_eng_pDirectionStr[pDirectionStr_SIZE] =
 
 static const ST::string s_eng_gpStrategicString[gpStrategicString_SIZE] =
 {
-	"%s have been detected in sector %c%d and another squad is about to arrive.",	//STR_DETECTED_SINGULAR
-	"%s have been detected in sector %c%d and other squads are about to arrive.",	//STR_DETECTED_PLURAL
+	"%s have been detected in sector %s and another squad is about to arrive.",	//STR_DETECTED_SINGULAR
+	"%s have been detected in sector %s and other squads are about to arrive.",	//STR_DETECTED_PLURAL
 	"Do you want to coordinate a simultaneous arrival?",													//STR_COORDINATE
 
 	//Dialog strings for enemies.
@@ -726,11 +726,11 @@ static const ST::string s_eng_gpStrategicString[gpStrategicString_SIZE] =
 
 	//various popup messages for battle conditions.
 
-	//%c%d is the sector -- ex:  A9
-	"Enemies attack your militia in sector %c%d.",
-	//%c%d is the sector -- ex:  A9
-	"Creatures attack your militia in sector %c%d.",
-	//1st %d refers to the number of civilians eaten by monsters,  %c%d is the sector -- ex:  A9
+	//%s -- ex:  A9
+	"Enemies attack your militia in sector %s.",
+	//%s -- ex:  A9
+	"Creatures attack your militia in sector %s.",
+	//1st %d refers to the number of civilians eaten by monsters,  %s -- ex:  A9
 	//Note:  the minimum number of civilians eaten will be two.
 	"Creatures attack and kill %d civilians in sector %s.",
 	//%s is the sector location -- ex:  A9: Omerta

--- a/src/game/Utils/_FrenchText.cc
+++ b/src/game/Utils/_FrenchText.cc
@@ -610,8 +610,8 @@ static const ST::string s_fr_pDirectionStr[pDirectionStr_SIZE] =
 
 static const ST::string s_fr_gpStrategicString[gpStrategicString_SIZE] =
 {
-	"%s détecté dans le secteur %c%d et une autre escouade est en route.",	//STR_DETECTED_SINGULAR
-	"%s détecté dans le secteur %c%d et d'autres escouades sont en route.",	//STR_DETECTED_PLURAL
+	"%s détecté dans le secteur %s et une autre escouade est en route.",	//STR_DETECTED_SINGULAR
+	"%s détecté dans le secteur %s et d'autres escouades sont en route.",	//STR_DETECTED_PLURAL
 	"Voulez-vous coordonner vos mouvements de troupe ?",													//STR_COORDINATE
 
 	//Dialog strings for enemies.
@@ -726,11 +726,11 @@ static const ST::string s_fr_gpStrategicString[gpStrategicString_SIZE] =
 
 	//various popup messages for battle conditions.
 
-	//%c%d is the sector -- ex:  A9
-	"L'ennemi attaque votre milice dans le secteur %c%d.",
-	//%c%d is the sector -- ex:  A9
-	"Les créatures attaquent votre milice dans le secteur %c%d.",
-	//1st %d refers to the number of civilians eaten by monsters,  %c%d is the sector -- ex:  A9
+	//%s -- ex:  A9
+	"L'ennemi attaque votre milice dans le secteur %s.",
+	//%s -- ex:  A9
+	"Les créatures attaquent votre milice dans le secteur %s.",
+	//1st %d refers to the number of civilians eaten by monsters,  %s -- ex:  A9
 	//Note:  the minimum number of civilians eaten will be two.
 	"Les créatures ont tué %d civils dans le secteur %s.",
 	//%s is the sector location -- ex:  A9: Omerta

--- a/src/game/Utils/_GermanText.cc
+++ b/src/game/Utils/_GermanText.cc
@@ -594,8 +594,8 @@ static const ST::string s_ger_pDirectionStr[pDirectionStr_SIZE] =
 
 static const ST::string s_ger_gpStrategicString[gpStrategicString_SIZE] =
 {
-	"%s wurden entdeckt in Sektor %c%d und ein weiterer Trupp wird gleich ankommen.",	//STR_DETECTED_SINGULAR
-	"%s wurden entdeckt in Sektor %c%d und weitere Trupps werden gleich ankommen.",	//STR_DETECTED_PLURAL
+	"%s wurden entdeckt in Sektor %s und ein weiterer Trupp wird gleich ankommen.",	//STR_DETECTED_SINGULAR
+	"%s wurden entdeckt in Sektor %s und weitere Trupps werden gleich ankommen.",	//STR_DETECTED_PLURAL
 	"Gleichzeitige Ankunft koordinieren?",													//STR_COORDINATE
 
 	//Dialog strings for enemies.
@@ -710,11 +710,11 @@ static const ST::string s_ger_gpStrategicString[gpStrategicString_SIZE] =
 
 	//various popup messages for battle conditions.
 
-	//%c%d is the sector -- ex: A9
-	"Feinde attackieren Ihre Miliz im Sektor %c%d.",
-	//%c%d is the sector -- ex: A9
-	"Monster attackieren Ihre Miliz im Sektor %c%d.",
-	//1st %d refers to the number of civilians eaten by monsters, %c%d is the sector -- ex: A9
+	//%s -- ex: A9
+	"Feinde attackieren Ihre Miliz im Sektor %s.",
+	//%s -- ex: A9
+	"Monster attackieren Ihre Miliz im Sektor %s.",
+	//1st %d refers to the number of civilians eaten by monsters, %s -- ex: A9
 	//Note: the minimum number of civilians eaten will be two.
 	"Monster attackieren und töten %d Zivilisten im Sektor %s.",
 	//%s is the sector -- ex: A9

--- a/src/game/Utils/_ItalianText.cc
+++ b/src/game/Utils/_ItalianText.cc
@@ -610,8 +610,8 @@ static const ST::string s_it_pDirectionStr[pDirectionStr_SIZE] =
 
 static const ST::string s_it_gpStrategicString[gpStrategicString_SIZE] =
 {
-	"%s sono stati individuati nel settore %c%d e un'altra squadra sta per arrivare.",	//STR_DETECTED_SINGULAR
-	"%s sono stati individuati nel settore %c%d e un'altra squadra sta per arrivare.",	//STR_DETECTED_PLURAL
+	"%s sono stati individuati nel settore %s e un'altra squadra sta per arrivare.",	//STR_DETECTED_SINGULAR
+	"%s sono stati individuati nel settore %s e un'altra squadra sta per arrivare.",	//STR_DETECTED_PLURAL
 	"Volete coordinare un attacco simultaneo?",													//STR_COORDINATE
 
 	//Dialog strings for enemies.
@@ -726,11 +726,11 @@ static const ST::string s_it_gpStrategicString[gpStrategicString_SIZE] =
 
 	//various popup messages for battle conditions.
 
-	//%c%d is the sector -- ex:  A9
-	"I nemici attaccano il vostro esercito nel settore %c%d.",
-	//%c%d is the sector -- ex:  A9
-	"Le creature attaccano il vostro esercito nel settore %c%d.",
-	//1st %d refers to the number of civilians eaten by monsters,  %c%d is the sector -- ex:  A9
+	//%s -- ex:  A9
+	"I nemici attaccano il vostro esercito nel settore %s.",
+	//%s -- ex:  A9
+	"Le creature attaccano il vostro esercito nel settore %s.",
+	//1st %d refers to the number of civilians eaten by monsters,  %s -- ex:  A9
 	//Note:  the minimum number of civilians eaten will be two.
 	"Le creature attaccano e uccidono %d civili nel settore %s.",
 	//%s is the sector location -- ex:  A9: Omerta

--- a/src/game/Utils/_PolishText.cc
+++ b/src/game/Utils/_PolishText.cc
@@ -610,8 +610,8 @@ static const ST::string s_pl_pDirectionStr[pDirectionStr_SIZE] =
 
 static const ST::string s_pl_gpStrategicString[gpStrategicString_SIZE] =
 {
-	"%s wykryto w sektorze %c%d, a inny oddział jest w drodze.",	//STR_DETECTED_SINGULAR
-	"%s wykryto w sektorze %c%d, a inne oddziały są w drodze.",	//STR_DETECTED_PLURAL
+	"%s wykryto w sektorze %s, a inny oddział jest w drodze.",	//STR_DETECTED_SINGULAR
+	"%s wykryto w sektorze %s, a inne oddziały są w drodze.",	//STR_DETECTED_PLURAL
 	"Chcesz skoordynować jednoczesne przybycie?",			//STR_COORDINATE
 
 	//Dialog strings for enemies.
@@ -726,16 +726,16 @@ static const ST::string s_pl_gpStrategicString[gpStrategicString_SIZE] =
 
 	//various popup messages for battle conditions.
 
-	//%c%d is the sector -- ex:  A9
-	"Nieprzyjaciel zatakował oddziały samoobrony w sektorze %c%d.",
-	//%c%d is the sector -- ex:  A9
-	"Stworzenia zaatakowały oddziały samoobrony w sektorze %c%d.",
-	//1st %d refers to the number of civilians eaten by monsters,  %c%d is the sector -- ex:  A9
+	//%s -- ex:  A9
+	"Nieprzyjaciel zatakował oddziały samoobrony w sektorze %s.",
+	//%s -- ex:  A9
+	"Stworzenia zaatakowały oddziały samoobrony w sektorze %s.",
+	//1st %d refers to the number of civilians eaten by monsters,  %s -- ex:  A9
 	//Note:  the minimum number of civilians eaten will be two.
 	"Stworzenia zatakowały i zabiły %d cywili w sektorze %s.",
-	//%c%d is the sector -- ex:  A9
+	//%s -- ex:  A9
 	"Nieprzyjaciel zatakował twoich najemników w sektorze %s.  Żaden z twoich najemników nie może walczyć!",
-	//%c%d is the sector -- ex:  A9
+	//%s -- ex:  A9
 	"Stworzenia zatakowały twoich najemników w sektorze %s.  Żaden z twoich najemników nie może walczyć!",
 
 };

--- a/src/game/Utils/_RussianText.cc
+++ b/src/game/Utils/_RussianText.cc
@@ -610,8 +610,8 @@ static const ST::string s_rus_pDirectionStr[pDirectionStr_SIZE] =
 
 static const ST::string s_rus_gpStrategicString[gpStrategicString_SIZE] =
 {
-	"%s обнаружены в секторе %c%d и вот-вот прибудет еще один отряд.", //STR_DETECTED_SINGULAR
-	"%s обнаружены в секторе %c%d и вот-вот прибудут еще отряды.",	//STR_DETECTED_PLURAL
+	"%s обнаружены в секторе %s и вот-вот прибудет еще один отряд.", //STR_DETECTED_SINGULAR
+	"%s обнаружены в секторе %s и вот-вот прибудут еще отряды.",	//STR_DETECTED_PLURAL
 	"Хотите координировать одновременное прибытие?",													//STR_COORDINATE
 
 	//Dialog strings for enemies.
@@ -726,11 +726,11 @@ static const ST::string s_rus_gpStrategicString[gpStrategicString_SIZE] =
 //!!!What about repeated "R" as hotkey?
 	//various popup messages for battle conditions.
 
-	//%c%d is the sector -- ex:  A9
-	"Враги атакуют ваше ополчение в секторе %c%d.",
+	//%s -- ex:  A9
+	"Враги атакуют ваше ополчение в секторе %s.",
 	//%c%d сектор -- напр:  A9
-	"Существа напали на ополчение в секторе %c%d.",
-	//1st %d refers to the number of civilians eaten by monsters,  %c%d is the sector -- ex:  A9
+	"Существа напали на ополчение в секторе %s.",
+	//1st %d refers to the number of civilians eaten by monsters,  %s -- ex:  A9
 	//Note:  the minimum number of civilians eaten will be two.
 	"Существа напали на гражданских, убито %d в секторе %s.",
 	//%s is the sector location -- ex:  A9: Omerta

--- a/src/sgp/Types.cc
+++ b/src/sgp/Types.cc
@@ -141,3 +141,13 @@ ST::string SGPSector::AsLongString(bool file) const
 	if (file) return ST::format("{c}{}_b{}", y + 'A' - 1, x, z);
 	return ST::format("{c}{}-{}", y + 'A' - 1, x, z);
 }
+
+// ST::format definition for SGPSector
+void format_type(const ST::format_spec &format, ST::format_writer &output, const SGPSector &value)
+{
+    if (value.z > 0) {
+		ST::format_type(format, output, value.AsLongString());
+	} else {
+		ST::format_type(format, output, value.AsShortString());
+	}
+}

--- a/src/sgp/Types.h
+++ b/src/sgp/Types.h
@@ -147,6 +147,9 @@ public:
 	ST::string AsLongString(bool file = false) const;
 };
 
+// String formatting for SGP sector
+void format_type(const ST::format_spec &format, ST::format_writer &output, const SGPSector &value);
+
 struct SDL_Color;
 typedef SDL_Color SGPPaletteEntry;
 


### PR DESCRIPTION
First commit fixes three invalid format strings for `SLOGD` and introduces `SGPSector` support for `ST::format`. Search for `{}{}` to find the replaced cases.

Second commit fixes invalid format strings in translations.

Should close https://github.com/ja2-stracciatella/ja2-stracciatella/issues/1569. I hope that these are all remaining cases...