### PR TITLE
Keep hand item and weapon mode in sync

### DIFF
--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -1426,6 +1426,10 @@ static void LoadSoldierStructure(HWFILE const f, UINT32 savegame_version, bool s
 		{
 			s->next_to_previous_attacker = NULL;
 		}
+
+		// Just in case this save encountered a rare bug or comes
+		// from a mod with a different weapon configuration.
+		EnsureConsistentWeaponMode(s);
 	}
 
 	// Fix robot

--- a/src/game/Tactical/Interface_Panels.cc
+++ b/src/game/Tactical/Interface_Panels.cc
@@ -1791,48 +1791,7 @@ static void SMInvClickCallback(MOUSE_REGION* pRegion, INT32 iReason)
 							}
 						}
 					}
-
-					// Setup a timer....
-					//guiMouseOverItemTime = GetJA2Clock( );
-					//gfCheckForMouseOverItem = TRUE;
-					//gbCheckForMouseOverItemPos = (INT8)uiHandPos;
 				}
-
-				/*
-				// Try to place here
-				if ( PlaceObject( gpSMCurrentMerc, (UINT8)uiHandPos, gpItemPointer ) )
-				{
-
-					if ( fDeductPoints )
-					{
-						// Deduct points
-						if ( gpItemPointerSoldier->bLife >= CONSCIOUSNESS )
-						{
-							DeductPoints( gpItemPointerSoldier,  2, 0 );
-						}
-						if ( gpSMCurrentMerc->bLife >= CONSCIOUSNESS )
-						{
-							DeductPoints( gpSMCurrentMerc,  2, 0 );
-						}
-					}
-
-					HandleTacticalEffectsOfEquipmentChange( gpSMCurrentMerc, uiHandPos, usOldItemIndex, usNewItemIndex );
-
-					// Dirty
-					fInterfacePanelDirty = DIRTYLEVEL2;
-
-					// Check if it's the same now!
-					if ( gpItemPointer->ubNumberOfObjects == 0 )
-					{
-						EndItemPointer( );
-					}
-
-					// Setup a timer....
-					guiMouseOverItemTime = GetJA2Clock( );
-					gfCheckForMouseOverItem = TRUE;
-					gbCheckForMouseOverItemPos = (INT8)uiHandPos;
-
-				}*/
 			}
 		}
 	}
@@ -3815,16 +3774,6 @@ void HandleTacticalEffectsOfEquipmentChange(SOLDIERTYPE* pSoldier, UINT32 uiInvP
 			// Could be because of GOGGLES change...  Re-create light...
 			DeleteSoldierLight( pSoldier );
 			PositionSoldierLight( pSoldier );
-		}
-	}
-	else
-	{
-		// as a minimum
-		if ((GCM->getItem(pSoldier->inv[HANDPOS].usItem)->isWeapon()) &&
-			GCM->getWeapon(pSoldier->inv[HANDPOS].usItem)->ubShotsPerBurst == 0)
-		{
-			pSoldier->bDoBurst = FALSE;
-			pSoldier->bWeaponMode = WM_NORMAL;
 		}
 	}
 }

--- a/src/game/Tactical/Items.cc
+++ b/src/game/Tactical/Items.cc
@@ -2100,6 +2100,29 @@ BOOLEAN PlaceObject( SOLDIERTYPE * pSoldier, INT8 bPos, OBJECTTYPE * pObj )
 		UpdateRobotControllerGivenController( pSoldier );
 	}
 
+	// Ensure the main hand item is in sync with the soldier's weapon mode.
+	if (pSoldier->bWeaponMode == WM_BURST)
+	{
+		pSoldier->bDoBurst = TRUE;
+		if (!IsGunBurstCapable(pSoldier, HANDPOS))
+		{
+			pSoldier->bDoBurst = FALSE;
+			pSoldier->bWeaponMode = WM_NORMAL;
+		}
+	}
+	else if (pSoldier->bWeaponMode == WM_ATTACHED)
+	{
+		if (!HasLauncher(pSoldier))
+		{
+			pSoldier->bDoBurst = FALSE;
+			pSoldier->bWeaponMode = WM_NORMAL;
+		}
+	}
+	else // WM_NORMAL
+	{
+		pSoldier->bDoBurst = FALSE;
+	}
+
 	return( TRUE );
 }
 

--- a/src/game/Tactical/Items.cc
+++ b/src/game/Tactical/Items.cc
@@ -2100,29 +2100,7 @@ BOOLEAN PlaceObject( SOLDIERTYPE * pSoldier, INT8 bPos, OBJECTTYPE * pObj )
 		UpdateRobotControllerGivenController( pSoldier );
 	}
 
-	// Ensure the main hand item is in sync with the soldier's weapon mode.
-	if (pSoldier->bWeaponMode == WM_BURST)
-	{
-		pSoldier->bDoBurst = TRUE;
-		if (!IsGunBurstCapable(pSoldier, HANDPOS))
-		{
-			pSoldier->bDoBurst = FALSE;
-			pSoldier->bWeaponMode = WM_NORMAL;
-		}
-	}
-	else if (pSoldier->bWeaponMode == WM_ATTACHED)
-	{
-		if (!HasLauncher(pSoldier))
-		{
-			pSoldier->bDoBurst = FALSE;
-			pSoldier->bWeaponMode = WM_NORMAL;
-		}
-	}
-	else // WM_NORMAL
-	{
-		pSoldier->bDoBurst = FALSE;
-	}
-
+	EnsureConsistentWeaponMode(pSoldier);
 	return( TRUE );
 }
 

--- a/src/game/Tactical/LoadSaveSoldierType.cc
+++ b/src/game/Tactical/LoadSaveSoldierType.cc
@@ -421,7 +421,7 @@ void ExtractSoldierType(const BYTE* const data, SOLDIERTYPE* const s, bool strac
 	EXTR_BOOL(d, s->fBlockedByAnotherMerc)
 	EXTR_I8(d, s->bBlockedByAnotherMercDirection)
 	EXTR_U16(d, s->usAttackingWeapon)
-	EXTR_I8(d, s->bWeaponMode)
+	s->bWeaponMode = d.read<WeaponModes>();
 	EXTR_SOLDIER(d, s->target)
 	EXTR_I8(d, s->bAIScheduleProgress)
 	EXTR_SKIP(d, 1)

--- a/src/game/Tactical/Soldier_Control.h
+++ b/src/game/Tactical/Soldier_Control.h
@@ -308,6 +308,15 @@ enum
 };
 
 
+enum WeaponModes : INT8
+{
+	WM_NORMAL = 0,
+	WM_BURST,
+	WM_ATTACHED,
+	NUM_WEAPON_MODES
+};
+
+
 #define SOLDIERTYPE_NAME_LENGTH 10
 
 
@@ -691,7 +700,7 @@ struct SOLDIERTYPE
 	INT8 bBlockedByAnotherMercDirection;
 	UINT16 usAttackingWeapon;
 	SOLDIERTYPE* target;
-	INT8 bWeaponMode;
+	WeaponModes bWeaponMode;
 	INT8 bAIScheduleProgress;
 	INT16 sOffWorldGridNo;
 	ANITILE* pAniTile;
@@ -828,14 +837,6 @@ struct SOLDIERTYPE
 
 #define LVL_INCREASE					0x0400
 
-
-enum WeaponModes
-{
-	WM_NORMAL = 0,
-	WM_BURST,
-	WM_ATTACHED,
-	NUM_WEAPON_MODES
-};
 
 // TYPEDEFS FOR ANIMATION PROFILES
 struct ANIM_PROF_TILE

--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -3816,36 +3816,46 @@ bool HasLauncher(const SOLDIERTYPE* const s)
 }
 
 
+// Ensure the main hand item is in sync with the soldier's weapon mode.
+void EnsureConsistentWeaponMode(SOLDIERTYPE* const s)
+{
+	if (s->bWeaponMode == WM_BURST)
+	{
+		if (!IsGunBurstCapable(s, HANDPOS))
+		{
+			s->bWeaponMode = WM_NORMAL;
+		}
+	}
+	else if (s->bWeaponMode == WM_ATTACHED)
+	{
+		if (!HasLauncher(s))
+		{
+			s->bWeaponMode = WM_NORMAL;
+		}
+	}
+
+	s->bDoBurst = s->bWeaponMode == WM_BURST;
+}
+
+
+// Change the soldier's weapon mode to the next possible in
+// the cycle NORMAL ➔ BURST ➔ ATTACHED
 void ChangeWeaponMode(SOLDIERTYPE* const s)
 {
 	// ATE: Don't do this if in a fire amimation.....
 	if (gAnimControl[s->usAnimState].uiFlags & ANIM_FIRE) return;
 
 	WeaponModes& mode = s->bWeaponMode;
-	switch (mode)
+	WeaponModes previousMode = mode;
+	mode = mode == WM_ATTACHED ? WM_NORMAL : static_cast<WeaponModes>(mode + 1);
+
+	EnsureConsistentWeaponMode(s);
+
+	if (previousMode == mode)
 	{
-		case WM_NORMAL:
-			if (IsGunBurstCapable(s, HANDPOS))
-			{
-				mode = WM_BURST;
-			}
-			else if (HasLauncher(s))
-			{
-				mode = WM_ATTACHED;
-			}
-			else
-			{
-				ScreenMsg(FONT_MCOLOR_LTYELLOW, MSG_UI_FEEDBACK, st_format_printf(g_langRes->Message[STR_NOT_BURST_CAPABLE], s->name));
-			}
-			break;
-
-		case WM_BURST: mode = (HasLauncher(s) ? WM_ATTACHED : WM_NORMAL); break;
-
-		default:
-		case WM_ATTACHED: mode = WM_NORMAL; break;
+		ScreenMsg(FONT_MCOLOR_LTYELLOW, MSG_UI_FEEDBACK, st_format_printf(g_langRes->Message[STR_NOT_BURST_CAPABLE], s->name));
 	}
 
-	s->bDoBurst    = (mode == WM_BURST);
 	DirtyMercPanelInterface(s, DIRTYLEVEL2);
 	gfUIForceReExamineCursorData = TRUE;
 }

--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -3808,7 +3808,7 @@ UINT32 CalcThrownChanceToHit(SOLDIERTYPE *pSoldier, INT16 sGridNo, UINT8 ubAimTi
 }
 
 
-static BOOLEAN HasLauncher(const SOLDIERTYPE* const s)
+bool HasLauncher(const SOLDIERTYPE* const s)
 {
 	OBJECTTYPE const& o = s->inv[HANDPOS];
 	return FindAttachment(&o, UNDER_GLAUNCHER) != ITEM_NOT_FOUND &&
@@ -3821,7 +3821,7 @@ void ChangeWeaponMode(SOLDIERTYPE* const s)
 	// ATE: Don't do this if in a fire amimation.....
 	if (gAnimControl[s->usAnimState].uiFlags & ANIM_FIRE) return;
 
-	INT8 mode = s->bWeaponMode;
+	WeaponModes& mode = s->bWeaponMode;
 	switch (mode)
 	{
 		case WM_NORMAL:
@@ -3845,7 +3845,6 @@ void ChangeWeaponMode(SOLDIERTYPE* const s)
 		case WM_ATTACHED: mode = WM_NORMAL; break;
 	}
 
-	s->bWeaponMode = mode;
 	s->bDoBurst    = (mode == WM_BURST);
 	DirtyMercPanelInterface(s, DIRTYLEVEL2);
 	gfUIForceReExamineCursorData = TRUE;

--- a/src/game/Tactical/Weapons.h
+++ b/src/game/Tactical/Weapons.h
@@ -180,6 +180,7 @@ extern UINT32 CalcChanceToPunch(SOLDIERTYPE *pAttacker, SOLDIERTYPE * pDefender,
 extern UINT32 CalcChanceToStab(SOLDIERTYPE * pAttacker,SOLDIERTYPE *pDefender, UINT8 ubAimTime);
 void ReloadWeapon(SOLDIERTYPE*, UINT8 inv_pos);
 bool IsGunBurstCapable(SOLDIERTYPE const*, UINT8 inv_pos);
+bool HasLauncher(SOLDIERTYPE const*);
 extern INT32 CalcBodyImpactReduction( UINT8 ubAmmoType, UINT8 ubHitLocation );
 INT32 TotalArmourProtection(SOLDIERTYPE&, UINT8 ubHitLocation, INT32 iImpact, UINT8 ubAmmoType);
 INT8 ArmourPercent(const SOLDIERTYPE* pSoldier);

--- a/src/game/Tactical/Weapons.h
+++ b/src/game/Tactical/Weapons.h
@@ -180,6 +180,7 @@ extern UINT32 CalcChanceToPunch(SOLDIERTYPE *pAttacker, SOLDIERTYPE * pDefender,
 extern UINT32 CalcChanceToStab(SOLDIERTYPE * pAttacker,SOLDIERTYPE *pDefender, UINT8 ubAimTime);
 void ReloadWeapon(SOLDIERTYPE*, UINT8 inv_pos);
 bool IsGunBurstCapable(SOLDIERTYPE const*, UINT8 inv_pos);
+void EnsureConsistentWeaponMode(SOLDIERTYPE*);
 bool HasLauncher(SOLDIERTYPE const*);
 extern INT32 CalcBodyImpactReduction( UINT8 ubAmmoType, UINT8 ubHitLocation );
 INT32 TotalArmourProtection(SOLDIERTYPE&, UINT8 ubHitLocation, INT32 iImpact, UINT8 ubAmmoType);


### PR DESCRIPTION
Ensure that SOLDIERTYPE::bWeaponMode and bDoBurst are sensible after
changing the soldier's hand item. Resolves #196.

This also partly fixes #1184:

- You can't crash the game any more by switching from a weapon with burst mode to another item and then throwing something.
- The problem that a throw attempt can turn into a burst if burst mode is enabled still exists.