### PR TITLE
AIMHistory: fix not being able to move past AIM founder via Next

### DIFF
--- a/src/game/Laptop/AIMHistory.cc
+++ b/src/game/Laptop/AIMHistory.cc
@@ -385,7 +385,7 @@ static void BtnHistoryMenuButtonCallback(GUI_BUTTON *btn, INT32 reason)
 				break;
 
 			case 4: //Next Page
-				if (gubCurPageNum + 1 < NUM_AIM_HISTORY_PAGES)
+				if (gubCurPageNum < NUM_AIM_HISTORY_PAGES)
 				{
 					gubCurPageNum++;
 					ChangingAimHistorySubPage(gubCurPageNum);


### PR DESCRIPTION
page 0 is the index, there are 5 subpages, so 6 in total, not 5