### PR TITLE
Fix Structure not defined warnings

### DIFF
--- a/src/game/Tactical/LOS.cc
+++ b/src/game/Tactical/LOS.cc
@@ -2183,18 +2183,6 @@ static BOOLEAN BulletHitMerc(BULLET* pBullet, STRUCTURE* pStructure, BOOLEAN fIn
 }
 
 
-static void BulletHitStructure(BULLET* pBullet, UINT16 usStructureID, INT32 iImpact, BOOLEAN fStopped)
-{
-	const FIXEDPT qCurrX = pBullet->qCurrX;
-	const FIXEDPT qCurrY = pBullet->qCurrY;
-	const FIXEDPT qCurrZ = pBullet->qCurrZ;
-	INT16 sXPos = FIXEDPT_TO_INT32(qCurrX + FloatToFixed(0.5f)); // + 0.5);
-	INT16 sYPos = FIXEDPT_TO_INT32(qCurrY + FloatToFixed(0.5f)); // (dCurrY + 0.5);
-	INT16 sZPos = CONVERT_HEIGHTUNITS_TO_PIXELS((INT16)FIXEDPT_TO_INT32(qCurrZ + FloatToFixed(0.5f)));// dCurrZ + 0.5) );
-	StructureHit(pBullet, sXPos, sYPos, sZPos, usStructureID, iImpact, fStopped);
-}
-
-
 static void BulletHitWindow(BULLET* pBullet, INT16 sGridNo, UINT16 usStructureID, BOOLEAN fBlowWindowSouth)
 {
 	WindowHit( sGridNo, usStructureID, fBlowWindowSouth, FALSE );
@@ -3689,7 +3677,7 @@ void MoveBullet(BULLET* const pBullet)
 					{
 						// hit a roof
 						StopBullet(pBullet);
-						BulletHitStructure(pBullet, 0, 0, TRUE);
+						StructureHit(pBullet, INVALID_STRUCTURE_ID, 0, TRUE);
 						return;
 					}
 
@@ -3894,7 +3882,7 @@ void MoveBullet(BULLET* const pBullet)
 			{
 				// ground is in the way!
 				StopBullet(pBullet);
-				BulletHitStructure(pBullet, INVALID_STRUCTURE_ID, 0, TRUE);
+				StructureHit(pBullet, INVALID_STRUCTURE_ID, 0, TRUE);
 				return;
 			}
 			// check for the existence of structures
@@ -3953,7 +3941,7 @@ void MoveBullet(BULLET* const pBullet)
 					pBullet->qCurrZ += pBullet->qIncrZ * iStepsToTravel;
 
 					StopBullet(pBullet);
-					BulletHitStructure(pBullet, INVALID_STRUCTURE_ID, 0, TRUE);
+					StructureHit(pBullet, INVALID_STRUCTURE_ID, 0, TRUE);
 					return;
 				}
 
@@ -4112,7 +4100,7 @@ void MoveBullet(BULLET* const pBullet)
 
 												// bullet must end here!
 												StopBullet(pBullet);
-												BulletHitStructure(pBullet, pStructure->usStructureID, 1, TRUE);
+												StructureHit(pBullet, pStructure->usStructureID, 1, TRUE);
 												return;
 											}
 										}
@@ -4171,13 +4159,13 @@ void MoveBullet(BULLET* const pBullet)
 											else if ( iRemainingImpact <= 0 )
 											{
 												StopBullet(pBullet);
-												BulletHitStructure(pBullet, pStructure->usStructureID, 1, TRUE);
+												StructureHit(pBullet, pStructure->usStructureID, 1, TRUE);
 												return;
 											}
 											else if (fHitStructure && (gubLocalStructureNumTimesHit[iStructureLoop] == 0) )
 											{
 												// play animation to indicate structure being hit
-												BulletHitStructure(pBullet, pStructure->usStructureID, 1, FALSE);
+												StructureHit(pBullet, pStructure->usStructureID, 1, FALSE);
 												gubLocalStructureNumTimesHit[iStructureLoop] = 1;
 											}
 										}
@@ -4208,7 +4196,7 @@ void MoveBullet(BULLET* const pBullet)
 							if ( 1 /*HandleBulletStructureInteraction( pBullet, pRoofStructure, &fHitStructure ) <= 0 */)
 							{
 								StopBullet(pBullet);
-								BulletHitStructure(pBullet, 0, 0, TRUE);
+								StructureHit(pBullet, INVALID_STRUCTURE_ID, 0, TRUE);
 								return;
 							}
 							/*

--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -1669,11 +1669,14 @@ void WeaponHit(SOLDIERTYPE* const pTargetSoldier, const UINT16 usWeaponIndex, co
 }
 
 
-void StructureHit(BULLET* const pBullet, const INT16 sXPos, const INT16 sYPos, const INT16 sZPos, const UINT16 usStructureID, const INT32 iImpact, const BOOLEAN fStopped)
+void StructureHit(BULLET* const pBullet, const UINT16 usStructureID, const INT32 iImpact, const BOOLEAN fStopped)
 {
+	const INT16 sXPos = FIXEDPT_TO_INT32(pBullet->qCurrX);
+	const INT16 sYPos = FIXEDPT_TO_INT32(pBullet->qCurrY);
+	const INT16 sZPos = CONVERT_HEIGHTUNITS_TO_PIXELS(FIXEDPT_TO_INT32(pBullet->qCurrZ));
+
 	BOOLEAN        fDoMissForGun = FALSE;
 	ANITILE        *pNode;
-	INT16          sGridNo;
 	ANITILE_PARAMS AniParams;
 	UINT32         uiMissVolume = MIDVOLUME;
 
@@ -1690,7 +1693,7 @@ void StructureHit(BULLET* const pBullet, const INT16 sXPos, const INT16 sYPos, c
 
 	const BOOLEAN fHitSameStructureAsBefore = (usStructureID == pBullet->usLastStructureHit);
 
-	sGridNo = MAPROWCOLTOPOS( (sYPos/CELL_Y_SIZE), (sXPos/CELL_X_SIZE) );
+	const GridNo sGridNo = pBullet->sGridNo;
 	if ( !fHitSameStructureAsBefore )
 	{
 		const INT8 level = (sZPos > WALL_HEIGHT ? 1 : 0);

--- a/src/game/Tactical/Weapons.h
+++ b/src/game/Tactical/Weapons.h
@@ -169,7 +169,7 @@ INT8 EffectiveArmour(const OBJECTTYPE* pObj);
 extern INT8 ArmourVersusExplosivesPercent( SOLDIERTYPE * pSoldier );
 extern BOOLEAN FireWeapon( SOLDIERTYPE *pSoldier , INT16 sTargetGridNo );
 void WeaponHit(SOLDIERTYPE* target, UINT16 usWeaponIndex, INT16 sDamage, INT16 sBreathLoss, UINT16 usDirection, INT16 sXPos, INT16 sYPos, INT16 sZPos, INT16 sRange, SOLDIERTYPE* attacker, UINT8 ubSpecial, UINT8 ubHitLocation);
-void StructureHit(BULLET* b, INT16 sXPos, INT16 sYPos, INT16 sZPos, UINT16 usStructureID, INT32 iImpact, BOOLEAN fStopped);
+void StructureHit(BULLET* b, UINT16 usStructureID, INT32 iImpact, BOOLEAN fStopped);
 extern void WindowHit( INT16 sGridNo, UINT16 usStructureID, BOOLEAN fBlowWindowSouth, BOOLEAN fLargeForce );
 extern INT32 BulletImpact( SOLDIERTYPE *pFirer, SOLDIERTYPE * pTarget, UINT8 ubHitLocation, INT32 iImpact, INT16 sHitBy, UINT8 * pubSpecial );
 BOOLEAN InRange(const SOLDIERTYPE* pSoldier, INT16 sGridNo);

--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -1206,11 +1206,7 @@ BOOLEAN StructureDensity( STRUCTURE * pStructure, UINT8 * pubLevel0, UINT8 * pub
 
 StructureDamageResult DamageStructure(STRUCTURE* const s, UINT8 damage, StructureDamageReason const reason, GridNo const grid_no, INT16 const x, INT16 const y, SOLDIERTYPE* const owner)
 {	// Do damage to a structure; returns TRUE if the structure should be removed
-	if (!s)
-	{
-		SLOGW("Structure is not defined");
-		return STRUCTURE_NOT_DAMAGED;
-	}
+	Assert(s);
 
 	if (s->fFlags & (STRUCTURE_PERSON | STRUCTURE_CORPSE))
 	{ // Don't hurt this structure, it's used for hit detection only


### PR DESCRIPTION
• Due to some fishy calculations in BulletHitStructure(), StructureHit()
occasionally ended up with the wrong GridNo.
• Two places used 0 instead of INVALID_STRUCTURE_ID

 I checked the other code locations that use BULLET's qCurrX, Y, Z but could not find any other place that also add 0.5 to these values.

I can only assume that this is not intentional but an actual bug, but it would be good to get more testing, that's why I changed the warning to an assert: it makes it less easy to ignore any remaining issues, if there are any.