### PR TITLE
Fix fast help active checks

### DIFF
--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -4386,20 +4386,7 @@ static void ContractButtonCallback(GUI_BUTTON* btn, INT32 reason)
 {
 	if (g_dialogue_box) return;
 
-	if (reason & MSYS_CALLBACK_REASON_LBUTTON_DWN)
-	{
-#if 0 // XXX was commented out
-		if (bSelectedDestChar != -1 || fPlotForHelicopter)
-		{
-			AbortMovementPlottingMode();
-			return;
-		}
-#endif
-
-		// redraw region
-		if (btn->HasFastHelp()) fCharacterInfoPanelDirty = TRUE;
-	}
-	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
+	if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
 		RequestContractMenu();
 	}

--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -4397,7 +4397,7 @@ static void ContractButtonCallback(GUI_BUTTON* btn, INT32 reason)
 #endif
 
 		// redraw region
-		if (btn->Area.uiFlags & MSYS_HAS_BACKRECT) fCharacterInfoPanelDirty = TRUE;
+		if (btn->HasFastHelp()) fCharacterInfoPanelDirty = TRUE;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{

--- a/src/game/Strategic/Map_Screen_Interface_Bottom.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Bottom.cc
@@ -315,12 +315,7 @@ static void DestroyButtonsForMapScreenInterfaceBottom()
 
 static void BtnLaptopCallback(GUI_BUTTON *btn, INT32 reason)
 {
-	if (reason & MSYS_CALLBACK_REASON_LBUTTON_DWN)
-	{
-		// redraw region
-		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
-	}
-	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
+	if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
 		RequestTriggerExitFromMapscreen(MAP_EXIT_TO_LAPTOP);
 	}
@@ -329,12 +324,7 @@ static void BtnLaptopCallback(GUI_BUTTON *btn, INT32 reason)
 
 static void BtnTacticalCallback(GUI_BUTTON *btn, INT32 reason)
 {
-	if (reason & MSYS_CALLBACK_REASON_LBUTTON_DWN)
-	{
-		// redraw region
-		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
-	}
-	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
+	if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
 		RequestTriggerExitFromMapscreen(MAP_EXIT_TO_TACTICAL);
 	}
@@ -343,14 +333,8 @@ static void BtnTacticalCallback(GUI_BUTTON *btn, INT32 reason)
 
 static void BtnOptionsFromMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 {
-	if (reason & MSYS_CALLBACK_REASON_LBUTTON_DWN)
+	if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
-		// redraw region
-		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
-	}
-	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
-	{
-		fMapScreenBottomDirty = TRUE;
 		RequestTriggerExitFromMapscreen(MAP_EXIT_TO_OPTIONS);
 	}
 }
@@ -388,8 +372,6 @@ static void BtnTimeCompressMoreMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 	if (reason & MSYS_CALLBACK_REASON_LBUTTON_DWN)
 	{
 		if (CommonTimeCompressionChecks()) return;
-		// redraw region
-		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
@@ -408,8 +390,6 @@ static void BtnTimeCompressLessMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 	if (reason & MSYS_CALLBACK_REASON_LBUTTON_DWN)
 	{
 		if (CommonTimeCompressionChecks()) return;
-		// redraw region
-		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
@@ -429,14 +409,10 @@ static void BtnMessageDownMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 
 	if (reason & MSYS_CALLBACK_REASON_LBUTTON_DWN)
 	{
-		// redraw region
-		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		uiLastRepeatScrollTime = 0;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
-		// redraw region
-		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		MapScreenMsgScrollDown(1);
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_REPEAT)
@@ -449,14 +425,10 @@ static void BtnMessageDownMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_DWN)
 	{
-		// redraw region
-		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		uiLastRepeatScrollTime = 0;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_UP)
 	{
-		// redraw region
-		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		MapScreenMsgScrollDown(MAX_MESSAGES_ON_MAP_BOTTOM);
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_REPEAT)
@@ -476,14 +448,10 @@ static void BtnMessageUpMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 
 	if (reason & MSYS_CALLBACK_REASON_LBUTTON_DWN)
 	{
-		// redraw region
-		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		uiLastRepeatScrollTime = 0;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
-		// redraw region
-		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		MapScreenMsgScrollUp(1);
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_REPEAT)
@@ -496,14 +464,10 @@ static void BtnMessageUpMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_DWN)
 	{
-		// redraw region
-		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		uiLastRepeatScrollTime = 0;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_UP)
 	{
-		// redraw region
-		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		MapScreenMsgScrollUp(MAX_MESSAGES_ON_MAP_BOTTOM);
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_REPEAT)

--- a/src/game/Strategic/Map_Screen_Interface_Bottom.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Bottom.cc
@@ -318,7 +318,7 @@ static void BtnLaptopCallback(GUI_BUTTON *btn, INT32 reason)
 	if (reason & MSYS_CALLBACK_REASON_LBUTTON_DWN)
 	{
 		// redraw region
-		if (btn->Area.uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
+		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
@@ -332,7 +332,7 @@ static void BtnTacticalCallback(GUI_BUTTON *btn, INT32 reason)
 	if (reason & MSYS_CALLBACK_REASON_LBUTTON_DWN)
 	{
 		// redraw region
-		if (btn->Area.uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
+		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
@@ -346,7 +346,7 @@ static void BtnOptionsFromMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 	if (reason & MSYS_CALLBACK_REASON_LBUTTON_DWN)
 	{
 		// redraw region
-		if (btn->uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
+		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
@@ -389,7 +389,7 @@ static void BtnTimeCompressMoreMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 	{
 		if (CommonTimeCompressionChecks()) return;
 		// redraw region
-		if (btn->uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
+		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
@@ -409,7 +409,7 @@ static void BtnTimeCompressLessMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 	{
 		if (CommonTimeCompressionChecks()) return;
 		// redraw region
-		if (btn->uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
+		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
@@ -430,13 +430,13 @@ static void BtnMessageDownMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 	if (reason & MSYS_CALLBACK_REASON_LBUTTON_DWN)
 	{
 		// redraw region
-		if (btn->uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
+		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		uiLastRepeatScrollTime = 0;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
 		// redraw region
-		if (btn ->uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
+		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		MapScreenMsgScrollDown(1);
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_REPEAT)
@@ -450,13 +450,13 @@ static void BtnMessageDownMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_DWN)
 	{
 		// redraw region
-		if (btn->uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
+		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		uiLastRepeatScrollTime = 0;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_UP)
 	{
 		// redraw region
-		if (btn->uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
+		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		MapScreenMsgScrollDown(MAX_MESSAGES_ON_MAP_BOTTOM);
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_REPEAT)
@@ -477,13 +477,13 @@ static void BtnMessageUpMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 	if (reason & MSYS_CALLBACK_REASON_LBUTTON_DWN)
 	{
 		// redraw region
-		if (btn->Area.uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
+		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		uiLastRepeatScrollTime = 0;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_UP)
 	{
 		// redraw region
-		if (btn->uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
+		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		MapScreenMsgScrollUp(1);
 	}
 	else if (reason & MSYS_CALLBACK_REASON_LBUTTON_REPEAT)
@@ -497,13 +497,13 @@ static void BtnMessageUpMapScreenCallback(GUI_BUTTON *btn, INT32 reason)
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_DWN)
 	{
 		// redraw region
-		if (btn->uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
+		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		uiLastRepeatScrollTime = 0;
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_UP)
 	{
 		// redraw region
-		if (btn->uiFlags & MSYS_HAS_BACKRECT) fMapScreenBottomDirty = TRUE;
+		if (btn->HasFastHelp()) fMapScreenBottomDirty = TRUE;
 		MapScreenMsgScrollUp(MAX_MESSAGES_ON_MAP_BOTTOM);
 	}
 	else if (reason & MSYS_CALLBACK_REASON_RBUTTON_REPEAT)

--- a/src/game/TileEngine/Render_Dirty.cc
+++ b/src/game/TileEngine/Render_Dirty.cc
@@ -259,19 +259,21 @@ void SaveBackgroundRects(void)
 }
 
 
-void FreeBackgroundRect(BACKGROUND_SAVE* const b)
+void FreeBackgroundRect(BACKGROUND_SAVE*& b)
 {
 	if (b == NULL) return;
 
 	b->fAllocated = FALSE;
+	b = nullptr;
 }
 
 
-void FreeBackgroundRectPending(BACKGROUND_SAVE* const b)
+void FreeBackgroundRectPending(BACKGROUND_SAVE*& b)
 {
 	if(b)
 	{
 		b->fPendingDelete = TRUE;
+		b = nullptr;
 	}
 }
 

--- a/src/game/TileEngine/Render_Dirty.h
+++ b/src/game/TileEngine/Render_Dirty.h
@@ -58,8 +58,10 @@ void ExecuteBaseDirtyRectQueue(void);
 // BACKGROUND RECT BUFFERING STUFF
 void             InitializeBackgroundRects(void);
 BACKGROUND_SAVE* RegisterBackgroundRect(BackgroundFlags, INT16 x, INT16 y, INT16 w, INT16 h);
-void             FreeBackgroundRect(BACKGROUND_SAVE*);
-void             FreeBackgroundRectPending(BACKGROUND_SAVE*);
+// This function will invalidate your BACKGROUND_SAVE pointer!
+void             FreeBackgroundRect(BACKGROUND_SAVE*&);
+// This function will invalidate your BACKGROUND_SAVE pointer!
+void             FreeBackgroundRectPending(BACKGROUND_SAVE*&);
 void             FreeBackgroundRectType(BackgroundFlags);
 void             RestoreBackgroundRects(void);
 void             SaveBackgroundRects(void);

--- a/src/sgp/Button_System.h
+++ b/src/sgp/Button_System.h
@@ -78,6 +78,7 @@ struct GUI_BUTTON
 	void SpecifyTextWrappedWidth(INT16 wrapped_width);
 
 	void AllowDisabledFastHelp();
+	bool HasFastHelp() { return Area.HasFastHelp(); }
 
 	enum DisabledStyle
 	{

--- a/src/sgp/Button_System.h
+++ b/src/sgp/Button_System.h
@@ -78,7 +78,6 @@ struct GUI_BUTTON
 	void SpecifyTextWrappedWidth(INT16 wrapped_width);
 
 	void AllowDisabledFastHelp();
-	bool HasFastHelp() { return Area.HasFastHelp(); }
 
 	enum DisabledStyle
 	{

--- a/src/sgp/MouseSystem.cc
+++ b/src/sgp/MouseSystem.cc
@@ -289,12 +289,11 @@ static void MSYS_UpdateMouseRegion(void)
 			if (!prev->FastHelpText.empty())
 			{
 #ifdef _JA2_RENDER_DIRTY
-				if (prev->uiFlags & MSYS_GOT_BACKGROUND)
+				if (prev->HasFastHelp())
 				{
 					FreeBackgroundRectPending(prev->FastHelpRect);
 				}
 #endif
-				prev->uiFlags &= ~MSYS_GOT_BACKGROUND;
 				prev->uiFlags &= ~MSYS_FASTHELP_RESET;
 			}
 
@@ -321,12 +320,11 @@ static void MSYS_UpdateMouseRegion(void)
 				if (!cur->FastHelpText.empty() && !(cur->uiFlags & MSYS_FASTHELP_RESET))
 				{
 #ifdef _JA2_RENDER_DIRTY
-					if (cur->uiFlags & MSYS_GOT_BACKGROUND)
+					if (cur->HasFastHelp())
 					{
 						FreeBackgroundRectPending(cur->FastHelpRect);
 					}
 #endif
-					cur->uiFlags &= ~MSYS_GOT_BACKGROUND;
 					cur->uiFlags |= MSYS_FASTHELP_RESET;
 				}
 				if (cur->uiFlags & MSYS_REGION_ENABLED)
@@ -446,12 +444,11 @@ static void MSYS_UpdateMouseRegion(void)
 							// Button was clicked so remove any FastHelp text
 							cur->uiFlags &= ~MSYS_FASTHELP;
 #ifdef _JA2_RENDER_DIRTY
-							if (cur->uiFlags & MSYS_GOT_BACKGROUND)
+							if (cur->HasFastHelp())
 							{
 								FreeBackgroundRectPending(cur->FastHelpRect);
 							}
 #endif
-							cur->uiFlags &= ~MSYS_GOT_BACKGROUND;
 							cur->uiFlags &= ~MSYS_FASTHELP_RESET;
 
 							cur->FastHelpTimer = gsFastHelpDelay;
@@ -564,6 +561,7 @@ void MSYS_DefineRegion(MOUSE_REGION* const r, UINT16 const tlx, UINT16 const tly
 	r->ButtonCallback     = buttoncallback;
 	r->FastHelpTimer      = 0;
 	r->FastHelpText       = ST::null;
+	r->FastHelpRect       = nullptr;
 	r->next               = 0;
 	r->prev               = 0;
 
@@ -593,10 +591,9 @@ void MSYS_RemoveRegion(MOUSE_REGION* const r)
 #endif
 
 #ifdef _JA2_RENDER_DIRTY
-	if (r->uiFlags & MSYS_HAS_BACKRECT)
+	if (r->HasFastHelp())
 	{
 		FreeBackgroundRectPending(r->FastHelpRect);
-		r->uiFlags &= ~MSYS_HAS_BACKRECT;
 	}
 #endif
 
@@ -665,10 +662,9 @@ void MOUSE_REGION::SetFastHelpText(const ST::string& str)
 	if (guiCurrentScreen == MAP_SCREEN) return;
 
 #ifdef _JA2_RENDER_DIRTY
-	if (uiFlags & MSYS_GOT_BACKGROUND) FreeBackgroundRectPending(FastHelpRect);
+	if (HasFastHelp()) FreeBackgroundRectPending(FastHelpRect);
 #endif
 
-	uiFlags &= ~MSYS_GOT_BACKGROUND;
 	uiFlags &= ~MSYS_FASTHELP_RESET;
 }
 
@@ -703,10 +699,9 @@ static void DisplayFastHelp(MOUSE_REGION* const r)
 	if (y <  0)                 y = 0;
 	if (y >= SCREEN_HEIGHT - h) y = SCREEN_HEIGHT - h - 15;
 
-	if (!(r->uiFlags & MSYS_GOT_BACKGROUND))
+	if (!r->HasFastHelp())
 	{
 		r->FastHelpRect = RegisterBackgroundRect(BGND_FLAG_PERMANENT | BGND_FLAG_SAVERECT, x, y, w, h);
-		r->uiFlags |= MSYS_GOT_BACKGROUND | MSYS_HAS_BACKRECT;
 	}
 	else
 	{

--- a/src/sgp/MouseSystem.h
+++ b/src/sgp/MouseSystem.h
@@ -27,8 +27,7 @@
 #define MSYS_REGION_EXISTS           0x00000010
 #define MSYS_REGION_ENABLED          0x00000040
 #define MSYS_FASTHELP                0x00000080
-#define MSYS_GOT_BACKGROUND          0x00000100
-#define MSYS_HAS_BACKRECT            0x00000200
+// 0x100 and 0x200 removed, were used to check if this region has a background save.
 #define MSYS_FASTHELP_RESET          0x00000400
 #define MSYS_ALLOW_DISABLED_FASTHELP 0x00000800
 
@@ -50,6 +49,8 @@ struct MOUSE_REGION
 	void SetUserPtr(void* ptr) { user.ptr = ptr; }
 
 	template<typename T> T* GetUserPtr() const { return static_cast<T*>(user.ptr); }
+
+	bool HasFastHelp() { return FastHelpRect != nullptr; }
 
 	INT16 X() const { return RegionTopLeftX; }
 	INT16 Y() const { return RegionTopLeftY; }
@@ -205,6 +206,7 @@ class MouseRegion : private MOUSE_REGION
 		using MOUSE_REGION::RelativeXPos;
 		using MOUSE_REGION::RelativeYPos;
 		using MOUSE_REGION::SetFastHelpText;
+		using MOUSE_REGION::HasFastHelp;
 		using MOUSE_REGION::SetUserPtr;
 		using MOUSE_REGION::uiFlags;
 };

--- a/src/sgp/MouseSystem.h
+++ b/src/sgp/MouseSystem.h
@@ -206,7 +206,6 @@ class MouseRegion : private MOUSE_REGION
 		using MOUSE_REGION::RelativeXPos;
 		using MOUSE_REGION::RelativeYPos;
 		using MOUSE_REGION::SetFastHelpText;
-		using MOUSE_REGION::HasFastHelp;
 		using MOUSE_REGION::SetUserPtr;
 		using MOUSE_REGION::uiFlags;
 };


### PR DESCRIPTION
• Several locations in Map_Screen_Interface_Bottom.cc were testing the wrong uiFlags.
• MSYS_RemoveRegion was testing a different flag than four other locations before
  calling FreeBackgroundRectPending.

The first bug (testing `GUI_BUTTON`'s uiFlags instead of `MOUSE_REGION`'s) seems harmless, we either redraw too often or miss one redraw, I didn't notice any display errors.

The second bug, however is more serious: there are five places in `MouseSystem.cc` that call `FreeBackgroundRectPending`, four of them tested the `MSYS_GOT_BACKGROUND` flag before and cleared this flag afterwards.

Only MSYS_RemoveRegion used `MSYS_HAS_BACKRECT` instead, which could theoretically lead to a second `FreeBackgroundRectPending` call for this `BACKGROUND_SAVE`. Worst case scenario would be that this structure was already allocated somewhere else between these two calls and we'd delete someone else's `BACKGROUND_SAVE`. I can't say whether this can actually happen in practice.

AFAICT we only have this flags because `FastHelpRect` was an INT32 in the original code base and you couldn't simple compare it to 0. Now that it is a pointer these flags are not necessary any more and, as seen here, just complicate things.

I hope this does not clash with #1552, but I think I'm touching different lines.