### PR TITLE
Do no update sight values in DecaySmokeEffects and DecayLightEffects

### DIFF
--- a/src/game/TileEngine/LightEffects.cc
+++ b/src/game/TileEngine/LightEffects.cc
@@ -121,7 +121,7 @@ LIGHTEFFECT* NewLightEffect(const INT16 sGridNo, const INT8 bType)
 }
 
 
-void DecayLightEffects( UINT32 uiTime )
+void DecayLightEffects(const UINT32 uiTime, const bool trashingWorld)
 {
 	// age all active tear gas clouds, deactivate those that are just dispersing
 	FOR_EACH_LIGHTEFFECT(l)
@@ -165,7 +165,7 @@ void DecayLightEffects( UINT32 uiTime )
 		}
 
 		// Handle sight here....
-		AllTeamsLookForAll(FALSE);
+		if(!trashingWorld) AllTeamsLookForAll(FALSE);
 	}
 }
 

--- a/src/game/TileEngine/LightEffects.h
+++ b/src/game/TileEngine/LightEffects.h
@@ -27,7 +27,7 @@ struct LIGHTEFFECT
 
 
 // Decays all light effects...
-void DecayLightEffects( UINT32 uiTime );
+void DecayLightEffects(UINT32 uiTime, bool trashingWorld = false);
 
 LIGHTEFFECT* NewLightEffect(INT16 sGridNo, INT8 bType);
 

--- a/src/game/TileEngine/SmokeEffects.cc
+++ b/src/game/TileEngine/SmokeEffects.cc
@@ -327,7 +327,7 @@ void RemoveSmokeEffectFromTile( INT16 sGridNo, INT8 bLevel )
 }
 
 
-void DecaySmokeEffects( UINT32 uiTime )
+void DecaySmokeEffects(const UINT32 uiTime, const bool trashingWorld)
 {
 	BOOLEAN fUpdate = FALSE;
 	BOOLEAN fSpreadEffect;
@@ -446,7 +446,7 @@ void DecaySmokeEffects( UINT32 uiTime )
 		}
 	}
 
-	AllTeamsLookForAll( TRUE );
+	if (!trashingWorld) AllTeamsLookForAll( TRUE );
 }
 
 

--- a/src/game/TileEngine/SmokeEffects.h
+++ b/src/game/TileEngine/SmokeEffects.h
@@ -38,7 +38,7 @@ struct SMOKEEFFECT
 SmokeEffectKind GetSmokeEffectOnTile(INT16 sGridNo, INT8 bLevel);
 
 // Decays all smoke effects...
-void DecaySmokeEffects( UINT32 uiTime );
+void DecaySmokeEffects(UINT32 uiTime, bool trashingWorld = false);
 
 // Add smoke to gridno
 // ( Replacement algorithm uses distance away )

--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -2538,8 +2538,8 @@ void TrashWorld(void)
 	TrashWorldItems();
 	TrashOverheadMap();
 
-	DecaySmokeEffects(0xffffff);
-	DecayLightEffects(0xffffff);
+	DecaySmokeEffects(0xffffff, true);
+	DecayLightEffects(0xffffff, true);
 	ResetSmokeEffects();
 	ResetLightEffects();
 


### PR DESCRIPTION
Let the callers of these functions call AllTeamsLookForAll themselves when
they need to.