### PR TITLE
Fix incorrect schemas for weapons and item replacements

### DIFF
--- a/rust/stracciatella/src/schemas/yaml/tactical-map-item-replacements.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/tactical-map-item-replacements.schema.yaml
@@ -9,11 +9,11 @@ items:
     replace items with something else, or ignore totally. This does not affect
     items created from other means.
 
-    This is intended for compatibility and for maps that was originally built 
+    This is intended for compatibility and for maps that were originally built
     for different item sets (e.g. Wildfire maps).
 
-    Items are identified by either item index (if given integer), or internal 
-    name (if given string). Items mapped to 0 ("Nothing") are removed from map 
+    Items are identified by either item index (if given integer), or internal
+    name (if given string). Items mapped to 0 ("Nothing") are removed from map
     placements.
   properties:
     from:
@@ -21,13 +21,13 @@ items:
         - title: Internal ID
           $ref: types/id.schema.yaml
         - title: Internal numeric ID
-          $ref: types/uint8.schema.yaml
+          $ref: types/uint16.schema.yaml
     to:
       oneOf:
         - title: Internal ID
           $ref: types/id.schema.yaml
         - title: Internal numeric ID
-          $ref: types/uint8.schema.yaml
+          $ref: types/uint16.schema.yaml
   required:
   - from
   - to

--- a/rust/stracciatella/src/schemas/yaml/weapons.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/weapons.schema.yaml
@@ -7,7 +7,7 @@ items:
   properties:
     itemIndex:
       title: Item index
-      $ref: types/uint8.schema.yaml
+      $ref: types/uint16.schema.yaml
     internalName:
       title: Internal name
       $ref: types/id.schema.yaml
@@ -45,6 +45,7 @@ items:
     sound:
       title: Shot sound
       description: Path to sound that is played when a single shot is fired.
+      $ref: types/resource-path.schema.yaml
     burstSound:
       title: Burst sound
       description: |
@@ -55,13 +56,14 @@ items:
     silencedSound:
       title: Silenced shot sound
       description: Path to sound that is played when a single shot is fired and gun is silenced somehow.
-      $ref: types/int32.schema.yaml
+      $ref: types/resource-path.schema.yaml
     silencedBurstSound:
       title: Silenced burst sound
       description: |
         Path to sounds that are played as burst sounds for this calibre when the gun is silenced somehow.
 
         %d will replaced with the amount of bullets left in the gun.
+      $ref: types/resource-path.schema.yaml
     inventoryGraphics:
       title: Inventory Graphics
       description: Graphics that are used in the inventory interface for this item


### PR DESCRIPTION
- Weapons ids are item ids and should be uint16 (although they can only go from 0 - 70)
- Some weapon sound properties were missing their type
- Item ids should be uint16 for tactical item replacements