### PR TITLE
Fix indexing into m_sectorLandTypes

### DIFF
--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -1510,11 +1510,12 @@ const MovementCostsModel* DefaultContentManager::getMovementCosts() const
 int16_t DefaultContentManager::getSectorLandType(uint8_t const sectorID, uint8_t const sectorLevel) const
 {
 	SGPSector key = SGPSector::FromSectorID(sectorID, sectorLevel);
-	if (m_sectorLandTypes.find(key) == m_sectorLandTypes.end())
+	auto result = m_sectorLandTypes.find(key);
+	if (result == m_sectorLandTypes.end())
 	{
 		return -1;
 	}
-	return m_sectorLandTypes.at(key);
+	return result->second;
 }
 
 const CacheSectorsModel* DefaultContentManager::getCacheSectors() const


### PR DESCRIPTION
Should fix #1588 and #1589.

There might be some underlying issues with `SGPSector`. The `std::map` container we use expects the elements to be [Compare](https://en.cppreference.com/w/cpp/named_req/Compare). I'm not sure which of the listed constraints we currently violate with `SGPSector`, but to me it seems like we violate something, otherwise the error would probably not occur.