### PR TITLE
Merge cherry-picked build fixes into 0.19.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,8 @@ option(WITH_MAEMO "Build with right click mapped to F4 (menu button)" OFF)
 option(BUILD_LAUNCHER "Build the ja2 launcher application" ON)
 option(WITH_EDITOR_SLF "Include the latest free editor.slf" OFF)
 option(WITH_RUST_BINARIES "Include rust binaries in build" ON)
+# @see LOCAL_LUA_LIB in dependencies/lib-lua/CMakeLists.txt
+# @see LOCAL_SOL_LIB in dependencies/lib-sol2/CMakeLists.txt
 set(WITH_CUSTOM_LOCALE "" CACHE STRING "Set a custom locale at the start, leave empty to disable")
 
 if(MSVC)

--- a/dependencies/lib-lua/CMakeLists.txt
+++ b/dependencies/lib-lua/CMakeLists.txt
@@ -1,4 +1,21 @@
 # \file dependencies/lib-lua/CMakeLists.txt
+
+option(LOCAL_LUA_LIB "Download and build Lua instead of searching the system" ON)
+if (NOT LOCAL_LUA_LIB)
+    message(STATUS "Using system Lua")
+    find_package(Lua "5.3" REQUIRED)
+    if (NOT LUA_FOUND)
+        message(FATAL_ERROR "Lua 5.3 not found")
+    endif()
+
+    set(LUA_INCLUDE_DIRS "${LUA_INCLUDE_DIR}" PARENT_SCOPE)
+
+    add_library(lua INTERFACE)
+    target_link_libraries(lua INTERFACE "${LUA_LIBRARY}")
+
+    return()
+endif()
+
 message(STATUS "<lua>")
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.1)

--- a/dependencies/lib-miniaudio/CMakeLists.txt
+++ b/dependencies/lib-miniaudio/CMakeLists.txt
@@ -1,5 +1,46 @@
 # \file dependencies/lib-miniaudio/CMakeLists.txt
 
+option(LOCAL_MINIAUDIO_LIB "Download and build miniaudio instead of searching the system" ON)
+if (NOT LOCAL_MINIAUDIO_LIB)
+    message(STATUS "Using system miniaudio")
+
+    if (NOT DEFINED MINIAUDIO_INCLUDE_DIR)
+        message(FATAL_ERROR "MINIAUDIO_INCLUDE_DIR var not set")
+    endif()
+
+    include(CheckIncludeFileCXX)
+    set (CMAKE_REQUIRED_INCLUDES "${MINIAUDIO_INCLUDE_DIR}")
+
+    CHECK_INCLUDE_FILE_CXX("miniaudio.h" MINIAUDIO_FOUND)
+    if (NOT MINIAUDIO_FOUND)
+        message(FATAL_ERROR "miniaudio.h not found")
+    endif()
+
+    CHECK_INCLUDE_FILE_CXX("extras/stb_vorbis.c" STB_VORBIS_FOUND)
+    if (NOT STB_VORBIS_FOUND)
+        message(FATAL_ERROR "miniaudio extras/stb_vorbis.c not found")
+    endif()
+
+    include(CheckCXXSourceCompiles)
+    CHECK_CXX_SOURCE_COMPILES(
+        "
+            #include <miniaudio.h>
+            int main() {
+                static_assert(MA_VERSION_MAJOR == 0);
+                static_assert(MA_VERSION_MINOR == 10);
+            }
+        "
+        HAVE_MA_VERSION
+    )
+    if (NOT HAVE_MA_VERSION)
+        message(FATAL_ERROR "miniaudio does not have correct version, should be 0.10.x")
+    endif()
+
+    set(MINIAUDIO_INCLUDE_DIRS "${MINIAUDIO_INCLUDE_DIR}" PARENT_SCOPE)
+
+    return()
+endif()
+
 message(STATUS "<miniaudio>")
 
 # create getter

--- a/dependencies/lib-sol2/CMakeLists.txt
+++ b/dependencies/lib-sol2/CMakeLists.txt
@@ -1,5 +1,20 @@
 # \file dependencies/lib-sol2/CMakeLists.txt
 
+option(LOCAL_SOL_LIB "Download and build Sol2 instead of searching the system" ON)
+if (NOT LOCAL_SOL_LIB)
+    message(STATUS "Using system Sol2")
+    find_package(sol2 "3.2.2"
+        REQUIRED
+        PATH_SUFFIXES lib/cmake/sol2 # path to sol2-config.cmake
+    )
+    if (NOT sol2_FOUND)
+        message(FATAL_ERROR "Sol2 not found")
+    endif()
+
+    set(SOL_INCLUDE_DIR "${SOL2_INCLUDE_DIRS}" PARENT_SCOPE)
+    return()
+endif()
+
 message(STATUS "<sol2>")
 
 # create getter


### PR DESCRIPTION
These are needed for the OpenBSD package. Other systems will probably want them too to avoid embedded dependencies, FreeBSD for instance patched the source locally: https://cgit.freebsd.org/ports/tree/games/jaggedalliance2/files?id=a50372b91f2b327f3bc400d088e21f4b18c2a112
