### PR TITLE
[0.19.x] update miniaudio to 0.10.43

### DIFF
--- a/dependencies/lib-miniaudio/CMakeLists.txt
+++ b/dependencies/lib-miniaudio/CMakeLists.txt
@@ -22,18 +22,24 @@ if (NOT LOCAL_MINIAUDIO_LIB)
     endif()
 
     include(CheckCXXSourceCompiles)
+
+    # miniaudio doesn't do semver properly, check if any miniaudio-related build
+    # failures have something to do with ABI changes that the semver doesn't
+    # suggest.
     CHECK_CXX_SOURCE_COMPILES(
         "
             #include <miniaudio.h>
             int main() {
                 static_assert(MA_VERSION_MAJOR == 0);
                 static_assert(MA_VERSION_MINOR == 10);
+                static_assert(MA_VERSION_REVISION >= 43);
             }
         "
         HAVE_MA_VERSION
     )
     if (NOT HAVE_MA_VERSION)
-        message(FATAL_ERROR "miniaudio does not have correct version, should be 0.10.x")
+        message(FATAL_ERROR "miniaudio does not have correct version, should be
+        >= 0.10.43")
     endif()
 
     set(MINIAUDIO_INCLUDE_DIRS "${MINIAUDIO_INCLUDE_DIR}" PARENT_SCOPE)

--- a/dependencies/lib-miniaudio/getter/CMakeLists.txt.in
+++ b/dependencies/lib-miniaudio/getter/CMakeLists.txt.in
@@ -12,9 +12,9 @@ project(getter NONE)
 
 include(ExternalProject)
 externalproject_add(get-miniaudio
-    # This is version 0.10.20
-    URL "https://github.com/mackron/miniaudio/archive/634cdb028f340075ae8e8a1126620695688d2ac3.zip"
-    URL_MD5 "b30045e95cec65bfe1d9fe3639f480a2"
+    # This is version 0.10.43
+    URL "https://github.com/mackron/miniaudio/archive/8686f52e6625e562f4756b946696692c016324ab.zip"
+    URL_MD5 "7e682c814564dd64ee05dc34130a0e15"
     CMAKE_ARGS
         "-G@CMAKE_GENERATOR@"
         SOURCE_DIR          "@SRC_DIR@"

--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -106,7 +106,7 @@ struct SAMPLETAG
 	UINT32 uiBufferSize; // The size of the in-memory buffer
 	ma_format eInMemoryFormat;
 	UINT32 uiInMemoryChannels;
-	
+
 	ma_data_converter* pDataConverter; // pointer to a data converter that decodes the data from pData
 
 	SGPFile* pFile;  // pointer to a SDL_RWops representing the file that we stream from
@@ -498,7 +498,7 @@ static void FillRingBuffer(SOUNDTAG* channel) {
 			// We might not have as many bytes available
 			auto availableFrames = MIN(requiredInputFrameCount * bytesPerFrame, sample->uiBufferSize - posInBytes) / bytesPerFrame;
 			auto expectedOutputFrameCount = ma_data_converter_get_expected_output_frame_count(sample->pDataConverter, availableFrames);
-			
+
 			auto result = ma_data_converter_process_pcm_frames(
 				sample->pDataConverter,
 				sample->pInMemoryBuffer + posInBytes,
@@ -696,7 +696,7 @@ size_t MiniaudioReadProc(ma_decoder* pDecoder, void* pBufferOut, size_t bytesToR
 	return SDL_RWread(rwOps, pBufferOut, sizeof(UINT8), bytesToRead);
 }
 
-ma_bool32 MiniaudioSeekProc(ma_decoder* pDecoder, int byteOffset, ma_seek_origin origin) {
+ma_bool32 MiniaudioSeekProc(ma_decoder* pDecoder, ma_int64 byteOffset, ma_seek_origin origin) {
 	auto rwOps = (SDL_RWops*)pDecoder->pUserData;
 	auto sdlOrigin = RW_SEEK_SET;
 	if (origin == ma_seek_origin::ma_seek_origin_current) {
@@ -733,7 +733,7 @@ static SAMPLETAG* SoundLoadDisk(const char* pFilename)
 	{
 		auto isStreamed = TRUE;
 		SAMPLETAG* s = SoundGetEmptySample();
-		
+
 		// if we don't have a sample slot
 		if (s == NULL)
 		{
@@ -1027,7 +1027,7 @@ static BOOLEAN SoundInitHardware(void)
 
 		SDL_PauseAudio(0);
 		return TRUE;
-		
+
 	} catch (const std::runtime_error& err) {
 		SLOGE(ST::format(
 			"SoundInitHardware: {}",

--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -944,13 +944,13 @@ static void SoundCallback(void* userdata, Uint8* stream, int len)
 					gMixBuffer[2 * i + 1] += src[2 * i + 1] * vol_r >> 7;
 				}
 
-				if (samples < want_samples) {
+				rbResult = ma_pcm_rb_commit_read(Sound->pRingBuffer, samples, (void**)src);
+				if (samples < want_samples || rbResult == MA_AT_END) {
 					Sound->State = CHANNEL_DEAD;
 				}
 
-				rbResult = ma_pcm_rb_commit_read(Sound->pRingBuffer, samples, (void**)src);
-				if (rbResult != MA_SUCCESS) {
-					SLOGE("Could not commit read pointer for channel %d: %s", Sound - pSoundList, ma_result_description(rbResult));
+				if (rbResult != MA_SUCCESS && rbResult != MA_AT_END) {
+					SLOGE("Could not commit read pointer for channel {}: {}", Sound - pSoundList, ma_result_description(rbResult));
 				} else {
 					ringBuffersNeedService |= DoesChannelRingBufferNeedService(Sound);
 				}


### PR DESCRIPTION
Somewhere between versions 0.10.20 and 0.10.43, miniaudio changed the
type of the ma_decoder_seek_proc function type's 2nd parameter from int
to ma_int64. That's an ABI breakage warranting a major version bump, but
the project only bumped the patch version.

The latest Stracciatella master already runs on the latest miniaudio
version which is 0.11.9, but Stracciatella 0.19.x needs to update to
0.10.43 because package maintainers will try to package the latest
0.10.x miniaudio to satisfy the dependency and that causes a compile
error.