### PR TITLE
Fix OOB in AIMHistory

### DIFF
--- a/src/game/Laptop/AIMHistory.cc
+++ b/src/game/Laptop/AIMHistory.cc
@@ -61,7 +61,8 @@ static SGPVObject* guiContentButton;
 static UINT8   gubCurPageNum;
 static BOOLEAN gfInToc =  FALSE;
 static BOOLEAN gfExitingAimHistory;
-static BOOLEAN AimHistorySubPagesVisitedFlag[NUM_AIM_HISTORY_PAGES];
+// This flag gets set for the TOC and the actual history pages, therefore we need one more
+static BOOLEAN AimHistorySubPagesVisitedFlag[NUM_AIM_HISTORY_PAGES + 1];
 
 
 static MOUSE_REGION gSelectedHistoryTocMenuRegion[NUM_AIM_HISTORY_PAGES];
@@ -99,7 +100,7 @@ enum AimHistoryTextLocations
 
 void EnterInitAimHistory()
 {
-	std::fill_n(AimHistorySubPagesVisitedFlag, NUM_AIM_HISTORY_PAGES, 0);
+	std::fill(std::begin(AimHistorySubPagesVisitedFlag), std::end(AimHistorySubPagesVisitedFlag), 0);
 }
 
 


### PR DESCRIPTION
NUM_AIM_HISTORY_PAGES includes only the actual history pages without the TOC
but the 'visited' flag is also set for the TOC page.

Turns out ASAN is quite useful even when I can't enter the tactical screen. This problem was already found but not fixed correctly in #892, and then got exposed again by #1578.