### PR TITLE
Add integration points to change shop inventories and prices

### DIFF
--- a/src/externalized/scripting/FunctionsLibrary.cc
+++ b/src/externalized/scripting/FunctionsLibrary.cc
@@ -1,4 +1,5 @@
 #include "FunctionsLibrary.h"
+#include "Arms_Dealer_Init.h"
 #include "Campaign_Types.h"
 #include "Handle_Items.h"
 #include "Item_Types.h"
@@ -102,4 +103,26 @@ void PutGameStates(const std::string key, ExtraGameStatesTable const states)
 		else if (auto *f = std::get_if<float>(&v)) storables[k] = *f;
 	}
 	g_gameStates.Set(ST::format("scripts:{}", key), storables);
+}
+
+void GuaranteeAtLeastXItemsOfIndex(ArmsDealerID, UINT16, UINT8);
+void GuaranteeAtLeastXItemsOfIndex_(INT8 const bDealerID, UINT16 const usItemIndex, UINT8 const ubNumItems)
+{
+	GuaranteeAtLeastXItemsOfIndex((ArmsDealerID)bDealerID, usItemIndex, ubNumItems);
+}
+
+void RemoveRandomItemFromArmsDealerInventory(ArmsDealerID, UINT16, UINT8);
+void RemoveRandomItemFromDealerInventory(INT8 bDealerID, UINT16 usItemIndex, UINT8 ubHowMany)
+{
+	RemoveRandomItemFromArmsDealerInventory((ArmsDealerID)bDealerID, usItemIndex, ubHowMany);
+}
+
+std::vector<DEALER_ITEM_HEADER*> GetDealerInventory(UINT8 ubDealerID)
+{
+	std::vector<DEALER_ITEM_HEADER*> items{};
+	for (DEALER_ITEM_HEADER& i : gArmsDealersInventory[ubDealerID])
+	{
+		items.push_back(&i);
+	}
+	return items;
 }

--- a/src/externalized/scripting/FunctionsLibrary.h
+++ b/src/externalized/scripting/FunctionsLibrary.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Arms_Dealer.h"
+#include "Item_Types.h"
 #include "Types.h"
 #include "Observable.h"
 #include <variant>
@@ -23,6 +25,13 @@ struct SOLDIERTYPE;
 /*! \struct STRUCTURE
     \brief An structure element on the tactical map */
 struct STRUCTURE;
+
+/*! \defgroup funclib-dealers Shops and arms dealers
+    \brief Manage behavior, inventory and prices of dealers */
+
+/*! \struct DEALER_ITEM_HEADER
+    \brief An item in dealer's inventory */
+struct DEALER_ITEM_HEADER;
 
 /**
  * @defgroup observables Observables
@@ -76,16 +85,45 @@ extern Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT8, BOOLEAN> OnStruc
 
 /**
  * When the game about to be saved. This is the place to persist mod game states.
+ * @ingroup observables
  */
 extern Observable<> BeforeGameSaved;
 
 /**
  * Right after a game is loaded. This is the place to restore game states from a saved game.
+ * @ingroup observables
  */
 extern Observable<> OnGameLoaded;
 
+/**
+ * When a dealer/shopkeeper's inventory has been updated
+ * @ingroup observables
+ */
+extern Observable<> OnDealerInventoryUpdated;
+
+/**
+ * Calls for each item transferred from a dealer in a transaction
+ * @param bSelectedArmsDealerID ID of the dealer
+ * @param sItemIndex ID of the item being transacted
+ * @param fDealerSelling TRUE if the dealer is selling to the player. FALSE if the dealer is buying
+ * @ingroup observables
+ */
+extern Observable<INT8, UINT16, BOOLEAN> OnItemTransacted;
+
+/**
+ * Called when an item is being priced by a shopkeeper.
+ * The basic calculation already done at this point, and this gives an opportunity to modify the
+ * final unit price, to give special discounts, etc.
+ * @param gbSelectedArmsDealerID ID of the dealer
+ * @param usItemID ID of the item being priced
+ * @param fDealerSelling TRUE if the dealer is selling to the player. FALSE if the dealer is buying
+ * @param uiUnitPriceAdjusted The observer can override this value to change the item price
+ * @ingroup observables
+ */
+extern Observable<INT8, UINT16, BOOLEAN, UINT32_S*> OnItemPriced;
+
 /** @defgroup funclib-sectors Map sectors
- *  @brief Access and alter sectors' stratgic-level data
+ *  @brief Access and alter sectors' strategic-level data
  */
 
 /**
@@ -155,3 +193,30 @@ ExtraGameStatesTable GetGameStates(std::string key);
  * @param states a map of primitive types (string, numeric or boolean)
  */
 void PutGameStates(std::string key, ExtraGameStatesTable states);
+
+/**
+ * Refreshes the stocks and cash of all dealers.
+ * @ingroup funclib-dealers
+ */
+void DailyCheckOnItemQuantities();
+
+/**
+ * Make at least X number of the given item available to buy.
+ * @param bDealerID The ID of the dealer to update
+ * @param usItemIndex The index of the Item
+ * @param ubNumItems At least this Number of items will exist in the dealer's inventory
+ * @ingroup funclib-dealers
+ */
+void GuaranteeAtLeastXItemsOfIndex_(INT8, UINT16, UINT8);
+
+/** @ingroup funclib-dealers */
+void RemoveRandomItemFromDealerInventory(INT8 bArmsDealerID, UINT16 usItemIndex, UINT8 ubHowMany);
+
+/** @ingroup funclib-dealers */
+std::vector<DEALER_ITEM_HEADER*> GetDealerInventory(UINT8 ubDealerID);
+
+/** @ingroup funclib-dealers */
+BOOLEAN StartShopKeeperTalking(UINT16 usQuoteNum);
+
+/** @ingroup funclib-dealers */
+void EnterShopKeeperInterfaceScreen(UINT8 ubArmsDealer);

--- a/src/externalized/scripting/ScriptingExtensions.h
+++ b/src/externalized/scripting/ScriptingExtensions.h
@@ -8,7 +8,7 @@
  *
  * # Example
  * 
- * Lua scripting engine is enabled if your mod must provide scripts/main.lua
+ * Lua scripting engine is enabled if your mod provides scripts/main.lua
  * 
  * ```lua
  * -- Imports the enums.lua provided by the base game

--- a/src/externalized/scripting/ScriptingExtensionsLua.cc
+++ b/src/externalized/scripting/ScriptingExtensionsLua.cc
@@ -7,6 +7,7 @@
 #include <sol/sol.hpp>  // this needs to be included first
 #include "STStringHandler.h"
 
+#include "Arms_Dealer_Init.h"
 #include "Campaign_Types.h"
 #include "ContentManager.h"
 #include "FileMan.h"
@@ -219,12 +220,24 @@ static void RegisterUserTypes()
 		"ubBattleSoundID", &SOLDIERTYPE::ubBattleSoundID
 		);
 
+	lua.new_usertype<DEALER_ITEM_HEADER>("DEALER_ITEM_HEADER",
+		"ubTotalItems", &DEALER_ITEM_HEADER::ubTotalItems,
+		"ubPerfectItems", &DEALER_ITEM_HEADER::ubPerfectItems,
+		"ubStrayAmmo", &DEALER_ITEM_HEADER::ubStrayAmmo,
+		"uiOrderArrivalTime", &DEALER_ITEM_HEADER::uiOrderArrivalTime,
+		"ubQtyOnOrder", &DEALER_ITEM_HEADER::ubQtyOnOrder,
+		"fPreviouslyEligible", &DEALER_ITEM_HEADER::fPreviouslyEligible
+		);
+
 	lua.new_usertype<BOOLEAN_S>("BOOLEAN_S",
 		"val", &BOOLEAN_S::val
 		);
 	lua.new_usertype<UINT8_S>("UINT8_S",
 		"val", &UINT8_S::val
 		);
+	lua.new_usertype<UINT32_S>("UINT32_S",
+		"val", &UINT32_S::val
+	)	;
 }
 
 static void RegisterGlobals()
@@ -244,6 +257,13 @@ static void RegisterGlobals()
 
 	lua.set_function("GetGameStates", GetGameStates);
 	lua.set_function("PutGameStates", PutGameStates);
+
+	lua.set_function("DailyCheckOnItemQuantities", DailyCheckOnItemQuantities);
+	lua.set_function("GuaranteeAtLeastXItemsOfIndex", GuaranteeAtLeastXItemsOfIndex_);
+	lua.set_function("RemoveRandomItemFromDealerInventory", RemoveRandomItemFromDealerInventory);
+	lua.set_function("GetDealerInventory", GetDealerInventory);
+	lua.set_function("StartShopKeeperTalking", StartShopKeeperTalking);
+	lua.set_function("EnterShopKeeperInterfaceScreen", EnterShopKeeperInterfaceScreen);
 
 	lua.set_function("dofile",   []() { throw std::logic_error("dofile is not allowed. Use require instead"); });
 	lua.set_function("loadfile", []() { throw std::logic_error("loadfile is not allowed. Use require instead"); });
@@ -328,6 +348,9 @@ static void _RegisterListener(std::string observable, std::string luaFunc, ST::s
 	else if (observable == "OnSoldierCreated")           OnSoldierCreated.addListener(key, wrap<SOLDIERTYPE*>(luaFunc));
 	else if (observable == "BeforeGameSaved")            BeforeGameSaved.addListener(key, wrap<>(luaFunc));
 	else if (observable == "OnGameLoaded")               OnGameLoaded.addListener(key, wrap<>(luaFunc));
+	else if (observable == "OnDealerInventoryUpdated")   OnDealerInventoryUpdated.addListener(key, wrap<>(luaFunc));
+	else if (observable == "OnItemTransacted")           OnItemTransacted.addListener(key, wrap<INT8, UINT16, BOOLEAN>(luaFunc));
+	else if (observable == "OnItemPriced")               OnItemPriced.addListener(key, wrap<INT8, UINT16, BOOLEAN, UINT32_S*>(luaFunc));
 	else {
 		ST::string err = ST::format("There is no observable named '{}'", observable);
 		throw std::logic_error(err.to_std_string());

--- a/src/game/Tactical/Arms_Dealer_Init.cc
+++ b/src/game/Tactical/Arms_Dealer_Init.cc
@@ -12,7 +12,7 @@
 #include "Quests.h"
 #include "Scheduling.h"
 #include "Items.h"
-
+#include "Observable.h"
 #include "ContentManager.h"
 #include "DealerInventory.h"
 #include "DealerModel.h"
@@ -44,6 +44,7 @@ UINT8 gubLastSpecialItemAddedAtElement = 255;
 ARMS_DEALER_STATUS gArmsDealerStatus[ NUM_ARMS_DEALERS ];
 DEALER_ITEM_HEADER gArmsDealersInventory[ NUM_ARMS_DEALERS ][ MAXITEMS ];
 
+Observable<> OnDealerInventoryUpdated;
 
 static void AdjustCertainDealersInventory(void);
 static void InitializeOneArmsDealer(ArmsDealerID);
@@ -241,7 +242,7 @@ void LoadArmsDealerInventoryFromSavedGameFile(HWFILE const f, UINT32 const saveg
 
 
 static void ConvertCreatureBloodToElixir(void);
-static void DailyCheckOnItemQuantities(void);
+void DailyCheckOnItemQuantities();
 static void SimulateArmsDealerCustomer(void);
 
 
@@ -324,7 +325,7 @@ static void SimulateArmsDealerCustomer(void)
 }
 
 
-static void DailyCheckOnItemQuantities(void)
+void DailyCheckOnItemQuantities()
 {
 	UINT16  usItemIndex;
 	UINT8   ubMaxSupply;
@@ -488,11 +489,13 @@ static void AdjustCertainDealersInventory(void)
 	{
 		GuaranteeAtLeastXItemsOfIndex( ARMS_DEALER_FRANZ, VIDEO_CAMERA, 1 );
 	}
+
+	OnDealerInventoryUpdated();
 }
 
 
 static UINT32 GetArmsDealerItemTypeFromItemNumber(UINT16 usItem);
-static void RemoveRandomItemFromArmsDealerInventory(ArmsDealerID, UINT16 usItemIndex, UINT8 ubHowMany);
+void RemoveRandomItemFromArmsDealerInventory(ArmsDealerID, UINT16 usItemIndex, UINT8 ubHowMany);
 
 
 static void LimitArmsDealersInventory(ArmsDealerID const ubArmsDealer, UINT32 uiDealerItemType, UINT8 ubMaxNumberOfItemType)
@@ -1563,7 +1566,7 @@ void RemoveItemFromArmsDealerInventory(ArmsDealerID const ubArmsDealer, UINT16 c
 }
 
 
-static void RemoveRandomItemFromArmsDealerInventory(ArmsDealerID const ubArmsDealer, UINT16 const usItemIndex, UINT8 ubHowMany)
+void RemoveRandomItemFromArmsDealerInventory(ArmsDealerID const ubArmsDealer, UINT16 const usItemIndex, UINT8 ubHowMany)
 {
 	UINT8 ubWhichOne;
 	UINT8 ubSkippedAlready;

--- a/src/sgp/Types.h
+++ b/src/sgp/Types.h
@@ -207,5 +207,6 @@ namespace _Types
 
 typedef _Types::BoxedValue<BOOLEAN> BOOLEAN_S;
 typedef _Types::BoxedValue<UINT8>   UINT8_S;
+typedef _Types::BoxedValue<UINT32>  UINT32_S;
 
 #endif


### PR DESCRIPTION
# Summary

- Adding a couple of observables so mods can update dealers items and prices
- Exposing a few functions to manipulate shop keeper behaviour and their inventories
- Added support for passing UINT32 values to and from Lua

These should do nothing on its own, but allow Lua scripts to override items and prices. They allow mod support for things like Unfinished Business ([PATCH132](https://github.com/ja2-derek/ja2-ub-comparison/commit/70809a14)), and also #1205.


# Usage example

```lua
RegisterListener("OnDealerInventoryUpdated", "adjust_franz_inventory")

ARMS_DEALER_FRANZ = 2

-- Check every morning, and ensure Franz has a VideoCam to sell if the robot quest is started
function adjust_franz_inventory()
	if gubQuest[Quests.QUEST_DELIVER_VIDEO_CAMERA] == QuestStatuses.QUESTINPROGRESS then
		GuaranteeAtLeastXItemsOfIndex(ARMS_DEALER_FRANZ, Items.VIDEO_CAMERA, 1)
	end
end
```
