### PR TITLE
Try to avoid false positives from coverity scans

### DIFF
--- a/src/sgp/Debug.h
+++ b/src/sgp/Debug.h
@@ -7,7 +7,21 @@
 #define DEBUG_PRINT_FPS                         (0)             /**< Flag telling to print FPS (Frames per second) counter. */
 #define DEBUG_PRINT_GAME_CYCLE_TIME             (0)             /**< Flag telling to print how much time every game cycle takes. */
 
+// Don't ever define __COVERITY__. It is needed to avoid false positives during
+// a coverity scan from patterns like
+//
+//   Assert(p);
+//   p->something = 0;
+//
+// https://community.synopsys.com/s/question/0D534000046YuzbCAC/suppressing-assertsideeffect-for-functions-that-allow-for-sideeffects
+
+#ifndef __COVERITY__
 #define Assert(a)       (a) ? (void)0 : SLOGA("Assertion failed in {}, line {}", __FILE__, __LINE__)
 #define AssertMsg(a, b) (a) ? (void)0 : SLOGA("Assertion failed in {}, line {}:\n{}", __FILE__, __LINE__, b)
+#else
+extern void __coverity_panic__(void);
+#define Assert(condition)         (condition) ? (void)0 : __coverity_panic__()
+#define AssertMsg(condition, msg) (condition) ? (void)0 : __coverity_panic__()
+#endif
 
 #endif


### PR DESCRIPTION
Using Assert and AssertMsg can lead coverity scans to assume that the condition
we asserted could be false. For example

Assert(ptr); if (ptr->something == 0) ....

could create a defect report.

If this works as well as I hope it does, it should eliminate reduce the number of open defects quite a bit.
