### PR TITLE
Functions to make message boxes in Lua

### DIFF
--- a/src/externalized/scripting/FunctionsLibrary.cc
+++ b/src/externalized/scripting/FunctionsLibrary.cc
@@ -4,6 +4,8 @@
 #include "Handle_Items.h"
 #include "Item_Types.h"
 #include "Items.h"
+#include "JAScreens.h"
+#include "MessageBoxScreen.h"
 #include "Queen_Command.h"
 #include "SaveLoadGameStates.h"
 #include "StrategicMap.h"
@@ -125,4 +127,16 @@ std::vector<DEALER_ITEM_HEADER*> GetDealerInventory(UINT8 ubDealerID)
 		items.push_back(&i);
 	}
 	return items;
+}
+
+void DoScreenIndependantMessageBox(const ST::string &, MessageBoxFlags, MSGBOX_CALLBACK);
+void DoBasicMessageBox(const ST::string text)
+{
+	DoScreenIndependantMessageBox(text, MSG_BOX_FLAG_OK, NULL);
+}
+
+void ExecuteTacticalTextBox(INT16 sLeftPosition, INT16 sTopPosition, const ST::string &pString);
+void ExecuteTacticalTextBox_(INT16 sLeftPosition, INT16 sTopPosition, ST::string pString)
+{
+	ExecuteTacticalTextBox(sLeftPosition, sTopPosition, pString);
 }

--- a/src/externalized/scripting/FunctionsLibrary.h
+++ b/src/externalized/scripting/FunctionsLibrary.h
@@ -220,3 +220,26 @@ BOOLEAN StartShopKeeperTalking(UINT16 usQuoteNum);
 
 /** @ingroup funclib-dealers */
 void EnterShopKeeperInterfaceScreen(UINT8 ubArmsDealer);
+
+/**
+ * @defgroup ui-control UI controls
+ * @brief Functions for controlling the game UI
+ */
+
+/**
+ * Pops up a basic message box with only the text and an OK button. There is no callback on close and returns the control
+ * flow to the current screen. This is for messages that requires player's immediate attention.
+ * @param text
+ * @ingroup ui-control
+ */
+void DoBasicMessageBox(ST::string text);
+
+/**
+ * Displays a pop-up text box in the tactical view. This is suitable for storytelling, or describing a scene, situation
+ * or items. In Lua, this function is ExecuteTacticalTextBox.
+ * @param sLeftPosition On-screen X-position of the text box
+ * @param sTopPosition On-screen Y-position of the text box
+ * @param pString Text to display
+ * @ingroup ui-control
+ */
+void ExecuteTacticalTextBox_(INT16 sLeftPosition, INT16 sTopPosition, ST::string pString);

--- a/src/externalized/scripting/ScriptingExtensionsLua.cc
+++ b/src/externalized/scripting/ScriptingExtensionsLua.cc
@@ -255,6 +255,9 @@ static void RegisterGlobals()
 	lua.set_function("CreateMoney", CreateMoney);
 	lua.set_function("PlaceItem", PlaceItem);
 
+	lua.set_function("DoBasicMessageBox", DoBasicMessageBox);
+	lua.set_function("ExecuteTacticalTextBox", ExecuteTacticalTextBox_);
+
 	lua.set_function("GetGameStates", GetGameStates);
 	lua.set_function("PutGameStates", PutGameStates);
 

--- a/src/game/Tactical/Dialogue_Control.cc
+++ b/src/game/Tactical/Dialogue_Control.cc
@@ -949,7 +949,7 @@ static void HandleTacticalNPCTextUI(UINT8 ubCharacterNum, const ST::string& zQuo
 }
 
 
-static void ExecuteTacticalTextBox(INT16 sLeftPosition, INT16 sTopPosition, const ST::string& pString);
+void ExecuteTacticalTextBox(INT16 sLeftPosition, INT16 sTopPosition, const ST::string& pString);
 
 
 // Handlers for tactical UI stuff
@@ -1002,7 +1002,7 @@ static void RenderSubtitleBoxOverlay(VIDEO_OVERLAY* pBlitter);
 static void TextOverlayClickCallback(MOUSE_REGION* pRegion, INT32 iReason);
 
 
-static void ExecuteTacticalTextBox(INT16 sLeftPosition, INT16 sTopPosition, const ST::string& pString)
+void ExecuteTacticalTextBox(INT16 sLeftPosition, INT16 sTopPosition, const ST::string& pString)
 {
 	// check if mouse region created, if so, do not recreate
 	if (fTextBoxMouseRegionCreated) return;


### PR DESCRIPTION
Exposes 2 functions to Lua, so mods can create message pop-ups. See also #1205.

- DoBasicMessageBox - based on [DoScreenIndependantMessageBox](https://github.com/ja2-stracciatella/ja2-stracciatella/blob/e23678b74af7e7fa2ccaf067eb44993184af0a33/src/game/MessageBoxScreen.cc#L589)
- [ExecuteTacticalTextBox](https://github.com/ja2-stracciatella/ja2-stracciatella/blob/c3d48e93b9e6c4509ff5d9816594b50243504c75/src/game/Tactical/Dialogue_Control.cc#L952)

----

![-DoBasicMessageBox](https://user-images.githubusercontent.com/63151803/179705140-c6eee934-c56f-4e4a-9a3e-2b8fad921c99.png)
![-ExecuteTacticalTextBox](https://user-images.githubusercontent.com/63151803/179705156-06cdd753-eaca-4149-adae-ca074ee68c33.png)
 