### PR TITLE
Let Auto Resolve free the soldiers created for it

### DIFF
--- a/src/game/Strategic/Auto_Resolve.cc
+++ b/src/game/Strategic/Auto_Resolve.cc
@@ -1639,6 +1639,15 @@ static bool IsAnybodyWounded()
 }
 
 
+static void DeleteAutoResolveSoldier(SOLDIERTYPE *const s)
+{
+	// All Auto Resolve soldiers created in Soldier_Create have id #255
+	if (s->ubID != 255) throw std::logic_error("Trying to delete a non-AR soldier");
+	TacticalRemoveSoldier(*s);
+	delete s;
+}
+
+
 static void RemoveAutoResolveInterface(bool const delete_for_good)
 {
 	AUTORESOLVE_STRUCT& ar = *gpAR;
@@ -1671,7 +1680,7 @@ static void RemoveAutoResolveInterface(bool const delete_for_good)
 			SOLDIERTYPE& s = *gpMercs[i].pSoldier;
 			if (i >= ar.iActualMercFaces)
 			{
-				TacticalRemoveSoldier(s);
+				DeleteAutoResolveSoldier(&s);
 			}
 			else
 			{ // Record finishing information for our mercs
@@ -1781,7 +1790,7 @@ static void RemoveAutoResolveInterface(bool const delete_for_good)
 				}
 			}
 		}
-		TacticalRemoveSoldier(s);
+		DeleteAutoResolveSoldier(&s);
 		gpCivs[i] = SOLDIERCELL{};
 	}
 
@@ -1823,7 +1832,7 @@ static void RemoveAutoResolveInterface(bool const delete_for_good)
 	{
 		SOLDIERCELL& slot = gpEnemies[i];
 		if (!slot.pSoldier) continue;
-		TacticalRemoveSoldier(*slot.pSoldier);
+		DeleteAutoResolveSoldier(slot.pSoldier);
 		slot = SOLDIERCELL{};
 	}
 
@@ -2212,7 +2221,7 @@ static void ResetAutoResolveInterface(void)
 	while( gpAR->iNumMercFaces > gpAR->ubMercs && gpAR->iNumMercFaces > gpAR->iActualMercFaces )
 	{ //Removing temp mercs
 		gpAR->iNumMercFaces--;
-		TacticalRemoveSoldier(*gpMercs[gpAR->iNumMercFaces].pSoldier);
+		DeleteAutoResolveSoldier(gpMercs[gpAR->iNumMercFaces].pSoldier);
 		gpMercs[gpAR->iNumMercFaces].pSoldier = NULL;
 	}
 	while( gpAR->iNumMercFaces < gpAR->ubMercs && gpAR->iNumMercFaces >= gpAR->iActualMercFaces )

--- a/src/game/Tactical/Animation_Cache.cc
+++ b/src/game/Tactical/Animation_Cache.cc
@@ -6,19 +6,10 @@
 #include "Overhead.h"
 #include <climits>
 
-#define EMPTY_CACHE_ENTRY 65000
 
-
-void AnimationSurfaceCacheType::init(ProfileID const pid)
+void AnimationSurfaceCacheType::init(UINT8 const pid)
 {
 	mPid = pid;
-
-	// Zero entries
-	for ( int cnt = 0; cnt < ANIM_CACHE_SIZE; cnt++ )
-	{
-		usCachedSurfaces[ cnt ] = EMPTY_CACHE_ENTRY;
-		sCacheHits[ cnt ] = 0;
-	}
 
 	// Zero surface database history for this soldier
 	ClearAnimationSurfacesUsageHistory( pid );

--- a/src/game/Tactical/Animation_Cache.h
+++ b/src/game/Tactical/Animation_Cache.h
@@ -4,19 +4,21 @@
 #include "JA2Types.h"
 
 constexpr int ANIM_CACHE_SIZE = 3;
-
+constexpr UINT16 EMPTY_CACHE_ENTRY = 65000;
 
 class AnimationSurfaceCacheType
 {
-	UINT16    usCachedSurfaces[ANIM_CACHE_SIZE];
-	INT16     sCacheHits[ANIM_CACHE_SIZE];
-	ProfileID mPid;
+	// Ensure cache state is valid even if init is never called
+	// (the special soldiers created by Auto Resolve)
+	UINT16    usCachedSurfaces[ANIM_CACHE_SIZE]{ EMPTY_CACHE_ENTRY, EMPTY_CACHE_ENTRY, EMPTY_CACHE_ENTRY };
+	INT16     sCacheHits[ANIM_CACHE_SIZE]{ 0, 0, 0 };
+	UINT8     mPid{ 0 };
 
 public:
 	// Load an animation surface if it is not already cached.
 	void cache(UINT16 usSurfaceIndex, UINT16 usCurrentAnimation);
 	// Init the animation cache for the specified soldier.
-	void init(ProfileID usSoldierID);
+	void init(UINT8 usSoldierID);
 	// Unload all cached animation surfaces.
 	void free();
 };

--- a/src/game/Tactical/Soldier_Create.cc
+++ b/src/game/Tactical/Soldier_Create.cc
@@ -999,10 +999,10 @@ void InternalTacticalRemoveSoldier(SOLDIERTYPE& s, BOOLEAN const fRemoveVehicle)
 
 		DeleteSoldier(s);
 	}
-	else
+	else if (gfPersistantPBI)
 	{
-		if (gfPersistantPBI) DeleteSoldier(s);
-		delete &s;
+		DeleteSoldier(s);
+		// Auto_Resolve.cc is now responsible for freeing the memory allocated for its soldiers
 	}
 }
 


### PR DESCRIPTION
Make it crystal clear that we're not freeing one of the soldiers from the Menptr
array. Also fix the (harmless) warnings caused by #1571.

CID 275310

About these warnings: the AR soldiers aren't fully initialized but `DeleteSoldier()` doesn't know about that and tries to free the animation cache. That makes `UnLoadAnimationSurface()` unhappy and causes it to print one warning for every AR soldier. Ugly. Now every AnimationCache is always in a valid state, no matter where the outer SOLDIERTYPE was created.

And `ProfileID` is used for Merc Profiles, not soldier ids. 