### PR TITLE
coverity: enable asserts

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -39,7 +39,7 @@ jobs:
           cd ${COV_BUILD_DIR}
           cmake ${CMAKE_BUILD_OPTIONS} ..
         env:
-          CMAKE_BUILD_OPTIONS: "-DCMAKE_BUILD_TYPE=Release -DUSE_SCCACHE=OFF"
+          CMAKE_BUILD_OPTIONS: "-DCMAKE_BUILD_TYPE=Release -DUSE_SCCACHE=OFF -DENABLE_ASSERTS"
 
       - name: Run Coverity Scan Analysis Tool
         run: |


### PR DESCRIPTION
Continuation of trying to get Assert* false positives to vanish.

In the meanwhile I played with various models, for example trying to manually provide the one function needed from the templating of LogMessageST, toyed with other ideas, but this is the simplest next attempt — just don't ifdef the assert out for coverity, since it's not analyzing a debug build.