### PR TITLE
Do not use abs() before hypot()

### DIFF
--- a/src/game/Tactical/Merc_Hiring.cc
+++ b/src/game/Tactical/Merc_Hiring.cc
@@ -452,15 +452,12 @@ void UpdateAnyInTransitMercsWithGlobalArrivalSector( )
 }
 
 
+// Return the line of the length from origin to dest, truncated to the nearest integer
 static INT16 StrategicPythSpacesAway(INT16 sOrigin, INT16 sDest)
 {
 	SGPSector delta = SGPSector::FromStrategicIndex(sOrigin) - SGPSector::FromStrategicIndex(sDest);
 
-	delta.x = std::abs(delta.x);
-	delta.y = std::abs(delta.y);
-
-	// apply Pythagoras's theorem for right-handed triangle:
-	return (INT16) std::hypot(delta.x, delta.y);
+	return static_cast<INT16>(std::hypot(delta.x, delta.y));
 }
 
 

--- a/src/game/Tactical/Soldier_Create.cc
+++ b/src/game/Tactical/Soldier_Create.cc
@@ -2110,11 +2110,7 @@ static UINT8 GetLocationModifier(UINT8 ubSoldierClass)
 		default:
 			// how far is this sector from the palace ?
 			// the distance returned is in sectors, and the possible range is about 0-20
-			ubPalaceDistance = GetPythDistanceFromPalace(sSector);
-			if ( ubPalaceDistance > MAX_PALACE_DISTANCE )
-			{
-				ubPalaceDistance = MAX_PALACE_DISTANCE;
-			}
+			ubPalaceDistance = std::min<UINT8>(GetPythDistanceFromPalace(sSector), MAX_PALACE_DISTANCE);
 	}
 
 	// adjust for distance from Queen's palace (P3) (0 to +30)
@@ -2124,30 +2120,15 @@ static UINT8 GetLocationModifier(UINT8 ubSoldierClass)
 }
 
 
-
 // grab the distance from the palace
 UINT8 GetPythDistanceFromPalace(const SGPSector& sSector)
 {
-	UINT8 ubDistance = 0;
-	INT16 sRows = 0, sCols = 0;
-	float fValue = 0.0;
-
 	// grab number of rows and cols
-	sRows =(INT16)(std::abs(sSector.x - PALACE_SECTOR_X));
-	sCols =(INT16)(std::abs(sSector.y - PALACE_SECTOR_Y));
+	INT16 const sCols = sSector.x - PALACE_SECTOR_X;
+	INT16 const sRows = sSector.y - PALACE_SECTOR_Y;
 
-	// apply Pythagoras's theorem for right-handed triangle:
-	fValue = (float) std::hypot(sRows, sCols);
-	if(  fmod( fValue, 1.0f ) >= 0.50 )
-	{
-		ubDistance = (UINT8)( 1 + fValue );
-	}
-	else
-	{
-		ubDistance = ( UINT8 )fValue;
-	}
-
-	return( ubDistance );
+	double const distance = std::hypot(sRows, sCols);
+	return static_cast<UINT8>(std::round(distance));
 }
 
 

--- a/src/game/TileEngine/Isometric_Utils.cc
+++ b/src/game/TileEngine/Isometric_Utils.cc
@@ -452,11 +452,10 @@ BOOLEAN IsPointInScreenRectWithRelative( INT16 sXPos, INT16 sYPos, SGPRect *pRec
 
 INT16 PythSpacesAway(INT16 sOrigin, INT16 sDest)
 {
-	INT16 sRows = std::abs((sOrigin / MAXCOL) - (sDest / MAXCOL));
-	INT16 sCols = std::abs((sOrigin % MAXROW) - (sDest % MAXROW));
+	INT16 const sRows = (sOrigin / MAXCOL) - (sDest / MAXCOL);
+	INT16 const sCols = (sOrigin % MAXROW) - (sDest % MAXROW);
 
-	// apply Pythagoras's theorem for right-handed triangle:
-	return (INT16) std::hypot(sRows, sCols);
+	return static_cast<INT16>(std::hypot(sRows, sCols));
 }
 
 

--- a/src/game/TileEngine/Physics.cc
+++ b/src/game/TileEngine/Physics.cc
@@ -1498,8 +1498,7 @@ static FLOAT CalculateObjectTrajectory(INT16 sTargetZ, const OBJECTTYPE* pItem, 
 		(*psFinalGridNo) = sGridNo;
 	}
 
-	return (FLOAT) std::hypot(dDiffX, dDiffY);
-
+	return std::hypotf(dDiffX, dDiffY);
 }
 
 


### PR DESCRIPTION
The sign of hypot's arguments has no influence on its result.

So `GetPythDistanceFromPalace()` rounds its result while the others truncate. I doubt that was a conscious decision by the developers back then but I also see no need to change the game logic now.