### PR TITLE
Let FindNearestEdgePoint try harder to find a suitable gridno

### DIFF
--- a/src/game/Strategic/Scheduling.cc
+++ b/src/game/Strategic/Scheduling.cc
@@ -660,14 +660,17 @@ static void AutoProcessSchedule(SCHEDULENODE* pSchedule, INT32 index)
 			break;
 		case SCHEDULE_ACTION_LEAVESECTOR:
 		{
-			INT16 sGridNo;
-			sGridNo = FindNearestEdgePoint( pSoldier->sGridNo );
-			BumpAnyExistingMerc( sGridNo );
-			EVENT_SetSoldierPositionNoCenter(pSoldier, sGridNo, SSP_FORCE_DELETE);
-
-			sGridNo = FindNearbyPointOnEdgeOfMap( pSoldier, &bDirection );
-			BumpAnyExistingMerc( sGridNo );
-			EVENT_SetSoldierPositionNoCenter(pSoldier, sGridNo, SSP_FORCE_DELETE);
+			GridNo sGridNo = FindNearestEdgePoint(pSoldier->sGridNo);
+			if (sGridNo != NOWHERE)
+			{
+				BumpAnyExistingMerc(sGridNo);
+				EVENT_SetSoldierPositionNoCenter(pSoldier, sGridNo, SSP_FORCE_DELETE);
+			}
+			else
+			{
+				// Stay in place
+				sGridNo = pSoldier->sGridNo;
+			}
 
 			// ok, that tells us where the civ will return
 			pSoldier->sOffWorldGridNo = sGridNo;

--- a/src/game/TacticalAI/AI.h
+++ b/src/game/TacticalAI/AI.h
@@ -158,7 +158,7 @@ INT8  ExecuteAction(SOLDIERTYPE *pSoldier);
 INT16 FindBestNearbyCover(SOLDIERTYPE *pSoldier, INT32 morale, INT32 *pPercentBetter);
 INT16 FindClosestDoor( SOLDIERTYPE * pSoldier );
 INT16 FindNearbyPointOnEdgeOfMap( SOLDIERTYPE * pSoldier, INT8 * pbDirection );
-INT16 FindNearestEdgePoint( INT16 sGridNo );
+GridNo FindNearestEdgePoint(GridNo);
 
 //Kris:  Added these as I need specific searches on certain sides.
 enum


### PR DESCRIPTION
Fixes #1631

To compare the result of the old and the new code I added some SLOGI statements to print the result of `FindNearestEdgePoint`.

This is the testcase in #1631 with the current code:

> 2022-08-04T07:51:54 [INFO] game/TacticalAI/FindLocations.cc: FNE: 7406
2022-08-04T07:51:54 [INFO] game/TacticalAI/FindLocations.cc: FNE: 7724
2022-08-04T07:51:54 [INFO] game/TacticalAI/FindLocations.cc: FNE: 6929
2022-08-04T07:51:54 [INFO] game/TacticalAI/FindLocations.cc: FNE: 25601
2022-08-04T07:51:54 [ERROR] game/Tactical/PathAI.cc: Trying to calculate path from off-world gridno 25601 to 25601
2022-08-04T07:51:54 [INFO] game/TacticalAI/FindLocations.cc: FNE: 25601
2022-08-04T07:51:54 [ERROR] game/Tactical/PathAI.cc: Trying to calculate path from off-world gridno 25601 to 25601
2022-08-04T07:51:54 [INFO] game/TacticalAI/FindLocations.cc: FNE: 8042
2022-08-04T07:51:54 [INFO] game/TacticalAI/FindLocations.cc: FNE: 11219
2022-08-04T07:51:54 [INFO] game/TacticalAI/FindLocations.cc: FNE: 10901

And this is the new function in action:

> 2022-08-04T07:49:23 [INFO] game/TacticalAI/FindLocations.cc: FNE: 7406
2022-08-04T07:49:23 [INFO] game/TacticalAI/FindLocations.cc: FNE: 7724
2022-08-04T07:49:23 [INFO] game/TacticalAI/FindLocations.cc: FNE: 6929
2022-08-04T07:49:23 [INFO] game/TacticalAI/FindLocations.cc: FNE: 5498
2022-08-04T07:49:23 [INFO] game/TacticalAI/FindLocations.cc: FNE: 7641
2022-08-04T07:49:23 [INFO] game/TacticalAI/FindLocations.cc: FNE: 8042
2022-08-04T07:49:23 [INFO] game/TacticalAI/FindLocations.cc: FNE: 11219
2022-08-04T07:49:23 [INFO] game/TacticalAI/FindLocations.cc: FNE: 10901