### PR TITLE
Fix display of the debug pages

### DIFF
--- a/src/game/Tactical/OppList.cc
+++ b/src/game/Tactical/OppList.cc
@@ -2806,7 +2806,6 @@ void DebugSoldierPage2()
 		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, "Visible:",     s->bVisible);
 		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, "Direction:",   gzDirectionStr[s->bDirection]);
 		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, "DesDirection", gzDirectionStr[s->bDesiredDirection]);
-		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, "GridNo:",      s->sGridNo);
 		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, "Dest:",        s->sFinalDestination);
 		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, "Path Size:",   s->ubPathDataSize);
 		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, "Path Index:",  s->ubPathIndex);
@@ -2988,7 +2987,6 @@ void DebugSoldierPage3()
 
 		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, "PrevAnimation:",      gAnimControl[s->usOldAniState].zAnimStr);
 		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, "PrevAniCode:",        gusAnimInst[s->usOldAniState][s->sOldAniCode]);
-		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, "GridNo:",             s->sGridNo);
 		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, "AniCode:",            gusAnimInst[s->usAnimState][s->usAniCode]);
 		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, "No APS To fin Move:", s->fNoAPToFinishMove);
 		MPrintStat(DEBUG_PAGE_SECOND_COLUMN, y += h, "Bullets out:",        s->bBulletsLeft);

--- a/src/game/Utils/Debug_Pages.cc
+++ b/src/game/Utils/Debug_Pages.cc
@@ -25,27 +25,30 @@ void MHeader(INT32 x, INT32 y, const ST::string& header)
 
 void MPrintStat(INT32 x, INT32 y, const ST::string& header, INT32 val)
 {
-	MHeader(x, y, header);
-	MPrint(x+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("{}", val));
+	MPrintStat(x, y, header, ST::format("{}", val));
 }
 
 
 void MPrintStat(INT32 x, INT32 y, const ST::string& header, const ST::string& val)
 {
 	MHeader(x, y, header);
-	MPrint(x+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("{}", val));
+	MPrint(x+DEBUG_PAGE_LABEL_WIDTH, y, val);
+}
+
+
+void MPrintStat(INT32 const x, INT32 const y, ST::string const& header, char const* const val)
+{
+	MPrintStat(x, y, header, ST::string{val});
 }
 
 
 void MPrintStat(INT32 x, INT32 y, const ST::string& header, const void* val)
 {
-	MHeader(x, y, header);
-	MPrint(x+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("{#x}", reinterpret_cast<uintptr_t>(val)));
+	MPrintStat(x, y, header, ST::format("{#x}", reinterpret_cast<uintptr_t>(val)));
 }
 
 
 void MPrintStat(INT32 x, INT32 y, const ST::string& header, INT32 const val, INT32 const effective_val)
 {
-	MHeader(x, y, header);
-	MPrint(x+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("{} ( {} )", val, effective_val));
+	MPrintStat(x, y, header, ST::format("{} ( {} )", val, effective_val));
 }

--- a/src/game/Utils/Debug_Pages.h
+++ b/src/game/Utils/Debug_Pages.h
@@ -22,6 +22,7 @@ void MPageHeader(const ST::string& header);
 void MHeader(INT32 x, INT32 y, const ST::string& header);
 void MPrintStat(INT32 x, INT32 y, const ST::string& header, INT32 val);
 void MPrintStat(INT32 x, INT32 y, const ST::string& header, const ST::string& val);
+void MPrintStat(INT32 x, INT32 y, const ST::string& header, char const* val);
 void MPrintStat(INT32 x, INT32 y, const ST::string& header, const void* val);
 void MPrintStat(INT32 x, INT32 y, const ST::string& header, INT32 val, INT32 effective_val);
 


### PR DESCRIPTION
Print the actual debug strings, not their addresses.

Before:
![Screenshot_Before](https://user-images.githubusercontent.com/25463312/183014540-87415354-35e4-47e0-8b7c-6b48f6cc235d.jpg)

After:
![Screenshot_After](https://user-images.githubusercontent.com/25463312/183014598-61027c2e-9b08-4693-853d-bc131e4edf88.jpg)
.