### PR TITLE
Fix seven more Coverity issues

### DIFF
--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -1114,17 +1114,19 @@ void LoadSavedGame(const ST::string &saveName)
 		if (s) TacticalRemoveSoldier(*s);
 
 		// add the pilot at a random location!
-		SGPSector sMap;
+		// use B15 as fallback sector just in case we can't get a placement sector from GCM.
+		SGPSector sMap{SEC_B15};
 		auto placement = GCM->getNpcPlacement(SKYRIDER);
 		if (placement)
 		{
 			auto sector = placement->pickPlacementSector();
-
-			if (placement->useAlternateMap) SectorInfo[sector].uiFlags |= SF_USE_ALTERNATE_MAP;
-			sMap = SGPSector(sector);
+			if (sector != -1)
+			{
+				if (placement->useAlternateMap) SectorInfo[sector].uiFlags |= SF_USE_ALTERNATE_MAP;
+				sMap = SGPSector(sector);
+			}
 		}
-		MERCPROFILESTRUCT& p = GetProfile(SKYRIDER);
-		p.sSector = sMap;
+		GetProfile(SKYRIDER).sSector = sMap;
 	}
 
 	if (version < 68)

--- a/src/game/SaveLoadGame_unittest.cc
+++ b/src/game/SaveLoadGame_unittest.cc
@@ -4,6 +4,7 @@
 #include "SaveLoadGame.h"
 #include "FileMan.h"
 #include "externalized/TestUtils.h"
+#include <algorithm>
 
 const uint8_t s_savedGameHeaderVanilla[] = {
 	0x63,0x00,0x00,0x00,0x42,0x75,0x69,0x6c,0x64,0x20,0x30,0x34,0x2e,0x31,0x32,0x2e,
@@ -163,7 +164,10 @@ TEST(SaveLoadGameTest, savedGameHeaderValidityCheck)
 	EXPECT_EQ(isValidSavedGameHeader(header), true);
 
 	// parse vanilla header with "strac linux" parser; should be invalid
-	ParseSavedGameHeader(s_savedGameHeaderVanilla, header, true);
+	// this needs some padding bytes at the end to avoid a buffer overrun
+	uint8_t paddedVanillaHeader[SAVED_GAME_HEADER_ON_DISK_SIZE_STRAC_LIN]{};
+	std::copy_n(s_savedGameHeaderVanilla, SAVED_GAME_HEADER_ON_DISK_SIZE, paddedVanillaHeader);
+	ParseSavedGameHeader(paddedVanillaHeader, header, true);
 	EXPECT_EQ(isValidSavedGameHeader(header), false);
 
 	// parse "strac linux" header with vanilla parser; should be invalid

--- a/src/game/Strategic/Quests.cc
+++ b/src/game/Strategic/Quests.cc
@@ -583,7 +583,7 @@ BOOLEAN CheckFact(Fact const usFact, UINT8 const ubProfileID)
 			break;
 
 		case FACT_NPC_OWED_MONEY:
-			gubFact[FACT_NPC_OWED_MONEY] = (ubProfileID != NO_PROFILE && gMercProfiles[ubProfileID].iBalance < 0);
+			gubFact[FACT_NPC_OWED_MONEY] = ubProfileID < NUM_PROFILES && gMercProfiles[ubProfileID].iBalance < 0;
 			break;
 
 		case FACT_FATHER_DRUNK:

--- a/src/game/Strategic/Strategic_Event_Handler.cc
+++ b/src/game/Strategic/Strategic_Event_Handler.cc
@@ -389,10 +389,7 @@ static void HandleDelayedItemsArrival(UINT32 uiReason)
 					// 3 in 10 chance of a stun grenade
 					CreateItem( STUN_GRENADE, (INT8) (70 + Random( 10 )), &Object );
 					break;
-				case 6:
-				case 7:
-				case 8:
-				case 9:
+				default: // cases 6-9
 					// 4 in 10 chance of two 38s!
 					CreateItems( SW38, (INT8) (90 + Random( 10 )), 2, &Object );
 					break;

--- a/src/game/Strategic/Strategic_Movement.cc
+++ b/src/game/Strategic/Strategic_Movement.cc
@@ -1425,6 +1425,7 @@ static void HandleNonCombatGroupArrival(GROUP& g, bool const main_group, bool co
 		else
 		{
 			RemoveGroup(g);
+			return;
 		}
 	}
 

--- a/src/game/Tactical/Handle_Items.cc
+++ b/src/game/Tactical/Handle_Items.cc
@@ -942,7 +942,7 @@ ItemHandleResult HandleItem(SOLDIERTYPE* const s, INT16 usGridNo, const INT8 bLe
 	if (item->getCursor() == INVALIDCURS)
 	{
 		// Found detonator...
-		OBJECTTYPE& obj = s->inv[usHandItem];
+		OBJECTTYPE& obj = s->inv[HANDPOS];
 		if (FindAttachment(&obj, DETONATOR) != ITEM_NOT_FOUND || FindAttachment(&obj, REMDETONATOR))
 		{
 			StartBombMessageBox(s, usGridNo);

--- a/src/game/Tactical/Interface_Items.cc
+++ b/src/game/Tactical/Interface_Items.cc
@@ -1732,22 +1732,7 @@ void CycleItemDescriptionItem( )
 
 void InitItemDescriptionBox(SOLDIERTYPE* pSoldier, UINT8 ubPosition, INT16 sX, INT16 sY, UINT8 ubStatusIndex)
 {
-	OBJECTTYPE *pObject;
-
-	//DEF:
-	//if we are in the shopkeeper screen, and we are to use the
-	if( guiCurrentScreen == SHOPKEEPER_SCREEN && ubPosition == 255 )
-	{
-		pObject = pShopKeeperItemDescObject;
-	}
-
-	//else use item from the hand position
-	else
-	{
-		pObject = &(pSoldier->inv[ ubPosition ] );
-	}
-
-	InternalInitItemDescriptionBox(pObject, sX, sY, ubStatusIndex, pSoldier);
+	InternalInitItemDescriptionBox(&pSoldier->inv[ubPosition], sX, sY, ubStatusIndex, pSoldier);
 }
 
 

--- a/src/game/Tactical/ShopKeeper_Interface.cc
+++ b/src/game/Tactical/ShopKeeper_Interface.cc
@@ -5109,7 +5109,7 @@ static void InitShopKeeperItemDescBox(OBJECTTYPE* pObject, UINT8 ubPocket, UINT8
 
 	pShopKeeperItemDescObject = pObject;
 
-	InitItemDescriptionBox( gpSMCurrentMerc, 255, sPosX, sPosY, 0 );
+	InternalInitItemDescriptionBox(pObject, sPosX, sPosY, 0, gpSMCurrentMerc);
 
 	StartSKIDescriptionBox( );
 }


### PR DESCRIPTION
• Wrong index used into soldier's inventory (CID 249130)
• Buffer overrun in SaveLoadGame unit test (215865)
• harden logic in a workaround for a potential problem in ancient saves (250860)
• Coverity does know that Random(10) can only return 0-9 (81654)
• Safer array access in CheckFact (254706)
• Remove special SKI handling in InitItemDescriptionBox (249140)
• Write after free in HandleNonCombatGroupArrival (209947)

Two real bugs in the game (209947 and 249130), one in an unit test, and another that's unlikely to still be relevant (the fix for saves version 61-65). The other three are "make Coverity happy" changes, but at least one also gets rid of some horrible code in `InitItemDescriptionBox`