### PR TITLE
Fix two more world data OOB accesses

### DIFF
--- a/src/game/Tactical/Enemy_Soldier_Save.cc
+++ b/src/game/Tactical/Enemy_Soldier_Save.cc
@@ -428,7 +428,13 @@ void NewWayOfLoadingEnemySoldiersFromTempFile()
 			bp->ubSoldierClass      = dp->ubSoldierClass;
 			bp->ubCivilianGroup     = dp->ubCivilianGroup;
 			bp->fHasKeys            = dp->fHasKeys;
-			bp->usStartingGridNo    = dp->sInsertionGridNo;
+			// This tempfile might have been corrupted by a bug, in which case
+			// we would overwrite a valid insertion gridno with NOWHERE here.
+			// In that case we keep the original instead.
+			if (dp->sInsertionGridNo >= 0 && dp->sInsertionGridNo < WORLD_MAX)
+			{
+				bp->usStartingGridNo = dp->sInsertionGridNo;
+			}
 			bp->bPatrolCnt          = dp->bPatrolCnt;
 			memcpy(bp->sPatrolGrid, dp->sPatrolGrid, sizeof(INT16) * bp->bPatrolCnt);
 
@@ -439,6 +445,9 @@ void NewWayOfLoadingEnemySoldiersFromTempFile()
 				// Hacker has modified the stats on the enemy placements.
 				throw std::runtime_error("Invalid checksum for placement");
 			}
+
+			// Ensure both starting grids are consistent, must do this after the checksum calculation.
+			dp->sInsertionGridNo = bp->usStartingGridNo;
 
 			// Add preserved placements as long as they don't exceed the actual
 			// population.
@@ -586,7 +595,10 @@ void NewWayOfLoadingCiviliansFromTempFile()
 			bp->ubSoldierClass     = dp->ubSoldierClass;
 			bp->ubCivilianGroup    = dp->ubCivilianGroup;
 			bp->fHasKeys           = dp->fHasKeys;
-			bp->usStartingGridNo   = dp->sInsertionGridNo;
+			if (dp->sInsertionGridNo >= 0 && dp->sInsertionGridNo < WORLD_MAX)
+			{
+				bp->usStartingGridNo = dp->sInsertionGridNo;
+			}
 			bp->bPatrolCnt         = dp->bPatrolCnt;
 			memcpy(bp->sPatrolGrid, dp->sPatrolGrid, sizeof(INT16) * bp->bPatrolCnt);
 
@@ -597,6 +609,9 @@ void NewWayOfLoadingCiviliansFromTempFile()
 				// Hacker has modified the stats on the civilian placements.
 				throw std::runtime_error("Invalid checksum for placement");
 			}
+
+			// Ensure both starting grids are consistent, must do this after the checksum calculation.
+			dp->sInsertionGridNo = bp->usStartingGridNo;
 
 			if (dp->bLife < dp->bLifeMax)
 			{

--- a/src/game/Tactical/OppList.cc
+++ b/src/game/Tactical/OppList.cc
@@ -621,9 +621,17 @@ static void OtherTeamsLookForMan(SOLDIERTYPE* pOpponent);
 
 void HandleSight(SOLDIERTYPE& s, SightFlags const sight_flags)
 {
+	extern INT32 iHelicopterVehicleId; 	// I don't want to include a map screen header file for this
 	if (!s.bActive)                     return;
 	if (!s.bInSector)                   return;
 	if (s.uiStatusFlags & SOLDIER_DEAD) return;
+	if (s.bAssignment == VEHICLE && s.iVehicleId == iHelicopterVehicleId) return;
+
+	if (s.sGridNo == NOWHERE)
+	{
+		SLOGE("HandleSight: {} ({}) is NOWHERE", s.ubID, s.name);
+		return;
+	}
 
 	gubSightFlags = sight_flags;
 


### PR DESCRIPTION
1. The tempfile for some reason I couldn't figure out sometimes overwrites valid insertion grids with NOWHERE. I added extra checks to prevent that from happening.
2. Soldiers still in the helicopter are not visible on the map and therefore NOWHERE. This is valid, but they cannot be used in `HandleSight()`

I also finally caved in and added a NOWHERE check in HandleSight(). This should help @guijan with his DistanceVisible() crashes, but if we see this new error message we should treat it as a serious problem with the game logic that must be investigated.

Fixes #1634 and #1635.