### PR TITLE
Upgrade Android dependencies and clean up deprecations

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,10 +1,9 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlinx-serialization'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     ndkVersion "25.0.8775105"
 
     lintOptions {
@@ -50,6 +49,10 @@ android {
         }
     }
 
+    buildFeatures {
+        viewBinding true
+    }
+
     signingConfigs {
         release {
             storeFile file("${System.getenv("HOME")}/.stracciatella-android-signing-keys/keystore.jks")
@@ -85,17 +88,17 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.0.0-RC2"
-    implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
-    implementation 'androidx.activity:activity-ktx:1.1.0'
-    implementation 'com.google.android.material:material:1.2.1'
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2"
+    implementation 'androidx.core:core-ktx:1.8.0'
+    implementation 'androidx.appcompat:appcompat:1.4.2'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.activity:activity-ktx:1.5.1'
+    implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'com.github.noelchew:storage-chooser:2.0.4.4a'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
 }
 

--- a/android/app/src/main/java/io/github/ja2stracciatella/ConfigurationModel.kt
+++ b/android/app/src/main/java/io/github/ja2stracciatella/ConfigurationModel.kt
@@ -2,7 +2,6 @@ package io.github.ja2stracciatella
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import kotlinx.serialization.SerializationException
 
 class ConfigurationModel : ViewModel() {
 

--- a/android/app/src/main/java/io/github/ja2stracciatella/StracciatellaActivity.kt
+++ b/android/app/src/main/java/io/github/ja2stracciatella/StracciatellaActivity.kt
@@ -8,7 +8,7 @@ open class StracciatellaActivity : SDLActivity() {
         return arrayOf(
             "SDL2",
             "ja2"
-        );
+        )
     }
 
     // We suppress deprecation warnings here as our Android SDK minimum version
@@ -20,11 +20,11 @@ open class StracciatellaActivity : SDLActivity() {
         // Set app to fullscreen mode
         if (hasFocus) {
             window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                    or View.SYSTEM_UI_FLAG_FULLSCREEN
-                    or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                    or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                    or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                    or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
+                or View.SYSTEM_UI_FLAG_FULLSCREEN
+                or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
         }
     }
 }

--- a/android/app/src/main/java/io/github/ja2stracciatella/ui/main/DataTabFragment.kt
+++ b/android/app/src/main/java/io/github/ja2stracciatella/ui/main/DataTabFragment.kt
@@ -11,14 +11,16 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.codekidlabs.storagechooser.StorageChooser
 import io.github.ja2stracciatella.ConfigurationModel
-import io.github.ja2stracciatella.R
-import kotlinx.android.synthetic.main.fragment_launcher_data_tab.view.*
+import io.github.ja2stracciatella.databinding.FragmentLauncherDataTabBinding
 
 
 /**
  * A placeholder fragment containing a simple view.
  */
 class DataTabFragment : Fragment() {
+    private var _binding: FragmentLauncherDataTabBinding? = null
+    private val binding get() = _binding!!
+
     // Request permissions for game dir
     private val requestPermissionsCodeGameDir = 1001
     // Request permissions for save dir
@@ -27,37 +29,42 @@ class DataTabFragment : Fragment() {
     private lateinit var configurationModel: ConfigurationModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        configurationModel = ViewModelProvider(requireActivity()).get(ConfigurationModel::class.java)
+        configurationModel = ViewModelProvider(requireActivity())[ConfigurationModel::class.java]
         super.onCreate(savedInstanceState)
     }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        val tab = inflater.inflate(R.layout.fragment_launcher_data_tab, container, false)
+    ): View {
+        _binding = FragmentLauncherDataTabBinding.inflate(inflater, container, false)
 
         configurationModel.vanillaGameDir.observe(
             viewLifecycleOwner
         ) { vanillaGameDir ->
             if (vanillaGameDir.isNotEmpty()) {
-                tab.gameDirValueText.text = vanillaGameDir
+                binding.gameDirValueText.text = vanillaGameDir
             }
         }
         configurationModel.saveGameDir.observe(
             viewLifecycleOwner
         ) { saveGameDir ->
             if (saveGameDir.isNotEmpty()) {
-                tab.saveGameDirValueText.text = saveGameDir
+                binding.saveGameDirValueText.text = saveGameDir
             }
         }
-        tab.gameDirChooseButton?.setOnClickListener { _ ->
+        binding.gameDirChooseButton.setOnClickListener {
             showGameDirChooser()
         }
-        tab.saveGameDirChooseButton?.setOnClickListener { _ ->
+        binding.saveGameDirChooseButton.setOnClickListener {
             showSaveGameDirChooser()
         }
-        return tab
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     private fun showGameDirChooser() {
@@ -70,7 +77,7 @@ class DataTabFragment : Fragment() {
                 .withFragmentManager(activity?.fragmentManager)
                 .allowCustomPath(true)
                 .setType(StorageChooser.DIRECTORY_CHOOSER)
-                .build();
+                .build()
             directoryChooser.setOnSelectListener { path ->
                 configurationModel.apply {
                     setVanillaGameDir(path)
@@ -90,7 +97,7 @@ class DataTabFragment : Fragment() {
                 .withFragmentManager(activity?.fragmentManager)
                 .allowCustomPath(true)
                 .setType(StorageChooser.DIRECTORY_CHOOSER)
-                .build();
+                .build()
             directoryChooser.setOnSelectListener { path ->
                 configurationModel.apply {
                     setSaveGameDir(path)

--- a/android/app/src/main/java/io/github/ja2stracciatella/ui/main/PlaceholderFragment.kt
+++ b/android/app/src/main/java/io/github/ja2stracciatella/ui/main/PlaceholderFragment.kt
@@ -4,31 +4,30 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import io.github.ja2stracciatella.ConfigurationModel
-import io.github.ja2stracciatella.R
+import io.github.ja2stracciatella.databinding.FragmentLauncherBinding
 
 /**
  * A placeholder fragment containing a simple view.
  */
 class PlaceholderFragment : Fragment() {
+    private var _binding: FragmentLauncherBinding? = null
+    private val binding get() = _binding!!
 
     private lateinit var configurationModel: ConfigurationModel
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        val root = inflater.inflate(R.layout.fragment_launcher, container, false)
-        val textView: TextView = root.findViewById(R.id.section_label)
-        configurationModel = ViewModelProvider(requireActivity()).get(ConfigurationModel::class.java)
-        configurationModel.vanillaGameDir.observe(viewLifecycleOwner, Observer<String> {
-            textView.text = it
-        })
-        return root
+    ): View {
+        _binding = FragmentLauncherBinding.inflate(inflater, container, false)
+        configurationModel = ViewModelProvider(requireActivity())[ConfigurationModel::class.java]
+        configurationModel.vanillaGameDir.observe(viewLifecycleOwner) {
+            binding.sectionLabel.text = it
+        }
+        return binding.root
     }
 
     companion object {

--- a/android/app/src/main/java/io/github/ja2stracciatella/ui/main/SectionsPagerAdapter.kt
+++ b/android/app/src/main/java/io/github/ja2stracciatella/ui/main/SectionsPagerAdapter.kt
@@ -1,38 +1,36 @@
 package io.github.ja2stracciatella.ui.main
 
-import android.content.Context
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.FragmentPagerAdapter
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
 import io.github.ja2stracciatella.R
 
-private val TAB_TITLES = arrayOf(
-    R.string.tab_text_data,
-    R.string.tab_text_settings
-)
-
 /**
- * A [FragmentPagerAdapter] that returns a fragment corresponding to
+ * A [FragmentStateAdapter] that returns a fragment corresponding to
  * one of the sections/tabs/pages.
  */
-class SectionsPagerAdapter(private val context: Context, fm: FragmentManager) :
-    FragmentPagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
-
-    override fun getItem(position: Int): Fragment {
+class SectionsPagerAdapter(fa: FragmentActivity) : FragmentStateAdapter(fa) {
+    override fun createFragment(position: Int): Fragment {
         if (position == 0) {
-            return DataTabFragment.newInstance(position)
+            return DataTabFragment()
         }
         // getItem is called to instantiate the fragment for the given page.
         // Return a PlaceholderFragment (defined as a static inner class below).
-        return PlaceholderFragment.newInstance(position + 1)
+        return PlaceholderFragment()
     }
 
-    override fun getPageTitle(position: Int): CharSequence? {
-        return context.resources.getString(TAB_TITLES[position])
+    override fun getItemCount(): Int {
+        return TAB_TITLES.size
     }
 
-    override fun getCount(): Int {
-        // Show 2 total pages.
-        return 2
+    companion object {
+        private val TAB_TITLES = arrayOf(
+            R.string.tab_text_data,
+            R.string.tab_text_settings
+        )
+
+        fun getTabTitle(position: Int): Int {
+            return TAB_TITLES[position]
+        }
     }
 }

--- a/android/app/src/main/res/layout/activity_launcher.xml
+++ b/android/app/src/main/res/layout/activity_launcher.xml
@@ -26,9 +26,10 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?attr/colorPrimary" />
+
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.viewpager.widget.ViewPager
+    <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/view_pager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.10"
+    ext.kotlin_version = "1.6.21"
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
After doing the NDK upgrade, I decided to do the same for other android dependencies, while keeping the target sdk the same (because the issues described in https://github.com/ja2-stracciatella/ja2-stracciatella/issues/1592). I fixed all deprecations as well. Functionally there should be no changes.