### PR TITLE
Make OppList.cc more robust

### DIFF
--- a/src/game/Tactical/OppList.cc
+++ b/src/game/Tactical/OppList.cc
@@ -625,6 +625,7 @@ static bool IsSoldierValidForSightings(SOLDIERTYPE const& s)
 	return !(!s.bActive
 	      || !s.bInSector
 	      || s.uiStatusFlags & SOLDIER_DEAD
+	      || s.bLife <= 0 // should be redundant, but who knows?
 	      || (s.bAssignment == VEHICLE && s.iVehicleId == iHelicopterVehicleId));
 }
 

--- a/src/game/Tactical/OppList.cc
+++ b/src/game/Tactical/OppList.cc
@@ -619,13 +619,19 @@ static void OurTeamRadiosRandomlyAbout(SOLDIERTYPE* about);
 static void OtherTeamsLookForMan(SOLDIERTYPE* pOpponent);
 
 
-void HandleSight(SOLDIERTYPE& s, SightFlags const sight_flags)
+static bool IsSoldierValidForSightings(SOLDIERTYPE const& s)
 {
 	extern INT32 iHelicopterVehicleId; 	// I don't want to include a map screen header file for this
-	if (!s.bActive)                     return;
-	if (!s.bInSector)                   return;
-	if (s.uiStatusFlags & SOLDIER_DEAD) return;
-	if (s.bAssignment == VEHICLE && s.iVehicleId == iHelicopterVehicleId) return;
+	return !(!s.bActive
+	      || !s.bInSector
+	      || s.uiStatusFlags & SOLDIER_DEAD
+	      || (s.bAssignment == VEHICLE && s.iVehicleId == iHelicopterVehicleId));
+}
+
+
+void HandleSight(SOLDIERTYPE& s, SightFlags const sight_flags)
+{
+	if (!IsSoldierValidForSightings(s)) return;
 
 	if (s.sGridNo == NOWHERE)
 	{
@@ -734,7 +740,7 @@ void HandleSight(SOLDIERTYPE& s, SightFlags const sight_flags)
 		FOR_EACH_MERC(i)
 		{
 			SOLDIERTYPE& them = **i;
-			if (them.bLife < OKLIFE) continue;
+			if (!IsSoldierValidForSightings(them) || them.bLife < OKLIFE) continue;
 
 			// if this merc is on the same team as the target soldier
 			if (them.bTeam == s.bTeam) continue; // he doesn't look (he ALWAYS knows about him)
@@ -779,7 +785,7 @@ static void OurTeamRadiosRandomlyAbout(SOLDIERTYPE* const about)
 	{
 		// if this merc is in this sector, and well enough to look, then put him on
 		// our list
-		if (s->bInSector && s->bLife >= OKLIFE)
+		if (IsSoldierValidForSightings(*s) && s->bLife >= OKLIFE)
 			radio_men[radio_cnt++] = s;
 	}
 
@@ -818,7 +824,7 @@ static INT16 TeamNoLongerSeesMan(const UINT8 ubTeam, SOLDIERTYPE* const pOpponen
 			continue; // skip him, he's no teammate at all!
 
 		// if this merc is at base, on assignment, dead, unconscious
-		if (!pMate->bInSector || pMate->bLife < OKLIFE)
+		if (!IsSoldierValidForSightings(*pMate) || pMate->bLife < OKLIFE)
 			continue; // next merc
 
 		// if this teammate currently sees this opponent
@@ -1242,7 +1248,7 @@ static void ManLooksForOtherTeams(SOLDIERTYPE* pSoldier)
 	FOR_EACH_MERC(i)
 	{
 		SOLDIERTYPE* const pOpponent = *i;
-		if (pOpponent->bLife)
+		if (IsSoldierValidForSightings(*pOpponent))
 		{
 			// and if he's on another team...
 			if (pSoldier->bTeam != pOpponent->bTeam)
@@ -1369,7 +1375,7 @@ static INT16 ManLooksForMan(SOLDIERTYPE* pSoldier, SOLDIERTYPE* pOpponent, UINT8
 	}
 
 	// if we're somehow looking while inactive, at base, dead or dying
-	if (!pSoldier->bActive || !pSoldier->bInSector || (pSoldier->bLife < OKLIFE))
+	if (!IsSoldierValidForSightings(*pSoldier) || pSoldier->bLife < OKLIFE)
 	{
 		SLOGD("ManLooksForMan - WE are inactive/dead etc ID {}({})to ID {}",
 			pSoldier->ubID, pSoldier->name, pOpponent->ubID);
@@ -1379,8 +1385,7 @@ static INT16 ManLooksForMan(SOLDIERTYPE* pSoldier, SOLDIERTYPE* pOpponent, UINT8
 
 
 	// if we're somehow looking for a guy who is inactive, at base, or already dead
-	if (!pOpponent->bActive || !pOpponent->bInSector || pOpponent->bLife <= 0 ||
-		pOpponent->sGridNo == NOWHERE )
+	if (!IsSoldierValidForSightings(*pOpponent) || pOpponent->sGridNo == NOWHERE)
 	{
 		return(FALSE);
 	}
@@ -1531,14 +1536,11 @@ static void ManSeesMan(SOLDIERTYPE& s, SOLDIERTYPE& opponent, UINT8 const caller
 	if (opponent.ubID >= MAX_NUM_SOLDIERS) return;
 
 	// if we're somehow looking while inactive, at base, dying or already dead
-	if (!s.bActive)       return;
-	if (!s.bInSector)     return;
+	if (!IsSoldierValidForSightings(s)) return;
 	if (s.bLife < OKLIFE) return;
 
 	// if we're somehow seeing a guy who is inactive, at base, or already dead
-	if (!opponent.bActive)   return;
-	if (!opponent.bInSector) return;
-	if (opponent.bLife <= 0) return;
+	if (!IsSoldierValidForSightings(opponent)) return;
 
 	// If we're somehow seeing a guy who is on the same team
 	if (s.bTeam == opponent.bTeam) return;
@@ -1988,7 +1990,7 @@ static void OtherTeamsLookForMan(SOLDIERTYPE* pOpponent)
 		SOLDIERTYPE* const pSoldier = *i;
 
 		// if this merc is active, in this sector, and well enough to look
-		if (pSoldier->bLife >= OKLIFE  && (pSoldier->ubBodyType != LARVAE_MONSTER))
+		if (IsSoldierValidForSightings(*pSoldier) && pSoldier->bLife >= OKLIFE  && (pSoldier->ubBodyType != LARVAE_MONSTER))
 		{
 			// if this merc is on the same team as the target soldier
 			if (pSoldier->bTeam == pOpponent->bTeam)
@@ -2167,7 +2169,7 @@ static void UpdatePublic(const UINT8 ubTeam, SOLDIERTYPE* const s, const INT8 bN
 		FOR_EACH_IN_TEAM(pSoldier, ubTeam)
 		{
 			// if this soldier is active, in this sector, and well enough to look
-			if (pSoldier->bInSector && pSoldier->bLife >= OKLIFE && !(pSoldier->uiStatusFlags & SOLDIER_GASSED))
+			if (IsSoldierValidForSightings(*pSoldier) && pSoldier->bLife >= OKLIFE && !(pSoldier->uiStatusFlags & SOLDIER_GASSED))
 			{
 				// if soldier isn't aware of guynum, give him another chance to see
 				if (pSoldier->bOppList[s->ubID] == NOT_HEARD_OR_SEEN)
@@ -2298,8 +2300,7 @@ void BetweenTurnsVisibilityAdjustments()
 	FOR_EACH_SOLDIER(i)
 	{
 		SOLDIERTYPE& s = *i;
-		if (!s.bInSector)            continue;
-		if (s.bLife == 0)            continue;
+		if (!IsSoldierValidForSightings(s)) continue;
 		if (IsOnOurTeam(s))          continue;
 #ifdef WE_SEE_WHAT_MILITIA_SEES_AND_VICE_VERSA
 		if (s.bTeam == MILITIA_TEAM) continue;
@@ -2540,7 +2541,7 @@ void RadioSightings(SOLDIERTYPE* const pSoldier, SOLDIERTYPE* const about, UINT8
 
 
 		// make sure this merc is active, here & still alive (unconscious OK)
-		if (!pOpponent->bActive || !pOpponent->bInSector || !pOpponent->bLife)
+		if (!IsSoldierValidForSightings(*pOpponent))
 		{
 			SLOGD("RS: inactive/notInSector/life {}", pOpponent->ubID);
 			continue; // skip to the next merc
@@ -3620,7 +3621,7 @@ static void ProcessNoise(SOLDIERTYPE* const noise_maker, INT16 const sGridNo, IN
 		FOR_EACH_IN_TEAM(pSoldier, bTeam)
 		{
 			// if this "listener" is in no condition to care
-			if (!pSoldier->bInSector || pSoldier->uiStatusFlags & SOLDIER_DEAD ||
+			if (!IsSoldierValidForSightings(*pSoldier) ||
 				(pSoldier->bLife < OKLIFE) || pSoldier->ubBodyType == LARVAE_MONSTER)
 			{
 				continue; // skip him!
@@ -4330,7 +4331,7 @@ void VerifyAndDecayOpplist(SOLDIERTYPE *pSoldier)
 	{
 		SOLDIERTYPE* const pOpponent = *i;
 		// if this merc is active, here, and alive
-		if (pOpponent->bLife)
+		if (IsSoldierValidForSightings(*pOpponent))
 		{
 			// if this merc is on the same team, he's no opponent, so skip him
 			if (pSoldier->bTeam == pOpponent->bTeam)
@@ -4418,7 +4419,7 @@ void DecayIndividualOpplist(SOLDIERTYPE *pSoldier)
 	{
 		const SOLDIERTYPE* const pOpponent = *i;
 		// if this merc is active, here, and alive
-		if (pOpponent->bLife)
+		if (IsSoldierValidForSightings(*pOpponent))
 		{
 			// if this merc is on the same team, he's no opponent, so skip him
 			if (pSoldier->bTeam == pOpponent->bTeam)
@@ -4468,7 +4469,7 @@ void VerifyPublicOpplistDueToDeath(SOLDIERTYPE *pSoldier)
 		BOOLEAN bOpponentStillSeen = FALSE;
 
 		// if this opponent is active, here, and alive
-		if (pOpponent->bLife)
+		if (IsSoldierValidForSightings(*pOpponent))
 		{
 			// if this opponent is on the same team, he's no opponent, so skip him
 			if (pSoldier->bTeam == pOpponent->bTeam)
@@ -4489,7 +4490,7 @@ void VerifyPublicOpplistDueToDeath(SOLDIERTYPE *pSoldier)
 				{
 					const SOLDIERTYPE* const pTeamMate = *j;
 					// if this teammate is active, here, and alive
-					if (pTeamMate->bLife)
+					if (IsSoldierValidForSightings(*pTeamMate))
 					{
 						// if this opponent is NOT on the same team, then skip him
 						if (pTeamMate->bTeam != pSoldier->bTeam)
@@ -4833,8 +4834,8 @@ void CheckForAlertWhenEnemyDies(SOLDIERTYPE* pDyingSoldier)
 
 	FOR_EACH_IN_TEAM(pSoldier, pDyingSoldier->bTeam)
 	{
-		if (pSoldier->bInSector && pSoldier != pDyingSoldier && pSoldier->bLife >= OKLIFE &&
-			pSoldier->bAlertStatus < STATUS_RED)
+		if (IsSoldierValidForSightings(*pSoldier) && pSoldier != pDyingSoldier &&
+		    pSoldier->bLife >= OKLIFE && pSoldier->bAlertStatus < STATUS_RED)
 		{
 			// this guy might have seen the man die
 
@@ -4997,7 +4998,7 @@ static void CommunicateWatchedLoc(const SOLDIERTYPE* const watcher, const INT16 
 	CFOR_EACH_IN_TEAM(s, bTeam)
 	{
 		if (s == watcher) continue;
-		if (!s->bInSector || s->bLife < OKLIFE)
+		if (!IsSoldierValidForSightings(*s) || s->bLife < OKLIFE)
 		{
 			continue;
 		}
@@ -5151,7 +5152,7 @@ static void MakeBloodcatsHostile(void)
 {
 	FOR_EACH_IN_TEAM(s, CREATURE_TEAM)
 	{
-		if (s->ubBodyType == BLOODCAT && s->bInSector && s->bLife > 0)
+		if (s->ubBodyType == BLOODCAT && IsSoldierValidForSightings(*s))
 		{
 			SetSoldierNonNeutral(s);
 			RecalculateOppCntsDueToNoLongerNeutral(s);

--- a/src/game/Tactical/Tactical_Turns.cc
+++ b/src/game/Tactical/Tactical_Turns.cc
@@ -99,8 +99,8 @@ void HandleTacticalEndTurn()
 	}
 
 	DecayBombTimers();
-	DecaySmokeEffects(now);
-	DecayLightEffects(now);
+	DecaySmokeEffects(now, true);
+	DecayLightEffects(now, true);
 	DecayBloodAndSmells(now);
 	DecayRottingCorpseAIWarnings();
 

--- a/src/game/Tactical/TeamTurns.cc
+++ b/src/game/Tactical/TeamTurns.cc
@@ -290,8 +290,8 @@ static void EndTurnEvents(void)
 	// decay bomb timers and maybe set some off!
 	DecayBombTimers();
 
-	DecaySmokeEffects( GetWorldTotalSeconds( ) );
-	DecayLightEffects( GetWorldTotalSeconds( ) );
+	DecaySmokeEffects(GetWorldTotalSeconds(), true);
+	DecayLightEffects(GetWorldTotalSeconds(), true);
 
 	// decay AI warning values from corpses
 	DecayRottingCorpseAIWarnings();

--- a/src/game/TileEngine/LightEffects.cc
+++ b/src/game/TileEngine/LightEffects.cc
@@ -121,7 +121,7 @@ LIGHTEFFECT* NewLightEffect(const INT16 sGridNo, const INT8 bType)
 }
 
 
-void DecayLightEffects(const UINT32 uiTime, const bool trashingWorld)
+void DecayLightEffects(const UINT32 uiTime, const bool updateSightings)
 {
 	// age all active tear gas clouds, deactivate those that are just dispersing
 	FOR_EACH_LIGHTEFFECT(l)
@@ -165,7 +165,7 @@ void DecayLightEffects(const UINT32 uiTime, const bool trashingWorld)
 		}
 
 		// Handle sight here....
-		if(!trashingWorld) AllTeamsLookForAll(FALSE);
+		if (updateSightings) AllTeamsLookForAll(FALSE);
 	}
 }
 

--- a/src/game/TileEngine/LightEffects.h
+++ b/src/game/TileEngine/LightEffects.h
@@ -27,7 +27,7 @@ struct LIGHTEFFECT
 
 
 // Decays all light effects...
-void DecayLightEffects(UINT32 uiTime, bool trashingWorld = false);
+void DecayLightEffects(UINT32 uiTime, bool updateSightings);
 
 LIGHTEFFECT* NewLightEffect(INT16 sGridNo, INT8 bType);
 

--- a/src/game/TileEngine/Overhead_Map.cc
+++ b/src/game/TileEngine/Overhead_Map.cc
@@ -277,8 +277,8 @@ void HandleOverheadMap(void)
 	// clear for broken saves before TrashWorld took care of this
 	if (!gfEditMode && gfTacticalPlacementGUIActive)
 	{
-		DecaySmokeEffects(GetWorldTotalSeconds());
-		DecayLightEffects(GetWorldTotalSeconds());
+		DecaySmokeEffects(GetWorldTotalSeconds(), false);
+		DecayLightEffects(GetWorldTotalSeconds(), false);
 	}
 
 	RenderOverheadMap(0, WORLD_COLS / 2, STD_SCREEN_X, STD_SCREEN_Y, STD_SCREEN_X + 640, STD_SCREEN_Y + 320, FALSE);

--- a/src/game/TileEngine/SmokeEffects.cc
+++ b/src/game/TileEngine/SmokeEffects.cc
@@ -327,7 +327,7 @@ void RemoveSmokeEffectFromTile( INT16 sGridNo, INT8 bLevel )
 }
 
 
-void DecaySmokeEffects(const UINT32 uiTime, const bool trashingWorld)
+void DecaySmokeEffects(const UINT32 uiTime, const bool updateSightings)
 {
 	BOOLEAN fUpdate = FALSE;
 	BOOLEAN fSpreadEffect;
@@ -446,7 +446,7 @@ void DecaySmokeEffects(const UINT32 uiTime, const bool trashingWorld)
 		}
 	}
 
-	if (!trashingWorld) AllTeamsLookForAll( TRUE );
+	if (updateSightings) AllTeamsLookForAll(TRUE);
 }
 
 

--- a/src/game/TileEngine/SmokeEffects.h
+++ b/src/game/TileEngine/SmokeEffects.h
@@ -38,7 +38,7 @@ struct SMOKEEFFECT
 SmokeEffectKind GetSmokeEffectOnTile(INT16 sGridNo, INT8 bLevel);
 
 // Decays all smoke effects...
-void DecaySmokeEffects(UINT32 uiTime, bool trashingWorld = false);
+void DecaySmokeEffects(UINT32 uiTime, bool updateSightings);
 
 // Add smoke to gridno
 // ( Replacement algorithm uses distance away )

--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -2540,8 +2540,8 @@ void TrashWorld(void)
 	TrashWorldItems();
 	TrashOverheadMap();
 
-	DecaySmokeEffects(0xffffff, true);
-	DecayLightEffects(0xffffff, true);
+	DecaySmokeEffects(0xffffff, false);
+	DecayLightEffects(0xffffff, false);
 	ResetSmokeEffects();
 	ResetLightEffects();
 


### PR DESCRIPTION
This adds more checks in OppList.cc if a soldier should even be considered in several places, some of which even already had comments that this should be done.

The changes in the other files are necessary to stop us from already trying to update sightings while we are still on the overhead map placing mercs.

I've tested this patches with an ASan build (with a hacky workaround for the Z blitter problem) with @guijan's saves from #1634 and #1635, some of the other saves I have around and played my own campaign for over an hour without problems. No promises that the game is now completely stable because I'm still early in the campaign, but it's definitely improving.