### PR TITLE
Use const references to avoid copying

### DIFF
--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -1418,7 +1418,7 @@ const CreatureLairModel* DefaultContentManager::getCreatureLairByMineId(uint8_t 
 const MineModel* DefaultContentManager::getMineForSector(const SGPSector& sector) const
 {
 	auto sectorId = sector.AsByte();
-	for (auto m : m_mines)
+	for (const auto& m : m_mines)
 	{
 		if (sector.z == 0 && sectorId == m->entranceSector) return m;
 		for (auto s : m->mineSectors)

--- a/src/externalized/LoadingScreenModel.cc
+++ b/src/externalized/LoadingScreenModel.cc
@@ -46,7 +46,7 @@ LoadingScreenModel::LoadingScreenModel(std::vector<LoadingScreen> screensList_, 
 
 const LoadingScreen* LoadingScreenModel::getScreenForSector(uint8_t sectorId, uint8_t sectorLevel, bool isNight) const
 {
-	for (auto screen : screensMapping)
+	for (const auto& screen : screensMapping)
 	{
 		if (screen.sectorId == sectorId && screen.sectorLevel == sectorLevel)
 		{

--- a/src/externalized/mercs/MERCListingModel.cc
+++ b/src/externalized/mercs/MERCListingModel.cc
@@ -8,7 +8,7 @@
 #include <utility>
 
 MERCListingModel::MERCListingModel(uint8_t index_, uint8_t profileID_, uint8_t bioIndex_,
-	uint32_t minTotalSpending_, uint32_t minDays_, 
+	uint32_t minTotalSpending_, uint32_t minDays_,
 	std::vector<SpeckQuote> quotes_
 	) : index(index_), profileID(profileID_), bioIndex(bioIndex_),
 	    minTotalSpending(minTotalSpending_), minDays(minDays_),
@@ -22,7 +22,7 @@ bool MERCListingModel::isAvailableAtStart() const
 std::vector<SpeckQuote> MERCListingModel::getQuotesByType(SpeckQuoteType type) const
 {
 	std::vector<SpeckQuote> filtered;
-	for (auto q : quotes)
+	for (const auto& q : quotes)
 	{
 		if (q->type == type) filtered.push_back(q);
 	}
@@ -70,7 +70,7 @@ MERCListingModel* MERCListingModel::deserialize(uint8_t index, const rapidjson::
 			}
 			crossSellID = crossSellProfile->profileID;
 		}
-		
+
 		auto quote = std::make_shared<MERCSpeckQuote>(
 			r.GetUInt("quoteID"),
 			quoteType,
@@ -84,7 +84,7 @@ MERCListingModel* MERCListingModel::deserialize(uint8_t index, const rapidjson::
 		index,
 		profile->profileID,
 		r.GetUInt("bioIndex"),
-		r.getOptionalInt("minTotalSpending"), 
+		r.getOptionalInt("minTotalSpending"),
 		r.getOptionalInt("minDays"),
 		quotes
 	);

--- a/src/externalized/mercs/MercProfileInfo.cc
+++ b/src/externalized/mercs/MercProfileInfo.cc
@@ -53,7 +53,7 @@ void MercProfileInfo::validateData(const std::map<uint8_t, const MercProfileInfo
 	{
 		throw std::runtime_error("Too many merc profiles");
 	}
-	for (auto p : models)
+	for (const auto& p : models)
 	{
 		if (p.first != p.second->profileID)
 		{

--- a/src/externalized/strategic/CreatureLairModel.cc
+++ b/src/externalized/strategic/CreatureLairModel.cc
@@ -8,8 +8,8 @@
 
 
 CreatureLairModel::CreatureLairModel(const uint8_t lairId_, const uint8_t associatedMineId_, const uint8_t entranceSector_, const uint8_t entranceSectorLevel_, const std::vector<CreatureLairSector> lairSectors_, const std::vector<CreatureAttackSector> attackSectors_, const uint8_t warpExitSector_, const uint16_t warpExitGridNo_)
-	: lairId(lairId_), associatedMineId(associatedMineId_), 
-	entranceSector(entranceSector_), entranceSectorLevel(entranceSectorLevel_), 
+	: lairId(lairId_), associatedMineId(associatedMineId_),
+	entranceSector(entranceSector_), entranceSectorLevel(entranceSectorLevel_),
 	lairSectors(lairSectors_), attackSectors(attackSectors_),
 	warpExitSector(warpExitSector_), warpExitGridNo(warpExitGridNo_) {}
 
@@ -97,7 +97,7 @@ std::vector<CreatureAttackSector> readAttackSectors(const rapidjson::Value& json
 bool CreatureLairModel::isSectorInLair(const SGPSector& sector) const
 {
 	uint8_t sectorId = sector.AsByte();
-	for (auto sec : lairSectors)
+	for (const auto& sec : lairSectors)
 	{
 		if (sec.sectorId == sectorId && sec.sectorLevel == sector.z)
 		{
@@ -110,7 +110,7 @@ bool CreatureLairModel::isSectorInLair(const SGPSector& sector) const
 const CreatureAttackSector* CreatureLairModel::chooseTownSectorToAttack() const
 {
 	unsigned int totalChance = 0;
-	for (auto sec : attackSectors)
+	for (const auto& sec : attackSectors)
 	{
 		totalChance += sec.chance;
 	}
@@ -131,9 +131,9 @@ const CreatureAttackSector* CreatureLairModel::chooseTownSectorToAttack() const
 
 const CreatureAttackSector* CreatureLairModel::getTownAttackDetails(uint8_t sectorId) const
 {
-	for (auto& sec : attackSectors)
+	for (const auto& sec : attackSectors)
 	{
-		if (sec.sectorId == sectorId) 
+		if (sec.sectorId == sectorId)
 		{
 			return &sec;
 		}
@@ -191,7 +191,7 @@ void CreatureLairModel::validateData(const std::vector<const CreatureLairModel*>
 			ST::string err = ST::format("Invalid mineId {}", lair->associatedMineId);
 			throw std::runtime_error(err.to_std_string());
 		}
-		
+
 		// The first lair sector in list should be QUEEN_LAIR
 		if (lair->lairSectors.size() < 1 || lair->lairSectors[0].habitatType != QUEEN_LAIR)
 		{
@@ -201,7 +201,7 @@ void CreatureLairModel::validateData(const std::vector<const CreatureLairModel*>
 		// all lair sectors should be adjacent and defined as underground sector
 		SGPSector prev(0, 0, -1);
 		SGPSector curr;
-		for (auto sec : lair->lairSectors)
+		for (const auto& sec : lair->lairSectors)
 		{
 			curr = SGPSector::FromSectorID(sec.sectorId, sec.sectorLevel);
 			if (prev.z != -1)

--- a/src/game/Laptop/Mercs.cc
+++ b/src/game/Laptop/Mercs.cc
@@ -613,9 +613,9 @@ static BOOLEAN HasLarryRelapsed(void);
 
 /**
  * Returns the ProfileID of this profile listing.
- * 
- * This method handles LARRY logic (LARRY_NORMAL becoming LARRY_DRUNK once 
- * relapsed), and should always be used instead of directly accessing the 
+ *
+ * This method handles LARRY logic (LARRY_NORMAL becoming LARRY_DRUNK once
+ * relapsed), and should always be used instead of directly accessing the
  * field profileID
  */
 ProfileID GetProfileIDFromMERCListing(const MERCListingModel* listing)
@@ -1575,7 +1575,7 @@ static std::vector<UINT8> GetAvailableRandomQuotes()
 	for (const MERCListingModel* m : GCM->getMERCListings())
 	{
 		if (!IsMercMercAvailable(GetProfileIDFromMERCListing(m))) continue;
-		for (auto q : m->getQuotesByType(SpeckQuoteType::ADVERTISE))
+		for (const auto& q : m->getQuotesByType(SpeckQuoteType::ADVERTISE))
 		{
 			quotes.push_back(q->quoteID);
 		}
@@ -1657,7 +1657,7 @@ static BOOLEAN CanMercBeAvailableYet(const MERCListingModel* merc)
 }
 
 // update the value of ubLastMercAvailableId for save game compatability
-static void SetLastMercArrival(const MERCListingModel* merc) 
+static void SetLastMercArrival(const MERCListingModel* merc)
 {
 	switch (merc->profileID)
 	{
@@ -1673,10 +1673,10 @@ void SyncLastMercFromSaveGame()
 {
 	// This allows us to load saves from old versions and vanilla
 	//
-	// In the old implementation, the M.E.R.C. list has 2 LARRY profiles (NORMAL and DRUNK), so 
+	// In the old implementation, the M.E.R.C. list has 2 LARRY profiles (NORMAL and DRUNK), so
 	// the index is off by 1 for mercs after LARRY
 	//
-	// But this only accounts version upgrade. If you are downgrading, you may need to wait for 
+	// But this only accounts version upgrade. If you are downgrading, you may need to wait for
 	// a few days before the last merc becomes available again.
 	int iLastMercID = -1;
 	switch (LaptopSaveInfo.ubLastMercAvailableId)
@@ -1686,7 +1686,7 @@ void SyncLastMercFromSaveGame()
 	}
 
 	if (iLastMercID <= 0) return;
-	
+
 	for (const MERCListingModel* merc : GCM->getMERCListings())
 	{
 		// check for exactly the case that we are off by 1 due to LARRY

--- a/src/game/SaveLoadGameStates.h
+++ b/src/game/SaveLoadGameStates.h
@@ -79,7 +79,7 @@ public:
 	void SetVector(const ST::string& key, std::vector<T> vec)
 	{
 		std::vector<PRIMITIVE_VALUE> stored;
-		for (auto v : vec)
+		for (const auto& v : vec)
 		{
 			PRIMITIVE_VALUE var{std::in_place_type<T>, v};
 			stored.push_back(var);

--- a/src/game/Strategic/Creature_Spreading.cc
+++ b/src/game/Strategic/Creature_Spreading.cc
@@ -148,7 +148,7 @@ static void InitCreatureLair(const CreatureLairModel* lairModel)
 	giLairID = lairModel->lairId;
 
 	//initialize the linked list of lairs
-	for (auto sec : lairModel->lairSectors)
+	for (const auto& sec : lairModel->lairSectors)
 	{
 		auto next = NewDirective(sec.sectorId, sec.sectorLevel, sec.habitatType);
 		if (sec.habitatType == QUEEN_LAIR && !next->pLevel->ubNumCreatures)
@@ -696,7 +696,7 @@ BOOLEAN MineClearOfMonsters( UINT8 ubMineIndex )
 			SLOGE("Attempting to check if mine is clear but mine index is invalid ({}).", ubMineIndex);
 			return true;
 		}
-		for (auto sector : mine->mineSectors)
+		for (const auto& sector : mine->mineSectors)
 		{
 			if (CreaturesInUndergroundSector(sector[0], sector[1]))
 			{

--- a/src/game/Strategic/Game_Init.cc
+++ b/src/game/Strategic/Game_Init.cc
@@ -71,7 +71,7 @@ UINT8			gubScreenCount=0;
 
 static void InitNPCs()
 {
-	for (auto p : GCM->listNpcPlacements())
+	for (const auto& p : GCM->listNpcPlacements())
 	{
 		const NpcPlacementModel* placement = p.second;
 		if (placement->isSciFiOnly && !gGameOptions.fSciFi)

--- a/src/game/Strategic/Strategic_AI.cc
+++ b/src/game/Strategic/Strategic_AI.cc
@@ -2160,7 +2160,7 @@ void LoadStrategicAI(HWFILE const hFile)
 
 	// resize gArmyComp, ensuring all army compositions referenced by Garrison Groups exist
 	size_t numArmyCompositions = NUM_ARMY_COMPOSITIONS;
-	for (auto gGroup : gGarrisonGroup)
+	for (const auto& gGroup : gGarrisonGroup)
 	{
 		numArmyCompositions = std::max<size_t>(numArmyCompositions, gGroup.ubComposition + 1);
 	}

--- a/src/game/Tactical/Dialogue_Control.cc
+++ b/src/game/Tactical/Dialogue_Control.cc
@@ -212,7 +212,7 @@ void UnloadExternalNPCFaces()
 	fExternFacesLoaded = FALSE;
 
 	// Remove all external NPC faces.
-	for (auto entry : externalNPCFaces)
+	for (const auto& entry : externalNPCFaces)
 	{
 		DeleteFace(entry.second);
 	}

--- a/src/game/Tactical/Interface_Items.cc
+++ b/src/game/Tactical/Interface_Items.cc
@@ -5398,7 +5398,7 @@ void LoadInterfaceItemsGraphics()
 	guiSmallInventoryGraphicMissingSmallPocket = AddVideoObjectFromFile("sti/interface/inventory/inventory-graphic-not-found-small-sp.sti");
 	guiSmallInventoryGraphicMissingBigPocket = AddVideoObjectFromFile("sti/interface/inventory/inventory-graphic-not-found-small-bp.sti");
 
-	for (auto item : GCM->getAllSmallInventoryGraphicPaths()) {
+	for (const auto& item : GCM->getAllSmallInventoryGraphicPaths()) {
 		auto path = item.to_lower();
 		if (allInventoryGraphics.find(path) == allInventoryGraphics.end()) {
 			try {
@@ -5428,7 +5428,7 @@ void DeleteInterfaceItemsGraphics()
 	DeleteVideoObject(guiSecItemHiddenVO);
 	DeleteVideoObject(guiSmallInventoryGraphicMissingSmallPocket);
 	DeleteVideoObject(guiSmallInventoryGraphicMissingBigPocket);
-	for (auto v : allInventoryGraphics) {
+	for (const auto& v : allInventoryGraphics) {
 		DeleteVideoObject(v.second);
 	}
 	allInventoryGraphics.clear();

--- a/src/game/Utils/Observable.h
+++ b/src/game/Utils/Observable.h
@@ -8,7 +8,7 @@
 
 namespace _observable
 {
-	// placeholder struct for a no-args callback function to satisfy class template 
+	// placeholder struct for a no-args callback function to satisfy class template
 	struct Nil {};
 }
 
@@ -44,7 +44,7 @@ public:
 
 	/**
 	 * @brief Un-registers a listen identified by the given key
-	 * @param key 
+	 * @param key
 	 * @return the current instance for method chaining
 	*/
 	Observable<ARG1, ARGS...> removeListener(const ST::string key)
@@ -62,7 +62,7 @@ public:
 	/**
 	 * @brief Notifies all the registered callbacks, in lexical order of the listener keys
 	 * @tparam ARG1 first argument to the callback; uses default value if skipped
-	 * @tparam ...ARGS the remaining arguments to pass to the callback 
+	 * @tparam ...ARGS the remaining arguments to pass to the callback
 	 */
 	void notify(ARG1 arg1 = ARG1(), ARGS... args) const
 	{
@@ -70,7 +70,7 @@ public:
 			SLOGD("Observable has no listeners");
 		}
 
-		for (auto l : listeners)
+		for (const auto& l : listeners)
 		{
 			l.second(arg1, args...);
 		}


### PR DESCRIPTION
This is a fix for low-prio coverity issues of type `AUTO_CAUSES_COPY`. After the fix some unneccessary copies are avoided.