### PR TITLE
More Coverity fixes

### DIFF
--- a/src/game/Tactical/Items.cc
+++ b/src/game/Tactical/Items.cc
@@ -2704,7 +2704,7 @@ BOOLEAN ArmBomb( OBJECTTYPE * pObj, INT8 bSetting )
 	BOOLEAN fRemote = FALSE;
 	BOOLEAN fPressure = FALSE;
 	BOOLEAN fTimed = FALSE;
-	BOOLEAN	fSwitch = FALSE;
+	[[maybe_unused]] BOOLEAN fSwitch = FALSE; // only used as a code hint to improve readability
 
 	if (pObj->usItem == ACTION_ITEM)
 	{
@@ -2774,14 +2774,10 @@ BOOLEAN ArmBomb( OBJECTTYPE * pObj, INT8 bSetting )
 		}
 
 	}
-	else if (fSwitch)
+	else // this must be a switch, fSwitch == TRUE
 	{
 		pObj->bDetonatorType = BOMB_SWITCH;
 		pObj->bFrequency = bSetting;
-	}
-	else
-	{
-		return( FALSE );
 	}
 
 	pObj->fFlags |= OBJECT_ARMED_BOMB;

--- a/src/game/Tactical/Morale.cc
+++ b/src/game/Tactical/Morale.cc
@@ -566,6 +566,9 @@ void HandleMoraleEvent(SOLDIERTYPE *pSoldier, INT8 bMoraleEvent, const SGPSector
 			break;
 
 		case MORALE_MERC_MARRIED:
+			// needs specific soldier!
+			Assert(pSoldier);
+
 			// Female mercs get unhappy based on how sexist they are (=hate men),
 			// gentlemen males get unhappy too
 			FOR_EACH_IN_TEAM(i, OUR_TEAM)

--- a/src/game/Tactical/Soldier_Add.cc
+++ b/src/game/Tactical/Soldier_Add.cc
@@ -645,6 +645,7 @@ UINT16 FindGridNoFromSweetSpotWithStructDataFromSoldier(const SOLDIERTYPE* const
 						usAnimSurface = DetermineSoldierAnimationSurface( pSoldier, usAnimState );
 						// Get structure ref...
 						const STRUCTURE_FILE_REF* const pStructureFileRef = GetAnimationStructureRef(pSoldier, usAnimSurface, usAnimState);
+						Assert(pStructureFileRef);
 
 						// Check each struct in each direction
 						for( cnt3 = 0; cnt3 < 8; cnt3++ )
@@ -660,7 +661,6 @@ UINT16 FindGridNoFromSweetSpotWithStructDataFromSoldier(const SOLDIERTYPE* const
 					else
 					{
 						fDirectionFound = TRUE;
-						cnt3 = (UINT8)Random( 8 );
 					}
 
 					if ( fDirectionFound )

--- a/src/game/Tactical/Soldier_Ani.cc
+++ b/src/game/Tactical/Soldier_Ani.cc
@@ -85,7 +85,7 @@ static const DOUBLE gHopFenceForwardNWDist[NUMSOLDIERBODYTYPES]     = { 2.7, 1.0
 static const DOUBLE gHopFenceForwardFullSEDist[NUMSOLDIERBODYTYPES] = { 1.1, 1.0, 2.1, 1.1 };
 static const DOUBLE gHopFenceForwardFullNWDist[NUMSOLDIERBODYTYPES] = { 0.8, 0.2, 2.7, 0.8 };
 static const DOUBLE gFalloffBackwardsDist[NUMSOLDIERBODYTYPES]      = { 1, 0.8, 1, 1 };
-static const DOUBLE gClimbUpRoofDist[NUMSOLDIERBODYTYPES]           = { 2, 0.1, 2, 2 };
+static const float  gClimbUpRoofDist[NUMSOLDIERBODYTYPES]           = { 2.0f, 0.1f, 2.0f, 2.0f };
 static const DOUBLE gClimbUpRoofLATDist[NUMSOLDIERBODYTYPES]        = { 0.7, 0.5, 0.7, 0.5 };
 static const DOUBLE gClimbDownRoofStartDist[NUMSOLDIERBODYTYPES]    = { 5.0, 1.0, 1, 1 };
 static const DOUBLE gClimbUpRoofDistGoingLower[NUMSOLDIERBODYTYPES] = { 0.9, 0.1, 1, 1 };
@@ -802,14 +802,7 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 
 					// CODE: HANDLE CLIMBING ROOF,
 					// Move merc up
-					if ( pSoldier->bDirection == NORTH )
-					{
-						SetSoldierHeight( pSoldier, (FLOAT)(pSoldier->dHeightAdjustment + gClimbUpRoofDist[ pSoldier->ubBodyType ] ) );
-					}
-					else
-					{
-						SetSoldierHeight( pSoldier, (FLOAT)(pSoldier->dHeightAdjustment + gClimbUpRoofDist[ pSoldier->ubBodyType ] ) );
-					}
+					SetSoldierHeight(pSoldier, pSoldier->dHeightAdjustment + gClimbUpRoofDist[pSoldier->ubBodyType]);
 					break;
 
 				case 455:
@@ -826,14 +819,7 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 
 					// CODE: HANDLE CLIMBING ROOF,
 					// Move merc DOWN
-					if ( pSoldier->bDirection == NORTH )
-					{
-						SetSoldierHeight( pSoldier, (FLOAT)(pSoldier->dHeightAdjustment - gClimbUpRoofDist[ pSoldier->ubBodyType ] ) );
-					}
-					else
-					{
-						SetSoldierHeight( pSoldier, (FLOAT)(pSoldier->dHeightAdjustment - gClimbUpRoofDist[ pSoldier->ubBodyType ] ) );
-					}
+					SetSoldierHeight(pSoldier, pSoldier->dHeightAdjustment - gClimbUpRoofDist[pSoldier->ubBodyType]);
 					break;
 
 				case 457:
@@ -2538,13 +2524,6 @@ no_cry:
 			}
 			// Adjust frame control pos, and try again
 			pSoldier->usAniCode++;
-		}
-		else if ( sNewAniFrame == 999 )
-		{
-
-			// Go to start, by default
-			pSoldier->usAniCode = 0;
-
 		}
 
 	// Loop here until we break on a real item!

--- a/src/game/TacticalAI/AIMain.cc
+++ b/src/game/TacticalAI/AIMain.cc
@@ -1784,6 +1784,7 @@ INT8 ExecuteAction(SOLDIERTYPE *pSoldier)
 								pSoldier->ubID, sDoorGridNo );
 					CancelAIAction(pSoldier);
 					EndAIGuysTurn(*pSoldier);
+					break;
 				}
 
 				StartInteractiveObject(sDoorGridNo, *pStructure, *pSoldier, bDirection);

--- a/src/game/TacticalAI/Movement.cc
+++ b/src/game/TacticalAI/Movement.cc
@@ -12,6 +12,8 @@
 #include "Soldier_Macros.h"
 #include "Render_Fun.h"
 #include "Debug.h"
+#include <algorithm>
+#include <array>
 
 //
 // CJC's DG->JA2 conversion notes
@@ -302,7 +304,6 @@ INT16 InternalGoAsFarAsPossibleTowards(SOLDIERTYPE *pSoldier, INT16 sDesGrid, IN
 	INT16 sTempDest,sGoToGrid;
 	INT16 sOrigin;
 	UINT16 usMaxDist;
-	UINT8 ubDirection,ubDirsLeft,ubDirChecked[8],fFound = FALSE;
 	INT8 fPathFlags;
 
 	INT8 bAPsLeft = -1; // XXX HACK000E
@@ -390,32 +391,18 @@ INT16 InternalGoAsFarAsPossibleTowards(SOLDIERTYPE *pSoldier, INT16 sDesGrid, IN
 		else
 		{
 			// else look at the 8 nearest gridnos to sDesGrid for a valid destination
-
-			// clear ubDirChecked flag for all 8 directions
-			for (ubDirection = 0; ubDirection < 8; ubDirection++)
-				ubDirChecked[ubDirection] = FALSE;
-
-			ubDirsLeft = 8;
+			bool fFound = false;
 
 			// examine all 8 spots around 'sDesGrid'
 			// keep looking while directions remain and a satisfactory one not found
-			for (ubDirsLeft = 8; ubDirsLeft != 0; ubDirsLeft--)
+			// randomly select a direction which hasn't been 'checked' yet
+			std::array<UINT8, 8> directions{ 0, 1, 2, 3, 4, 5, 6, 7 };
+			std::shuffle(directions.begin(), directions.end(), gRandomEngine);
+
+			for (UINT8 const ubDirection : directions)
 			{
-				if (fFound)
-				{
-					break;
-				}
-				// randomly select a direction which hasn't been 'checked' yet
-				do
-				{
-					ubDirection = (UINT8) Random(8);
-				}
-				while (ubDirChecked[ubDirection]);
-
-				ubDirChecked[ubDirection] = TRUE;
-
 				// determine the gridno 1 tile away from current friend in this direction
-				sTempDest = NewGridNo(sDesGrid,DirectionInc( ubDirection + 1 ));
+				sTempDest = NewGridNo(sDesGrid, DirectionInc(ubDirection));
 
 				// if that's out of bounds, ignore it & check next direction
 				if (sTempDest == sDesGrid)
@@ -423,7 +410,7 @@ INT16 InternalGoAsFarAsPossibleTowards(SOLDIERTYPE *pSoldier, INT16 sDesGrid, IN
 
 				if (LegalNPCDestination(pSoldier,sTempDest,ENSURE_PATH,NOWATER,0))
 				{
-					fFound = TRUE;            // found a spot
+					fFound = true;           // found a spot
 					break;                   // stop checking in other directions
 				}
 			}

--- a/src/game/TileEngine/Physics.cc
+++ b/src/game/TileEngine/Physics.cc
@@ -1813,16 +1813,14 @@ static FLOAT CalculateSoldierMaxForce(const SOLDIERTYPE* pSoldier, FLOAT dDegree
 }
 
 
-#define MAX_MISS_BY	30
-#define MIN_MISS_BY	1
-#define MAX_MISS_RADIUS	5
-
-
 static UINT16 RandomGridFromRadius(INT16 sSweetGridNo, INT8 ubMinRadius, INT8 ubMaxRadius);
 
 
 void CalculateLaunchItemParamsForThrow(SOLDIERTYPE* const pSoldier, INT16 sGridNo, const UINT8 ubLevel, const INT16 sEndZ, OBJECTTYPE* const pItem, INT8 bMissBy, const UINT8 ubActionCode, SOLDIERTYPE* const target)
 {
+	constexpr INT8 MAX_MISS_BY = 30;
+	constexpr INT8 MIN_MISS_BY = 1;
+
 	FLOAT    dForce, dDegrees;
 	INT16    sDestX, sDestY, sSrcX, sSrcY;
 	vector_3 vForce, vDirNormal;
@@ -1847,20 +1845,10 @@ void CalculateLaunchItemParamsForThrow(SOLDIERTYPE* const pSoldier, INT16 sGridN
 		bMissBy = 0;
 	}
 
-	//if ( 0 )
 	if ( bMissBy > 0 )
 	{
-		// Max the miss variance
-		if ( bMissBy > MAX_MISS_BY )
-		{
-			bMissBy = MAX_MISS_BY;
-		}
-
-		// Min the miss varience...
-		if ( bMissBy < MIN_MISS_BY )
-		{
-			bMissBy = MIN_MISS_BY;
-		}
+		// Min/Max the miss variance
+		bMissBy = std::clamp(bMissBy, MIN_MISS_BY, MAX_MISS_BY);
 
 		// Adjust position, force, angle
 		SLOGD("Throw miss by: {}", bMissBy);


### PR DESCRIPTION
• Missing null check (14638, 254710)
• Logical dead code (81428, 81439, 81442, 81443)
• Unused value (81671)
• Identical code in different branches (81477)
• Dereference after null check (81474)

Nothing really substantial this time. I used the opportunity to change the bad algorithm to loop over all directions in a random order.