### PR TITLE
Another round of Coverity fixes

### DIFF
--- a/src/externalized/VanillaWeapons_unittests.cc
+++ b/src/externalized/VanillaWeapons_unittests.cc
@@ -11,6 +11,7 @@
 #include "GamePolicy.h"
 #include "MagazineModel.h"
 #include "WeaponModels.h"
+#include <utility>
 
 TEST(Items, weaponsLoading)
 {
@@ -133,12 +134,11 @@ TEST(Items, GetLauncherFromLaunchable)
 
 TEST(Items, ValidAttachment)
 {
-	auto const oldGCM{GCM};
-	std::unique_ptr<DefaultContentManager> const cm(DefaultContentManagerUT::createDefaultCMForTesting());
+	std::unique_ptr<DefaultContentManager> cm(DefaultContentManagerUT::createDefaultCMForTesting());
 	ASSERT_TRUE(cm->loadGameData());
-	GCM = cm.get();
+	auto const oldGCM = std::exchange(GCM, cm.release());
 
-	bool& extra_attachments = const_cast<GamePolicy *>(cm->getGamePolicy())->extra_attachments;
+	bool& extra_attachments = const_cast<GamePolicy *>(GCM->getGamePolicy())->extra_attachments;
 
 	extra_attachments = false;
 	EXPECT_TRUE(ValidAttachment(ITEMDEFINE::DETONATOR, ITEMDEFINE::HMX));
@@ -171,6 +171,7 @@ TEST(Items, ValidAttachment)
 	EXPECT_FALSE(ValidAttachment(ITEMDEFINE::AUTO_ROCKET_RIFLE, ITEMDEFINE::BRASS_KNUCKLES));
 	EXPECT_FALSE(ValidAttachment(0xf083, 0x8c12));
 
+	delete GCM;
 	GCM = oldGCM;
 }
 

--- a/src/game/Editor/EditScreen.cc
+++ b/src/game/Editor/EditScreen.cc
@@ -3194,6 +3194,8 @@ static void DrawObjectsBasedOnSelectionRegion(void)
 			if( fSkipTest || PerformDensityTest() )
 			{
 				iMapIndex = MAPROWCOLTOPOS( y, x );
+				if (iMapIndex < 0 || iMapIndex >= WORLD_MAX) continue;
+
 				switch( iDrawMode )
 				{
 					case DRAW_MODE_EXITGRID:

--- a/src/game/Strategic/Quests.cc
+++ b/src/game/Strategic/Quests.cc
@@ -614,7 +614,7 @@ BOOLEAN CheckFact(Fact const usFact, UINT8 const ubProfileID)
 			gubFact[FACT_BRENDA_DEAD] = (GetProfile(BRENDA).bMercStatus == MERC_IS_DEAD);
 			break;
 		case FACT_NPC_IS_ENEMY:
-			gubFact[FACT_NPC_IS_ENEMY] = (ubProfileID != NO_PROFILE) && (CheckNPCIsEnemy(ubProfileID) ||
+			gubFact[FACT_NPC_IS_ENEMY] = (ubProfileID < NUM_PROFILES) && (CheckNPCIsEnemy(ubProfileID) ||
 				gMercProfiles[ubProfileID].ubMiscFlags2 & PROFILE_MISC_FLAG2_NEEDS_TO_SAY_HOSTILE_QUOTE);
 			break;
 			/*
@@ -797,7 +797,7 @@ BOOLEAN CheckFact(Fact const usFact, UINT8 const ubProfileID)
 			break;
 
 		case FACT_LOYALTY_OKAY:
-			bTown = ubProfileID != NO_PROFILE ? gMercProfiles[ubProfileID].bTown : BLANK_SECTOR;
+			bTown = ubProfileID < NUM_PROFILES ? gMercProfiles[ubProfileID].bTown : BLANK_SECTOR;
 			if( ( bTown != BLANK_SECTOR ) && gTownLoyalty[ bTown ].fStarted && gfTownUsesLoyalty[ bTown ])
 			{
 				gubFact[usFact] = ( (gTownLoyalty[ bTown ].ubRating >= LOYALTY_LOW_THRESHOLD ) && (gTownLoyalty[ bTown ].ubRating < LOYALTY_OK_THRESHOLD ) );
@@ -809,7 +809,7 @@ BOOLEAN CheckFact(Fact const usFact, UINT8 const ubProfileID)
 			break;
 
 		case FACT_LOYALTY_LOW:
-			bTown = ubProfileID != NO_PROFILE ? gMercProfiles[ubProfileID].bTown : BLANK_SECTOR;
+			bTown = ubProfileID < NUM_PROFILES ? gMercProfiles[ubProfileID].bTown : BLANK_SECTOR;
 			if( ( bTown != BLANK_SECTOR ) && gTownLoyalty[ bTown ].fStarted && gfTownUsesLoyalty[ bTown ])
 			{
 				// if Skyrider, ignore low loyalty until he has monologues, and wait at least a day since the latest monologue to avoid a hot/cold attitude
@@ -830,7 +830,7 @@ BOOLEAN CheckFact(Fact const usFact, UINT8 const ubProfileID)
 			break;
 
 		case FACT_LOYALTY_HIGH:
-			bTown = ubProfileID != NO_PROFILE ? gMercProfiles[ubProfileID].bTown : BLANK_SECTOR;
+			bTown = ubProfileID < NUM_PROFILES ? gMercProfiles[ubProfileID].bTown : BLANK_SECTOR;
 			if( ( bTown != BLANK_SECTOR ) && gTownLoyalty[ bTown ].fStarted && gfTownUsesLoyalty[ bTown ])
 			{
 				gubFact[usFact] = (gTownLoyalty[ gMercProfiles[ ubProfileID ].bTown ].ubRating >= LOYALTY_HIGH_THRESHOLD );
@@ -902,19 +902,19 @@ BOOLEAN CheckFact(Fact const usFact, UINT8 const ubProfileID)
 			break;
 
 		case FACT_FIRST_BARTENDER:
-			gubFact[ usFact ] = ubProfileID != NO_PROFILE && (gMercProfiles[ubProfileID].bNPCData == 1 || (gMercProfiles[ubProfileID].bNPCData == 0 && CountBartenders() == 0));
+			gubFact[ usFact ] = ubProfileID < NUM_PROFILES && (gMercProfiles[ubProfileID].bNPCData == 1 || (gMercProfiles[ubProfileID].bNPCData == 0 && CountBartenders() == 0));
 			break;
 
 		case FACT_SECOND_BARTENDER:
-			gubFact[ usFact ] = ubProfileID != NO_PROFILE && (gMercProfiles[ubProfileID].bNPCData == 2 || (gMercProfiles[ubProfileID].bNPCData == 0 && CountBartenders() == 1));
+			gubFact[ usFact ] = ubProfileID < NUM_PROFILES && (gMercProfiles[ubProfileID].bNPCData == 2 || (gMercProfiles[ubProfileID].bNPCData == 0 && CountBartenders() == 1));
 			break;
 
 		case FACT_THIRD_BARTENDER:
-			gubFact[ usFact ] = ubProfileID != NO_PROFILE && (gMercProfiles[ubProfileID].bNPCData == 3 || (gMercProfiles[ubProfileID].bNPCData == 0 && CountBartenders() == 2));
+			gubFact[ usFact ] = ubProfileID < NUM_PROFILES && (gMercProfiles[ubProfileID].bNPCData == 3 || (gMercProfiles[ubProfileID].bNPCData == 0 && CountBartenders() == 2));
 			break;
 
 		case FACT_FOURTH_BARTENDER:
-			gubFact[ usFact ] = ubProfileID != NO_PROFILE && (gMercProfiles[ubProfileID].bNPCData == 4 || (gMercProfiles[ubProfileID].bNPCData == 0 && CountBartenders() == 3));
+			gubFact[ usFact ] = ubProfileID < NUM_PROFILES && (gMercProfiles[ubProfileID].bNPCData == 4 || (gMercProfiles[ubProfileID].bNPCData == 0 && CountBartenders() == 3));
 			break;
 
 		case FACT_NPC_NOT_UNDER_FIRE:
@@ -993,7 +993,7 @@ BOOLEAN CheckFact(Fact const usFact, UINT8 const ubProfileID)
 			break;
 
 		case FACT_NPC_BANDAGED_TODAY:
-			gubFact[usFact] = ubProfileID != NO_PROFILE && (gMercProfiles[ ubProfileID ].ubMiscFlags2 & PROFILE_MISC_FLAG2_BANDAGED_TODAY) != 0;
+			gubFact[usFact] = ubProfileID < NUM_PROFILES && (gMercProfiles[ ubProfileID ].ubMiscFlags2 & PROFILE_MISC_FLAG2_BANDAGED_TODAY) != 0;
 			break;
 
 		case FACT_PLAYER_IN_SAME_ROOM:

--- a/src/game/Tactical/Morale.cc
+++ b/src/game/Tactical/Morale.cc
@@ -721,21 +721,32 @@ void HourlyMoraleUpdate()
 			if (opinion == HATED_OPINION)
 			{
 				INT8 const hated = WhichHated(s->ubProfile, other->ubProfile);
-				if (hated < 0) SLOGW("Unexpected WhichHated() result");
-				else found_hated = hated >=2 ||
-					 // Learn to hate which has become full-blown hatred, full strength
-					 p.bHatedCount[hated] <= p.bHatedTime[hated];
-
-				if (found_hated)
+				INT8 hated_time = 0;
+				if (hated > 2)
 				{
-					// We're teamed with someone we hate! We HATE this! Ignore everyone else!
+					// Learn to hate which has become full-blown hatred, full strength
+					found_hated = true;
 					break;
 				}
+				else if (hated >= 0)
+				{
+					hated_time = p.bHatedTime[hated];
+					if (p.bHatedCount[hated] <= hated_time)
+					{
+						// We're teamed with someone we hate! We HATE this! Ignore everyone else!
+						found_hated = true;
+						break;
+					}
+				}
+				else
+				{
+					SLOGW("Unexpected WhichHated() result");
+				}
+
 				// Otherwise just mix this opinion in with everyone else
 
 				// Scale according to how close to we are to snapping
 				//KM : Divide by 0 error found.  Wrapped into an if statement.
-				INT8 const hated_time = p.bHatedTime[hated];
 				if (hated_time != 0)
 				{
 					opinion = (INT32)opinion * (hated_time - p.bHatedCount[hated]) / hated_time;

--- a/src/game/Tactical/Soldier_Add.cc
+++ b/src/game/Tactical/Soldier_Add.cc
@@ -1013,7 +1013,7 @@ static void InternalAddSoldierToSector(SOLDIERTYPE* const s, BOOLEAN calculate_d
 		}
 
 		// Override calculated direction if we were told to....
-		if (s->ubInsertionDirection > 100)
+		if (s->ubInsertionDirection >= 100)
 		{
 			s->ubInsertionDirection -= 100;
 			calculate_direction      = FALSE;
@@ -1044,6 +1044,7 @@ static void InternalAddSoldierToSector(SOLDIERTYPE* const s, BOOLEAN calculate_d
 	}
 
 	if (gTacticalStatus.uiFlags & LOADING_SAVED_GAME) direction = s->bDirection;
+	if (direction >= 100) direction -= 100;
 	AddSoldierToSectorGridNo(s, gridno, direction, use_animation, anim_state, anim_code);
 
 	CheckForPotentialAddToBattleIncrement(s);

--- a/src/game/TacticalAI/NPC.cc
+++ b/src/game/TacticalAI/NPC.cc
@@ -185,7 +185,9 @@ static NPCQuoteInfo* ExtractNPCQuoteInfoArrayFromFile(HWFILE const f)
 		EXTR_U16( d, i->fFlags)
 		EXTR_I16( d, i->sRequiredItem)
 		EXTR_U16( d, i->usFactMustBeTrue)
+		if (i->usFactMustBeTrue > FACT_PLAYER_KILLED_BOXERS) i->usFactMustBeTrue = FACT_NONE;
 		EXTR_U16( d, i->usFactMustBeFalse)
+		if (i->usFactMustBeFalse > FACT_PLAYER_KILLED_BOXERS) i->usFactMustBeFalse = FACT_NONE;
 		EXTR_U8(  d, i->ubQuest)
 		EXTR_U8(  d, i->ubFirstDay)
 		EXTR_U8(  d, i->ubLastDay)


### PR DESCRIPTION
> Release the wrapper object in an items unit test (CID 219694)
> Out of bounds array accesses (81526, 81541, 249147, 254706)
> 
> Attempt to address the "Untrusted value as argument" CIDs
>     
> Ensure that `usFactMustBeFalse` and `usFactMustBeTrue` are in range before using them as array indices.
 
The check in `EditScreen.cc` may be necessary (I use the editor too rarely to be sure) but other than that these changes shouldn't do anything except reduce the number of incidents.

