### PR TITLE
More Coverity fixes

### DIFF
--- a/src/externalized/mercs/MercProfileInfo.cc
+++ b/src/externalized/mercs/MercProfileInfo.cc
@@ -53,7 +53,7 @@ void MercProfileInfo::validateData(const std::map<uint8_t, const MercProfileInfo
 	{
 		throw std::runtime_error("Too many merc profiles");
 	}
-	for (auto p : models)
+	for (auto const& p : models)
 	{
 		if (p.first != p.second->profileID)
 		{

--- a/src/game/Editor/EditorItems.cc
+++ b/src/game/Editor/EditorItems.cc
@@ -727,7 +727,7 @@ void AddSelectedItemToWorld(INT16 sGridNo)
 	switch (tempObject.usItem)
 	{
 		case MINE:
-			if (bVisibility == BURIED) usFlags |= WORLD_ITEM_ARMED_BOMB;
+			// Nothing to do here?
 			break;
 
 		case MONEY:

--- a/src/game/Editor/Smoothing_Utils.cc
+++ b/src/game/Editor/Smoothing_Utils.cc
@@ -82,7 +82,7 @@ UINT16 SearchForRoofType(UINT32 const map_idx)
 				for (LEVELNODE const* i = gpWorldLevelData[grid_no].pRoofHead; i; i = i->pNext)
 				{
 					UINT32 const tile_type = GetTileType(i->usIndex);
-					if (tile_type < FIRSTROOF && LASTROOF < tile_type) continue;
+					if (tile_type < FIRSTROOF || tile_type > LASTROOF) continue;
 					// found a roof, so return its type.
 					return tile_type;
 				}

--- a/src/game/Laptop/Mercs.cc
+++ b/src/game/Laptop/Mercs.cc
@@ -529,15 +529,13 @@ static void ScheduleNewMercsToBeAvailable();
 static BOOLEAN ShouldTheMercSiteServerGoDown(void);
 
 
-void DailyUpdateOfMercSite( UINT16 usDate)
+void DailyUpdateOfMercSite()
 {
-	INT32 iNumDays;
-
 	//if its the first day, leave
-	if( usDate == 1 )
+	if (GetWorldDay() == 1)
 		return;
 
-	iNumDays = 0;
+	INT32 iNumDays = 0;
 
 	//loop through all of the hired mercs from M.E.R.C.
 	for (const MERCListingModel* m : GCM->getMERCListings())
@@ -977,7 +975,6 @@ static BOOLEAN GetSpeckConditionalOpening(BOOLEAN fJustEnteredScreen)
 {
 	static UINT16	usQuoteToSay=MERC_VIDEO_SPECK_SPEECH_NOT_TALKING;
 	BOOLEAN	fCanSayLackOfPaymentQuote = TRUE;
-	BOOLEAN fCanUseIdleTag = FALSE;
 
 	//If we just entered the screen, reset some variables
 	if( fJustEnteredScreen )
@@ -1008,12 +1005,13 @@ static BOOLEAN GetSpeckConditionalOpening(BOOLEAN fJustEnteredScreen)
 	else if( LaptopSaveInfo.ubPlayerBeenToMercSiteStatus == MERC_SITE_SECOND_VISIT )
 	{
 		StartSpeckTalking( SPECK_QUOTE_ALTERNATE_OPENING_1_TOUGH_START );
-		fCanUseIdleTag = TRUE;
 	}
 
 	// We have been here at least 2 times before, Check which quote we should use
 	else
 	{
+		BOOLEAN fCanUseIdleTag = FALSE;
+
 		//if the player has not hired any MERC mercs before
 		// CJC Dec 1 2002: fixing this, so near-bankrupt msg will play
 		if( !IsAnyMercMercsHired( ) && CalcMercDaysServed() == 0)
@@ -1097,29 +1095,12 @@ static BOOLEAN GetSpeckConditionalOpening(BOOLEAN fJustEnteredScreen)
 
 		if( fCanUseIdleTag )
 		{
-			UINT8 ubRandom = Random( 100 );
-
-			if( ubRandom < 50 )
+			if (Chance(50))
 			{
-				ubRandom = Random( 4 );
-
-				switch( ubRandom )
-				{
-					case 0:
-						StartSpeckTalking( SPECK_QUOTE_ALTERNATE_OPENING_TAG_ON_AFTER_OTHER_TAGS_1 );
-						break;
-					case 1:
-						StartSpeckTalking( SPECK_QUOTE_ALTERNATE_OPENING_TAG_ON_AFTER_OTHER_TAGS_2 );
-						break;
-					case 2:
-						StartSpeckTalking( SPECK_QUOTE_ALTERNATE_OPENING_TAG_ON_AFTER_OTHER_TAGS_3 );
-						break;
-					case 3:
-						StartSpeckTalking( SPECK_QUOTE_ALTERNATE_OPENING_TAG_ON_AFTER_OTHER_TAGS_4 );
-						break;
-					default:
-						SLOGA("GetSpeckConditionalOpening: Problem with random");
-				}
+				// Ensure these quotes are contiguous
+				static_assert(SPECK_QUOTE_ALTERNATE_OPENING_TAG_ON_AFTER_OTHER_TAGS_1 ==
+				              SPECK_QUOTE_ALTERNATE_OPENING_TAG_ON_AFTER_OTHER_TAGS_4 - 3);
+				StartSpeckTalking(SPECK_QUOTE_ALTERNATE_OPENING_TAG_ON_AFTER_OTHER_TAGS_1 + Random(4));
 			}
 		}
 	}

--- a/src/game/Laptop/Mercs.cc
+++ b/src/game/Laptop/Mercs.cc
@@ -1575,7 +1575,7 @@ static std::vector<UINT8> GetAvailableRandomQuotes()
 	for (const MERCListingModel* m : GCM->getMERCListings())
 	{
 		if (!IsMercMercAvailable(GetProfileIDFromMERCListing(m))) continue;
-		for (auto q : m->getQuotesByType(SpeckQuoteType::ADVERTISE))
+		for (auto const& q : m->getQuotesByType(SpeckQuoteType::ADVERTISE))
 		{
 			quotes.push_back(q->quoteID);
 		}

--- a/src/game/Laptop/Mercs.h
+++ b/src/game/Laptop/Mercs.h
@@ -57,7 +57,7 @@ void RenderMercs(void);
 void InitMercBackGround(void);
 void DrawMecBackGround(void);
 void RemoveMercBackGround(void);
-void DailyUpdateOfMercSite( UINT16 usDate);
+void DailyUpdateOfMercSite();
 ProfileID GetProfileIDFromMERCListingIndex(UINT8 ubMercIndex);
 ProfileID GetProfileIDFromMERCListing(const MERCListingModel* listing);
 void DisplayTextForSpeckVideoPopUp(const ST::string& str);

--- a/src/game/Strategic/Auto_Resolve.cc
+++ b/src/game/Strategic/Auto_Resolve.cc
@@ -993,8 +993,6 @@ UINT32 VirtualSoldierDressWound(SOLDIERTYPE* pSoldier, SOLDIERTYPE* pVictim, OBJ
 	else
 	{
 		uiMedcost = uiActual;
-		if ( uiMedcost == 0 && uiActual > 0)
-			uiMedcost = 1;
 		if ( uiMedcost > (UINT32)sKitPts)		// can't afford it
 			uiMedcost = uiActual = sKitPts;   	// recalc cost AND aid
 	}

--- a/src/game/Strategic/Creature_Spreading.cc
+++ b/src/game/Strategic/Creature_Spreading.cc
@@ -696,7 +696,7 @@ BOOLEAN MineClearOfMonsters( UINT8 ubMineIndex )
 			SLOGE("Attempting to check if mine is clear but mine index is invalid ({}).", ubMineIndex);
 			return true;
 		}
-		for (auto sector : mine->mineSectors)
+		for (auto const& sector : mine->mineSectors)
 		{
 			if (CreaturesInUndergroundSector(sector[0], sector[1]))
 			{

--- a/src/game/Strategic/Game_Event_Hook.cc
+++ b/src/game/Strategic/Game_Event_Hook.cc
@@ -110,7 +110,7 @@ BOOLEAN ExecuteStrategicEvent( STRATEGICEVENT *pEvent )
 		//Called once a day to update the number of days that a hired merc from M.E.R.C. has been on contract.
 		// Also if the player hasn't paid for a while Specks will start sending e-mails to the player
 		case EVENT_DAILY_UPDATE_OF_MERC_SITE:
-			DailyUpdateOfMercSite( (UINT16)GetWorldDay() );
+			DailyUpdateOfMercSite();
 			break;
 		case EVENT_DAY3_ADD_EMAIL_FROM_SPECK:
 			AddEmail(MERC_INTRO, MERC_INTRO_LENGTH, SPECK_FROM_MERC, GetWorldTotalMin( ) );

--- a/src/game/Strategic/Game_Events.cc
+++ b/src/game/Strategic/Game_Events.cc
@@ -67,7 +67,7 @@ static void AdjustClockToEventStamp(STRATEGICEVENT* pEvent, UINT32* puiAdjustmen
 void ProcessPendingGameEvents(UINT32 uiAdjustment, const UINT8 ubWarpCode)
 {
 	STRATEGICEVENT *curr, *pEvent, *prev, *temp;
-	BOOLEAN fDeleteEvent = FALSE, fDeleteQueuedEvent = FALSE;
+	BOOLEAN fDeleteEvent = FALSE;
 
 	gfTimeInterrupt = FALSE;
 	gfProcessingGameEvents = TRUE;
@@ -96,12 +96,10 @@ void ProcessPendingGameEvents(UINT32 uiAdjustment, const UINT8 ubWarpCode)
 			{ //make sure that we are processing the last event for that second
 				AdjustClockToEventStamp( curr, &uiAdjustment );
 
-				fDeleteEvent = ExecuteStrategicEvent( curr );
+				fDeleteEvent = ExecuteStrategicEvent(curr);
 
-				if( curr && prev && fDeleteQueuedEvent )
-				{ //The only case where we are deleting a node in the middle of the list
-					prev->next = curr->next;
-				}
+				//The only case where we are deleting a node in the middle of the list
+				//This will happen down below in the if (fDeleteEvent) block
 			}
 			else
 			{ //We are at the current target warp time however, there are still other events following in this time cycle.

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -1695,15 +1695,6 @@ static BOOLEAN TraceCharAnimatedRoute(PathSt* const pPath, const BOOLEAN fForceU
 					iArrow = EAST_ARROW;
 				iArrowSector += eastOffset;
 			}
-			else if((iDeltaA==1)&&(iDeltaB==-1))
-			{
-				iDirection=EAST_LINE;
-				if(!ubCounter)
-					iArrow=W_EAST_ARROW;
-				else
-					iArrow=EAST_ARROW;
-				iArrowSector += eastOffset;
-			}
 			else if((iDeltaA==-WORLD_MAP_X)&&(iDeltaB==WORLD_MAP_X))
 			{
 				iDirection=NORTH_LINE;

--- a/src/game/Strategic/PreBattle_Interface.cc
+++ b/src/game/Strategic/PreBattle_Interface.cc
@@ -54,7 +54,7 @@
 #include "Render_Dirty.h"
 #include "VSurface.h"
 #include "UILayout.h"
-
+#include <optional>
 #include <string_theory/format>
 #include <string_theory/string>
 
@@ -1253,7 +1253,7 @@ static void PutNonSquadMercsInBattleSectorOnSquads(BOOLEAN fExitVehicles)
 
 static void PutNonSquadMercsInPlayerGroupOnSquads(GROUP* const pGroup, const BOOLEAN fExitVehicles)
 {
-	INT8 bUniqueVehicleSquad = -1;
+	std::optional<INT8> bUniqueVehicleSquad;
 	if (pGroup->fVehicle)
 	{
 		// put these guys on their own squad (we need to return their group ID, and can only return one, so they need a unique one
@@ -1275,7 +1275,7 @@ static void PutNonSquadMercsInPlayerGroupOnSquads(GROUP* const pGroup, const BOO
 		// if involved, but off-duty (includes mercs inside vehicles!)
 
 		// if in a vehicle, pull him out
-		if (s.bAssignment == VEHICLE)
+		if (bUniqueVehicleSquad)
 		{
 			if (fExitVehicles)
 			{
@@ -1286,8 +1286,7 @@ static void PutNonSquadMercsInPlayerGroupOnSquads(GROUP* const pGroup, const BOO
 				 * group attack, the mercs could be coming from different sides, and the
 				 * placement screen can't handle mercs on the same squad arriving from
 				 * different edges! */
-				BOOLEAN const fSuccess = AddCharacterToSquad(&s, bUniqueVehicleSquad);
-				(void)fSuccess;
+				BOOLEAN const fSuccess = AddCharacterToSquad(&s, *bUniqueVehicleSquad);
 				Assert(fSuccess);
 			}
 		}

--- a/src/game/Strategic/Strategic_AI.cc
+++ b/src/game/Strategic/Strategic_AI.cc
@@ -125,7 +125,6 @@ BOOLEAN gfUseAlternateQueenPosition = FALSE;
 
 //padding for generic globals
 #define SAI_PADDING_BYTES		97
-INT8		gbPadding[SAI_PADDING_BYTES]; // XXX HACK000B
 //patrol group info plus padding
 std::vector<PATROL_GROUP> gPatrolGroup;
 //army composition info plus padding
@@ -2073,7 +2072,7 @@ void SaveStrategicAI(HWFILE const hFile)
 	hFile->write(&gubHoursGracePeriod,                1);
 	hFile->write(&gusPlayerBattleVictories,           2);
 	hFile->write(&gfUseAlternateQueenPosition,        1);
-	hFile->write(gbPadding,           SAI_PADDING_BYTES);
+	hFile->seek(SAI_PADDING_BYTES, FileSeekMode::FILE_SEEK_FROM_CURRENT);
 	//Save the army composition (which does get modified)
 	hFile->write(gArmyComp.data(), gArmyComp.size() * sizeof(ARMY_COMPOSITION));
 	i = SAVED_ARMY_COMPOSITIONS - gArmyComp.size();
@@ -2131,7 +2130,7 @@ void LoadStrategicAI(HWFILE const hFile)
 	hFile->read(&gubHoursGracePeriod,                1);
 	hFile->read(&gusPlayerBattleVictories,           2);
 	hFile->read(&gfUseAlternateQueenPosition,        1);
-	hFile->read(gbPadding,           SAI_PADDING_BYTES);
+	hFile->seek(SAI_PADDING_BYTES, FileSeekMode::FILE_SEEK_FROM_CURRENT);
 	//Restore the army composition
 	gArmyComp.clear();
 	gArmyComp.assign(SAVED_ARMY_COMPOSITIONS, ARMY_COMPOSITION{});
@@ -2260,12 +2259,12 @@ void LoadStrategicAI(HWFILE const hFile)
 	{
 		UNDERGROUND_SECTORINFO *pSector;
 		pSector = FindUnderGroundSector(SGPSector(4, 11, 1));
-		if( pSector->ubNumTroops + pSector->ubNumElites > 20 )
+		if (pSector && pSector->ubNumTroops + pSector->ubNumElites > 20)
 		{
 			pSector->ubNumTroops -= 2;
 		}
 		pSector = FindUnderGroundSector(SGPSector(3, 15, 1));
-		if( pSector->ubNumTroops + pSector->ubNumElites > 20 )
+		if (pSector && pSector->ubNumTroops + pSector->ubNumElites > 20)
 		{
 			pSector->ubNumTroops -= 2;
 		}

--- a/src/game/Strategic/Strategic_Mines.cc
+++ b/src/game/Strategic/Strategic_Mines.cc
@@ -806,6 +806,8 @@ void IssueHeadMinerQuote(UINT8 const mine_idx, HeadMinerQuote const quote_type)
 
 UINT8 GetHeadMinersMineIndex( UINT8 ubMinerProfileId)
 {
+	Assert(ubMinerProfileId < NUM_PROFILES);
+
 	// find which mine this guy represents
 	for (auto mine : GCM->getMines())
 	{
@@ -816,7 +818,7 @@ UINT8 GetHeadMinersMineIndex( UINT8 ubMinerProfileId)
 	}
 
 	// not found!
-	SLOGA("Illegal profile id receieved or something is very wrong");
+	SLOGE("Illegal profile id receieved or something is very wrong");
 	return 0;
 }
 

--- a/src/game/Tactical/Campaign.cc
+++ b/src/game/Tactical/Campaign.cc
@@ -384,12 +384,10 @@ static void ChangeStat(MERCPROFILESTRUCT& p, SOLDIERTYPE* const pSoldier, StatKi
 	UINT32 *puiStatTimerPtr = NULL;
 	BOOLEAN fChangeTypeIncrease;
 	BOOLEAN fChangeSalary;
-	UINT32 uiLevelCnt;
 	UINT8 ubMercMercIdValue = 0;
 	UINT16 usIncreaseValue = 0;
-	UINT16 usSubpointsPerPoint;
 
-	usSubpointsPerPoint = SubpointsPerPoint(ubStat, p.bExpLevel);
+	UINT16 const usSubpointsPerPoint = SubpointsPerPoint(ubStat, p.bExpLevel);
 
 	// build ptrs to appropriate profiletype stat fields
 	switch( ubStat )
@@ -461,7 +459,8 @@ static void ChangeStat(MERCPROFILESTRUCT& p, SOLDIERTYPE* const pSoldier, StatKi
 			break;
 
 		default:
-			break;
+			// SubpointsPerPoint() already logs an error for invalid ubStat values
+			return;
 	}
 
 
@@ -720,7 +719,7 @@ static void ChangeStat(MERCPROFILESTRUCT& p, SOLDIERTYPE* const pSoldier, StatKi
 			if (fChangeSalary)
 			{
 				// increase all salaries and medical deposits, once for each level gained
-				for (uiLevelCnt = 0; uiLevelCnt < (UINT32) sPtsChanged; uiLevelCnt++)
+				for (INT16 levelCnt = 0; levelCnt < sPtsChanged; ++levelCnt)
 				{
 					p.sSalary = (INT16) CalcNewSalary(p.sSalary, fChangeTypeIncrease,
 										MAX_DAILY_SALARY);

--- a/src/game/Tactical/Civ_Quotes.cc
+++ b/src/game/Tactical/Civ_Quotes.cc
@@ -394,7 +394,6 @@ static UINT8 DetermineCivQuoteEntry(SOLDIERTYPE* pCiv, UINT8* pubCivHintToUse, B
 	BOOLEAN bCivLowLoyalty = FALSE;
 	BOOLEAN bCivHighLoyalty = FALSE;
 	INT8    bCivHint;
-	INT8    bMineId;
 	BOOLEAN bMiners = FALSE;
 
 	(*pubCivHintToUse) = 0;
@@ -601,7 +600,8 @@ static UINT8 DetermineCivQuoteEntry(SOLDIERTYPE* pCiv, UINT8* pubCivHintToUse, B
 			// Not done yet.
 
 			// Are they working for us?
-			bMineId = GetIdOfMineForSector(gWorldSector);
+			INT8 const bMineId = GetIdOfMineForSector(gWorldSector);
+			Assert(bMineId >= 0);
 
 			if ( PlayerControlsMine( bMineId ) )
 			{

--- a/src/game/Tactical/Handle_Items.cc
+++ b/src/game/Tactical/Handle_Items.cc
@@ -2519,12 +2519,12 @@ void SoldierGiveItemFromAnimation( SOLDIERTYPE *pSoldier )
 			// Now intiate conv
 			InitiateConversationFull(pTSoldier, pSoldier, APPROACH_GIVINGITEM, 0, &TempObject);
 		}
+
+		pTSoldier->uiStatusFlags &= (~SOLDIER_ENGAGEDINACTION );
 	}
 
 	// OK, disengage buddy
 	pSoldier->uiStatusFlags &= (~SOLDIER_ENGAGEDINACTION );
-	pTSoldier->uiStatusFlags &= (~SOLDIER_ENGAGEDINACTION );
-
 }
 
 

--- a/src/game/TileEngine/Ambient_Control.h
+++ b/src/game/TileEngine/Ambient_Control.h
@@ -9,7 +9,7 @@ UINT32 SetupNewAmbientSound( UINT32 uiAmbientID );
 void StopAmbients(void);
 void DeleteAllAmbients(void);
 
-extern AMBIENTDATA_STRUCT		gAmbData[ MAX_AMBIENT_SOUNDS ];
-extern INT16								gsNumAmbData;
+inline AMBIENTDATA_STRUCT gAmbData[MAX_AMBIENT_SOUNDS];
+inline INT16 gsNumAmbData = 0;
 
 #endif


### PR DESCRIPTION
>     Do not throw an exception into an empty catch block
>     
>     Also remove a strcpy(), CID 214897, and clean up Mercs.cc a bit (clang-tidy
>     found a dead store).
> 
>     Fix several logical dead code CIDs
>     
>     CID 81429, 81432, 81433, 81437, 81438, 81441
> 
>     Fix two "Improper use of negative value" CIDs
>     
>     Coverity can't know that if pGroup->fVehicle is true s.bAssignment == VEHICLE
>     must also be true.
>     
>     CIDs 81500, 81503
> 
>     Do not deref a null return value in LoadStrategicAI()
>     
>     CID 210845
> 
>     Don't deref a null pointer in SoldierGiveItemFromAnimation()
>     
>     CID 81466
> 
>     Do not deref a null pointer when ChangeStat receives an invalid argument
>     
>     CID 81464
> 
>     Use const references in ranged for loops
>     
>     CIDs 275760, 275761, 275779
> 
>     Rework quest number logic in NPCConsiderQuote()
>     
>     Try to convince Coverity that NPCQuoteInfo::ubQuest is properly validated.
>     Add an assertion in GetHeadMinersMineIndex() to protect against an OOB access.
>     
>     CIDs 81526, 254706 and 13 "Untrusted value as argument" CIDs

If Coverity accepts all these changes (which of course isn't a given) it would reduce the number of incidents by 29. Game play wise these changes should not have any effect, since the changes just remove some dead code or implement the same thing a bit differently.