### PR TITLE
Fix Android package name

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -67,9 +67,6 @@ elif [[ "$CI_TARGET" == "android" ]]; then
   export BUILD_TOOL_ARGS="-p ../android assemble$ANDROID_BUILD_TYPE -PbuildDir=$(pwd)/ci-build"
   export RUN_TESTS=false
   export PACKAGE_NAME="ja2-stracciatella_$(./android/gradlew -q -p ./android projectVersion)-$VERSION_TAG+$(git rev-parse --short HEAD)_android.apk"
-
-  # Gradle requires at least java 11
-  export JAVA_HOME="$JAVA_HOME_17_X64"
 else
   echo "unexpected target ${CI_TARGET}"
   exit 1

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -71,11 +71,13 @@ jobs:
           ${{ matrix.cfg.target }}-rust-v2-${{ hashFiles('rust') }}
           ${{ matrix.cfg.target }}-rust-v2-
 
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - name: Set up JDK 18
+      uses: actions/setup-java@v3
       if: matrix.cfg.target == 'android'
       with:
-        java-version: 1.8
+        distribution: temurin
+        java-version: 18
+        cache: 'gradle'
 
     - name: Setup Android SDK
       uses: android-actions/setup-android@v2


### PR DESCRIPTION
Currently the version is not contained in the Android package name. Example: `ja2-stracciatella_-1648pullrequest+d295641_android.apk `

Seems like this is caused by the wrong java version used for the related `gradlew` call.