### PR TITLE
Do not call NPCReachedDestination() for soldiers without a MercProfile

### DIFF
--- a/src/externalized/mercs/MercProfile.cc
+++ b/src/externalized/mercs/MercProfile.cc
@@ -3,14 +3,14 @@
 #include "Soldier_Profile.h"
 #include "Soldier_Profile_Type.h"
 
-MercProfile::MercProfile(ProfileID profileID)
-	: m_profileID(profileID), m_profile(&gMercProfiles[profileID])
+MercProfile::MercProfile(ProfileID profileID) : m_profileID(profileID)
 {
-	if (m_profileID >= lengthof(gMercProfiles))
+	if (m_profileID >= NUM_PROFILES)
 	{
 		ST::string err = ST::format("invalid m_profileID '{}'", m_profileID);
-		throw std::runtime_error(err.to_std_string());
+		throw std::out_of_range(err.c_str());
 	}
+	m_profile = &gMercProfiles[profileID];
 }
 
 MercProfile::MercProfile(const MercProfileInfo* info)

--- a/src/game/Tactical/Overhead.h
+++ b/src/game/Tactical/Overhead.h
@@ -136,8 +136,6 @@ static inline SOLDIERTYPE& GetMan(UINT const idx)
 	return Menptr[idx];
 }
 
-typedef UINT8 SoldierID;
-
 static inline SoldierID Soldier2ID(const SOLDIERTYPE* const s)
 {
 	return s != NULL ? s->ubID : NOBODY;

--- a/src/game/Tactical/Soldier_Control.h
+++ b/src/game/Tactical/Soldier_Control.h
@@ -23,7 +23,7 @@
 
 #define LOCKED_NO_NEWGRIDNO				2
 
-#define NO_PROFILE					200
+constexpr ProfileID NO_PROFILE = 200;
 
 #define BATTLE_SND_LOWER_VOLUME			1
 
@@ -316,6 +316,7 @@ enum WeaponModes : INT8
 	NUM_WEAPON_MODES
 };
 
+using SoldierID = UINT8;
 
 #define SOLDIERTYPE_NAME_LENGTH 10
 
@@ -323,7 +324,7 @@ enum WeaponModes : INT8
 struct SOLDIERTYPE
 {
 	// ID
-	UINT8 ubID;
+	SoldierID ubID;
 
 	// DESCRIPTION / STATS, ETC
 	UINT8 ubBodyType;
@@ -374,8 +375,6 @@ struct SOLDIERTYPE
 
 	UINT8 ubMovementNoiseHeard;// 8 flags by direction
 
-	// 23 bytes so far
-
 	// WORLD POSITION STUFF
 	FLOAT dXPos;
 	FLOAT dYPos;
@@ -389,8 +388,6 @@ struct SOLDIERTYPE
 
 	INT8 bCollapsed; // collapsed due to being out of APs
 	INT8 bBreathCollapsed; // collapsed due to being out of APs
-	// 50 bytes so far
-
 
 	UINT8 ubDesiredHeight;
 	UINT16 usPendingAnimation;
@@ -400,8 +397,6 @@ struct SOLDIERTYPE
 	BOOLEAN fPausedMove;
 	BOOLEAN fUIdeadMerc; // UI Flags for removing a newly dead merc
 	BOOLEAN fUICloseMerc; // UI Flags for closing panels
-
-
 
 	TIMECOUNTER UpdateCounter;
 	TIMECOUNTER DamageCounter;
@@ -426,8 +421,7 @@ struct SOLDIERTYPE
 
 	BOOLEAN fContinueMoveAfterStanceChange;
 
-	// 60
-	AnimationSurfaceCacheType AnimCache; // will be 9 bytes once changed to pointers
+	AnimationSurfaceCacheType AnimCache;
 
 	INT8 bLife; // current life (hit points or health)
 	UINT8 bSide;
@@ -479,7 +473,7 @@ struct SOLDIERTYPE
 	ST::string SkinPal;
 
 	UINT16 *pShades[ NUM_SOLDIER_SHADES ]; // Shading tables
-	UINT16 *pGlowShades[ 20 ]; //
+	UINT16 *pGlowShades[20];
 	INT8 bMedical;
 	BOOLEAN fBeginFade;
 	UINT8 ubFadeLevel;
@@ -607,7 +601,7 @@ struct SOLDIERTYPE
 	TIMECOUNTER BlinkSelCounter;
 	TIMECOUNTER PortraitFlashCounter;
 	BOOLEAN fDeadSoundPlayed;
-	UINT8 ubProfile;
+	ProfileID ubProfile;
 	UINT8 ubQuoteRecord;
 	UINT8 ubQuoteActionID;
 	UINT8 ubBattleSoundID;

--- a/src/game/Tactical/Soldier_Profile.h
+++ b/src/game/Tactical/Soldier_Profile.h
@@ -20,7 +20,7 @@ static inline MERCPROFILESTRUCT& GetProfile(ProfileID const id)
 }
 
 //enums for the mercs
-enum NPCIDs
+enum NPCIDs : ProfileID
 {
 	BARRY   =  0,
 	BLOOD   =  1,
@@ -186,6 +186,8 @@ enum NPCIDs
 	NPC167,
 	NPC168,
 	NPC169
+
+	// 200 is NO_PROFILE, defined in Soldier_Control.h
 };
 
 BOOLEAN IsProfileIdAnAimOrMERCMerc(UINT8 ubProfileID);

--- a/src/game/Tactical/Soldier_Tile.cc
+++ b/src/game/Tactical/Soldier_Tile.cc
@@ -497,7 +497,7 @@ void HandleNextTileWaiting(SOLDIERTYPE* const pSoldier)
 				if ( sCost > 0 )
 				{
 					// Is the next tile blocked too?
-					sNewGridNo = NewGridNo( (UINT16)pSoldier->sGridNo, DirectionInc( guiPathingData[ 0 ] ) );
+					sNewGridNo = NewGridNo(pSoldier->sGridNo, DirectionInc(guiPathingData[0]));
 
 					bPathBlocked = TileIsClear( pSoldier, guiPathingData[ 0 ], sNewGridNo, pSoldier->bLevel );
 
@@ -510,12 +510,12 @@ void HandleNextTileWaiting(SOLDIERTYPE* const pSoldier)
 							gfPlotPathToExitGrid = TRUE;
 						}
 
-						sCost = (INT16) FindBestPath( pSoldier, sCheckGridNo, pSoldier->bLevel, pSoldier->usUIMovementMode, NO_COPYROUTE, PATH_IGNORE_PERSON_AT_DEST );
+						FindBestPath(pSoldier, sCheckGridNo, pSoldier->bLevel, pSoldier->usUIMovementMode, NO_COPYROUTE, PATH_IGNORE_PERSON_AT_DEST);
 
 						gfPlotPathToExitGrid = FALSE;
 
 						// Is the next tile in this new path blocked too?
-						sNewGridNo = NewGridNo( (UINT16)pSoldier->sGridNo, DirectionInc( guiPathingData[ 0 ] ) );
+						sNewGridNo = NewGridNo(pSoldier->sGridNo, DirectionInc(guiPathingData[0]));
 
 						bPathBlocked = TileIsClear( pSoldier, guiPathingData[ 0 ], sNewGridNo, pSoldier->bLevel );
 
@@ -600,7 +600,10 @@ void HandleNextTileWaiting(SOLDIERTYPE* const pSoldier)
 								// check to see if we're there now!
 								if (pSoldier->sGridNo == pSoldier->sAbsoluteFinalDestination)
 								{
-									NPCReachedDestination(pSoldier, FALSE);
+									if (pSoldier->ubProfile != NO_PROFILE)
+									{
+										NPCReachedDestination(pSoldier, FALSE);
+									}
 									pSoldier->bNextAction = AI_ACTION_WAIT;
 									pSoldier->usNextActionData = 500;
 									return;

--- a/src/game/TacticalAI/NPC.cc
+++ b/src/game/TacticalAI/NPC.cc
@@ -1912,14 +1912,13 @@ void ConverseFull(UINT8 const ubNPC, UINT8 const ubMerc, Approach bApproach, UIN
 				}
 				else if ( pQuotePtr->usGoToGridno == NO_MOVE && pQuotePtr->sActionData > 0 )
 				{
-					SOLDIERTYPE* const pSoldier = FindSoldierByProfileID(ubNPC);
-					if (pSoldier)
+					if (pNPC)
 					{
-						ZEROTIMECOUNTER( pSoldier->AICounter );
-						if (pSoldier->bNextAction == AI_ACTION_WAIT)
+						ZEROTIMECOUNTER(pNPC->AICounter);
+						if (pNPC->bNextAction == AI_ACTION_WAIT)
 						{
-							pSoldier->bNextAction = AI_ACTION_NONE;
-							pSoldier->usNextActionData = 0;
+							pNPC->bNextAction = AI_ACTION_NONE;
+							pNPC->usNextActionData = 0;
 						}
 					}
 					NPCDoAction( ubNPC, (UINT16) (pQuotePtr->sActionData), ubRecordNum );
@@ -1928,37 +1927,38 @@ void ConverseFull(UINT8 const ubNPC, UINT8 const ubMerc, Approach bApproach, UIN
 				// Movement?
 				if ( pQuotePtr->usGoToGridno != NO_MOVE )
 				{
-					SOLDIERTYPE* const pSoldier = FindSoldierByProfileID(ubNPC);
-
 					// stupid hack CC
-					if (pSoldier && ubNPC == KYLE)
+					if (pNPC && ubNPC == KYLE)
 					{
 						// make sure he has keys
-						pSoldier->bHasKeys = TRUE;
+						pNPC->bHasKeys = TRUE;
 					}
-					if (pSoldier && pSoldier->sGridNo == pQuotePtr->usGoToGridno )
+					if (pNPC && pNPC->sGridNo == pQuotePtr->usGoToGridno )
 					{
 						// search for quotes to trigger immediately!
-						pSoldier->ubQuoteRecord = ubRecordNum + 1; // add 1 so that the value is guaranteed nonzero
-						NPCReachedDestination( pSoldier, TRUE );
+						pNPC->ubQuoteRecord = ubRecordNum + 1; // add 1 so that the value is guaranteed nonzero
+						NPCReachedDestination(pNPC, TRUE);
 					}
 					else
 					{
 						// turn off cowering
-						if ( pNPC->uiStatusFlags & SOLDIER_COWERING)
+						if (pNPC)
 						{
-							//pNPC->uiStatusFlags &= ~SOLDIER_COWERING;
-							EVENT_InitNewSoldierAnim( pNPC, STANDING, 0 , FALSE );
+							if (pNPC->uiStatusFlags & SOLDIER_COWERING)
+							{
+								//pNPC->uiStatusFlags &= ~SOLDIER_COWERING;
+								EVENT_InitNewSoldierAnim(pNPC, STANDING, 0 , FALSE);
+							}
+
+							pNPC->ubQuoteRecord = ubRecordNum + 1; // add 1 so that the value is guaranteed nonzero
 						}
 
-						pSoldier->ubQuoteRecord = ubRecordNum + 1; // add 1 so that the value is guaranteed nonzero
-
-						if (pQuotePtr->sActionData == NPC_ACTION_TELEPORT_NPC)
+						if (pNPC && pQuotePtr->sActionData == NPC_ACTION_TELEPORT_NPC)
 						{
 							BumpAnyExistingMerc( pQuotePtr->usGoToGridno );
-							TeleportSoldier(*pSoldier, pQuotePtr->usGoToGridno, false);
+							TeleportSoldier(*pNPC, pQuotePtr->usGoToGridno, false);
 							// search for quotes to trigger immediately!
-							NPCReachedDestination( pSoldier, FALSE );
+							NPCReachedDestination(pNPC, FALSE);
 						}
 						else
 						{


### PR DESCRIPTION
Fixes #1657. Also fixes an OOB in the MercProfile constructor and cleans up struct SOLDIERTYPE a little.