### PR TITLE
Ensure RegisterBackgroundRect properly initializes BACKGROUND_SAVE structs

### DIFF
--- a/src/game/TileEngine/Render_Dirty.h
+++ b/src/game/TileEngine/Render_Dirty.h
@@ -47,7 +47,7 @@ struct VIDEO_OVERLAY
 
 
 // GLOBAL VARIABLES
-extern SGPRect gDirtyClipRect;
+inline SGPRect gDirtyClipRect;
 
 
 // DIRTY QUEUE


### PR DESCRIPTION
`GetFreeBackgroundBuffer` does not guarantee that the returned `BACKGROUND_SAVE` is in a clean state so `RegisterBackgroundRect` must always set all members of this struct.

Without a reliable way to reproduce #1661 this is nothing more than an educated guess. I have definitely seen structs which had `fDisabled` set which can certainly cause graphical corruptions.  Another possible cause might be non-null `pSaveArea` or `pZSaveArea` pointers which would confuse `RestoreBackgroundRects` and `SaveBackgroundRects`. Vanilla had some extra checks which would have hidden this problem.