### PR TITLE
Script extension points on new merc hired

### DIFF
--- a/src/externalized/scripting/FunctionsLibrary.cc
+++ b/src/externalized/scripting/FunctionsLibrary.cc
@@ -8,6 +8,7 @@
 #include "MessageBoxScreen.h"
 #include "Queen_Command.h"
 #include "SaveLoadGameStates.h"
+#include "Soldier_Profile.h"
 #include "StrategicMap.h"
 #include <stdexcept>
 #include <string>
@@ -68,6 +69,11 @@ OBJECTTYPE* CreateMoney(const UINT32 amt)
 void PlaceItem(const INT16 sGridNo, OBJECTTYPE* const pObject, const INT8 ubVisibility)
 {
 	AddItemToPool(sGridNo, pObject, static_cast<Visibility>(ubVisibility), 0, 0, 0);
+}
+
+MERCPROFILESTRUCT* GetMercProfile(const UINT8 ubProfileID)
+{
+	return &(GetProfile(ubProfileID));
 }
 
 ExtraGameStatesTable GetGameStates(const std::string key)

--- a/src/externalized/scripting/FunctionsLibrary.h
+++ b/src/externalized/scripting/FunctionsLibrary.h
@@ -25,6 +25,9 @@ struct SOLDIERTYPE;
 /*! \struct STRUCTURE
     \brief An structure element on the tactical map */
 struct STRUCTURE;
+/*! \struct MERCPROFILESTRUCT
+    \brief Profile of a character in game; controls soldier's name, appearance and others */
+struct MERCPROFILESTRUCT;
 
 /*! \defgroup funclib-dealers Shops and arms dealers
     \brief Manage behavior, inventory and prices of dealers */
@@ -79,11 +82,6 @@ extern Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT32, BOOLEAN_S*> Bef
 extern Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT8, BOOLEAN> OnStructureDamaged;
 
 /**
- * @defgroup funclib-general General 
- * @brief Functions to compose mod modules
- */
-
-/**
  * When the game about to be saved. This is the place to persist mod game states.
  * @ingroup observables
  */
@@ -121,6 +119,30 @@ extern Observable<INT8, UINT16, BOOLEAN> OnItemTransacted;
  * @ingroup observables
  */
 extern Observable<INT8, UINT16, BOOLEAN, UINT32_S*> OnItemPriced;
+
+ /*
+ * When a merc has just be hired and the soldier was just created in the world.
+ * @param soldier the soldier being hired
+ * @ingroup observables
+ */
+extern Observable<SOLDIERTYPE*> OnMercHired;
+
+/**
+ * When an RPC has been recruited into our team.
+ * @param soldier the RPC just recruited
+ * @ingroup observables
+ */
+extern Observable<SOLDIERTYPE*> OnRPCRecruited;
+
+/**
+ * @defgroup funclib-general General
+ * @brief Functions to compose mod modules
+ */
+
+/**
+ * @defgroup funclib-mercs Personnel
+ * @brief Functions to access soldiers and characters in the game
+ */
 
 /** @defgroup funclib-sectors Map sectors
  *  @brief Access and alter sectors' strategic-level data
@@ -180,9 +202,18 @@ OBJECTTYPE* CreateMoney(const UINT32 amt);
 void PlaceItem(const INT16 sGridNo, OBJECTTYPE* const pObject, const INT8 bVisibility);
 
 /**
+ * Gets the Merc Profile data object by profile ID
+ * @param ubProfileID a valid Profile ID
+ * @return pointer to a MERCPROFILESTRUCT struct
+ * @ingroup funclib-mercs
+ */
+MERCPROFILESTRUCT* GetMercProfile(UINT8 ubProfileID);
+
+/**
  * Retrieves a key-value mapping from saved game states.
  * @param key provide a unique key so it will not clash with other mods
  * @return
+ * @ingroup funclib-general
  */
 ExtraGameStatesTable GetGameStates(std::string key);
 
@@ -191,6 +222,7 @@ ExtraGameStatesTable GetGameStates(std::string key);
  * persisted in game saves, and can be retrieved with GetGameStates.
  * @param key provide a unique key so it will not clash with other mods
  * @param states a map of primitive types (string, numeric or boolean)
+ * @ingroup funclib-general
  */
 void PutGameStates(std::string key, ExtraGameStatesTable states);
 

--- a/src/externalized/scripting/ScriptingExtensionsLua.cc
+++ b/src/externalized/scripting/ScriptingExtensionsLua.cc
@@ -132,6 +132,12 @@ void InitScriptingEngine()
 
 static void RegisterUserTypes()
 {
+	lua.new_usertype<SGPSector>("SGPSector",
+		"x", &SGPSector::x,
+		"y", &SGPSector::y,
+		"z", &SGPSector::z
+		);
+
 	lua.new_usertype<SECTORINFO>("SECTORINFO",
 		"ubNumAdmins", &SECTORINFO::ubNumAdmins,
 		"ubNumTroops", &SECTORINFO::ubNumTroops,

--- a/src/externalized/scripting/ScriptingExtensionsLua.cc
+++ b/src/externalized/scripting/ScriptingExtensionsLua.cc
@@ -18,9 +18,10 @@
 #include "Logger.h"
 #include "Overhead.h"
 #include "Quests.h"
+#include "Soldier_Profile.h"
+#include "Soldier_Profile_Type.h"
 #include "StrategicMap.h"
 #include "Structure.h"
-#include <set>
 #include <stdexcept>
 #include <string>
 #include <string_theory/format>
@@ -192,8 +193,14 @@ static void RegisterUserTypes()
 	lua.new_usertype<SOLDIERTYPE>("SOLDIERTYPE",
 		"ubID", &SOLDIERTYPE::ubID,
 		"ubProfile", &SOLDIERTYPE::ubProfile,
+		"name", &SOLDIERTYPE::name,
+
+		"ubWhatKindOfMercAmI", &SOLDIERTYPE::ubWhatKindOfMercAmI,
+		"bActive", &SOLDIERTYPE::bActive,
+
 		"ubBodyType", &SOLDIERTYPE::ubBodyType,
 		"ubSoldierClass", &SOLDIERTYPE::ubSoldierClass,
+		"uiAnimSubFlags", &SOLDIERTYPE::uiAnimSubFlags,
 		"bTeam", &SOLDIERTYPE::bTeam,
 		"ubCivilianGroup", &SOLDIERTYPE::ubCivilianGroup,
 		"bNeutral", &SOLDIERTYPE::bNeutral,
@@ -202,6 +209,7 @@ static void RegisterUserTypes()
 		"bLife", &SOLDIERTYPE::bLife,
 		"bBreath", &SOLDIERTYPE::bBreath,
 		"bBreathMax", &SOLDIERTYPE::bBreathMax,
+		"sBreathRed", &SOLDIERTYPE::sBreathRed,
 		"bCamo", &SOLDIERTYPE::bCamo,
 
 		"bAgility", &SOLDIERTYPE::bAgility,
@@ -223,8 +231,56 @@ static void RegisterUserTypes()
 		"VestPal", &SOLDIERTYPE::VestPal,
 		"SkinPal", &SOLDIERTYPE::SkinPal,
 
-		"ubBattleSoundID", &SOLDIERTYPE::ubBattleSoundID
-		);
+		"ubBattleSoundID", &SOLDIERTYPE::ubBattleSoundID,
+
+		"sSector", &SOLDIERTYPE::sSector,
+		"fBetweenSectors", &SOLDIERTYPE::fBetweenSectors,
+
+		"iTotalContractLength", &SOLDIERTYPE::iTotalContractLength,
+		"iEndofContractTime", &SOLDIERTYPE::iEndofContractTime
+	);
+
+	lua.new_usertype<MERCPROFILESTRUCT>("MERCPROFILESTRUCT",
+		"zNickname", &MERCPROFILESTRUCT::zNickname,
+		"zName", &MERCPROFILESTRUCT::zName,
+
+		"ubBodyType", &MERCPROFILESTRUCT::ubBodyType,
+		"ubFaceIndex", &MERCPROFILESTRUCT::ubFaceIndex,
+		"usEyesX", &MERCPROFILESTRUCT::usEyesX,
+		"usEyesY", &MERCPROFILESTRUCT::usEyesY,
+		"usMouthX", &MERCPROFILESTRUCT::usMouthX,
+		"usMouthY", &MERCPROFILESTRUCT::usMouthY,
+
+		"ubNeedForSleep", &MERCPROFILESTRUCT::ubNeedForSleep,
+
+		"bSkillTrait", &MERCPROFILESTRUCT::bSkillTrait,
+		"bSkillTrait2", &MERCPROFILESTRUCT::bSkillTrait2,
+
+		"bAgility", &MERCPROFILESTRUCT::bAgility,
+		"bDexterity", &MERCPROFILESTRUCT::bDexterity,
+		"bExplosive", &MERCPROFILESTRUCT::bExplosive,
+		"bLeadership", &MERCPROFILESTRUCT::bLeadership,
+		"bMarksmanship", &MERCPROFILESTRUCT::bMarksmanship,
+		"bMechanical", &MERCPROFILESTRUCT::bMechanical,
+		"bMedical", &MERCPROFILESTRUCT::bMedical,
+		"bStrength", &MERCPROFILESTRUCT::bStrength,
+		"bWisdom", &MERCPROFILESTRUCT::bWisdom,
+
+		"bTown", &MERCPROFILESTRUCT::bTown,
+		"sSector", &MERCPROFILESTRUCT::sSector,
+		"sGridNo", &MERCPROFILESTRUCT::sGridNo,
+		"ubLastDateSpokenTo", &MERCPROFILESTRUCT::ubLastDateSpokenTo,
+
+		"iMercMercContractLength", &MERCPROFILESTRUCT::iMercMercContractLength,
+		"sSalary", &MERCPROFILESTRUCT::sSalary,
+		"uiWeeklySalary", &MERCPROFILESTRUCT::uiWeeklySalary,
+		"uiBiWeeklySalary", &MERCPROFILESTRUCT::uiBiWeeklySalary,
+		"bMedicalDeposit", &MERCPROFILESTRUCT::bMedicalDeposit,
+		"sMedicalDepositAmount", &MERCPROFILESTRUCT::sMedicalDepositAmount,
+		"usOptionalGearCost", &MERCPROFILESTRUCT::usOptionalGearCost,
+
+		"iBalance", &MERCPROFILESTRUCT::iBalance
+	);
 
 	lua.new_usertype<DEALER_ITEM_HEADER>("DEALER_ITEM_HEADER",
 		"ubTotalItems", &DEALER_ITEM_HEADER::ubTotalItems,
@@ -263,6 +319,8 @@ static void RegisterGlobals()
 
 	lua.set_function("DoBasicMessageBox", DoBasicMessageBox);
 	lua.set_function("ExecuteTacticalTextBox", ExecuteTacticalTextBox_);
+
+	lua.set_function("GetMercProfile", GetMercProfile);
 
 	lua.set_function("GetGameStates", GetGameStates);
 	lua.set_function("PutGameStates", PutGameStates);
@@ -360,6 +418,8 @@ static void _RegisterListener(std::string observable, std::string luaFunc, ST::s
 	else if (observable == "OnDealerInventoryUpdated")   OnDealerInventoryUpdated.addListener(key, wrap<>(luaFunc));
 	else if (observable == "OnItemTransacted")           OnItemTransacted.addListener(key, wrap<INT8, UINT16, BOOLEAN>(luaFunc));
 	else if (observable == "OnItemPriced")               OnItemPriced.addListener(key, wrap<INT8, UINT16, BOOLEAN, UINT32_S*>(luaFunc));
+	else if (observable == "OnMercHired")                OnMercHired.addListener(key, wrap<SOLDIERTYPE*>(luaFunc));
+	else if (observable == "OnRPCRecruited")             OnRPCRecruited.addListener(key, wrap<SOLDIERTYPE*>(luaFunc));
 	else {
 		ST::string err = ST::format("There is no observable named '{}'", observable);
 		throw std::logic_error(err.to_std_string());

--- a/src/game/Tactical/Merc_Hiring.cc
+++ b/src/game/Tactical/Merc_Hiring.cc
@@ -45,6 +45,7 @@
 #include "GamePolicy.h"
 #include "GameInstance.h"
 #include "ContentManager.h"
+#include "Observable.h"
 
 #include <string_theory/string>
 
@@ -54,6 +55,9 @@
 extern BOOLEAN gfTacticalDoHeliRun;
 extern BOOLEAN gfFirstHeliRun;
 SGPSector g_merc_arrive_sector;
+
+Observable<SOLDIERTYPE*> OnMercHired{};
+
 
 void CreateSpecialItem(SOLDIERTYPE* const s, UINT16 item)
 {
@@ -217,6 +221,8 @@ INT8 HireMerc(MERC_HIRE_STRUCT& h)
 
 	// remove the merc from the Personnel screens departed list (if they have never been hired before, its ok to call it)
 	RemoveNewlyHiredMercFromPersonnelDepartedList(s->ubProfile);
+
+	OnMercHired(s);
 
 	gfAtLeastOneMercWasHired = TRUE;
 	return MERC_HIRE_OK;

--- a/src/game/Tactical/Soldier_Create.cc
+++ b/src/game/Tactical/Soldier_Create.cc
@@ -437,13 +437,14 @@ try
 			break;
 	}
 
+	OnSoldierCreated(s);
+
 	if (guiCurrentScreen == AUTORESOLVE_SCREEN)
 	{
 		s->sSector = SGPSector(GetAutoResolveSectorID());
 		return s;
 	}
 
-	OnSoldierCreated(s);
 
 	Assert(s->usAnimState == STANDING);
 

--- a/src/game/Tactical/Soldier_Profile.cc
+++ b/src/game/Tactical/Soldier_Profile.cc
@@ -45,6 +45,7 @@
 #include "Items.h"
 #include "GameRes.h"
 #include "Faces.h"
+#include "Observable.h"
 
 #include "ContentManager.h"
 #include "GameInstance.h"
@@ -54,6 +55,7 @@
 
 extern BOOLEAN gfProfileDataLoaded;
 
+Observable<SOLDIERTYPE*> OnRPCRecruited;
 
 BOOLEAN	gfPotentialTeamChangeDuringDeath = FALSE;
 
@@ -742,6 +744,8 @@ BOOLEAN RecruitRPC( UINT8 ubCharNum )
 
 	//remove the merc from the Personnel screens departed list ( if they have never been hired before, its ok to call it )
 	RemoveNewlyHiredMercFromPersonnelDepartedList( pSoldier->ubProfile );
+
+	OnRPCRecruited(pNewSoldier);
 
 	return( TRUE );
 }


### PR DESCRIPTION
This adds new functions for mods to manipulate soldiers via scripts. This allows more complex logic on soldiers (skills, name, stats and appearances of RPC, hired mercs, enemies) which can depend on progress, current squad composition, fact, events, or items owned.

## Summary

Exposing a new function and a data type via Lua:

 - `GetMercProfile()`
 - `SGPSector`

New observable extension points:

 - `OnMercHired`
 - `OnRPCRecruited`
 - `OnSoldierCreated` now covers AutoResolve battles too

## Example use-cases

 - Make enemies soldiers tougher on specific events
 - Dynamically grant RPCs, depending on what skills you need the most (or the least)
 - Update stats or skills of un-hired soldiers to simulate growth




