### PR TITLE
Touch control fixes

### DIFF
--- a/src/game/Laptop/AIMFacialIndex.cc
+++ b/src/game/Laptop/AIMFacialIndex.cc
@@ -91,7 +91,7 @@ void EnterAimFacialIndex()
 						(INT16)(usPosY + AIM_FI_PORTRAIT_HEIGHT),
 						MSYS_PRIORITY_HIGH,
 						CURSOR_WWW, SelectMercFaceMoveRegionCallBack,
-						MouseCallbackPrimarySecondary<MOUSE_REGION>(SelectMercFaceRegionCallBackPrimary, SelectMercFaceRegionCallBackSecondary));
+						MouseCallbackPrimarySecondary(SelectMercFaceRegionCallBackPrimary, SelectMercFaceRegionCallBackSecondary));
 			MSYS_SetRegionUserData( &gMercFaceMouseRegions[ i ], 0, i);
 
 			guiAimFiFace[i] = LoadSmallPortrait(GetProfile(AimMercArray[i]));
@@ -105,7 +105,7 @@ void EnterAimFacialIndex()
 
 	MSYS_DefineRegion(&gScreenMouseRegions, LAPTOP_SCREEN_UL_X, LAPTOP_SCREEN_WEB_UL_Y,
 				LAPTOP_SCREEN_LR_X, LAPTOP_SCREEN_WEB_LR_Y, MSYS_PRIORITY_HIGH-1,
-				CURSOR_LAPTOP_SCREEN, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary<MOUSE_REGION>(MSYS_NO_CALLBACK, SelectScreenRegionCallBackSecondary));
+				CURSOR_LAPTOP_SCREEN, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary(MSYS_NO_CALLBACK, SelectScreenRegionCallBackSecondary));
 
 	InitAimMenuBar();
 	InitAimDefaults();

--- a/src/game/Laptop/AIMMembers.cc
+++ b/src/game/Laptop/AIMMembers.cc
@@ -493,7 +493,7 @@ void EnterAIMMembers()
 	//** Mouse Regions **
 	MSYS_DefineRegion(&gSelectedFaceRegion, PORTRAIT_X, PORTRAIT_Y,
 				PORTRAIT_X + PORTRAIT_WIDTH , PORTRAIT_Y + PORTRAIT_HEIGHT, MSYS_PRIORITY_HIGH,
-				CURSOR_WWW, SelectFaceMovementRegionCallBack, MouseCallbackPrimarySecondary<MOUSE_REGION>(SelectFaceRegionCallBackPrimary, SelectFaceRegionCallBackSecondary));
+				CURSOR_WWW, SelectFaceMovementRegionCallBack, MouseCallbackPrimarySecondary(SelectFaceRegionCallBackPrimary, SelectFaceRegionCallBackSecondary));
 
 	// if user clicks in the area, the merc will shut up!
 	MSYS_DefineRegion(&gSelectedShutUpMercRegion, LAPTOP_SCREEN_UL_X, LAPTOP_SCREEN_WEB_UL_Y,

--- a/src/game/Laptop/BobbyRMailOrder.cc
+++ b/src/game/Laptop/BobbyRMailOrder.cc
@@ -404,7 +404,7 @@ void EnterBobbyRMailOrder()
 	//s on screen.  When user clicks anywhere the graphic disappears
 	MSYS_DefineRegion(&gSelectedConfirmOrderRegion, LAPTOP_SCREEN_UL_X, LAPTOP_SCREEN_WEB_UL_Y ,
 				LAPTOP_SCREEN_LR_X, LAPTOP_SCREEN_WEB_LR_Y, MSYS_PRIORITY_HIGH+1,
-				CURSOR_WWW, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary<MOUSE_REGION>(SelectConfirmOrderRegionCallBackPrimary, SelectConfirmOrderRegionCallBackSecondary));
+				CURSOR_WWW, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary(SelectConfirmOrderRegionCallBackPrimary, SelectConfirmOrderRegionCallBackSecondary));
 	gSelectedConfirmOrderRegion.Disable();
 
 	//click on the shipping location to activate the drop down menu

--- a/src/game/Laptop/EMail.cc
+++ b/src/game/Laptop/EMail.cc
@@ -259,7 +259,7 @@ static void InitializeMouseRegions(void)
 		const UINT16 w = LINE_WIDTH;
 		const UINT16 h = MIDDLE_WIDTH;
 		MOUSE_REGION* const r = &pEmailRegions[i];
-		MSYS_DefineRegion(r, x, y, x + w, y + h, MSYS_PRIORITY_NORMAL + 2, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary<MOUSE_REGION>(EmailBtnCallBackPrimary, EmailBtnCallBackSecondary, EmailBtnCallBackScroll));
+		MSYS_DefineRegion(r, x, y, x + w, y + h, MSYS_PRIORITY_NORMAL + 2, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary(EmailBtnCallBackPrimary, EmailBtnCallBackSecondary, EmailBtnCallBackScroll));
 		MSYS_SetRegionUserData(r, 0, i);
 	}
 

--- a/src/game/Laptop/Laptop.cc
+++ b/src/game/Laptop/Laptop.cc
@@ -1862,13 +1862,13 @@ void GoToWebPage(INT32 iPageId)
 
 static void BookmarkMvtCallBack(MOUSE_REGION* pRegion, UINT32 iReason)
 {
-	if (iReason == MSYS_CALLBACK_REASON_MOVE)
-	{
-		iHighLightBookLine=MSYS_GetRegionUserData(pRegion, 0);
-	}
-	if (iReason == MSYS_CALLBACK_REASON_LOST_MOUSE)
+	if (iReason & MSYS_CALLBACK_REASON_LOST_MOUSE)
 	{
 		iHighLightBookLine = -1;
+	}
+	else if (iReason & MSYS_CALLBACK_REASON_MOVE)
+	{
+		iHighLightBookLine=MSYS_GetRegionUserData(pRegion, 0);
 	}
 }
 

--- a/src/game/Laptop/Laptop.cc
+++ b/src/game/Laptop/Laptop.cc
@@ -1337,7 +1337,7 @@ static void WWWRegionButtonCallbackSecondary(GUI_BUTTON* btn, UINT32 reason);
 static void CreateLaptopButtons(void)
 {
 	MakeButton(0,  66, EmailRegionButtonCallback,     30, pLaptopIcons[0], gzLaptopHelpText[LAPTOP_BN_HLP_TXT_VIEW_EMAIL]);
-	MakeButton(1,  98, MouseCallbackPrimarySecondary<GUI_BUTTON>(WWWRegionButtonCallbackPrimary, WWWRegionButtonCallbackSecondary), 30, pLaptopIcons[1], gzLaptopHelpText[LAPTOP_BN_HLP_TXT_BROWSE_VARIOUS_WEB_SITES]);
+	MakeButton(1,  98, ButtonCallbackPrimarySecondary(WWWRegionButtonCallbackPrimary, WWWRegionButtonCallbackSecondary), 30, pLaptopIcons[1], gzLaptopHelpText[LAPTOP_BN_HLP_TXT_BROWSE_VARIOUS_WEB_SITES]);
 	MakeButton(2, 130, FilesRegionButtonCallback,     30, pLaptopIcons[5], gzLaptopHelpText[LAPTOP_BN_HLP_TXT_VIEW_FILES_AND_EMAIL_ATTACHMENTS]);
 	MakeButton(3, 194, PersonnelRegionButtonCallback, 30, pLaptopIcons[3], gzLaptopHelpText[LAPTOP_BN_HLP_TXT_VIEW_TEAM_INFO]);
 	MakeButton(4, 162, HistoryRegionButtonCallback,   30, pLaptopIcons[4], gzLaptopHelpText[LAPTOP_BN_HLP_TXT_READ_LOG_OF_EVENTS]);
@@ -2169,7 +2169,7 @@ void LapTopScreenCallBackSecondary(MOUSE_REGION* pRegion, UINT32 iReason)
 	HandleRightButtonUpEvent();
 }
 
-MOUSE_CALLBACK LapTopScreenCallBack = MouseCallbackPrimarySecondary<MOUSE_REGION>(LapTopScreenCallBackPrimary, LapTopScreenCallBackSecondary);
+MOUSE_CALLBACK LapTopScreenCallBack = MouseCallbackPrimarySecondary(LapTopScreenCallBackPrimary, LapTopScreenCallBackSecondary);
 
 void DoLapTopMessageBox(MessageBoxStyleID ubStyle, const ST::string& str, ScreenID uiExitScreen, MessageBoxFlags ubFlags, MSGBOX_CALLBACK ReturnCallback)
 {

--- a/src/game/Laptop/Personnel.cc
+++ b/src/game/Laptop/Personnel.cc
@@ -922,7 +922,7 @@ static void CreateDestroyMouseRegionsForPersonnelPortraits(BOOLEAN create)
 			const UINT16 tly = SMALL_PORTRAIT_START_Y + i / PERSONNEL_PORTRAIT_NUMBER_WIDTH * SMALL_PORT_HEIGHT;
 			const UINT16 brx = tlx + SMALL_PORTRAIT_WIDTH;
 			const UINT16 bry = tly + SMALL_PORTRAIT_HEIGHT;
-			MSYS_DefineRegion(&gPortraitMouseRegions[i], tlx, tly, brx, bry, MSYS_PRIORITY_HIGHEST, CURSOR_LAPTOP_SCREEN, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary<MOUSE_REGION>(PersonnelPortraitCallbackPrimary, PersonnelPortraitCallbackSecondary));
+			MSYS_DefineRegion(&gPortraitMouseRegions[i], tlx, tly, brx, bry, MSYS_PRIORITY_HIGHEST, CURSOR_LAPTOP_SCREEN, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary(PersonnelPortraitCallbackPrimary, PersonnelPortraitCallbackSecondary));
 			MSYS_SetRegionUserData(&gPortraitMouseRegions[i], 0, i);
 		}
 

--- a/src/game/Strategic/Assignments.cc
+++ b/src/game/Strategic/Assignments.cc
@@ -2852,7 +2852,7 @@ static void CreateDestroyMouseRegionsForAssignmentMenu(void)
 		for (UINT32 i = 0; i < GetNumberOfLinesOfTextInBox(ghAssignmentBox); ++i)
 		{
 			MOUSE_REGION* const r = &gAssignmentMenuRegion[i];
-			MSYS_DefineRegion(r, x, y, x + w, y + dy, MSYS_PRIORITY_HIGHEST - 4, MSYS_NO_CURSOR, AssignmentMenuMvtCallBack, MouseCallbackPrimarySecondary<MOUSE_REGION>(AssignmentMenuBtnCallbackPrimary, AssignmentMenuBtnCallbackSecondary));
+			MSYS_DefineRegion(r, x, y, x + w, y + dy, MSYS_PRIORITY_HIGHEST - 4, MSYS_NO_CURSOR, AssignmentMenuMvtCallBack, MouseCallbackPrimarySecondary(AssignmentMenuBtnCallbackPrimary, AssignmentMenuBtnCallbackSecondary));
 			MSYS_SetRegionUserData(r, 0, i);
 			y += dy;
 		}
@@ -3756,7 +3756,7 @@ void CreateDestroyMouseRegionsForContractMenu(void)
 		for (UINT32 i = 0; i < GetNumberOfLinesOfTextInBox(box); ++i)
 		{
 			MOUSE_REGION* const r = &gContractMenuRegion[i];
-			MSYS_DefineRegion(r, x, y, x + w, y + dy, MSYS_PRIORITY_HIGHEST - 4, MSYS_NO_CURSOR, ContractMenuMvtCallback, MouseCallbackPrimarySecondary<MOUSE_REGION>(ContractMenuBtnCallbackPrimary, ContractMenuBtnCallbackSecondary));
+			MSYS_DefineRegion(r, x, y, x + w, y + dy, MSYS_PRIORITY_HIGHEST - 4, MSYS_NO_CURSOR, ContractMenuMvtCallback, MouseCallbackPrimarySecondary(ContractMenuBtnCallbackPrimary, ContractMenuBtnCallbackSecondary));
 			MSYS_SetRegionUserData(r, 0, i);
 			y += dy;
 		}
@@ -3818,7 +3818,7 @@ static void CreateDestroyMouseRegionsForTrainingMenu(void)
 		{
 			// add mouse region for each line of text..and set user data
 			MOUSE_REGION* const r = &gTrainingMenuRegion[i];
-			MSYS_DefineRegion(r, x, y, x + w, y + h, MSYS_PRIORITY_HIGHEST - 3, MSYS_NO_CURSOR, TrainingMenuMvtCallBack, MouseCallbackPrimarySecondary<MOUSE_REGION>(TrainingMenuBtnCallbackPrimary, TrainingMenuBtnCallbackSecondary, TrainingMenuBtnCallbackMarkDirty));
+			MSYS_DefineRegion(r, x, y, x + w, y + h, MSYS_PRIORITY_HIGHEST - 3, MSYS_NO_CURSOR, TrainingMenuMvtCallBack, MouseCallbackPrimarySecondary(TrainingMenuBtnCallbackPrimary, TrainingMenuBtnCallbackSecondary, TrainingMenuBtnCallbackMarkDirty));
 			MSYS_SetRegionUserData(r, 0, i);
 			y += h;
 		}

--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -1520,7 +1520,7 @@ ScreenID MapScreenHandle(void)
 		LoadCharacters();
 
 
-		MOUSE_CALLBACK mapViewRegionCallback = MouseCallbackPrimarySecondary<MOUSE_REGION>(MapViewRegionPrimaryCallback, MapViewRegionSecondaryCallback);
+		MOUSE_CALLBACK mapViewRegionCallback = MouseCallbackPrimarySecondary(MapViewRegionPrimaryCallback, MapViewRegionSecondaryCallback);
 		// set up regions
 		MSYS_DefineRegion( &gMapViewRegion, MAP_VIEW_START_X + MAP_GRID_X, MAP_VIEW_START_Y + MAP_GRID_Y,MAP_VIEW_START_X + MAP_VIEW_WIDTH+MAP_GRID_X-1, MAP_VIEW_START_Y + MAP_VIEW_HEIGHT-1 + 8, MSYS_PRIORITY_HIGH - 3,
 					MSYS_NO_CURSOR, MapViewRegionMovementCallback, mapViewRegionCallback );
@@ -1532,7 +1532,7 @@ ScreenID MapScreenHandle(void)
 					ItemRegionMvtCallback , ItemRegionBtnCallback );
 
 		MSYS_DefineRegion( &gCharInfoFaceRegion, (INT16) PLAYER_INFO_FACE_START_X, (INT16) PLAYER_INFO_FACE_START_Y, (INT16) PLAYER_INFO_FACE_END_X, (INT16) PLAYER_INFO_FACE_END_Y, MSYS_PRIORITY_HIGH,
-					MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary<MOUSE_REGION>(FaceRegionBtnCallbackPrimary, FaceRegionBtnCallbackSecondary) );
+					MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary(FaceRegionBtnCallbackPrimary, FaceRegionBtnCallbackSecondary) );
 
 		MSYS_DefineRegion(&gMPanelRegion, INV_REGION_X, INV_REGION_Y, INV_REGION_X + INV_REGION_WIDTH, INV_REGION_Y + INV_REGION_HEIGHT, MSYS_PRIORITY_HIGH, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MSYS_NO_CALLBACK);
 		// screen mask for animated cursors
@@ -3499,7 +3499,7 @@ void CreateDestroyMapInvButton()
 
 		INV_REGION_DESC gSCamoXY = {INV_BODY_X, INV_BODY_Y};
 
-		InitInvSlotInterface(g_ui.m_invSlotPositionMap, &gSCamoXY, MAPInvMoveCallback, MouseCallbackPrimarySecondary<MOUSE_REGION>(MAPInvClickCallbackPrimary, MAPInvClickCallbackSecondary, MAPInvClickCallbackCancelMessage), MAPInvMoveCamoCallback, MAPInvClickCamoCallback);
+		InitInvSlotInterface(g_ui.m_invSlotPositionMap, &gSCamoXY, MAPInvMoveCallback, MouseCallbackPrimarySecondary(MAPInvClickCallbackPrimary, MAPInvClickCallbackSecondary, MAPInvClickCallbackCancelMessage), MAPInvMoveCamoCallback, MAPInvClickCamoCallback);
 		gMPanelRegion.Enable();
 
 		// switch hand region help text to "Exit Inventory"
@@ -4212,13 +4212,13 @@ static void CreateMouseRegionsForTeamList(void)
 
 		const UINT16 w = NAME_WIDTH;
 		CharacterRegions& r = g_character_regions[i];
-		MakeRegion(&r.name,        i, NAME_X,           y, w,                    TeamListInfoRegionMvtCallBack,        MouseCallbackPrimarySecondary<MOUSE_REGION>(TeamListInfoRegionBtnCallBackPrimary, TeamListInfoRegionBtnCallBackSecondary),        pMapScreenMouseRegionHelpText[0]); // name region
-		MakeRegion(&r.assignment,  i, ASSIGN_X,         y, ASSIGN_WIDTH,         TeamListAssignmentRegionMvtCallBack,  MouseCallbackPrimarySecondary<MOUSE_REGION>(TeamListAssignmentRegionBtnCallBackPrimary, TeamListAssignmentRegionBtnCallBackSecondary),  pMapScreenMouseRegionHelpText[1]); // assignment region
-		MakeRegion(&r.sleep,       i, SLEEP_X,          y, SLEEP_WIDTH,          TeamListSleepRegionMvtCallBack,       MouseCallbackPrimarySecondary<MOUSE_REGION>(TeamListSleepRegionBtnCallBackPrimary, TeamListSleepRegionBtnCallBackSecondary),       pMapScreenMouseRegionHelpText[5]); // sleep region
+		MakeRegion(&r.name,        i, NAME_X,           y, w,                    TeamListInfoRegionMvtCallBack,        MouseCallbackPrimarySecondary(TeamListInfoRegionBtnCallBackPrimary, TeamListInfoRegionBtnCallBackSecondary),        pMapScreenMouseRegionHelpText[0]); // name region
+		MakeRegion(&r.assignment,  i, ASSIGN_X,         y, ASSIGN_WIDTH,         TeamListAssignmentRegionMvtCallBack,  MouseCallbackPrimarySecondary(TeamListAssignmentRegionBtnCallBackPrimary, TeamListAssignmentRegionBtnCallBackSecondary),  pMapScreenMouseRegionHelpText[1]); // assignment region
+		MakeRegion(&r.sleep,       i, SLEEP_X,          y, SLEEP_WIDTH,          TeamListSleepRegionMvtCallBack,       MouseCallbackPrimarySecondary(TeamListSleepRegionBtnCallBackPrimary, TeamListSleepRegionBtnCallBackSecondary),       pMapScreenMouseRegionHelpText[5]); // sleep region
 		// same function as name regions, so uses the same callbacks
-		MakeRegion(&r.location,    i, LOC_X,            y, LOC_WIDTH,            TeamListInfoRegionMvtCallBack,        MouseCallbackPrimarySecondary<MOUSE_REGION>(TeamListInfoRegionBtnCallBackPrimary, TeamListInfoRegionBtnCallBackSecondary),        pMapScreenMouseRegionHelpText[0]); // location region
-		MakeRegion(&r.destination, i, DEST_ETA_X,       y, DEST_ETA_WIDTH,       TeamListDestinationRegionMvtCallBack, MouseCallbackPrimarySecondary<MOUSE_REGION>(TeamListDestinationRegionBtnCallBackPrimary, TeamListDestinationRegionBtnCallBackSecondary), pMapScreenMouseRegionHelpText[2]); // destination region
-		MakeRegion(&r.contract,    i, TIME_REMAINING_X, y, TIME_REMAINING_WIDTH, TeamListContractRegionMvtCallBack,    MouseCallbackPrimarySecondary<MOUSE_REGION>(TeamListContractRegionBtnCallBackPrimary, TeamListContractRegionBtnCallBackSecondary),    pMapScreenMouseRegionHelpText[3]); // contract region
+		MakeRegion(&r.location,    i, LOC_X,            y, LOC_WIDTH,            TeamListInfoRegionMvtCallBack,        MouseCallbackPrimarySecondary(TeamListInfoRegionBtnCallBackPrimary, TeamListInfoRegionBtnCallBackSecondary),        pMapScreenMouseRegionHelpText[0]); // location region
+		MakeRegion(&r.destination, i, DEST_ETA_X,       y, DEST_ETA_WIDTH,       TeamListDestinationRegionMvtCallBack, MouseCallbackPrimarySecondary(TeamListDestinationRegionBtnCallBackPrimary, TeamListDestinationRegionBtnCallBackSecondary), pMapScreenMouseRegionHelpText[2]); // destination region
+		MakeRegion(&r.contract,    i, TIME_REMAINING_X, y, TIME_REMAINING_WIDTH, TeamListContractRegionMvtCallBack,    MouseCallbackPrimarySecondary(TeamListContractRegionBtnCallBackPrimary, TeamListContractRegionBtnCallBackSecondary),    pMapScreenMouseRegionHelpText[3]); // contract region
 	}
 }
 

--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -3659,15 +3659,14 @@ static void MAPInvMoveCallback(MOUSE_REGION* pRegion, UINT32 iReason)
 	if ( pSoldier->inv[ uiHandPos ].usItem == NOTHING )
 		return;
 
-	if (iReason == MSYS_CALLBACK_REASON_GAIN_MOUSE )
-	//if( ( iReason == MSYS_CALLBACK_REASON_MOVE ) || ( iReason == MSYS_CALLBACK_REASON_GAIN_MOUSE ) )
+	if (iReason & MSYS_CALLBACK_REASON_GAIN_MOUSE )
 	{
 		guiMouseOverItemTime = GetJA2Clock( );
 		gfCheckForMouseOverItem = TRUE;
 		HandleCompatibleAmmoUI( pSoldier, (INT8)uiHandPos, FALSE );
 		gbCheckForMouseOverItemPos = (INT8)uiHandPos;
 	}
-	if (iReason == MSYS_CALLBACK_REASON_LOST_MOUSE )
+	else if (iReason & MSYS_CALLBACK_REASON_LOST_MOUSE )
 	{
 		HandleCompatibleAmmoUI( pSoldier, (INT8)uiHandPos, FALSE );
 		gfCheckForMouseOverItem = FALSE;

--- a/src/game/Strategic/Map_Screen_Interface.cc
+++ b/src/game/Strategic/Map_Screen_Interface.cc
@@ -3042,7 +3042,7 @@ void CreateScreenMaskForMoveBox( void )
 	if (!fScreenMaskForMoveCreated)
 	{
 		// set up the screen mask
-		MSYS_DefineRegion(&gMoveBoxScreenMask, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, MSYS_PRIORITY_HIGHEST - 4, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary<MOUSE_REGION>(MoveScreenMaskBtnCallbackPrimary, MoveScreenMaskBtnCallbackSecondary));
+		MSYS_DefineRegion(&gMoveBoxScreenMask, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, MSYS_PRIORITY_HIGHEST - 4, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary(MoveScreenMaskBtnCallbackPrimary, MoveScreenMaskBtnCallbackSecondary));
 
 		fScreenMaskForMoveCreated = TRUE;
 	}

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -2841,7 +2841,7 @@ void CreateDestroyMilitiaPopUPRegions(void)
 			MOUSE_REGION* const r = &gMapScreenMilitiaBoxRegions[i];
 			UINT16        const x = MAP_MILITIA_BOX_POS_X + MAP_MILITIA_MAP_X + i % MILITIA_BOX_ROWS * MILITIA_BOX_BOX_WIDTH;
 			UINT16        const y = MAP_MILITIA_BOX_POS_Y + MAP_MILITIA_MAP_Y + i / MILITIA_BOX_ROWS * MILITIA_BOX_BOX_HEIGHT;
-			MSYS_DefineRegion(r, x, y, x + MILITIA_BOX_BOX_WIDTH, y + MILITIA_BOX_BOX_HEIGHT, MSYS_PRIORITY_HIGHEST - 3, MSYS_NO_CURSOR, MilitiaRegionMoveCallback, MouseCallbackPrimarySecondary<MOUSE_REGION>(MilitiaRegionClickCallbackPrimary, MilitiaRegionClickCallbackSecondary));
+			MSYS_DefineRegion(r, x, y, x + MILITIA_BOX_BOX_WIDTH, y + MILITIA_BOX_BOX_HEIGHT, MSYS_PRIORITY_HIGHEST - 3, MSYS_NO_CURSOR, MilitiaRegionMoveCallback, MouseCallbackPrimarySecondary(MilitiaRegionClickCallbackPrimary, MilitiaRegionClickCallbackSecondary));
 			MSYS_SetRegionUserData(r, 0, i);
 		}
 
@@ -3017,7 +3017,7 @@ void CreateDestroyMilitiaSectorButtons()
 		INT16       y = MAP_MILITIA_BOX_POS_Y + MAP_MILITIA_MAP_Y + sSectorMilitiaMapSector / MILITIA_BOX_ROWS * MILITIA_BOX_BOX_HEIGHT + 2;
 		for (INT32 i = 0; i != 3; y += MILITIA_BTN_HEIGHT, ++i)
 		{
-			GUIButtonRef b = QuickCreateButtonImg(INTERFACEDIR "/militia.sti", 3, 4, x, y, MSYS_PRIORITY_HIGHEST - 1, MouseCallbackPrimarySecondary<GUI_BUTTON>(MilitiaButtonCallbackPrimary, MilitiaButtonCallbackSecondary));
+			GUIButtonRef b = QuickCreateButtonImg(INTERFACEDIR "/militia.sti", 3, 4, x, y, MSYS_PRIORITY_HIGHEST - 1, ButtonCallbackPrimarySecondary(MilitiaButtonCallbackPrimary, MilitiaButtonCallbackSecondary));
 			giMapMilitiaButton[i] = b;
 			b->SetUserData(i);
 			b->SpecifyGeneralTextAttributes(ST::null, FONT10ARIAL, gsMilitiaSectorButtonColors[i], FONT_BLACK);

--- a/src/game/Strategic/Map_Screen_Interface_Map_Inventory.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map_Inventory.cc
@@ -470,7 +470,7 @@ static void CreateMapInventoryPoolSlots(void)
 		UINT16        const y       = STD_SCREEN_Y + inv_box->y;
 		UINT16        const w       = inv_box->w;
 		UINT16        const h       = inv_box->h;
-		MSYS_DefineRegion(&MapInventoryPoolMask, x, y, x + w - 1, y + h - 1, MSYS_PRIORITY_HIGH, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary<MOUSE_REGION>(MSYS_NO_CALLBACK, MapInvenPoolScreenMaskCallbackSecondary, MapInvenPoolScreenMaskCallbackScroll));
+		MSYS_DefineRegion(&MapInventoryPoolMask, x, y, x + w - 1, y + h - 1, MSYS_PRIORITY_HIGH, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary(MSYS_NO_CALLBACK, MapInvenPoolScreenMaskCallbackSecondary, MapInvenPoolScreenMaskCallbackScroll));
 	}
 
 	const SGPBox* const slot_box = &g_sector_inv_slot_box;
@@ -484,7 +484,7 @@ static void CreateMapInventoryPoolSlots(void)
 		UINT16        const w  = reg_box->w;
 		UINT16        const h  = reg_box->h;
 		MOUSE_REGION* const r  = &MapInventoryPoolSlots[i];
-		MSYS_DefineRegion(r, x, y, x + w - 1, y + h - 1, MSYS_PRIORITY_HIGH, MSYS_NO_CURSOR, MapInvenPoolSlotsMove, MouseCallbackPrimarySecondary<MOUSE_REGION>(MapInvenPoolSlotsPrimary, MapInvenPoolSlotsSecondary, MapInvenPoolSlotsScroll));
+		MSYS_DefineRegion(r, x, y, x + w - 1, y + h - 1, MSYS_PRIORITY_HIGH, MSYS_NO_CURSOR, MapInvenPoolSlotsMove, MouseCallbackPrimarySecondary(MapInvenPoolSlotsPrimary, MapInvenPoolSlotsSecondary, MapInvenPoolSlotsScroll));
 		MSYS_SetRegionUserData(r, 0, i);
 	}
 }

--- a/src/game/Tactical/Interface_Items.cc
+++ b/src/game/Tactical/Interface_Items.cc
@@ -278,10 +278,6 @@ SOLDIERTYPE *gpItemPopupSoldier;
 // inventory description done button for mapscreen
 GUIButtonRef giMapInvDescButton;
 
-
-static BOOLEAN gfItemPopupRegionCallbackEndFix = FALSE;
-
-
 struct INV_DESC_STATS
 {
 	INT16 sX;
@@ -1784,14 +1780,14 @@ void InternalInitItemDescriptionBox(OBJECTTYPE* const o, const INT16 sX, const I
 	gubItemDescStatusIndex = ubStatusIndex;
 	gpItemDescSoldier      = s;
 	fItemDescDelete        = FALSE;
-	MOUSE_CALLBACK itemDescCallback = MouseCallbackPrimarySecondary<MOUSE_REGION>(ItemDescCallbackPrimary, ItemDescCallbackSecondary);
+	MOUSE_CALLBACK itemDescCallback = MouseCallbackPrimarySecondary(ItemDescCallbackPrimary, ItemDescCallbackSecondary);
 
 	// Build a mouse region here that is over any others.....
 	if (in_map)
 	{
 		MSYS_DefineRegion(&gInvDesc, gsInvDescX, gsInvDescY, gsInvDescX + MAP_ITEMDESC_WIDTH, gsInvDescY + MAP_ITEMDESC_HEIGHT, MSYS_PRIORITY_HIGHEST - 2, CURSOR_NORMAL, MSYS_NO_CALLBACK, itemDescCallback);
 
-		giMapInvDescButton = QuickCreateButtonImg(INTERFACEDIR "/itemdescdonebutton.sti", 0, 1, gsInvDescX + 204, gsInvDescY + 107, MSYS_PRIORITY_HIGHEST, MouseCallbackPrimarySecondary<GUI_BUTTON>(ItemDescDoneButtonCallbackPrimary, ItemDescDoneButtonCallbackSecondary));
+		giMapInvDescButton = QuickCreateButtonImg(INTERFACEDIR "/itemdescdonebutton.sti", 0, 1, gsInvDescX + 204, gsInvDescY + 107, MSYS_PRIORITY_HIGHEST, ButtonCallbackPrimarySecondary(ItemDescDoneButtonCallbackPrimary, ItemDescDoneButtonCallbackSecondary));
 
 		fShowDescriptionFlag = TRUE;
 	}
@@ -1891,14 +1887,14 @@ void InternalInitItemDescriptionBox(OBJECTTYPE* const o, const INT16 sX, const I
 			const UINT16        w = agi->item_box.w;
 			const UINT16        h = agi->item_box.h;
 			MOUSE_REGION* const r = &gItemDescAttachmentRegions[i];
-			MSYS_DefineRegion(r, x, y, x + w, y + h, MSYS_PRIORITY_HIGHEST, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary<MOUSE_REGION>(ItemDescAttachmentsCallbackPrimary, ItemDescAttachmentsCallbackSecondary));
+			MSYS_DefineRegion(r, x, y, x + w, y + h, MSYS_PRIORITY_HIGHEST, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary(ItemDescAttachmentsCallbackPrimary, ItemDescAttachmentsCallbackSecondary));
 			MSYS_SetRegionUserData(r, 0, i);
 		}
 		SetAttachmentTooltips();
 	}
 	else
 	{
-		GUI_CALLBACK btnMoneyButtonCallback = MouseCallbackPrimarySecondary<GUI_BUTTON>(BtnMoneyButtonCallbackPrimary, BtnMoneyButtonCallbackSecondary, BtnMoneyButtonCallbackOther);
+		GUI_CALLBACK btnMoneyButtonCallback = ButtonCallbackPrimarySecondary(BtnMoneyButtonCallbackPrimary, BtnMoneyButtonCallbackSecondary, BtnMoneyButtonCallbackOther);
 
 		gRemoveMoney = REMOVE_MONEY{};
 		gRemoveMoney.uiTotalAmount    = o->uiMoneyAmount;
@@ -3810,18 +3806,17 @@ void InitItemStackPopup(SOLDIERTYPE* const pSoldier, UINT8 const ubPosition, INT
 		UINT32 col = cnt % MAX_STACK_POPUP_WIDTH;
 
 		// Build a mouse region here that is over any others.....
-		MOUSE_CALLBACK itemPopupRegionCallback = MouseCallbackPrimarySecondary<MOUSE_REGION>(ItemPopupRegionCallbackPrimary, ItemPopupRegionCallbackSecondary, MSYS_NO_CALLBACK, true);
+		MOUSE_CALLBACK itemPopupRegionCallback = MouseCallbackPrimarySecondary(ItemPopupRegionCallbackPrimary, ItemPopupRegionCallbackSecondary, MSYS_NO_CALLBACK, true);
 		MSYS_DefineRegion(&gItemPopupRegions[cnt], sCenX + col * usPopupWidth, sCenY + row * usPopupHeight, sCenX + (col + 1) * usPopupWidth, sCenY + (row+1) * usPopupHeight, MSYS_PRIORITY_HIGHEST, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, itemPopupRegionCallback);
 		MSYS_SetRegionUserData( &gItemPopupRegions[cnt], 0, cnt );
 
 		//OK, for each item, set dirty text if applicable!
 		gItemPopupRegions[cnt].SetFastHelpText(GCM->getItem(pSoldier->inv[ubPosition].usItem)->getName());
-		gfItemPopupRegionCallbackEndFix = FALSE;
 	}
 
 
 	// Build a mouse region here that is over any others.....
-	MSYS_DefineRegion(&gItemPopupRegion, gsItemPopupInvX, gsItemPopupInvY, gsItemPopupInvX + gsItemPopupInvWidth, gsItemPopupInvY + gsItemPopupInvHeight, MSYS_PRIORITY_HIGH, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary<MOUSE_REGION>(ItemPopupFullRegionCallbackPrimary, ItemPopupFullRegionCallbackSecondary));
+	MSYS_DefineRegion(&gItemPopupRegion, gsItemPopupInvX, gsItemPopupInvY, gsItemPopupInvX + gsItemPopupInvWidth, gsItemPopupInvY + gsItemPopupInvHeight, MSYS_PRIORITY_HIGH, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary(ItemPopupFullRegionCallbackPrimary, ItemPopupFullRegionCallbackSecondary));
 
 
 	//Disable all faces
@@ -3982,12 +3977,11 @@ void InitKeyRingPopup(SOLDIERTYPE* const pSoldier, INT16 const sInvX, INT16 cons
 			MSYS_NO_CURSOR, MSYS_NO_CALLBACK, KeyRingSlotInvClickCallback
 		);
 		MSYS_SetRegionUserData( &gKeyRingRegions[cnt], 0, cnt );
-		//gfItemPopupRegionCallbackEndFix = FALSE;
 	}
 
 
 	// Build a mouse region here that is over any others.....
-	MSYS_DefineRegion(&gItemPopupRegion, sInvX, sInvY, sInvX + sInvWidth, sInvY + sInvHeight, MSYS_PRIORITY_HIGH, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary<MOUSE_REGION>(ItemPopupFullRegionCallbackPrimary, ItemPopupFullRegionCallbackSecondary));
+	MSYS_DefineRegion(&gItemPopupRegion, sInvX, sInvY, sInvX + sInvWidth, sInvY + sInvHeight, MSYS_PRIORITY_HIGH, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary(ItemPopupFullRegionCallbackPrimary, ItemPopupFullRegionCallbackSecondary));
 
 
 	//Disable all faces
@@ -4205,12 +4199,6 @@ static void ItemDescDoneButtonCallbackSecondary(GUI_BUTTON *btn, UINT32 reason)
 
 static void ItemPopupRegionCallbackPrimary(MOUSE_REGION* pRegion, UINT32 iReason)
 {
-	// TO ALLOW ME TO DELETE REGIONS IN CALLBACKS!
-	if ( gfItemPopupRegionCallbackEndFix )
-	{
-		return;
-	}
-
 	UINT32 uiItemPos = MSYS_GetRegionUserData( pRegion, 0 );
 
 	//If one in our hand, place it
@@ -4291,19 +4279,7 @@ static void ItemPopupRegionCallbackPrimary(MOUSE_REGION* pRegion, UINT32 iReason
 
 static void ItemPopupRegionCallbackSecondary(MOUSE_REGION* pRegion, UINT32 iReason)
 {
-	// TO ALLOW ME TO DELETE REGIONS IN CALLBACKS!
-	if ( gfItemPopupRegionCallbackEndFix )
-	{
-		return;
-	}
-
 	UINT32 uiItemPos = MSYS_GetRegionUserData( pRegion, 0 );
-
-	// Get Description....
-	// Some global stuff here - for esc, etc
-	//Remove
-	gfItemPopupRegionCallbackEndFix = TRUE;
-
 
 	DeleteItemStackPopup( );
 

--- a/src/game/Tactical/Interface_Panels.cc
+++ b/src/game/Tactical/Interface_Panels.cc
@@ -924,7 +924,7 @@ void InitializeSMPanel()
 	x = dx + SM_SELMERC_FACE_X;
 	y = dy + SM_SELMERC_FACE_Y;
 
-	MOUSE_CALLBACK selectedMercButtonCallback = MouseCallbackPrimarySecondary<MOUSE_REGION>(SelectedMercButtonCallbackPrimary, SelectedMercButtonCallbackSecondary, MSYS_NO_CALLBACK, true);
+	MOUSE_CALLBACK selectedMercButtonCallback = MouseCallbackPrimarySecondary(SelectedMercButtonCallbackPrimary, SelectedMercButtonCallbackSecondary, MSYS_NO_CALLBACK, true);
 	//DEfine region for selected guy panel
 	MSYS_DefineRegion(&gSM_SELMERCPanelRegion, x, y, x + SM_SELMERC_FACE_WIDTH, y + SM_SELMERC_FACE_HEIGHT, MSYS_PRIORITY_NORMAL, MSYS_NO_CURSOR, SelectedMercButtonMoveCallback, selectedMercButtonCallback);
 
@@ -948,7 +948,7 @@ void InitializeSMPanel()
 	//DEfine region for selected guy panel
 	MSYS_DefineRegion(&gSM_SELMERCBarsRegion, dx + 62, dy + 2, dx + 85, dy + 51, MSYS_PRIORITY_NORMAL, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, selectedMercButtonCallback);
 
-	MOUSE_CALLBACK smInvClickCallback = MouseCallbackPrimarySecondary<MOUSE_REGION>(SMInvClickCallbackPrimary, SMInvClickCallbackSecondary, MSYS_NO_CALLBACK, true);
+	MOUSE_CALLBACK smInvClickCallback = MouseCallbackPrimarySecondary(SMInvClickCallbackPrimary, SMInvClickCallbackSecondary, MSYS_NO_CALLBACK, true);
 	InitInvSlotInterface(g_ui.m_invSlotPositionTac, &g_ui.m_invCamoRegion, SMInvMoveCallback, smInvClickCallback, SMInvMoveCamoCallback, SMInvClickCamoCallback);
 	InitKeyRingInterface(KeyRingItemPanelButtonCallback);
 
@@ -2287,7 +2287,7 @@ void InitializeTEAMPanel()
 	{
 		INT32 const face_x = dx + TM_FACE_X;
 		INT32 const face_y = dy + TM_FACE_Y;
-		MOUSE_CALLBACK mercFacePanelCallback = MouseCallbackPrimarySecondary<MOUSE_REGION>(MercFacePanelCallbackPrimary, MercFacePanelCallbackSecondary, MSYS_NO_CALLBACK, true);
+		MOUSE_CALLBACK mercFacePanelCallback = MouseCallbackPrimarySecondary(MercFacePanelCallbackPrimary, MercFacePanelCallbackSecondary, MSYS_NO_CALLBACK, true);
 
 		MakeRegion(tp, tp.face, face_x, face_y, TM_FACE_WIDTH, TM_FACE_HEIGHT,
 				MercFacePanelMoveCallback, mercFacePanelCallback);
@@ -2308,9 +2308,9 @@ void InitializeTEAMPanel()
 		INT32 const hand_x = dx + TM_INV_HAND1STARTX;
 		INT32 const hand_y = dy + TM_INV_HAND1STARTY;
 		MakeRegion(tp, tp.first_hand, hand_x, hand_y, TM_INV_WIDTH, TM_INV_HEIGHT,
-				MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary<MOUSE_REGION>(TMClickFirstHandInvCallbackPrimary, TMClickFirstHandInvCallbackSecondary));
+				MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary(TMClickFirstHandInvCallbackPrimary, TMClickFirstHandInvCallbackSecondary));
 		MakeRegion(tp, tp.second_hand, hand_x, hand_y + TM_INV_HAND_SEPY, TM_INV_WIDTH,
-				TM_INV_HEIGHT, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary<MOUSE_REGION>(TMClickSecondHandInvCallbackPrimary, TMClickSecondHandInvCallbackSecondary));
+				TM_INV_HEIGHT, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary(TMClickSecondHandInvCallbackPrimary, TMClickSecondHandInvCallbackSecondary));
 
 		dx += TM_INV_HAND_SEP;
 	}
@@ -3577,7 +3577,7 @@ void KeyRingSlotInvClickCallbackSecondary( MOUSE_REGION * pRegion, UINT32 iReaso
 	}
 }
 
-MOUSE_CALLBACK KeyRingSlotInvClickCallback = MouseCallbackPrimarySecondary<MOUSE_REGION>(KeyRingSlotInvClickCallbackPrimary, KeyRingSlotInvClickCallbackSecondary, MSYS_NO_CALLBACK, true);
+MOUSE_CALLBACK KeyRingSlotInvClickCallback = MouseCallbackPrimarySecondary(KeyRingSlotInvClickCallbackPrimary, KeyRingSlotInvClickCallbackSecondary, MSYS_NO_CALLBACK, true);
 
 void ShopKeeperInterface_SetSMpanelButtonsState(bool const enabled)
 {

--- a/src/game/Tactical/Interface_Panels.cc
+++ b/src/game/Tactical/Interface_Panels.cc
@@ -1401,7 +1401,7 @@ static void SMInvMoveCallback(MOUSE_REGION* pRegion, UINT32 iReason)
 	if ( gpSMCurrentMerc->inv[ uiHandPos ].usItem == NOTHING )
 		return;
 
-	if (iReason == MSYS_CALLBACK_REASON_GAIN_MOUSE)
+	if (iReason & MSYS_CALLBACK_REASON_GAIN_MOUSE)
 	{
 		if ( gpItemPointer == NULL )
 		{
@@ -1411,7 +1411,7 @@ static void SMInvMoveCallback(MOUSE_REGION* pRegion, UINT32 iReason)
 			gbCheckForMouseOverItemPos = (INT8)uiHandPos;
 		}
 	}
-	if (iReason == MSYS_CALLBACK_REASON_LOST_MOUSE )
+	else if (iReason & MSYS_CALLBACK_REASON_LOST_MOUSE )
 	{
 		if ( gpItemPointer == NULL )
 		{
@@ -1425,14 +1425,14 @@ static void SMInvMoveCallback(MOUSE_REGION* pRegion, UINT32 iReason)
 
 static void SMInvMoveCamoCallback(MOUSE_REGION* const pRegion, const UINT32 iReason)
 {
-	if (iReason == MSYS_CALLBACK_REASON_GAIN_MOUSE )
+	if (iReason & MSYS_CALLBACK_REASON_GAIN_MOUSE )
 	{
 		// Setup a timer....
 		guiMouseOverItemTime = GetJA2Clock( );
 		gfCheckForMouseOverItem = TRUE;
 		gbCheckForMouseOverItemPos = NO_SLOT;
 	}
-	if (iReason == MSYS_CALLBACK_REASON_LOST_MOUSE )
+	else if (iReason & MSYS_CALLBACK_REASON_LOST_MOUSE )
 	{
 		HandleCompatibleAmmoUI( gpSMCurrentMerc, (INT8)NO_SLOT, FALSE );
 		gfCheckForMouseOverItem = FALSE;
@@ -3626,7 +3626,7 @@ static void ConfirmationToDepositMoneyToPlayersAccount(MessageBoxReturnValue);
 
 static void SMInvMoneyButtonCallback(MOUSE_REGION* pRegion, UINT32 iReason)
 {
-	if (iReason == MSYS_CALLBACK_REASON_POINTER_DWN )
+	if (iReason & MSYS_CALLBACK_REASON_POINTER_DWN )
 	{
 		//If the current merc is to far away, dont allow anything to be done
 		if( gfSMDisableForItems )

--- a/src/game/Tactical/ShopKeeper_Interface.cc
+++ b/src/game/Tactical/ShopKeeper_Interface.cc
@@ -1221,7 +1221,7 @@ static void CreateSkiInventorySlotMouseRegions(void)
 		UINT16 const y = SKI_ARMS_DEALERS_INV_START_Y + i / SKI_NUM_ARMS_DEALERS_INV_COLS * SKI_INV_OFFSET_Y;
 		{
 			MOUSE_REGION* const r = &gDealersInventoryMouseRegions[i];
-			MSYS_DefineRegion(r, x, y, x + SKI_INV_SLOT_WIDTH, y + SKI_INV_SLOT_HEIGHT, MSYS_PRIORITY_HIGH, CURSOR_NORMAL, SelectDealersInventoryMovementRegionCallBack, MouseCallbackPrimarySecondary<MOUSE_REGION>(SelectDealersInventoryRegionCallBackPrimary, SelectDealersInventoryRegionCallBackSecondary, SelectDealersInventoryRegionCallBackScroll));
+			MSYS_DefineRegion(r, x, y, x + SKI_INV_SLOT_WIDTH, y + SKI_INV_SLOT_HEIGHT, MSYS_PRIORITY_HIGH, CURSOR_NORMAL, SelectDealersInventoryMovementRegionCallBack, MouseCallbackPrimarySecondary(SelectDealersInventoryRegionCallBackPrimary, SelectDealersInventoryRegionCallBackSecondary, SelectDealersInventoryRegionCallBackScroll));
 			MSYS_SetRegionUserData(r, 0, i);
 		}
 		if (does_repairs)
@@ -1234,7 +1234,7 @@ static void CreateSkiInventorySlotMouseRegions(void)
 	}
 
 	// Create the mouse regions for the shopkeeper's trading slots
-	MOUSE_CALLBACK selectDealersOfferSlotsRegionCallBack = MouseCallbackPrimarySecondary<MOUSE_REGION>(SelectDealersOfferSlotsRegionCallBackPrimary, SelectDealersOfferSlotsRegionCallBackSecondary);
+	MOUSE_CALLBACK selectDealersOfferSlotsRegionCallBack = MouseCallbackPrimarySecondary(SelectDealersOfferSlotsRegionCallBackPrimary, SelectDealersOfferSlotsRegionCallBackSecondary);
 	for (UINT32 i = 0; i != SKI_NUM_TRADING_INV_SLOTS; ++i)
 	{
 		UINT16 const x = SKI_ARMS_DEALERS_TRADING_INV_X + i % SKI_NUM_TRADING_INV_COLS * SKI_INV_OFFSET_X;
@@ -1254,7 +1254,7 @@ static void CreateSkiInventorySlotMouseRegions(void)
 	}
 
 	// Create the mouse regions for the Players trading slots
-	MOUSE_CALLBACK selectPlayersOfferSlotsRegionCallBack = MouseCallbackPrimarySecondary<MOUSE_REGION>(SelectPlayersOfferSlotsRegionCallBackPrimary, SelectPlayersOfferSlotsRegionCallBackSecondary);
+	MOUSE_CALLBACK selectPlayersOfferSlotsRegionCallBack = MouseCallbackPrimarySecondary(SelectPlayersOfferSlotsRegionCallBackPrimary, SelectPlayersOfferSlotsRegionCallBackSecondary);
 	for (UINT32 i = 0; i != SKI_NUM_TRADING_INV_SLOTS; ++i)
 	{
 		UINT16 const x = SKI_PLAYERS_TRADING_INV_X + i % SKI_NUM_TRADING_INV_COLS * SKI_INV_OFFSET_X;

--- a/src/game/TileEngine/Overhead_Map.cc
+++ b/src/game/TileEngine/Overhead_Map.cc
@@ -386,7 +386,7 @@ void GoIntoOverheadMap( )
 
 	MSYS_DefineRegion(&OverheadBackgroundRegion, STD_SCREEN_X, STD_SCREEN_Y, STD_SCREEN_X + 640, STD_SCREEN_Y + 360, MSYS_PRIORITY_HIGH, CURSOR_NORMAL, MSYS_NO_CALLBACK, MSYS_NO_CALLBACK);
 
-	MSYS_DefineRegion(&OverheadRegion, STD_SCREEN_X, STD_SCREEN_Y, STD_SCREEN_X + 640, STD_SCREEN_Y + 320, MSYS_PRIORITY_HIGH, CURSOR_NORMAL, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary<MOUSE_REGION>(ClickOverheadRegionCallbackPrimary, ClickOverheadRegionCallbackSecondary));
+	MSYS_DefineRegion(&OverheadRegion, STD_SCREEN_X, STD_SCREEN_Y, STD_SCREEN_X + 640, STD_SCREEN_Y + 320, MSYS_PRIORITY_HIGH, CURSOR_NORMAL, MSYS_NO_CALLBACK, MouseCallbackPrimarySecondary(ClickOverheadRegionCallbackPrimary, ClickOverheadRegionCallbackSecondary));
 
 	// LOAD CLOSE ANIM
 	uiOVERMAP = AddVideoObjectFromFile(INTERFACEDIR "/map_bord.sti");

--- a/src/game/TileEngine/Radar_Screen.cc
+++ b/src/game/TileEngine/Radar_Screen.cc
@@ -75,7 +75,7 @@ void InitRadarScreen()
 	UINT16        const w = RADAR_WINDOW_WIDTH;
 	UINT16        const h = RADAR_WINDOW_HEIGHT;
 	MOUSE_REGION* const r = &gRadarRegion;
-	MSYS_DefineRegion(r, x, y, x + w, y + h, MSYS_PRIORITY_HIGHEST, 0, RadarRegionMoveCallback, MouseCallbackPrimarySecondary<MOUSE_REGION>(RadarRegionButtonCallbackPrimary, RadarRegionButtonCallbackSecondary));
+	MSYS_DefineRegion(r, x, y, x + w, y + h, MSYS_PRIORITY_HIGHEST, 0, RadarRegionMoveCallback, MouseCallbackPrimarySecondary(RadarRegionButtonCallbackPrimary, RadarRegionButtonCallbackSecondary));
 	r->Disable();
 }
 

--- a/src/game/TileEngine/Radar_Screen.cc
+++ b/src/game/TileEngine/Radar_Screen.cc
@@ -134,7 +134,7 @@ static void RadarRegionMoveCallback(MOUSE_REGION* pRegion, UINT32 iReason)
 	// check if we are allowed to do anything?
 	if (!fRenderRadarScreen) return;
 
-	if (iReason == MSYS_CALLBACK_REASON_MOVE )
+	if (iReason & MSYS_CALLBACK_REASON_MOVE )
 	{
 		if ( pRegion->ButtonState & MSYS_LEFT_BUTTON )
 		{

--- a/src/sgp/Button_System.cc
+++ b/src/sgp/Button_System.cc
@@ -1709,3 +1709,13 @@ UINT16 GetGenericButtonFillColor(void)
 {
 	return GenericButtonFillColors;
 }
+
+GUI_CALLBACK ButtonCallbackPrimarySecondary(
+	GUI_CALLBACK primaryAction,
+	GUI_CALLBACK secondaryAction,
+	GUI_CALLBACK allEvents,
+	bool triggerPrimaryOnMouseDown
+)
+{
+	return CallbackPrimarySecondary<GUI_BUTTON, BUTTON_ENABLED>(primaryAction, secondaryAction, allEvents, triggerPrimaryOnMouseDown);
+}

--- a/src/sgp/Button_System.h
+++ b/src/sgp/Button_System.h
@@ -1,7 +1,6 @@
 // by Kris Morness (originally created by Bret Rowden)
 
-#ifndef BUTTON_SYSTEM_H
-#define BUTTON_SYSTEM_H
+#pragma once
 
 #include "MouseSystem.h"
 
@@ -40,6 +39,13 @@ struct GUI_BUTTON;
 
 // GUI_BUTTON callback function type
 typedef std::function<void(GUI_BUTTON*, UINT32)> GUI_CALLBACK;
+
+GUI_CALLBACK ButtonCallbackPrimarySecondary(
+	GUI_CALLBACK primaryAction,
+	GUI_CALLBACK secondaryAction,
+	GUI_CALLBACK allEvents = nullptr,
+	bool triggerPrimaryOnMouseDown = false
+);
 
 // GUI_BUTTON structure definitions.
 struct GUI_BUTTON
@@ -286,5 +292,3 @@ const ButtonDimensions* GetDimensionsOfButtonPic(const BUTTON_PICS*);
 UINT16 GetGenericButtonFillColor(void);
 
 void ReleaseAnchorMode(void);
-
-#endif

--- a/src/sgp/MouseSystem.cc
+++ b/src/sgp/MouseSystem.cc
@@ -682,8 +682,6 @@ static void MSYS_UpdateMouseRegion(void)
 /* Inits a MOUSE_REGION structure for use with the mouse system */
 void MSYS_DefineRegion(MOUSE_REGION* const r, UINT16 const tlx, UINT16 const tly, UINT16 const brx, UINT16 const bry, INT8 priority, UINT16 const crsr, MOUSE_CALLBACK const movecallback, MOUSE_CALLBACK const buttoncallback)
 {
-	AssertMsg(!(r->uiFlags & MSYS_REGION_EXISTS), "Attempting to define a mouse region that already exists.");
-
 	if (priority <= MSYS_PRIORITY_LOWEST) priority = MSYS_PRIORITY_LOWEST;
 
 	r->PriorityLevel      = priority;

--- a/src/sgp/MouseSystem.cc
+++ b/src/sgp/MouseSystem.cc
@@ -974,3 +974,13 @@ void MOUSE_REGION::AllowDisabledRegionFastHelp(bool const allow)
 		uiFlags &= ~MSYS_ALLOW_DISABLED_FASTHELP;
 	}
 }
+
+MOUSE_CALLBACK MouseCallbackPrimarySecondary(
+	MOUSE_CALLBACK primaryAction,
+	MOUSE_CALLBACK secondaryAction,
+	MOUSE_CALLBACK allEvents,
+	bool triggerPrimaryOnMouseDown
+)
+{
+	return CallbackPrimarySecondary<MOUSE_REGION, MSYS_REGION_ENABLED>(primaryAction, secondaryAction, allEvents, triggerPrimaryOnMouseDown);
+}


### PR DESCRIPTION
This should fix:

- #1679: Caused by the mouse region deleted within its callback, leading to a segfault. We now guard against deleted / disabled regions in `MouseCallbackPrimarySecondary` and `ButtonCallbackPrimarySecondary` before calling the callbacks
- #1666: We now always compare callback reason flags using the `&` operator
- Assertion messages on tactical placement screen: The array was not properly zeroed out when resetting merc placements