### PR TITLE
Cleanup clang compiler warnings

### DIFF
--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -163,7 +163,7 @@ void deleteElements(std::map<K, const V*> map)
 	map.clear();
 }
 
-DefaultContentManager::~DefaultContentManager()
+DefaultContentManager::~DefaultContentManager() noexcept(false)
 {
 	SLOGD("Shutting Down Content Manager");
 	for (const ItemModel* item : m_items)

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -275,10 +275,10 @@ protected:
 	 * @param profileID
 	 * @return pointer to a MercProfileInfo. Never returns null. A pointer to the empty instance is returned if not defined in JSON.
 	 */
-	const MercProfileInfo* getMercProfileInfo(uint8_t profileID) const;
+	const MercProfileInfo* getMercProfileInfo(uint8_t profileID) const override;
 	/**
 	 * @param profile
 	 * @return pointer to a MercProfileInfo. Returns null if not defined in JSON
 	 */
-	const MercProfileInfo* getMercProfileInfoByName(const ST::string& profile) const;
+	const MercProfileInfo* getMercProfileInfoByName(const ST::string& profile) const override;
 };

--- a/src/game/GameScreen.cc
+++ b/src/game/GameScreen.cc
@@ -212,7 +212,7 @@ void EnterTacticalScreen(void)
 	if( !gfTacticalPlacementGUIActive )
 	{
 		//make sure the gsCurInterfacePanel is valid
-		if( gsCurInterfacePanel < 0 || gsCurInterfacePanel >= NUM_UI_PANELS )
+		if( gsCurInterfacePanel >= NUM_UI_PANELS )
 			gsCurInterfacePanel = TEAM_PANEL;
 
 		SetCurrentInterfacePanel(gsCurInterfacePanel);

--- a/src/game/Strategic/Assignments.cc
+++ b/src/game/Strategic/Assignments.cc
@@ -1356,7 +1356,6 @@ static UINT16 HealPatient(SOLDIERTYPE* pPatient, SOLDIERTYPE* pDoctor, UINT16 us
 {
 	// heal patient and return the number of healing pts used
 	UINT16 usHealingPtsLeft;
-	UINT16 usTotalFullPtsUsed = 0;
 	UINT16 usTotalHundredthsUsed = 0;
 	INT8 bPointsToUse = 0;
 	INT8 bPointsUsed = 0;
@@ -1402,7 +1401,6 @@ static UINT16 HealPatient(SOLDIERTYPE* pPatient, SOLDIERTYPE* pDoctor, UINT16 us
 
 				bPointsToUse -= bPointsHealed;
 				usHealingPtsLeft -= bPointsHealed;
-				usTotalFullPtsUsed += bPointsHealed;
 
 				// heal person the amount / POINT_COST_PER_HEALTH_BELOW_OKLIFE
 				pPatient -> bLife += (bPointsHealed / POINT_COST_PER_HEALTH_BELOW_OKLIFE);
@@ -1441,7 +1439,6 @@ static UINT16 HealPatient(SOLDIERTYPE* pPatient, SOLDIERTYPE* pDoctor, UINT16 us
 
 				bPointsToUse -= bPointsHealed;
 				usHealingPtsLeft -= bPointsHealed;
-				usTotalFullPtsUsed += bPointsHealed;
 
 				pPatient -> bLife += bPointsHealed;
 

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -2185,8 +2185,6 @@ static void ShowPeopleInMotion(const SGPSector& sSector)
 void DisplayDistancesForHelicopter()
 {
 	static INT16 sOldYPosition = 0;
-
-	SGPSector sMap;
 	INT16 const sYPosition = gsHighlightSector.IsValid() && gsHighlightSector.y >= 13 ?
 			MAP_HELICOPTER_UPPER_ETA_POPUP_Y : MAP_HELICOPTER_ETA_POPUP_Y;
 

--- a/src/game/Strategic/Strategic_AI.cc
+++ b/src/game/Strategic/Strategic_AI.cc
@@ -1948,7 +1948,6 @@ void EvaluateQueenSituation()
 	INT32 iRandom, iWeight;
 	UINT32 uiOffset;
 	UINT16 usDefencePoints;
-	INT32 iSumOfAllWeights = 0;
 
 	// figure out how long it shall be before we call this again
 
@@ -1997,9 +1996,6 @@ void EvaluateQueenSituation()
 		iWeight = gGarrisonGroup[ i ].bWeight;
 		if( iWeight > 0 )
 		{	//if group is requesting reinforcements.
-
-			iSumOfAllWeights += iWeight;	// debug only!
-
 			if( iRandom < iWeight && !gGarrisonGroup[ i ].ubPendingGroupID &&
 					EnemyPermittedToAttackSector( NULL, gGarrisonGroup[ i ].ubSectorID ) &&
 					GarrisonRequestingMinimumReinforcements( i ) )
@@ -2026,8 +2022,6 @@ void EvaluateQueenSituation()
 		iWeight = gPatrolGroup[ i ].bWeight;
 		if( iWeight > 0 )
 		{
-			iSumOfAllWeights += iWeight;	// debug only!
-
 			if( iRandom < iWeight && !gPatrolGroup[ i ].ubPendingGroupID && PatrolRequestingMinimumReinforcements( i ) )
 			{ //This is the group that gets the reinforcements!
 				SendReinforcementsForPatrol( i, NULL );

--- a/src/game/Tactical/Interface_Items.cc
+++ b/src/game/Tactical/Interface_Items.cc
@@ -465,15 +465,8 @@ static void GenerateProsString(ST::string& zItemPros, const OBJECTTYPE& o, UINT3
 	UINT32 uiStringLength = 0;
 	ST::string zTemp;
 	UINT16 usItem = o.usItem;
-	UINT8 ubWeight;
 
 	zItemPros = ST::null;
-
-	ubWeight = GCM->getItem(usItem)->getWeight();
-	if (GCM->getItem(usItem)->getItemClass() == IC_GUN)
-	{
-		ubWeight += GCM->getItem(o.usGunAmmoItem)->getWeight();
-	}
 
 	if (GCM->getItem(usItem)->getWeight() <= EXCEPTIONAL_WEIGHT)
 	{

--- a/src/game/Tactical/LOS.cc
+++ b/src/game/Tactical/LOS.cc
@@ -4294,7 +4294,6 @@ INT32 CheckForCollision(FLOAT dX, FLOAT dY, FLOAT dZ, FLOAT dDeltaX, FLOAT dDelt
 	STRUCTURE * pStructure, *pTempStructure;
 
 	SOLDIERTYPE * pTarget;
-	FLOAT dTargetZMin;
 	FLOAT dTargetZMax;
 
 	INT16 sX, sY;
@@ -4340,15 +4339,7 @@ INT32 CheckForCollision(FLOAT dX, FLOAT dY, FLOAT dZ, FLOAT dDeltaX, FLOAT dDelt
 	{
 		// a merc! that isn't us :-)
 		pTarget = pMapElement->pMercHead->pSoldier;
-		//dTargetX = pTarget->dXPos;
-		//dTargetY = pTarget->dYPos;
-		dTargetZMin = 0.0f;
 		CalculateSoldierZPos( pTarget, HEIGHT, &dTargetZMax );
-		if (pTarget->bLevel > 0)
-		{
-			// on roof
-			dTargetZMin += WALL_HEIGHT_UNITS;
-		}
 	}
 	else
 	{

--- a/src/game/Tactical/Touch_UI.cc
+++ b/src/game/Tactical/Touch_UI.cc
@@ -175,6 +175,8 @@ void TacticalTouchUIConfirmCallback(GUI_BUTTON*, UINT32 reason) {
 					break;
 				case HANDCURSOR_MODE:
 					HandleHandCursorClick( guiCurrentCursorGridNo, &guiPendingOverrideEvent );
+				default:
+					break;
 			}
 		}
 	}
@@ -202,8 +204,6 @@ void TacticalTouchUIBurstCallback(GUI_BUTTON*, UINT32 reason) {
 		auto const& selected = GetSelectedMan();
 
 		if (guiCurrentCursorGridNo == NOWHERE || selected == NULL) return;
-
-		bool const enable_burst = IsGunBurstCapable(selected, HANDPOS) || FindAttachment(&(selected->inv[HANDPOS]), UNDER_GLAUNCHER) != ITEM_NOT_FOUND;
 
 		ChangeWeaponMode(selected);
 	}

--- a/src/game/TacticalAI/CreatureDecideAction.cc
+++ b/src/game/TacticalAI/CreatureDecideAction.cc
@@ -152,7 +152,7 @@ void CreatureCall( SOLDIERTYPE * pCaller )
 
 static INT8 CreatureDecideActionGreen(SOLDIERTYPE* pSoldier)
 {
-	INT32 iChance, iSneaky = 10;
+	INT32 iChance = 10;
 	//INT8  bInWater;
 	INT8  bInGas;
 
@@ -262,12 +262,12 @@ static INT8 CreatureDecideActionGreen(SOLDIERTYPE* pSoldier)
 		// modify chance of patrol (and whether it's a sneaky one) by attitude
 		switch (pSoldier->bAttitude)
 		{
-			case DEFENSIVE:      iChance += -10;                 break;
-			case BRAVESOLO:      iChance +=   5;                 break;
-			case BRAVEAID:                                       break;
-			case CUNNINGSOLO:    iChance +=   5;  iSneaky += 10; break;
-			case CUNNINGAID:                      iSneaky +=  5; break;
-			case AGGRESSIVE:     iChance +=  10;  iSneaky += -5; break;
+			case DEFENSIVE:      iChance += -10;  break;
+			case BRAVESOLO:      iChance +=   5;  break;
+			case BRAVEAID:                        break;
+			case CUNNINGSOLO:    iChance +=   5;  break;
+			case CUNNINGAID:                      break;
+			case AGGRESSIVE:     iChance +=  10;  break;
 		}
 
 		// reduce chance for any injury, less likely to wander around when hurt
@@ -425,7 +425,7 @@ static INT8 CreatureDecideActionYellow(SOLDIERTYPE* pSoldier)
 	// monster AI - heard something
 	INT16 sNoiseGridNo;
 	INT32 iNoiseValue;
-	INT32 iChance, iSneaky;
+	INT32 iChance;
 	BOOLEAN fClimb;
 	BOOLEAN fReachable;
 	//INT16 sClosestFriend;
@@ -498,7 +498,6 @@ static INT8 CreatureDecideActionYellow(SOLDIERTYPE* pSoldier)
 
 		// remember that noise value is negative, and closer to 0 => more important!
 		iChance = 75 + iNoiseValue;
-		iSneaky = 30;
 
 		// set base chance according to orders
 		switch (pSoldier->bOrders)
@@ -516,12 +515,12 @@ static INT8 CreatureDecideActionYellow(SOLDIERTYPE* pSoldier)
 		// modify chance of patrol (and whether it's a sneaky one) by attitude
 		switch (pSoldier->bAttitude)
 		{
-			case DEFENSIVE:      iChance += -10;  iSneaky +=  15;  break;
-			case BRAVESOLO:      iChance +=  10;                   break;
-			case BRAVEAID:       iChance +=   5;                   break;
-			case CUNNINGSOLO:    iChance +=   5;  iSneaky +=  30;  break;
-			case CUNNINGAID:                      iSneaky +=  30;  break;
-			case AGGRESSIVE:     iChance +=  20;  iSneaky += -10;  break;
+			case DEFENSIVE:      iChance += -10;  break;
+			case BRAVESOLO:      iChance +=  10;  break;
+			case BRAVEAID:       iChance +=   5;  break;
+			case CUNNINGSOLO:    iChance +=   5;  break;
+			case CUNNINGAID:                      break;
+			case AGGRESSIVE:     iChance +=  20;  break;
 		}
 
 		// reduce chance if breath is down, less likely to wander around when tired

--- a/src/game/TacticalAI/DecideAction.cc
+++ b/src/game/TacticalAI/DecideAction.cc
@@ -641,7 +641,7 @@ static INT8 DecideActionNamedNPC(SOLDIERTYPE* pSoldier)
 
 static INT8 DecideActionGreen(SOLDIERTYPE* pSoldier)
 {
-	INT32 iChance, iSneaky = 10;
+	INT32 iChance = 10;
 	INT8  bInWater,bInGas;
 
 	const BOOLEAN fCivilian =
@@ -905,13 +905,13 @@ static INT8 DecideActionGreen(SOLDIERTYPE* pSoldier)
 		// modify chance of patrol (and whether it's a sneaky one) by attitude
 		switch (pSoldier->bAttitude)
 		{
-			case DEFENSIVE:      iChance += -10;                 break;
-			case BRAVESOLO:      iChance +=   5;                 break;
-			case BRAVEAID:                                       break;
-			case CUNNINGSOLO:    iChance +=   5;  iSneaky += 10; break;
-			case CUNNINGAID:                      iSneaky +=  5; break;
-			case AGGRESSIVE:     iChance +=  10;  iSneaky += -5; break;
-			case ATTACKSLAYONLY: iChance +=  10;  iSneaky += -5; break;
+			case DEFENSIVE:      iChance += -10;  break;
+			case BRAVESOLO:      iChance +=   5;  break;
+			case BRAVEAID:                        break;
+			case CUNNINGSOLO:    iChance +=   5;  break;
+			case CUNNINGAID:                      break;
+			case AGGRESSIVE:     iChance +=  10;  break;
+			case ATTACKSLAYONLY: iChance +=  10;  break;
 		}
 
 		// reduce chance for any injury, less likely to wander around when hurt
@@ -1078,7 +1078,7 @@ static INT8 DecideActionYellow(SOLDIERTYPE* pSoldier)
 	INT32 iDummy;
 	INT16 sNoiseGridNo;
 	INT32 iNoiseValue;
-	INT32 iChance, iSneaky;
+	INT32 iChance;
 	INT16 sClosestFriend;
 	const BOOLEAN fCivilian =
 		IsOnCivTeam(pSoldier) &&
@@ -1251,7 +1251,6 @@ static INT8 DecideActionYellow(SOLDIERTYPE* pSoldier)
 		{
 			// remember that noise value is negative, and closer to 0 => more important!
 			iChance = 95 + (iNoiseValue / 3);
-			iSneaky = 30;
 
 			// increase
 
@@ -1271,13 +1270,13 @@ static INT8 DecideActionYellow(SOLDIERTYPE* pSoldier)
 			// modify chance of patrol (and whether it's a sneaky one) by attitude
 			switch (pSoldier->bAttitude)
 			{
-				case DEFENSIVE:      iChance += -10;  iSneaky +=  15;  break;
-				case BRAVESOLO:      iChance +=  10;                   break;
-				case BRAVEAID:       iChance +=   5;                   break;
-				case CUNNINGSOLO:    iChance +=   5;  iSneaky +=  30;  break;
-				case CUNNINGAID:                      iSneaky +=  30;  break;
-				case AGGRESSIVE:     iChance +=  20;  iSneaky += -10;  break;
-				case ATTACKSLAYONLY:	iChance +=  20;  iSneaky += -10;  break;
+				case DEFENSIVE:      iChance += -10;     break;
+				case BRAVESOLO:      iChance +=  10;     break;
+				case BRAVEAID:       iChance +=   5;     break;
+				case CUNNINGSOLO:    iChance +=   5;     break;
+				case CUNNINGAID:                         break;
+				case AGGRESSIVE:     iChance +=  20;     break;
+				case ATTACKSLAYONLY:	iChance +=  20;  break;
 			}
 
 
@@ -1314,7 +1313,6 @@ static INT8 DecideActionYellow(SOLDIERTYPE* pSoldier)
 		{
 			// there a chance enemy soldier choose to go "help" his friend
 			iChance = 50 - SpacesAway(pSoldier->sGridNo,sClosestFriend);
-			iSneaky = 10;
 
 			// set base chance according to orders
 			switch (pSoldier->bOrders)
@@ -1332,13 +1330,13 @@ static INT8 DecideActionYellow(SOLDIERTYPE* pSoldier)
 			// modify chance of patrol (and whether it's a sneaky one) by attitude
 			switch (pSoldier->bAttitude)
 			{
-				case DEFENSIVE:      iChance += -10;  iSneaky +=  15;        break;
-				case BRAVESOLO:                                              break;
-				case BRAVEAID:       iChance +=  20;  iSneaky += -10;        break;
-				case CUNNINGSOLO:                     iSneaky +=  30;        break;
-				case CUNNINGAID:     iChance +=  20;  iSneaky +=  20;        break;
-				case AGGRESSIVE:     iChance += -20;  iSneaky += -20;        break;
-				case ATTACKSLAYONLY: iChance += -20;  iSneaky += -20;        break;
+				case DEFENSIVE:      iChance += -10;  break;
+				case BRAVESOLO:                       break;
+				case BRAVEAID:       iChance +=  20;  break;
+				case CUNNINGSOLO:                     break;
+				case CUNNINGAID:     iChance +=  20;  break;
+				case AGGRESSIVE:     iChance += -20;  break;
+				case ATTACKSLAYONLY: iChance += -20;  break;
 			}
 
 			// reduce chance if breath is down, less likely to wander around when tired
@@ -1370,7 +1368,6 @@ static INT8 DecideActionYellow(SOLDIERTYPE* pSoldier)
 		{
 			// remember that noise value is negative, and closer to 0 => more important!
 			iChance = 25;
-			iSneaky = 30;
 
 			// set base chance according to orders
 			switch (pSoldier->bOrders)
@@ -1388,13 +1385,13 @@ static INT8 DecideActionYellow(SOLDIERTYPE* pSoldier)
 			// modify chance (and whether it's sneaky) by attitude
 			switch (pSoldier->bAttitude)
 			{
-				case DEFENSIVE:      iChance +=  10;  iSneaky +=  15;  break;
-				case BRAVESOLO:      iChance += -15;  iSneaky += -20;  break;
-				case BRAVEAID:       iChance += -20;  iSneaky += -20;  break;
-				case CUNNINGSOLO:    iChance +=  20;  iSneaky +=  30;  break;
-				case CUNNINGAID:     iChance +=  15;  iSneaky +=  30;  break;
-				case AGGRESSIVE:     iChance += -10;  iSneaky += -10;  break;
-				case ATTACKSLAYONLY: iChance += -10;  iSneaky += -10;  break;
+				case DEFENSIVE:      iChance +=  10; break;
+				case BRAVESOLO:      iChance += -15; break;
+				case BRAVEAID:       iChance += -20; break;
+				case CUNNINGSOLO:    iChance +=  20; break;
+				case CUNNINGAID:     iChance +=  15; break;
+				case AGGRESSIVE:     iChance += -10; break;
+				case ATTACKSLAYONLY: iChance += -10; break;
 			}
 
 

--- a/src/game/TileEngine/Tactical_Placement_GUI.cc
+++ b/src/game/TileEngine/Tactical_Placement_GUI.cc
@@ -522,7 +522,7 @@ static void KillTacticalPlacementGUI(void)
 		MSYS_RemoveRegion(&m.region);
 	}
 
-	if( gsCurInterfacePanel < 0 || gsCurInterfacePanel >= NUM_UI_PANELS )
+	if( gsCurInterfacePanel >= NUM_UI_PANELS )
 		gsCurInterfacePanel = TEAM_PANEL;
 
 	SetCurrentInterfacePanel(gsCurInterfacePanel);


### PR DESCRIPTION
This cleans up some compiler warnings I get from clang:

- Variables that are only assigned to, but never used
- Conflicts between function declaration and function definition
- Comparisons of signed values using `< 0`
- Missing cases in switches