### PR TITLE
Store state for whom assignment menu is shown separately

### DIFF
--- a/src/game/Strategic/Assignments.h
+++ b/src/game/Strategic/Assignments.h
@@ -161,6 +161,7 @@ extern PopUpBox* ghMoveBox;
 extern BOOLEAN fShownContractMenu;
 extern BOOLEAN fShownAssignmentMenu;
 extern BOOLEAN fShowRepairMenu;
+extern SOLDIERTYPE* gAssignmentTargetSoldier;
 
 extern BOOLEAN fFirstClickInAssignmentScreenMask;
 

--- a/src/game/Strategic/Town_Militia.cc
+++ b/src/game/Strategic/Town_Militia.cc
@@ -446,9 +446,6 @@ void HandleInterfaceMessageForCostOfTrainingMilitia( SOLDIERTYPE *pSoldier )
 		return;
 	}
 
-	// ok to start training, ask player
-
-
 	if( iNumberOfSectors > 1 )
 	{
 		sString = st_format_printf(pMilitiaConfirmStrings[6], iNumberOfSectors, giTotalCostOfTraining, pMilitiaConfirmStrings[1]);
@@ -530,7 +527,6 @@ static void HandleInterfaceMessageForContinuingTrainingMilitia(SOLDIERTYPE* cons
 	sString = st_format_printf(pMilitiaConfirmStrings[ 3 ], sStringB, pMilitiaConfirmStrings[ 4 ], giTotalCostOfTraining);
 
 	// ask player whether he'd like to continue training
-	//DoScreenIndependantMessageBox( sString, MSG_BOX_FLAG_YESNO, PayMilitiaTrainingYesNoBoxCallback );
 	DoMapMessageBox( MSG_BOX_BASIC_STYLE, sString, MAP_SCREEN, MSG_BOX_FLAG_YESNO, PayMilitiaTrainingYesNoBoxCallback );
 }
 
@@ -820,7 +816,7 @@ static void BuildListOfUnpaidTrainableSectors()
 	}
 	else
 	{ // Handle for tactical
-		AddIfTrainingUnpaidSector(*gUIFullTarget);
+		AddIfTrainingUnpaidSector(*pMilitiaTrainerSoldier);
 	}
 }
 


### PR DESCRIPTION
Closing #1691.

Also makes militia training callback use the already separately stored state for the currently selected soldier.