### PR TITLE
Don't recomment odd resolutions in Android launcher

### DIFF
--- a/android/app/src/main/java/io/github/ja2stracciatella/LauncherActivity.kt
+++ b/android/app/src/main/java/io/github/ja2stracciatella/LauncherActivity.kt
@@ -118,10 +118,10 @@ class LauncherActivity : AppCompatActivity() {
             val scalingInt = scaling.toInt()
             val width = Resolution.DEFAULT.width + ((screenWidth - Resolution.DEFAULT.width.toInt() * scalingInt) / scalingInt).toUInt()
             val height = Resolution.DEFAULT.height + ((screenHeight - Resolution.DEFAULT.height.toInt() * scalingInt) / scalingInt).toUInt()
-            return Resolution(width, height)
+            return Resolution(width - (width % 2u), height - (height % 2u))
         }
         val width = Resolution.DEFAULT.width + ((screenWidth - Resolution.DEFAULT.width.toInt() * scaling) / scaling).toUInt()
-        return Resolution(width, Resolution.DEFAULT.height)
+        return Resolution(width - (width % 2u), Resolution.DEFAULT.height)
     }
 
     private fun startGame() {


### PR DESCRIPTION
We currently have rendering issues with odd resolutions, but the Android laucher didn't take that into account when recommending a resolution.

This is bad experience for new players, as they will get corrupted graphics by default.

The actual rendering issue: https://github.com/ja2-stracciatella/ja2-stracciatella/issues/1694