### PR TITLE
Fix segmentation fault in NumberOfPeopleInSquad()

### DIFF
--- a/src/game/Tactical/Morale.cc
+++ b/src/game/Tactical/Morale.cc
@@ -169,9 +169,9 @@ void DecayTacticalMoraleModifiers(void)
 				if (s->bMorale < 50)
 				{
 					BOOLEAN handle_nervous;
-					if (s->ubGroupID != 0 && PlayerIDGroupInMotion(s->ubGroupID))
+					if (s->ubGroupID != 0 && s->bAssignment <= SQUAD_20 && PlayerIDGroupInMotion(s->ubGroupID))
 					{
-						handle_nervous = NumberOfPeopleInSquad(s->ubGroupID) == 1;
+						handle_nervous = NumberOfPeopleInSquad(s->bAssignment) == 1;
 					}
 					else if (s->bInSector)
 					{


### PR DESCRIPTION
Groups are not squads. Regressed by patch from #1608.

I found this while testing the 0.20 RC. It's a must-fix IMO.