### PR TITLE
Fix exiting the map to the south on higher resolutions

### DIFF
--- a/src/game/TileEngine/RenderWorld.cc
+++ b/src/game/TileEngine/RenderWorld.cc
@@ -2421,7 +2421,7 @@ static BOOLEAN ApplyScrolling(INT16 sTempRenderCenterX, INT16 sTempRenderCenterY
 		gfScrolledToLeft   = std::abs(sTopLeftWorldX  - gsLeftX) <= std::abs(SCROLL_LEFT_PADDING);
 		gfScrolledToRight  = std::abs(sBottomRightWorldX  - gsRightX) <= std::abs(SCROLL_RIGHT_PADDING) + CELL_X_SIZE;
 		gfScrolledToTop    = std::abs(sTopLeftWorldY  - gsTopY) <= std::abs(SCROLL_TOP_PADDING);
-		gfScrolledToBottom = std::abs(sBottomRightWorldY  - gsBottomY) <= std::abs(SCROLL_BOTTOM_PADDING) + CELL_Y_SIZE;
+		gfScrolledToBottom = std::abs(sBottomRightWorldY  - gsBottomY) <= std::abs(SCROLL_BOTTOM_PADDING) + CELL_Y_SIZE * 2;
 
 		SetPositionSndsVolumeAndPanning();
 	}


### PR DESCRIPTION
This is a fix for the issue @lynxlynxlynx discovered in #1680. Exiting south was only possible in low resolutions. This should be fixed now. TBH the scrolling code is still quite incomprehensible to me, so I just increased the padding when the world is considered "scrolled all the way down". As the world actively scrolls down anyways when the exit cursor is shown I think this is an ok solution.