### PR TITLE
Fix double events for mouse input on touch devices

### DIFF
--- a/src/sgp/Input.cc
+++ b/src/sgp/Input.cc
@@ -274,6 +274,9 @@ void MouseWheelScroll(const SDL_MouseWheelEvent* WheelEv)
 }
 
 void FingerMove(const SDL_TouchFingerEvent* event) {
+	#ifdef SDL_MOUSE_TOUCHID
+	if (event->touchId == SDL_MOUSE_TOUCHID) return;
+	#endif
 	if (event->fingerId != gMainFingerId) return;
 	gfIsUsingTouch = true;
 
@@ -283,6 +286,10 @@ void FingerMove(const SDL_TouchFingerEvent* event) {
 }
 
 void FingerDown(const SDL_TouchFingerEvent* event) {
+	#ifdef SDL_MOUSE_TOUCHID
+	if (event->touchId == SDL_MOUSE_TOUCHID) return;
+	#endif
+
 	gMainFingerId = event->fingerId;
 	gfIsUsingTouch = true;
 
@@ -292,6 +299,9 @@ void FingerDown(const SDL_TouchFingerEvent* event) {
 }
 
 void FingerUp(const SDL_TouchFingerEvent* event) {
+	#ifdef SDL_MOUSE_TOUCHID
+	if (event->touchId == SDL_MOUSE_TOUCHID) return;
+	#endif
 	if (event->fingerId != gMainFingerId) return;
 	gfIsUsingTouch = true;
 


### PR DESCRIPTION
It seems like there is also touch emulation for mouse events not only the other way around.

It's a bit more complex. There is a hint `SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH` for SDL2 `2.0.4` to `2.0.10`, to separate touch and mouse on Android. After `2.0.10` we have `SDL_MOUSE_TOUCHID`. I chose just to cover the second part, as we compile with `2.0.20` anyways for Android. The `#ifdefs` are there for older SDL versions on Linux.

Should close #1710.