### PR TITLE
Address new clang 15 warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,7 +270,7 @@ endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CFLAGS}")
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-missing-braces -Wno-unused-function -Wno-deprecated-declarations -Wtype-limits")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-missing-braces -Wno-unused-function -Wno-deprecated-declarations -Wtype-limits -Wignored-qualifiers")
 endif()
 
 set(

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -148,12 +148,12 @@ public:
 	virtual const MineModel* getMine(uint8_t mineId) const = 0;
 	virtual const std::vector<const MineModel*>& getMines() const = 0;
 	virtual const std::vector<const SamSiteModel*>& getSamSites() const = 0;
-	virtual const int8_t findSamIDBySector(uint8_t sectorId) const = 0;
+	virtual       int8_t findSamIDBySector(uint8_t sectorId) const = 0;
 	virtual const SamSiteModel* findSamSiteBySector(uint8_t sectorId) const = 0;
 	virtual const std::vector<const StrategicMapSecretModel*>& getMapSecrets() const = 0;
 
 	/* returns the index of the controlling SAM site , or -1 if sector is not covered */
-	virtual const int8_t getControllingSamSite(uint8_t sectorId) const = 0;
+	virtual       int8_t getControllingSamSite(uint8_t sectorId) const = 0;
 
 	virtual const TownModel* getTown(int8_t townId) const = 0;
 	virtual const std::map<int8_t, const TownModel*>& getTowns() const = 0;
@@ -163,7 +163,7 @@ public:
 	virtual const CacheSectorsModel* getCacheSectors() const = 0;
 	virtual const MovementCostsModel* getMovementCosts() const = 0;
 	/* Returns land type index for special sectors. Return -1 if no special land type is defined */
-	virtual int16_t getSectorLandType(uint8_t sectorID, uint8_t sectorLevel) const = 0;
+	virtual       int16_t getSectorLandType(uint8_t sectorID, uint8_t sectorLevel) const = 0;
 	virtual const std::map<uint8_t, const NpcPlacementModel*>& listNpcPlacements() const = 0;
 	virtual const NpcPlacementModel* getNpcPlacement(uint8_t profileId) const = 0;
 

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -67,6 +67,7 @@
 #include <string_theory/string>
 
 #include <stdexcept>
+#include <utility>
 
 #define BASEDATADIR    "data"
 
@@ -84,7 +85,7 @@ DefaultContentManager::DefaultContentManager(RustPointer<EngineOptions> engineOp
 	mExtendedGunChoice(ARMY_GUN_LEVELS),
 	m_vfs(Vfs_create())
 {
-	m_engineOptions = move(engineOptions);
+	m_engineOptions = std::move(engineOptions);
 	m_modManager.reset(ModManager_create(m_engineOptions.get()));
 	if (m_modManager.get() == NULL) {
 		RustPointer<char> err{ getRustError() };
@@ -119,7 +120,7 @@ DefaultContentManager::DefaultContentManager(RustPointer<EngineOptions> engineOp
 		auto error = ST::format("Failed to create temporary directory: {}", err.get());
 		throw std::runtime_error(error.c_str());
 	}
-	m_tempDir = move(tempDir);
+	m_tempDir = std::move(tempDir);
 	RustPointer<char> tempDirPath(TempDir_path(m_tempDir.get()));
 	m_tempFiles = std::make_unique<DirFs>(tempDirPath.get());
 
@@ -1451,7 +1452,7 @@ const std::vector<const SamSiteModel*>& DefaultContentManager::getSamSites() con
 	return m_samSites;
 }
 
-const int8_t DefaultContentManager::findSamIDBySector(uint8_t sectorId) const
+int8_t DefaultContentManager::findSamIDBySector(uint8_t sectorId) const
 {
 	for (size_t i = 0; i < m_samSites.size(); i++)
 	{
@@ -1469,7 +1470,7 @@ const SamSiteModel* DefaultContentManager::findSamSiteBySector(uint8_t sectorId)
 	return (i > -1) ? m_samSites[i] : NULL;
 }
 
-const int8_t DefaultContentManager::getControllingSamSite(uint8_t sectorId) const
+int8_t DefaultContentManager::getControllingSamSite(uint8_t sectorId) const
 {
 	return m_samSitesAirControl->getControllingSamSiteID(sectorId);
 }

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -131,16 +131,16 @@ public:
 	virtual const MineModel* getMine(uint8_t mineId) const override;
 	virtual const std::vector<const MineModel*>& getMines() const override;
 	virtual const std::vector<const SamSiteModel*>& getSamSites() const override;
-	virtual const int8_t findSamIDBySector(uint8_t sectorId) const override;
+	virtual       int8_t findSamIDBySector(uint8_t sectorId) const override;
 	virtual const SamSiteModel* findSamSiteBySector(uint8_t sectorId) const override;
-	virtual const int8_t getControllingSamSite(uint8_t sectorId) const override;
+	virtual       int8_t getControllingSamSite(uint8_t sectorId) const override;
 	virtual const TownModel* getTown(int8_t townId) const  override;
 	virtual const std::map<int8_t, const TownModel*>& getTowns() const override;
 	virtual const ST::string getTownName(uint8_t townId) const override;
 	virtual const ST::string getTownLocative(uint8_t townId) const override;
 	virtual const std::vector <const UndergroundSectorModel*>& getUndergroundSectors() const override;
 	virtual const MovementCostsModel* getMovementCosts() const override;
-	virtual int16_t getSectorLandType(uint8_t sectorID, uint8_t sectorLevel) const override;
+	virtual       int16_t getSectorLandType(uint8_t sectorID, uint8_t sectorLevel) const override;
 	virtual const std::vector<const StrategicMapSecretModel*>& getMapSecrets() const override;
 	virtual const CacheSectorsModel* getCacheSectors() const override;
 

--- a/src/externalized/DefaultContentManagerUT.cc
+++ b/src/externalized/DefaultContentManagerUT.cc
@@ -2,9 +2,10 @@
 
 #include "sgp/FileMan.h"
 #include "externalized/TestUtils.h"
+#include <utility>
 
 DefaultContentManagerUT::DefaultContentManagerUT(RustPointer<EngineOptions> engineOptions)
-	: DefaultContentManager(move(engineOptions))
+	: DefaultContentManager(std::move(engineOptions))
 {
 }
 
@@ -21,7 +22,7 @@ DefaultContentManagerUT* DefaultContentManagerUT::createDefaultCMForTesting()
 
 	EngineOptions_setVanillaGameDir(engineOptions.get(), gameResRootPath.c_str());
 
-	DefaultContentManagerUT* cm = new DefaultContentManagerUT(move(engineOptions));
+	DefaultContentManagerUT* cm = new DefaultContentManagerUT(std::move(engineOptions));
 
 	return cm;
 }

--- a/src/externalized/ModPackContentManager.cc
+++ b/src/externalized/ModPackContentManager.cc
@@ -5,9 +5,10 @@
 
 #include "Debug.h"
 #include "Logger.h"
+#include <utility>
 
 ModPackContentManager::ModPackContentManager(RustPointer<EngineOptions> engineOptions)
-	:DefaultContentManager(move(engineOptions))
+	:DefaultContentManager(std::move(engineOptions))
 {
 	uint32_t nMods = EngineOptions_getModsLength(m_engineOptions.get());
 	std::vector<ST::string> modNames;

--- a/src/externalized/strategic/BloodCatSpawnsModel.cc
+++ b/src/externalized/strategic/BloodCatSpawnsModel.cc
@@ -9,7 +9,7 @@ BloodCatSpawnsModel::BloodCatSpawnsModel(uint8_t sectorId_,
 			isLair(isLair_), isArena(isArena_),
 			bloodCatsSpawnsEasy(bloodCatsSpawnsEasy_), bloodCatsSpawnsMedium(bloodCatsSpawnsMedium_), bloodCatsSpawnsHard(bloodCatsSpawnsHard_) {}
 
-const int8_t BloodCatSpawnsModel::getSpawnsByDifficulty(uint8_t difficultyLevel) const
+int8_t BloodCatSpawnsModel::getSpawnsByDifficulty(uint8_t const difficultyLevel) const
 {
 	switch (difficultyLevel) {
 		case DIF_LEVEL_EASY:

--- a/src/externalized/strategic/BloodCatSpawnsModel.h
+++ b/src/externalized/strategic/BloodCatSpawnsModel.h
@@ -13,7 +13,7 @@ public:
 		bool isLair_, bool isArena_, 
 		int8_t bloodCatsEasy_, int8_t bloodCatsMedium_, int8_t bloodCatsHard_);
 
-	const int8_t getSpawnsByDifficulty(uint8_t difficultyLevel) const;
+	int8_t getSpawnsByDifficulty(uint8_t difficultyLevel) const;
 	static BloodCatSpawnsModel* deserialize(JsonObjectReader& obj);
 
 	const uint8_t sectorId;

--- a/src/externalized/strategic/MovementCostsModel.cc
+++ b/src/externalized/strategic/MovementCostsModel.cc
@@ -15,25 +15,25 @@ void readIntIntoVector(const rapidjson::Value& jsonArray, IntIntVector& vec, siz
 MovementCostsModel::MovementCostsModel(IntIntVector traverseWE_, IntIntVector traverseNS_, IntIntVector traverseThrough_, IntIntVector travelRatings_)
 	:traverseWE(traverseWE_), traverseNS(traverseNS_), traverseThrough(traverseThrough_), travelRatings(travelRatings_) {}
 
-const uint8_t MovementCostsModel::getTraversibilityWestEast(const SGPSector& sSector) const
+uint8_t MovementCostsModel::getTraversibilityWestEast(const SGPSector& sSector) const
 {
 	Assert(sSector.x == 17 || sSector.IsValid());
 	return traverseWE[sSector.y - 1][sSector.x - 1];
 }
 
-const uint8_t MovementCostsModel::getTraversibilityNorthSouth(const SGPSector& sSector) const
+uint8_t MovementCostsModel::getTraversibilityNorthSouth(const SGPSector& sSector) const
 {
 	Assert(sSector.y == 17 || sSector.IsValid());
 	return traverseNS[sSector.y - 1][sSector.x - 1];
 }
 
-const uint8_t MovementCostsModel::getTraversibilityThrough(const SGPSector& sSector) const
+uint8_t MovementCostsModel::getTraversibilityThrough(const SGPSector& sSector) const
 {
 	Assert(sSector.IsValid());
 	return traverseThrough[sSector.y - 1][sSector.x - 1];
 }
 
-const uint8_t MovementCostsModel::getTravelRating(const SGPSector& sSector) const
+uint8_t MovementCostsModel::getTravelRating(const SGPSector& sSector) const
 {
 	Assert(sSector.IsValid());
 	return travelRatings[sSector.y - 1][sSector.x - 1];

--- a/src/externalized/strategic/MovementCostsModel.h
+++ b/src/externalized/strategic/MovementCostsModel.h
@@ -12,10 +12,10 @@ class MovementCostsModel
 public:
 	MovementCostsModel(IntIntVector traverseWE_, IntIntVector traverseNS_, IntIntVector traverseThrough_, IntIntVector travelRatings_);
 
-	const uint8_t getTraversibilityWestEast(const SGPSector& sSector) const;
-	const uint8_t getTraversibilityNorthSouth(const SGPSector& sSector) const;
-	const uint8_t getTraversibilityThrough(const SGPSector& sSector) const;
-	const uint8_t getTravelRating(const SGPSector& sSector) const;
+	uint8_t getTraversibilityWestEast(const SGPSector& sSector) const;
+	uint8_t getTraversibilityNorthSouth(const SGPSector& sSector) const;
+	uint8_t getTraversibilityThrough(const SGPSector& sSector) const;
+	uint8_t getTravelRating(const SGPSector& sSector) const;
 	static MovementCostsModel* deserialize(const rapidjson::Document& root, const TraversibilityMap& mapping);
 
 protected:

--- a/src/externalized/strategic/SamSiteModel.cc
+++ b/src/externalized/strategic/SamSiteModel.cc
@@ -17,7 +17,7 @@ SamSiteModel::SamSiteModel(uint8_t sectorId_, std::array<GridNo, 2> gridNos_)
 	graphicIndex = (gridNos[0] - gridNos[1] == WORLD_COLS) ? SAM_GRAPHIC_INDEX_NE_SW : SAM_GRAPHIC_INDEX_NW_SE;
 }
 
-const bool SamSiteModel::doesSamExistHere(const SGPSector& sector, GridNo const gridNo) const
+bool SamSiteModel::doesSamExistHere(const SGPSector& sector, GridNo const gridNo) const
 {
 	return sector == SGPSector(sectorId)
 		&& std::find(gridNos.begin(), gridNos.end(), gridNo) != gridNos.end()

--- a/src/externalized/strategic/SamSiteModel.h
+++ b/src/externalized/strategic/SamSiteModel.h
@@ -7,7 +7,7 @@ class SamSiteModel
 {
 public:
 	SamSiteModel(uint8_t sectorId_, std::array<GridNo, 2> gridNos_);
-	const bool doesSamExistHere(const SGPSector& sector, GridNo const gridno) const;
+	bool doesSamExistHere(const SGPSector& sector, GridNo const gridno) const;
 
 	static SamSiteModel* deserialize(const rapidjson::Value& obj);
 	static void validateData(const std::vector<const SamSiteModel*>& models);

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -1221,7 +1221,7 @@ bool IMPSavedProfileDoesFileExist(const ST::string& nickname)
 	return fexists;
 }
 
-SGPFile* const IMPSavedProfileOpenFileForRead(const ST::string& nickname)
+SGPFile* IMPSavedProfileOpenFileForRead(const ST::string& nickname)
 {
 	if (!IMPSavedProfileDoesFileExist(nickname)) {
 		throw std::runtime_error(ST::format("Lost IMP with nickname '{}'!", nickname).to_std_string());
@@ -1230,7 +1230,7 @@ SGPFile* const IMPSavedProfileOpenFileForRead(const ST::string& nickname)
 	return f;
 }
 
-SGPFile* const IMPSavedProfileOpenFileForWrite(const ST::string& nickname)
+static SGPFile* IMPSavedProfileOpenFileForWrite(const ST::string& nickname)
 {
 	ST::string profile_filename = IMPSavedProfileCreateFilename(nickname);
 	SGPFile *f = GCM->saveGameFiles()->openForWriting(profile_filename, true);

--- a/src/game/SaveLoadGame.h
+++ b/src/game/SaveLoadGame.h
@@ -109,7 +109,7 @@ extern UINT32 guiJA2EncryptionSet;
 // IMP save and import profile
 ST::string IMPSavedProfileCreateFilename(const ST::string& nickname);
 bool IMPSavedProfileDoesFileExist(const ST::string& nickname);
-SGPFile* const IMPSavedProfileOpenFileForRead(const ST::string& nickname);
+SGPFile* IMPSavedProfileOpenFileForRead(const ST::string& nickname);
 int IMPSavedProfileLoadMercProfile(const ST::string& nickname);
 void IMPSavedProfileLoadInventory(const ST::string& nickname, SOLDIERTYPE *pSoldier);
 

--- a/src/game/Strategic/StrategicMap.cc
+++ b/src/game/Strategic/StrategicMap.cc
@@ -2056,7 +2056,6 @@ BOOLEAN OKForSectorExit( INT8 bExitDirection, UINT16 usAdditionalData, UINT32 *p
 	BOOLEAN     fOnlySelectedGuy = FALSE;
 	SOLDIERTYPE *pValidSoldier = NULL;
 	UINT8       ubReturnVal = FALSE;
-	UINT8       ubNumControllableMercs = 0;
 	UINT8       ubNumMercs = 0, ubNumEPCs = 0;
 	UINT8       ubPlayerControllableMercsInSquad = 0;
 
@@ -2095,8 +2094,6 @@ BOOLEAN OKForSectorExit( INT8 bExitDirection, UINT16 usAdditionalData, UINT32 *p
 			//not more than once.
 			pValidSoldier = pSoldier;
 
-			ubNumControllableMercs++;
-
 			//We need to keep track of the number of EPCs and mercs in this squad.  If we have
 			//only one merc and one or more EPCs, then we can't allow the merc to tactically traverse,
 			//if he is the only merc near enough to traverse.
@@ -2108,7 +2105,6 @@ BOOLEAN OKForSectorExit( INT8 bExitDirection, UINT16 usAdditionalData, UINT32 *p
 				if( AM_A_ROBOT( pSoldier ) && !CanRobotBeControlled( pSoldier ) )
 				{
 					gfRobotWithoutControllerAttemptingTraversal = TRUE;
-					ubNumControllableMercs--;
 					continue;
 				}
 			}

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -445,11 +445,11 @@ int main(int argc, char* argv[])
 		uint32_t n = EngineOptions_getModsLength(params.get());
 		if(n > 0)
 		{
-			cm = new ModPackContentManager(move(params));
+			cm = new ModPackContentManager(std::move(params));
 		}
 		else
 		{
-			cm = new DefaultContentManager(move(params));
+			cm = new DefaultContentManager(std::move(params));
 		}
 
 		cm->logConfiguration();


### PR DESCRIPTION
clang 15 has enabled a new warning,  unqualified-std-cast-call, by default and found another useless variable. While I was fixing warnings anyway, I also enabled -Wignored-qualifiers.