### PR TITLE
Change function signature of (G|S)etClippingRect

### DIFF
--- a/src/game/Editor/EditScreen.cc
+++ b/src/game/Editor/EditScreen.cc
@@ -695,7 +695,6 @@ static BOOLEAN DrawTempMouseCursorObject(void)
 //Displays the current drawing object in the small, lower left window of the editor's toolbar.
 void ShowCurrentDrawingMode( void )
 {
-	SGPRect			ClipRect, NewRect;
 	INT32				iShowMode;
 	UINT16			usUseIndex;
 	UINT16			usObjIndex;
@@ -707,13 +706,13 @@ void ShowCurrentDrawingMode( void )
 	INT32 const h =  58;
 
 	// Set up a clipping rectangle for the display window.
+	SGPRect NewRect;
 	NewRect.iLeft   = x;
 	NewRect.iTop    = y;
 	NewRect.iRight  = x + w;
 	NewRect.iBottom = y + h;
 
-	GetClippingRect(&ClipRect);
-	SetClippingRect(&NewRect);
+	SGPRect const ClipRect = SetClippingRect(NewRect);
 
 	// Clear it out
 	ColorFillVideoSurfaceArea(FRAME_BUFFER, x, y, x + w, y + h, 0);
@@ -931,7 +930,7 @@ void ShowCurrentDrawingMode( void )
 	}
 
 	InvalidateRegion(x, y, x + w, y + h);
-	SetClippingRect(&ClipRect);
+	SetClippingRect(ClipRect);
 }
 
 

--- a/src/game/Editor/EditorItems.cc
+++ b/src/game/Editor/EditorItems.cc
@@ -195,7 +195,6 @@ static void DrawItemCentered(const ItemModel * item, SGPVSurface* const vs, INT3
 
 void InitEditorItemsInfo(ToolbarMode const uiItemType)
 {
-	SGPRect	SaveRect, NewRect;
 	INT16 i, x, y;
 	UINT16 usCounter;
 	ST::string pStr;
@@ -302,12 +301,12 @@ void InitEditorItemsInfo(ToolbarMode const uiItemType)
 	x = 0;
 	y = 0;
 	usCounter = 0;
+	SGPRect	NewRect;
 	NewRect.iTop    = 0;
 	NewRect.iBottom = h;
 	NewRect.iLeft   = 0;
 	NewRect.iRight  = w;
-	GetClippingRect(&SaveRect);
-	SetClippingRect(&NewRect);
+	SGPRect const SaveRect = SetClippingRect(NewRect);
 	if( eInfo.uiItemType == TBAR_MODE_ITEM_KEYS )
 	{ //Keys use a totally different method for determining
 		for( i = 0; i < eInfo.sNumItems; i++ )
@@ -467,7 +466,7 @@ void InitEditorItemsInfo(ToolbarMode const uiItemType)
 		}
 	}
 	SetFontDestBuffer(FRAME_BUFFER);
-	SetClippingRect(&SaveRect);
+	SetClippingRect(SaveRect);
 	gfRenderTaskbar = TRUE;
 }
 

--- a/src/game/Editor/SelectWin.cc
+++ b/src/game/Editor/SelectWin.cc
@@ -1125,15 +1125,14 @@ static void DisplayWindowFunc(DisplayList*, INT16 top_cut_off, SGPBox const* are
 //	Displays the objects in the display list to the selection window.
 static void DrawSelections(void)
 {
-	SGPRect					ClipRect, NewRect;
+	SGPRect NewRect;
 
 	NewRect.iLeft   = g_sel_win_box.x;
 	NewRect.iTop    = g_sel_win_box.y;
 	NewRect.iRight  = g_sel_win_box.x + g_sel_win_box.w - 1;
 	NewRect.iBottom = g_sel_win_box.y + g_sel_win_box.h - 1;
 
-	GetClippingRect(&ClipRect);
-	SetClippingRect(&NewRect);
+	SGPRect const ClipRect = SetClippingRect(NewRect);
 
 	SetFont( gpLargeFontType1 );
 	SetFontShade(LARGEFONT1, FONT_SHADE_GREY_165);
@@ -1142,7 +1141,7 @@ static void DrawSelections(void)
 
 	SetFontShade(LARGEFONT1, FONT_SHADE_NEUTRAL);
 
-	SetClippingRect(&ClipRect);
+	SetClippingRect(ClipRect);
 }
 
 

--- a/src/game/SaveLoadScreen.cc
+++ b/src/game/SaveLoadScreen.cc
@@ -576,16 +576,16 @@ static void RenderSaveLoadScreen(void)
 }
 
 static void RenderScrollBar(void) {
-	SGPRect	previousClippingRect, clippingRect;
-	GetClippingRect(&previousClippingRect);
+	SGPRect	clippingRect;
 	clippingRect.set(SLG_SCROLLBAR_POS_X, SLG_SCROLLBAR_INNER_POS_Y, SLG_SCROLLBAR_POS_X + SLG_SCROLLBAR_WIDTH, SLG_SCROLLBAR_INNER_POS_Y + SLG_SCROLLBAR_INNER_HEIGHT);
-	SetClippingRect(&clippingRect);
+	SGPRect const previousClippingRect = SetClippingRect(clippingRect);
+
 	auto tileHeight = guiSlgScrollbarStracciatella->SubregionProperties(SLG_SCROLL_BAR_INNER_GRAPHICS_NUMBER).usHeight;
 	auto repetitions = uint32_t(ceil(double(SLG_SCROLLBAR_INNER_HEIGHT) / double(tileHeight)));
 	for (uint32_t i = 0; i < repetitions; i++) {
 		BltVideoObject(FRAME_BUFFER, guiSlgScrollbarStracciatella, SLG_SCROLL_BAR_INNER_GRAPHICS_NUMBER, SLG_SCROLLBAR_POS_X, SLG_SCROLLBAR_INNER_POS_Y + i * tileHeight);
 	}
-	SetClippingRect(&previousClippingRect);
+	SetClippingRect(previousClippingRect);
 
 	auto maxTop = gSavedGamesList.size() - NUM_SAVE_GAMES;
 	auto currentTop = gCurrentScrollTop;

--- a/src/game/Strategic/Auto_Resolve.cc
+++ b/src/game/Strategic/Auto_Resolve.cc
@@ -857,8 +857,6 @@ static void RenderSoldierCellBars(SOLDIERCELL* pCell)
 
 static void BuildInterfaceBuffer(void)
 {
-	SGPRect					ClipRect;
-	SGPRect					DestRect;
 	INT32						x,y;
 
 	//Setup the blitting clip regions, so we don't draw outside of the region (for excess panelling)
@@ -866,6 +864,7 @@ static void BuildInterfaceBuffer(void)
 	gpAR->rect.y = (SCREEN_HEIGHT - gpAR->rect.h) / 2;
 	if (gpAR->rect.y > 120) gpAR->rect.y -= 40;
 
+	SGPRect DestRect;
 	DestRect.iLeft			= 0;
 	DestRect.iTop				= 0;
 	DestRect.iRight			= gpAR->rect.w;
@@ -873,8 +872,7 @@ static void BuildInterfaceBuffer(void)
 
 	gpAR->iInterfaceBuffer = AddVideoSurface(gpAR->rect.w, gpAR->rect.h, PIXEL_DEPTH);
 
-	GetClippingRect( &ClipRect );
-	SetClippingRect( &DestRect );
+	SGPRect const ClipRect = SetClippingRect(DestRect);
 
 	//Blit the back panels...
 	for( y = DestRect.iTop; y < DestRect.iBottom; y += 40 )
@@ -919,7 +917,7 @@ static void BuildInterfaceBuffer(void)
 	y = gpAR->rect.h - 40;
 	BltVideoObject( gpAR->iInterfaceBuffer, gpAR->iPanelImages, BOT_MIDDLE, x, y);
 
-	SetClippingRect( &ClipRect );
+	SetClippingRect(ClipRect);
 }
 
 

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -55,6 +55,7 @@
 #include <stdexcept>
 #include <string_theory/format>
 #include <string_theory/string>
+#include <utility>
 #include <vector>
 
 // // Scroll region width
@@ -1978,17 +1979,14 @@ void RestoreBackgroundForMapGrid(const SGPSector& sMap)
 
 void ClipBlitsToMapViewRegion( void )
 {
-	SGPRect *pRectToUse = &MapScreenRect;
-
-	SetClippingRect( pRectToUse );
-	gOldClipRect = gDirtyClipRect;
-	gDirtyClipRect = *pRectToUse;
+	SetClippingRect(MapScreenRect);
+	gOldClipRect = std::exchange(gDirtyClipRect, MapScreenRect);
 }
 
 void RestoreClipRegionToFullScreen( void )
 {
 	SGPRect FullScreenRect = { 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT };
-	SetClippingRect( &FullScreenRect );
+	SetClippingRect(FullScreenRect);
 	gDirtyClipRect = gOldClipRect;
 }
 

--- a/src/sgp/Button_System.cc
+++ b/src/sgp/Button_System.cc
@@ -1248,8 +1248,7 @@ static void DrawIconOnButton(const GUI_BUTTON* b)
 	INT32 IconY = NewClip.iTop;
 
 	// Get current clip area
-	SGPRect OldClip;
-	GetClippingRect(&OldClip);
+	SGPRect const OldClip = GetClippingRect();
 
 	// Clip button's viewable area coords to screen
 	if (NewClip.iLeft < OldClip.iLeft) NewClip.iLeft = OldClip.iLeft;
@@ -1314,12 +1313,12 @@ static void DrawIconOnButton(const GUI_BUTTON* b)
 	}
 
 	// Set the clipping rectangle to the viewable area of the button
-	SetClippingRect(&NewClip);
+	SetClippingRect(NewClip);
 
 	BltVideoObject(ButtonDestBuffer, hvObject, b->usIconIndex, xp, yp);
 
 	// Restore previous clip region
-	SetClippingRect(&OldClip);
+	SetClippingRect(OldClip);
 }
 
 
@@ -1345,8 +1344,7 @@ static void DrawTextOnButton(const GUI_BUTTON* b)
 	const INT32 TextY = NewClip.iTop;
 
 	// Get the current clipping area
-	SGPRect OldClip;
-	GetClippingRect(&OldClip);
+	SGPRect const OldClip = GetClippingRect();
 
 	// Clip the button's viewable area to the screen
 	if (NewClip.iLeft < OldClip.iLeft) NewClip.iLeft = OldClip.iLeft;
@@ -1573,8 +1571,7 @@ static void DrawGenericButton(const GUI_BUTTON* b)
 	UINT16* const pDestBuf         = l.Buffer<UINT16>();
 	UINT32  const uiDestPitchBYTES = l.Pitch();
 
-	SGPRect ClipRect;
-	GetClippingRect(&ClipRect);
+	SGPRect const ClipRect = GetClippingRect();
 
 	// Draw the button's borders and corners (horizontally)
 	for (INT32 q = 0; q < NumChunksWide; q++)

--- a/src/sgp/VObject_Blitters.cc
+++ b/src/sgp/VObject_Blitters.cc
@@ -7,9 +7,8 @@
 #include "VObject_Blitters.h"
 #include "VSurface.h"
 #include "WCheck.h"
+#include <utility>
 
-
-SGPRect	ClippingRect;
 							//555      565
 UINT32	guiTranslucentMask=0x3def; //0x7bef;		// mask for halving 5,6,5
 
@@ -2631,19 +2630,16 @@ void Blt8BPPDataTo16BPPBufferHalf(UINT16* const dst_buf, UINT32 const uiDestPitc
 }
 
 
-void SetClippingRect(SGPRect *clip)
+SGPRect SetClippingRect(SGPRect const clip)
 {
-	Assert(clip!=NULL);
-	Assert(clip->iLeft < clip->iRight);
-	Assert(clip->iTop < clip->iBottom);
-	ClippingRect = *clip;
+	Assert(clip.iLeft < clip.iRight && clip.iTop < clip.iBottom);
+	return std::exchange(ClippingRect, clip);
 }
 
 
-void GetClippingRect(SGPRect *clip)
+SGPRect GetClippingRect()
 {
-	Assert(clip!=NULL);
-	*clip = ClippingRect;
+	return ClippingRect;
 }
 
 

--- a/src/sgp/VObject_Blitters.h
+++ b/src/sgp/VObject_Blitters.h
@@ -2,11 +2,12 @@
 #define __VOBJECT_BLITTERS
 
 
-extern SGPRect		ClippingRect;
+inline SGPRect		ClippingRect;
 extern UINT32			guiTranslucentMask;
 
-extern void SetClippingRect(SGPRect *clip);
-void GetClippingRect(SGPRect *clip);
+// Sets the clipping rect and returns the replaced rect
+SGPRect SetClippingRect(SGPRect clip);
+SGPRect GetClippingRect();
 
 
 BOOLEAN BltIsClipped(const SGPVObject* hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex, const SGPRect* clipregion);

--- a/src/sgp/VSurface.cc
+++ b/src/sgp/VSurface.cc
@@ -220,8 +220,7 @@ void BltVideoSurfaceHalf(SGPVSurface* const dst, SGPVSurface* const src, INT32 c
 
 void ColorFillVideoSurfaceArea(SGPVSurface* const dst, INT32 iDestX1, INT32 iDestY1, INT32 iDestX2, INT32 iDestY2, const UINT16 Color16BPP)
 {
-	SGPRect Clip;
-	GetClippingRect(&Clip);
+	SGPRect const Clip = GetClippingRect();
 
 	if (iDestX1 < Clip.iLeft) iDestX1 = Clip.iLeft;
 	if (iDestX1 > Clip.iRight) return;


### PR DESCRIPTION
Passing `SGPRect` by value instead of by pointer so we do not have to assert the pointers are not null.

Not that it matter much but this should be about as efficient as the current method or even a tiny bit better because an `SGPRect` fits into a 64-bit register (2 registers on 32-bit systems).