### PR TITLE
Fix AttemptToChangeLevel

### DIFF
--- a/src/game/TileEngine/Exit_Grids.cc
+++ b/src/game/TileEngine/Exit_Grids.cc
@@ -190,8 +190,7 @@ void AttemptToChangeFloorLevel(INT8 const relative_z_level)
 		gfOverrideInsertionWithExitGrid = TRUE;
 		/* change all current mercs in the loaded sector, and move them to the new
 		 * sector. */
-		SGPSector adjustedSector = gWorldSector;
-		gWorldSector.z = look_for_level;
+		SGPSector const adjustedSector(gWorldSector.x, gWorldSector.y, look_for_level);
 		MoveAllGroupsInCurrentSectorToSector(adjustedSector);
 		if (look_for_level)
 		{
@@ -203,6 +202,7 @@ void AttemptToChangeFloorLevel(INT8 const relative_z_level)
 		}
 		SetCurrentWorldSector(adjustedSector);
 		gfOverrideInsertionWithExitGrid = FALSE;
+		break;
 	}
 }
 


### PR DESCRIPTION
With cheats enabled,  Ctrl + PgUp/PgDown should allow you to change floor levels. This is currently broken.

I found this while looking at #1720, but since this is a cheats-only function it cannot be the cause of that problem.