### PR TITLE
Check indices of MSYS user data functions at compile time

### DIFF
--- a/src/sgp/MouseSystem.cc
+++ b/src/sgp/MouseSystem.cc
@@ -756,19 +756,6 @@ void MSYS_SetCurrentCursor(UINT16 Cursor)
 }
 
 
-void MSYS_SetRegionUserData(MOUSE_REGION* const r, UINT32 const index, INT32 const userdata)
-{
-	if (lengthof(r->user.data) <= index) throw std::logic_error("User data index is out of range");
-	r->user.data[index] = userdata;
-}
-
-
-INT32 MSYS_GetRegionUserData(MOUSE_REGION const* const r, UINT32 const index)
-{
-	if (lengthof(r->user.data) <= index) throw std::logic_error("User data index is out of range");
-	return r->user.data[index];
-}
-
 // This function will force a re-evaluation of mouse regions
 // Usually used to force change of mouse cursor if panels switch, etc
 void RefreshMouseRegions( )

--- a/src/sgp/MouseSystem.h
+++ b/src/sgp/MouseSystem.h
@@ -45,8 +45,11 @@ struct MOUSE_REGION
 	void AllowDisabledRegionFastHelp(bool allow);
 
 	void SetUserPtr(void* ptr) { user.ptr = ptr; }
-
 	template<typename T> T* GetUserPtr() const { return static_cast<T*>(user.ptr); }
+	template<size_t index>
+	constexpr INT32 GetUserData() const { static_assert(index < 4); return user.data[index]; }
+	template<size_t index>
+	constexpr void SetUserData(INT32 const data) { static_assert(index < 4); user.data[index] = data; }
 
 	bool HasFastHelp() { return FastHelpRect != nullptr; }
 
@@ -150,10 +153,10 @@ void MSYS_DefineRegion(MOUSE_REGION *region,UINT16 tlx,UINT16 tly,UINT16 brx,UIN
 void MSYS_RemoveRegion(MOUSE_REGION *region);
 
 /* Set one of the user data entries in a mouse region */
-void MSYS_SetRegionUserData(MOUSE_REGION*, UINT32 index, INT32 userdata);
+#define MSYS_SetRegionUserData(region, index, data) ((region)->SetUserData<(index)>((data)))
 
 /* Retrieve one of the user data entries in a mouse region */
-INT32 MSYS_GetRegionUserData(MOUSE_REGION const*, UINT32 index);
+#define MSYS_GetRegionUserData(region, index) ((region)->GetUserData<(index)>())
 
 // Create a callback with primary and secondary and all actions callbacks
 // Primary action will be triggered on left mouse button up (or mouse button down if triggerOnMouseDown is true), or short touch


### PR DESCRIPTION
All of the current callers of MSYS_(G|S)etRegionUserData use constants for the index so it is pointless to check it at runtime.

In theory this prevents us from using variables for the indices in the future, but I don't see that as a real problem:
- nothing is stopping you from accessing the user.data array directly
- now that MOUSE_CALLBACK is defined as a std::function, you have a much more powerful way to pass data to your callbacks by using lambdas.