### PR TITLE
Fix fallout from PR 1724 and disable some compiler warnings again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,11 @@ endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CFLAGS}")
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wtype-limits -Wignored-qualifiers")
+    if (LOCAL_RAPIDJSON_LIB)
+        # There has not been an official new RapidJSON release since 2016; some C++ features
+        # it uses have been deprecated since then.
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+    endif()
 endif()
 
 set(

--- a/src/game/Utils/Cursors.cc
+++ b/src/game/Utils/Cursors.cc
@@ -105,6 +105,9 @@ static CursorFileData CursorFileDatabase[] =
 #define SUBCNTX(cur, idx) cur, idx, 0, CENTER_SUBCURSOR, 0
 #define SUBHIDE(cur, idx) cur, idx, 0, HIDE_SUBCURSOR,   HIDE_SUBCURSOR
 #define SUBNORM(cur, idx) cur, idx, 0, 0,                0
+// Strictly speaking the CursorDataBrace is missing lots of braces,
+// but globally disabling the warning seems overblown.
+#pragma GCC diagnostic ignored "-Wmissing-braces"
 
 static CursorData CursorDatabase[] =
 {

--- a/src/sgp/Types.h
+++ b/src/sgp/Types.h
@@ -170,12 +170,12 @@ typedef SGPFile* HWFILE;
 
 
 #ifdef __cplusplus
-#	define ENUM_BITSET(type)                                                                   \
-		static inline type operator ~  (type  a)         { return     (type)~(int)a;           } \
-		static inline type operator &  (type  a, type b) { return     (type)((int)a & (int)b); } \
-		static inline type operator &= (type& a, type b) { return a = (type)((int)a & (int)b); } \
-		static inline type operator |  (type  a, type b) { return     (type)((int)a | (int)b); } \
-		static inline type operator |= (type& a, type b) { return a = (type)((int)a | (int)b); }
+#	define ENUM_BITSET(type)                                                                 \
+		constexpr type operator ~  (type  a)         { return     (type)~(int)a;           } \
+		constexpr type operator &  (type  a, type b) { return     (type)((int)a & (int)b); } \
+		constexpr type operator &= (type& a, type b) { return a = (type)((int)a & (int)b); } \
+		constexpr type operator |  (type  a, type b) { return     (type)((int)a | (int)b); } \
+		constexpr type operator |= (type& a, type b) { return a = (type)((int)a | (int)b); }
 #else
 #	define ENUM_BITSET(type)
 #endif


### PR DESCRIPTION
Wmissing-braces is triggered by Cursors.cc, Wunused-function can be triggered if the ENUM_BITSET macro is used and Wdeprecated-declarations is needed by the official latest RapidJSON release.

I should have investigated this better (turning sccache off helps), but a full rebuild with the local RapidJSON library currently produces lots of warnings.