### PR TITLE
Add an overload for AddVideoObjectFromFile

### DIFF
--- a/src/game/GameRes.cc
+++ b/src/game/GameRes.cc
@@ -7,6 +7,7 @@
 
 #include "Directories.h"
 #include "Text.h"
+#include "VObject.h"
 #include "GameMode.h"
 #include "EncodingCorrectors.h"
 
@@ -376,6 +377,13 @@ char const* GetMLGFilename(MultiLanguageGraphic const id)
 
 	throw std::runtime_error(ST::format("Multilanguage resource {} is not found", id).to_std_string());
 }
+
+
+SGPVObject* AddVideoObjectFromFile(MultiLanguageGraphic const mlg)
+{
+	return AddVideoObjectFromFile(GetMLGFilename(mlg));
+}
+
 
 STRING_ENC_TYPE getStringEncType()
 {

--- a/src/game/GameRes.h
+++ b/src/game/GameRes.h
@@ -12,6 +12,8 @@
 
 #include <vector>
 
+class SGPVObject;
+
 /** List of supported game versions (localizations). */
 using GameVersion = VanillaVersion;
 
@@ -54,6 +56,8 @@ enum MultiLanguageGraphic
 };
 
 char const* GetMLGFilename(MultiLanguageGraphic);
+// Shortcut for AddVideoObjectFromFile(GetMLGFilename(id))
+SGPVObject* AddVideoObjectFromFile(MultiLanguageGraphic);
 
 /** Choose game version. */
 void setGameVersion(GameVersion ver);

--- a/src/game/Laptop/AIM.cc
+++ b/src/game/Laptop/AIM.cc
@@ -217,34 +217,26 @@ void EnterAIM()
 	// load the Links graphic and add it
 	guiLinks = AddVideoObjectFromFile(LAPTOPDIR "/links.sti");
 
-	const char* ImageFile;
-
 	// load the History graphic and add it
-	ImageFile = GetMLGFilename(MLG_HISTORY);
-	guiHistory = AddVideoObjectFromFile(ImageFile);
+	guiHistory = AddVideoObjectFromFile(MLG_HISTORY);
 
 	// load the Wanring graphic and add it
-	ImageFile = GetMLGFilename(MLG_WARNING);
-	guiWarning = AddVideoObjectFromFile(ImageFile);
+	guiWarning = AddVideoObjectFromFile(MLG_WARNING);
 
 	// load the flower advertisment and add it
 	guiFlowerAdvertisement = AddVideoObjectFromFile(LAPTOPDIR "/flowerad_16.sti");
 
 	// load the your ad advertisment and add it
-	ImageFile = GetMLGFilename(MLG_YOURAD13);
-	guiAdForAdsImages = AddVideoObjectFromFile(ImageFile);
+	guiAdForAdsImages = AddVideoObjectFromFile(MLG_YOURAD13);
 
 	// load the insurance advertisment and add it
-	ImageFile = GetMLGFilename(MLG_INSURANCEAD10);
-	guiInsuranceAdImages = AddVideoObjectFromFile(ImageFile);
+	guiInsuranceAdImages = AddVideoObjectFromFile(MLG_INSURANCEAD10);
 
 	// load the funeral advertisment and add it
-	ImageFile = GetMLGFilename(MLG_FUNERALAD9);
-	guiFuneralAdImages = AddVideoObjectFromFile(ImageFile);
+	guiFuneralAdImages = AddVideoObjectFromFile(MLG_FUNERALAD9);
 
-	// load the funeral advertisment and add it
-	ImageFile = GetMLGFilename(MLG_BOBBYRAYAD21);
-	guiBobbyRAdImages = AddVideoObjectFromFile(ImageFile);
+	// load Bobby Ray's advertisement and add it
+	guiBobbyRAdImages = AddVideoObjectFromFile(MLG_BOBBYRAYAD21);
 
 
 	//** Mouse Regions **
@@ -406,8 +398,7 @@ void InitAimDefaults()
 	guiRustBackGround = AddVideoObjectFromFile(LAPTOPDIR "/rustbackground.sti");
 
 	// load the Aim Symbol graphic and add it
-	const char* const ImageFile = GetMLGFilename(MLG_AIMSYMBOL);
-	guiAimSymbol = AddVideoObjectFromFile(ImageFile);
+	guiAimSymbol = AddVideoObjectFromFile(MLG_AIMSYMBOL);
 
 	//Mouse region for the Links
 	MSYS_DefineRegion(&gSelectedAimLogo, AIM_SYMBOL_X, AIM_SYMBOL_Y,

--- a/src/game/Laptop/AIMLinks.cc
+++ b/src/game/Laptop/AIMLinks.cc
@@ -55,11 +55,11 @@ void EnterAimLinks()
 	InitAimMenuBar();
 
 	// Load the Bobby link graphic.
-	guiBobbyLink = AddVideoObjectFromFile(GetMLGFilename(MLG_BOBBYRAYLINK));
+	guiBobbyLink = AddVideoObjectFromFile(MLG_BOBBYRAYLINK);
 	// Load the Funeral graphic.
-	guiFuneralLink = AddVideoObjectFromFile(GetMLGFilename(MLG_MORTUARYLINK));
+	guiFuneralLink = AddVideoObjectFromFile(MLG_MORTUARYLINK);
 	// Load the Insurance graphic.
-	guiInsuranceLink = AddVideoObjectFromFile(GetMLGFilename(MLG_INSURANCELINK));
+	guiInsuranceLink = AddVideoObjectFromFile(MLG_INSURANCELINK);
 
 	UINT16 const  x    = STD_SCREEN_X + AIM_LINK_LINK_OFFSET_X;
 	UINT16        y    = AIM_LINK_BOBBY_LINK_Y;

--- a/src/game/Laptop/AIMSort.cc
+++ b/src/game/Laptop/AIMSort.cc
@@ -145,19 +145,14 @@ void EnterAimSort()
 	// load the SortBy box graphic and add it
 	guiSortByBox = AddVideoObjectFromFile(LAPTOPDIR "/sortby.sti");
 
-	const char* ImageFile;
-
 	// load the ToAlumni graphic and add it
-	ImageFile = GetMLGFilename(MLG_TOALUMNI);
-	guiToAlumni = AddVideoObjectFromFile(ImageFile);
+	guiToAlumni = AddVideoObjectFromFile(MLG_TOALUMNI);
 
 	// load the ToMugShots graphic and add it
-	ImageFile = GetMLGFilename(MLG_TOMUGSHOTS);
-	guiToMugShots = AddVideoObjectFromFile(ImageFile);
+	guiToMugShots = AddVideoObjectFromFile(MLG_TOMUGSHOTS);
 
 	// load the ToStats graphic and add it
-	ImageFile = GetMLGFilename(MLG_TOSTATS);
-	guiToStats = AddVideoObjectFromFile(ImageFile);
+	guiToStats = AddVideoObjectFromFile(MLG_TOSTATS);
 
 	// load the SelectLight graphic and add it
 	guiSelectLight = AddVideoObjectFromFile(LAPTOPDIR "/selectlight.sti");

--- a/src/game/Laptop/BobbyR.cc
+++ b/src/game/Laptop/BobbyR.cc
@@ -188,11 +188,8 @@ void EnterBobbyR()
 
 	InitBobbyRWoodBackground();
 
-	const char* ImageFile;
-
 	// load the Bobbyname graphic and add it
-	ImageFile = GetMLGFilename(MLG_BOBBYNAME);
-	guiBobbyName = AddVideoObjectFromFile(ImageFile);
+	guiBobbyName = AddVideoObjectFromFile(MLG_BOBBYNAME);
 
 	// load the plaque graphic and add it
 	guiPlaque = AddVideoObjectFromFile(LAPTOPDIR "/bobbyplaques.sti");
@@ -204,8 +201,7 @@ void EnterBobbyR()
 	guiBottomHinge = AddVideoObjectFromFile(LAPTOPDIR "/bobbybottomhinge.sti");
 
 	// load the Store Plaque graphic and add it
-	ImageFile = GetMLGFilename(MLG_STOREPLAQUE);
-	guiStorePlaque = AddVideoObjectFromFile(ImageFile);
+	guiStorePlaque = AddVideoObjectFromFile(MLG_STOREPLAQUE);
 
 	// load the Handle graphic and add it
 	guiHandle = AddVideoObjectFromFile(LAPTOPDIR "/bobbyhandle.sti");

--- a/src/game/Laptop/BobbyRMailOrder.cc
+++ b/src/game/Laptop/BobbyRMailOrder.cc
@@ -335,8 +335,7 @@ void EnterBobbyRMailOrder()
 	guiDeliverySpeedGraphic = AddVideoObjectFromFile(LAPTOPDIR "/bobbydeliveryspeed.sti");
 
 	// load the delivery speed graphic and add it
-	const char* const ImageFile = GetMLGFilename(MLG_CONFIRMORDER);
-	guiConfirmGraphic = AddVideoObjectFromFile(ImageFile);
+	guiConfirmGraphic = AddVideoObjectFromFile(MLG_CONFIRMORDER);
 
 	// load the delivery speed graphic and add it
 	guiTotalSaveArea = AddVideoObjectFromFile(LAPTOPDIR "/totalsavearea.sti");

--- a/src/game/Laptop/Florist.cc
+++ b/src/game/Laptop/Florist.cc
@@ -170,14 +170,12 @@ void InitFloristDefaults()
 	if( guiCurrentLaptopMode == LAPTOP_MODE_FLORIST )
 	{
 		// load the small title graphic and add it
-		const char* const ImageFile = GetMLGFilename(MLG_LARGEFLORISTSYMBOL);
-		guiLargeTitleSymbol = AddVideoObjectFromFile(ImageFile);
+		guiLargeTitleSymbol = AddVideoObjectFromFile(MLG_LARGEFLORISTSYMBOL);
 	}
 	else
 	{
 		// load the leaf back graphic and add it
-		const char* const ImageFile = GetMLGFilename(MLG_SMALLFLORISTSYMBOL);
-		guiSmallTitleSymbol = AddVideoObjectFromFile(ImageFile);
+		guiSmallTitleSymbol = AddVideoObjectFromFile(MLG_SMALLFLORISTSYMBOL);
 
 		//flower title homepage link
 		MSYS_DefineRegion(&gSelectedFloristTitleHomeLinkRegion, FLORIST_SMALL_TITLE_X, FLORIST_SMALL_TITLE_Y,

--- a/src/game/Laptop/Funeral.cc
+++ b/src/game/Laptop/Funeral.cc
@@ -109,12 +109,10 @@ static void SelectRipSignRegionCallBack(MOUSE_REGION* pRegion, UINT32 iReason);
 
 void EnterFuneral()
 {
-	const char* ImageFile;
 	UINT16 usPosX, i;
 
 	// load the Closed graphic and add it
-	ImageFile = GetMLGFilename(MLG_CLOSED);
-	guiClosedSign = AddVideoObjectFromFile(ImageFile);
+	guiClosedSign = AddVideoObjectFromFile(MLG_CLOSED);
 
 	// load the Left column graphic and add it
 	guiLeftColumn = AddVideoObjectFromFile(LAPTOPDIR "/leftcolumn.sti");
@@ -126,12 +124,10 @@ void EnterFuneral()
 	guiMarbleBackground = AddVideoObjectFromFile(LAPTOPDIR "/marble.sti");
 
 	// load the McGillicuttys sign graphic and add it
-	ImageFile = GetMLGFilename(MLG_MCGILLICUTTYS);
-	guiMcGillicuttys = AddVideoObjectFromFile(ImageFile);
+	guiMcGillicuttys = AddVideoObjectFromFile(MLG_MCGILLICUTTYS);
 
 	// load the Mortuary  graphic and add it
-	ImageFile = GetMLGFilename(MLG_MORTUARY);
-	guiMortuary = AddVideoObjectFromFile(ImageFile);
+	guiMortuary = AddVideoObjectFromFile(MLG_MORTUARY);
 
 	// load the right column graphic and add it
 	guiRightColumn = AddVideoObjectFromFile(LAPTOPDIR "/rightcolumn.sti");

--- a/src/game/Laptop/IMPVideoObjects.cc
+++ b/src/game/Laptop/IMPVideoObjects.cc
@@ -95,8 +95,7 @@ void RenderProfileBackGround( void )
 void LoadIMPSymbol(void)
 {
 	// this procedure will load the IMP main symbol into memory
-	const char* const ImageFile = GetMLGFilename(MLG_IMPSYMBOL);
-	guiIMPSYMBOL = AddVideoObjectFromFile(ImageFile);
+	guiIMPSYMBOL = AddVideoObjectFromFile(MLG_IMPSYMBOL);
 }
 
 

--- a/src/game/Laptop/Insurance.cc
+++ b/src/game/Laptop/Insurance.cc
@@ -106,8 +106,7 @@ void EnterInsurance()
 	InitInsuranceDefaults();
 
 	// load the Insurance title graphic and add it
-	const char* const ImageFile = GetMLGFilename(MLG_INSURANCETITLE);
-	guiInsuranceTitleImage = AddVideoObjectFromFile(ImageFile);
+	guiInsuranceTitleImage = AddVideoObjectFromFile(MLG_INSURANCETITLE);
 
 	// load the red bar on the side of the page and add it
 	guiInsuranceBulletImage = AddVideoObjectFromFile(LAPTOPDIR "/bullet.sti");
@@ -227,8 +226,7 @@ void InitInsuranceDefaults()
 	if( guiCurrentLaptopMode != LAPTOP_MODE_INSURANCE )
 	{
 		// load the small title for the every page other then the first page
-		const char* const ImageFile = GetMLGFilename(MLG_SMALLTITLE);
-		guiInsuranceSmallTitleImage = AddVideoObjectFromFile(ImageFile);
+		guiInsuranceSmallTitleImage = AddVideoObjectFromFile(MLG_SMALLTITLE);
 
 		//create the link to the home page on the small titles
 		MSYS_DefineRegion(&gSelectedInsuranceTitleLinkRegion, INSURANCE_SMALL_TITLE_X+85,

--- a/src/game/Laptop/Mercs_Account.cc
+++ b/src/game/Laptop/Mercs_Account.cc
@@ -102,8 +102,7 @@ void EnterMercsAccount()
 	InitMercBackGround();
 
 	// load the Arrow graphic and add it
-	const char* const ImageFile = GetMLGFilename(MLG_ORDERGRID);
-	guiMercOrderGrid = AddVideoObjectFromFile(ImageFile);
+	guiMercOrderGrid = AddVideoObjectFromFile(MLG_ORDERGRID);
 
 	// load the Arrow graphic and add it
 	guiAccountNumberGrid = AddVideoObjectFromFile(LAPTOPDIR "/accountnumber.sti");

--- a/src/game/Laptop/Mercs_Files.cc
+++ b/src/game/Laptop/Mercs_Files.cc
@@ -148,8 +148,7 @@ void EnterMercsFiles()
 	InitMercBackGround();
 
 	// load the stats box graphic and add it
-	const char* const ImageFile = GetMLGFilename(MLG_STATSBOX);
-	guiStatsBox = AddVideoObjectFromFile(ImageFile);
+	guiStatsBox = AddVideoObjectFromFile(MLG_STATSBOX);
 
 	// load the Portrait box graphic and add it
 	guiPortraitBox = AddVideoObjectFromFile(LAPTOPDIR "/portraitbox.sti");

--- a/src/game/Options_Screen.cc
+++ b/src/game/Options_Screen.cc
@@ -267,8 +267,7 @@ static void EnterOptionsScreen(void)
 	guiOptionBackGroundImage = AddVideoObjectFromFile(INTERFACEDIR "/optionscreenbase.sti");
 
 	// load button, title graphic and add it
-	const char* const ImageFile = GetMLGFilename(MLG_OPTIONHEADER);
-	guiOptionsAddOnImages = AddVideoObjectFromFile(ImageFile);
+	guiOptionsAddOnImages = AddVideoObjectFromFile(MLG_OPTIONHEADER);
 
 	giOptionsButtonImages = LoadButtonImage(INTERFACEDIR "/optionscreenaddons.sti", 2, 3);
 

--- a/src/game/SaveLoadScreen.cc
+++ b/src/game/SaveLoadScreen.cc
@@ -403,7 +403,7 @@ static void EnterSaveLoadScreen()
 
 	// Load main background and add ons graphic
 	guiSlgBackGroundImage = AddVideoObjectFromFile(INTERFACEDIR "/loadscreen.sti");
-	guiBackGroundAddOns   = AddVideoObjectFromFile(GetMLGFilename(MLG_LOADSAVEHEADER));
+	guiBackGroundAddOns = AddVideoObjectFromFile(MLG_LOADSAVEHEADER);
 	guiSlgAddonsStracciatella = AddVideoObjectFromFile("sti/interface/save-load-addons.sti");
 	guiSlgScrollbarStracciatella = AddVideoObjectFromFile("sti/interface/scroll-bar.sti");
 

--- a/src/game/Strategic/PreBattle_Interface.cc
+++ b/src/game/Strategic/PreBattle_Interface.cc
@@ -280,8 +280,7 @@ void InitPreBattleInterface(GROUP* const battle_group, bool const persistent_pbi
 	MSYS_DefineRegion(&PBInterfaceBlanket, STD_SCREEN_X + 0, STD_SCREEN_Y + 0, STD_SCREEN_X + 261, STD_SCREEN_Y + 359, MSYS_PRIORITY_HIGHEST - 5, 0, MSYS_NO_CALLBACK, MSYS_NO_CALLBACK);
 
 	// Create the panel
-	char const* const panel_file = GetMLGFilename(MLG_PREBATTLEPANEL);
-	uiInterfaceImages = AddVideoObjectFromFile(panel_file);
+	uiInterfaceImages = AddVideoObjectFromFile(MLG_PREBATTLEPANEL);
 
 	// Create the 3 buttons
 	iPBButtonImage[0] = LoadButtonImage(INTERFACEDIR "/prebattlebutton.sti", 0, 1);


### PR DESCRIPTION
A shortcut for AddVideoObjectFromFile(GetMLGFilename()), this also saves a pair of ST::string constructor/destructor calls at the calling location.

Fairly trivial stuff, but it reduces code size at the calling sites by combining four function calls into one.