### PR TITLE
Upgrade GitHub Action builder image

### DIFF
--- a/.ci/ci-build.sh
+++ b/.ci/ci-build.sh
@@ -88,13 +88,6 @@ if [[ "$RUN_TESTS" == "true" ]]; then
   if [[ "$CI_TARGET" == "linux" ]]; then
     ./AppDir/usr/bin/ja2 -unittests
     ./AppDir/usr/bin/ja2-launcher -help
-
-    # Smoke test to check if the binary can run on older distros
-    DISTRO_IMAGE="debian:10"
-    PACKAGES="libfontconfig1 libx11-6 libsdl2-2.0.0 libfltk1.3 libfltk-images1.3"
-    SETUP_COMMAND="apt-get update && apt-get -yq install $PACKAGES"
-    docker run -v "$(pwd)/AppDir/usr/bin:/ja2" "$DISTRO_IMAGE" bash -c "$SETUP_COMMAND && /ja2/ja2 -help"
-
   else
     ./ja2 -unittests
     ./ja2-launcher -help

--- a/.ci/ci-setup.sh
+++ b/.ci/ci-setup.sh
@@ -37,10 +37,7 @@ elif [[ "$CI_TARGET" == "linux-mingw64" ]]; then
     GCC_VER="${TARGET_GCC_MAJOR_VERSION:-8}"
 
     # MinGW compiler for cross-compiling
-    linux-install-via-apt-get build-essential mingw-w64 "gcc-$GCC_VER" "g++-$GCC_VER"
-
-    # choose a new-enough version of gcc
-    linux-set-gcc-version "$GCC_VER"
+    linux-install-via-apt-get build-essential mingw-w64 g++-mingw-w64-x86-64-posix
 
     # sccache for compilation caching
     linux-install-sccache

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   coverity_scan:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -18,7 +18,7 @@ jobs:
           target: linux
 
         - name: Linux mingw64
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           target: linux-mingw64
 
         - name: Mac

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -14,11 +14,11 @@ jobs:
       matrix:
         cfg:
         - name: Linux
-          os: ubuntu-18.04
+          os: ubuntu-20.04
           target: linux
 
         - name: Linux mingw64
-          os: ubuntu-18.04
+          os: ubuntu-20.04
           target: linux-mingw64
 
         - name: Mac
@@ -26,7 +26,7 @@ jobs:
           target: mac
 
         - name: Android
-          os: ubuntu-18.04
+          os: ubuntu-20.04
           target: android
 
     name: ${{ matrix.cfg.name }} ${{ github.ref }}


### PR DESCRIPTION
The image we use (ubuntu-18.04) is in the process to be deprecated.

- Announcement: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/
- Details: https://github.com/actions/runner-images/issues/6002