### PR TITLE
Remove unnecessary ST::string.c_str calls

### DIFF
--- a/src/externalized/AmmoTypeModel.cc
+++ b/src/externalized/AmmoTypeModel.cc
@@ -15,7 +15,7 @@ AmmoTypeModel::~AmmoTypeModel() = default;
 void AmmoTypeModel::serializeTo(JsonObject &obj) const
 {
 	obj.AddMember("index",                index);
-	obj.AddMember("internalName",         internalName.c_str());
+	obj.AddMember("internalName",         internalName);
 }
 
 AmmoTypeModel* AmmoTypeModel::deserialize(JsonObjectReader &obj)

--- a/src/externalized/CalibreModel.cc
+++ b/src/externalized/CalibreModel.cc
@@ -30,14 +30,14 @@ CalibreModel::~CalibreModel() = default;
 
 void CalibreModel::serializeTo(JsonObject &obj) const
 {
-	obj.AddMember("index",			index);
-	obj.AddMember("internalName",	internalName.c_str());
-	obj.AddMember("sound",			sound.c_str());
-	obj.AddMember("burstSound",		burstSound.c_str());
-	obj.AddMember("silencedSound",		silencedSound.c_str());
-	obj.AddMember("silencedBurstSound",	silencedBurstSound.c_str());
-	obj.AddMember("showInHelpText",       showInHelpText);
-	obj.AddMember("monsterWeapon",        monsterWeapon);
+	obj.AddMember("index",              index);
+	obj.AddMember("internalName",       internalName);
+	obj.AddMember("sound",              sound);
+	obj.AddMember("burstSound",         burstSound);
+	obj.AddMember("silencedSound",      silencedSound);
+	obj.AddMember("silencedBurstSound", silencedBurstSound);
+	obj.AddMember("showInHelpText",     showInHelpText);
+	obj.AddMember("monsterWeapon",      monsterWeapon);
 }
 
 CalibreModel* CalibreModel::deserialize(JsonObjectReader &obj)

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -320,9 +320,7 @@ const FactParamsModel* DefaultContentManager::getFactParams(Fact fact) const
 /** Get map file path. */
 ST::string DefaultContentManager::getMapPath(const ST::string& mapName) const
 {
-	ST::string result = MAPSDIR;
-	result += '/';
-	result += mapName.c_str();
+	ST::string const result = MAPSDIR "/" + mapName;
 
 	SLOGD("map file {}", result);
 
@@ -332,9 +330,7 @@ ST::string DefaultContentManager::getMapPath(const ST::string& mapName) const
 /** Get radar map resource name. */
 ST::string DefaultContentManager::getRadarMapResourceName(const ST::string &mapName) const
 {
-	ST::string result = RADARMAPSDIR;
-	result += "/";
-	result += mapName;
+	ST::string const result = RADARMAPSDIR "/" + mapName;
 
 	SLOGD("map file {}", result);
 
@@ -794,7 +790,7 @@ void DefaultContentManager::loadStringRes(const ST::string& name, std::vector<co
 	}
 
 	fullName += ".json";
-	auto json = readJsonDataFileWithSchema(fullName.c_str());
+	auto json = readJsonDataFileWithSchema(fullName);
 	std::vector<ST::string> utf8_encoded;
 	JsonUtility::parseListStrings(*json, utf8_encoded);
 	for (const ST::string &str : utf8_encoded)
@@ -1053,7 +1049,7 @@ bool DefaultContentManager::loadAllDealersAndInventory()
 	for (auto dealer : m_dealers)
 	{
 		ST::string filename = dealer->getInventoryDataFileName(this);
-		m_dealersInventory[dealer->dealerID] = loadDealerInventory(filename.c_str());
+		m_dealersInventory[dealer->dealerID] = loadDealerInventory(filename);
 	}
 	m_bobbyRayNewInventory                        = loadDealerInventory("bobby-ray-inventory-new.json");
 	m_bobbyRayUsedInventory                       = loadDealerInventory("bobby-ray-inventory-used.json");

--- a/src/externalized/LoadingScreenModel.cc
+++ b/src/externalized/LoadingScreenModel.cc
@@ -85,15 +85,13 @@ LoadingScreenModel* LoadingScreenModel::deserialize(const rapidjson::Value& scre
 	for (auto& item : screensList.GetArray())
 	{
 		JsonObjectReader r(item);
-		screens.push_back(
-			LoadingScreen(index++, r.GetString("internalName"), r.GetString("filename"))
-		);
+		screens.emplace_back(static_cast<uint8_t>(index++), r.GetString("internalName"), r.GetString("filename"));
 	}
 
-	std::map<std::string, uint8_t> namesMapping;
+	std::map<ST::string, uint8_t> namesMapping;
 	for (index = 0; index < screens.size(); index++)
 	{
-		std::string name = screens[index].internalName.to_std_string();
+		ST::string const& name = screens[index].internalName;
 		namesMapping[name] = static_cast<uint8_t>(index);
 	}
 

--- a/src/externalized/MagazineModel.cc
+++ b/src/externalized/MagazineModel.cc
@@ -32,7 +32,7 @@ MagazineModel::MagazineModel(uint16_t itemIndex_,
 void MagazineModel::serializeTo(JsonObject &obj) const
 {
 	obj.AddMember("itemIndex",            itemIndex);
-	obj.AddMember("internalName",         internalName.c_str());
+	obj.AddMember("internalName",         internalName);
 	obj.AddMember("calibre",              calibre->internalName);
 	obj.AddMember("capacity",             capacity);
 	obj.AddMember("ammoType",             ammoType->internalName);

--- a/src/externalized/ModPackContentManager.cc
+++ b/src/externalized/ModPackContentManager.cc
@@ -43,18 +43,18 @@ ST::string* ModPackContentManager::loadDialogQuoteFromFile(const ST::string& fil
 	if(it != m_dialogQuotesMap.end())
 	{
 		SLOGD("cached quote {} {}", quote_number, jsonFileName);
-		return new ST::string(it->second[quote_number].c_str());
+		return new ST::string(it->second[quote_number]);
 	}
 	else
 	{
-		if(doesGameResExists(jsonFileName.c_str()))
+		if(doesGameResExists(jsonFileName))
 		{
 			AutoSGPFile f(openGameResForReading(jsonFileName));
 			ST::string jsonQuotes = f->readStringToEnd();
 			std::vector<ST::string> quotes;
 			JsonUtility::parseJsonToListStrings(jsonQuotes.c_str(), quotes);
 			m_dialogQuotesMap[jsonFileName] = quotes;
-			return new ST::string(quotes[quote_number].c_str());
+			return new ST::string(quotes[quote_number]);
 		}
 		else
 		{

--- a/src/externalized/army/GarrisonGroupModel.cc
+++ b/src/externalized/army/GarrisonGroupModel.cc
@@ -6,7 +6,7 @@ GARRISON_GROUP GarrisonGroupModel::deserialize(JsonObjectReader& obj, const std:
 {
 	auto sector = obj.GetString("sector");
 	uint8_t sectorId = JsonUtility::parseSectorID(sector);
-	uint8_t compositionId = armyCompMapping.at(std::string(obj.GetString("composition")));
+	uint8_t compositionId = armyCompMapping.at(obj.GetString("composition"));
 
 	GARRISON_GROUP group{};
 	group.ubSectorID = sectorId;

--- a/src/game/Editor/LoadScreen.cc
+++ b/src/game/Editor/LoadScreen.cc
@@ -155,12 +155,12 @@ static void ChangeDirectory(const ST::string directory, bool resetState) {
 		if (FileMan::getParentPath(gCurrentDirectory, false) != "") {
 			gFileList.push_back(FileDialogEntry { FileType::Parent, ".." });
 		}
-		std::vector<ST::string> dirs = FileMan::findAllDirsInDir(directory.c_str(), true, false, true);
+		std::vector<ST::string> dirs = FileMan::findAllDirsInDir(directory, true, false, true);
 		for (const ST::string &dir : dirs)
 		{
 			gFileList.push_back(FileDialogEntry { FileType::Directory, dir });
 		}
-		std::vector<ST::string> files = FileMan::findAllFilesInDir(directory.c_str(), true, false, true);
+		std::vector<ST::string> files = FileMan::findAllFilesInDir(directory, true, false, true);
 		for (const ST::string &file : files)
 		{
 			gFileList.push_back(FileDialogEntry { FileType::File, file });
@@ -871,7 +871,7 @@ static ScreenID ProcessFileIO(void)
 			if( gfShowPits )
 				RemoveAllPits();
 			OptimizeSchedules();
-			if ( !SaveWorldAbsolute( gFileForIO.c_str() ) )
+			if (!SaveWorldAbsolute(gFileForIO))
 			{
 				if( gfErrorCatch )
 				{

--- a/src/game/Laptop/IMP_Begin_Screen.cc
+++ b/src/game/Laptop/IMP_Begin_Screen.cc
@@ -303,7 +303,7 @@ static void BtnIMPBeginScreenDoneCallback(GUI_BUTTON *btn, UINT32 reason)
 		else if (GCM->getGamePolicy()->imp_load_saved_merc_by_nickname && IMPSavedProfileDoesFileExist(pNickNameString))
 		{
 			fLoadingCharacterForPreviousImpProfile = true;
-			LaptopSaveInfo.iVoiceId = IMPSavedProfileLoadMercProfile(pNickNameString.c_str());
+			LaptopSaveInfo.iVoiceId = IMPSavedProfileLoadMercProfile(pNickNameString);
 			MERCPROFILESTRUCT& profile_saved = gMercProfiles[PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId];
 			iPortraitNumber = profile_saved.ubFaceIndex - 200;
 			fCharacterIsMale = ( profile_saved.bSex == MALE );

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -1505,7 +1505,7 @@ static void SaveFileToSavedGame(SGPFile* fileToSave, HWFILE const hFile)
 	hFile->write(pData, uiFileSize);
 }
 
-void SaveFilesToSavedGame(char const* const pSrcFileName, HWFILE const hFile)
+void SaveFilesToSavedGame(ST::string const& pSrcFileName, HWFILE const hFile)
 {
 	AutoSGPFile hSrcFile(GCM->tempFiles()->openForReading(pSrcFileName));
 	SaveFileToSavedGame(hSrcFile, hFile);
@@ -1528,7 +1528,7 @@ static void LoadFileFromSavedGame(SGPFile* fileToWrite, HWFILE const hFile)
 	fileToWrite->write(pData, uiFileSize);
 }
 
-void LoadFilesFromSavedGame(char const* const pSrcFileName, HWFILE const hFile)
+void LoadFilesFromSavedGame(ST::string const& pSrcFileName, HWFILE const hFile)
 {
 	AutoSGPFile hSrcFile(GCM->tempFiles()->openForWriting(pSrcFileName, true));
 	LoadFileFromSavedGame(hSrcFile, hFile);

--- a/src/game/SaveLoadGame.h
+++ b/src/game/SaveLoadGame.h
@@ -93,8 +93,8 @@ BOOLEAN SaveGame(const ST::string &saveName, const ST::string& gameDesc);
 void    LoadSavedGame(const ST::string &saveName);
 void BackupSavedGame(const ST::string &saveName);
 
-void SaveFilesToSavedGame(char const* pSrcFileName, HWFILE);
-void LoadFilesFromSavedGame(char const* pSrcFileName, HWFILE);
+void SaveFilesToSavedGame(ST::string const& SrcFileName, HWFILE);
+void LoadFilesFromSavedGame(ST::string const& SrcFileName, HWFILE);
 
 void GetBestPossibleSectorXYZValues(SGPSector& sSector);
 

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -2719,7 +2719,7 @@ void LoadMapScreenInterfaceMapGraphics()
 		const ST::string& path = s->secretMapIcon;
 		if (!path.empty() && gSecretSiteIcons.find(path) == gSecretSiteIcons.end())
 		{
-			gSecretSiteIcons[path] = AddVideoObjectFromFile(path.c_str());
+			gSecretSiteIcons[path] = AddVideoObjectFromFile(path);
 		}
 	}
 }

--- a/src/game/Tactical/Animation_Data.cc
+++ b/src/game/Tactical/Animation_Data.cc
@@ -549,7 +549,7 @@ void InitAnimationSystem()
 	{
 		for ( cnt2 = 0; cnt2 < NUM_STRUCT_IDS; cnt2++ )
 		{
-			const char* Filename = gAnimStructureDatabase[cnt1][cnt2].Filename;
+			ST::string const Filename{gAnimStructureDatabase[cnt1][cnt2].Filename};
 
 			if (GCM->doesGameResExists(Filename))
 			{

--- a/src/game/Tactical/Dialogue_Control.cc
+++ b/src/game/Tactical/Dialogue_Control.cc
@@ -897,7 +897,7 @@ static BOOLEAN GetDialogue(const MercProfile &profile, UINT16 usQuoteNum, ST::st
 		bool success = false;
 		try
 		{
-			ST::string* quote = GCM->loadDialogQuoteFromFile(zFilename.c_str(), usQuoteNum);
+			ST::string* quote = GCM->loadDialogQuoteFromFile(zFilename, usQuoteNum);
 			if(quote)
 			{
 				zDialogueText = *quote;

--- a/src/game/Tactical/Interface_Items.cc
+++ b/src/game/Tactical/Interface_Items.cc
@@ -5353,7 +5353,7 @@ void LoadInterfaceItemsGraphics()
 		auto path = item.to_lower();
 		if (allInventoryGraphics.find(path) == allInventoryGraphics.end()) {
 			try {
-				auto vObject = AddVideoObjectFromFile(item.c_str());
+				auto vObject = AddVideoObjectFromFile(item);
 				allInventoryGraphics.insert_or_assign(path, vObject);
 			} catch (const std::runtime_error &ex) {
 				SLOGE("Error loading small inventory graphic `{}`: {}", item, ex.what());

--- a/src/game/Tactical/Interface_Panels.cc
+++ b/src/game/Tactical/Interface_Panels.cc
@@ -3796,7 +3796,7 @@ void DeleteInterfacePanelGraphics()
 
 static SGPVSurfaceAuto* CreateVideoSurfaceFromObjectFile(const ST::string& filename, UINT16 usRegionIndex)
 {
-	SGPVObject* vo = AddVideoObjectFromFile(filename.c_str());
+	SGPVObject* vo = AddVideoObjectFromFile(filename);
 	auto r = vo->SubregionProperties(usRegionIndex);
 	auto* sf = new SGPVSurfaceAuto(r.usWidth, r.usHeight, PIXEL_DEPTH);
 	BltVideoObject(sf, vo, usRegionIndex, 0, 0);

--- a/src/game/Tactical/Rotting_Corpses.cc
+++ b/src/game/Tactical/Rotting_Corpses.cc
@@ -526,7 +526,7 @@ try
 	// Add structure data.....
 	CheckForAndAddTileCacheStructInfo(n, c->def.sGridNo, ani->sCachedTileID, GetCorpseStructIndex(pCorpseDef, TRUE));
 
-	const STRUCTURE_FILE_REF* const pStructureFileRef = GetCachedTileStructureRefFromFilename(zFilename.c_str());
+	const STRUCTURE_FILE_REF* const pStructureFileRef = GetCachedTileStructureRefFromFilename(zFilename);
 	if (pStructureFileRef != NULL)
 	{
 		const UINT16                  usStructIndex   = GetCorpseStructIndex(pCorpseDef, TRUE);
@@ -1074,7 +1074,6 @@ INT16 FindNearestAvailableGridNoForCorpse( ROTTING_CORPSE_DEFINITION *pDef, INT8
 	INT32 leftmost;
 	BOOLEAN fFound = FALSE;
 	SOLDIERTYPE soldier{};
-	STRUCTURE_FILE_REF *pStructureFileRef = NULL;
 	UINT8 ubBestDirection=0;
 	BOOLEAN fSetDirection = FALSE;
 
@@ -1084,7 +1083,7 @@ INT16 FindNearestAvailableGridNoForCorpse( ROTTING_CORPSE_DEFINITION *pDef, INT8
 	// Used to find struct data for this corpse...
 	ST::string zFilename(FileMan::getFileNameWithoutExt(zCorpseFilenames[pDef->ubType]));
 
-	pStructureFileRef = GetCachedTileStructureRefFromFilename( zFilename.c_str() );
+	STRUCTURE_FILE_REF const * const pStructureFileRef = GetCachedTileStructureRefFromFilename(zFilename);
 
 	sSweetGridNo = pDef->sGridNo;
 

--- a/src/game/Tactical/Tactical_Save.cc
+++ b/src/game/Tactical/Tactical_Save.cc
@@ -69,7 +69,7 @@ static void AddTempFileToSavedGame(HWFILE const f, UINT32 const flags, SectorFla
 	if (!(flags & type)) return;
 
 	ST::string const map_name = GetMapTempFileName(type, sMap);
-	SaveFilesToSavedGame(map_name.c_str(), f);
+	SaveFilesToSavedGame(map_name, f);
 }
 
 
@@ -112,7 +112,7 @@ static void RetrieveTempFileFromSavedGame(HWFILE const f, UINT32 const flags, Se
 	if (!(flags & type)) return;
 
 	ST::string const map_name = GetMapTempFileName(type, sector);
-	LoadFilesFromSavedGame(map_name.c_str(), f);
+	LoadFilesFromSavedGame(map_name, f);
 }
 
 

--- a/src/game/TileEngine/Overhead_Map.cc
+++ b/src/game/TileEngine/Overhead_Map.cc
@@ -102,13 +102,13 @@ void InitNewOverheadDB(TileSetID const ubTilesetID)
 		SGPVObject* vo;
 		try
 		{
-			vo = AddVideoObjectFromFile(res.resourceFileName.c_str());
+			vo = AddVideoObjectFromFile(res.resourceFileName);
 		}
 		catch (std::exception &e)
 		{
 			SLOGD("{}", e.what());
 			// Load one we know about
-			vo = AddVideoObjectFromFile(GCM->getTilesetResourceName(GetDefaultTileset(), ST::string("t/") + "grass.sti").c_str());
+			vo = AddVideoObjectFromFile(GCM->getTilesetResourceName(GetDefaultTileset(), "t/grass.sti"));
 		}
 
 		gSmTileSurf[i].vo = vo;

--- a/src/game/TileEngine/Radar_Screen.cc
+++ b/src/game/TileEngine/Radar_Screen.cc
@@ -87,7 +87,7 @@ void LoadRadarScreenBitmap(const ST::string& filename)
 	// Grab the Map image
 	ST::string image_filename(GCM->getRadarMapResourceName(FileMan::replaceExtension(FileMan::getFileName(filename), "sti")));
 
-	SGPVObject* const radar = AddVideoObjectFromFile(image_filename.c_str());
+	SGPVObject* const radar = AddVideoObjectFromFile(image_filename);
 	gusRadarImage = radar;
 
 	// ATE: Add a shade table!

--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -237,7 +237,7 @@ void FreeStructureFile(STRUCTURE_FILE_REF* const sfr)
 
 
 // Loads a structure file's data as a honking chunk o' memory
-static void LoadStructureData(char const* const filename, STRUCTURE_FILE_REF* const sfr, UINT32* const structure_data_size)
+static void LoadStructureData(ST::string const& filename, STRUCTURE_FILE_REF* const sfr, UINT32* const structure_data_size)
 {
 	AutoSGPFile f(GCM->openGameResForReading(filename));
 
@@ -385,7 +385,7 @@ static void CreateFileStructureArrays(STRUCTURE_FILE_REF* const pFileRef, UINT32
 }
 
 
-STRUCTURE_FILE_REF* LoadStructureFile(char const* const filename)
+STRUCTURE_FILE_REF* LoadStructureFile(ST::string const& filename)
 { // NB should be passed in expected number of structures so we can check equality
 	SGP::AutoObj<STRUCTURE_FILE_REF, FreeStructureFileRef> sfr(new STRUCTURE_FILE_REF{});
 	UINT32 data_size = 0;

--- a/src/game/TileEngine/Structure.h
+++ b/src/game/TileEngine/Structure.h
@@ -6,6 +6,7 @@
 #include "Structure_Internals.h"
 #include "Overhead_Types.h"
 #include "Sound_Control.h"
+#include "string_theory/string"
 
 #define NOTHING_BLOCKING			0
 #define BLOCKING_REDUCE_RANGE			1
@@ -38,7 +39,7 @@ enum StructureDamageReason
 
 
 // functions at the structure database level
-STRUCTURE_FILE_REF* LoadStructureFile(const char* szFileName);
+STRUCTURE_FILE_REF* LoadStructureFile(ST::string const& fileName);
 void FreeAllStructureFiles( void );
 void FreeStructureFile(STRUCTURE_FILE_REF*);
 

--- a/src/game/TileEngine/Tile_Cache.cc
+++ b/src/game/TileEngine/Tile_Cache.cc
@@ -49,7 +49,7 @@ void InitTileCache(void)
 	{
 		TILE_CACHE_STRUCT tc;
 		tc.rootName = FileMan::getFileNameWithoutExt(file);
-		tc.pStructureFileRef = LoadStructureFile(file.c_str());
+		tc.pStructureFileRef = LoadStructureFile(file);
 
 		if (tc.rootName.compare_i("l_dead1") == 0)
 		{
@@ -85,7 +85,7 @@ void DeleteTileCache( )
 }
 
 
-INT32 GetCachedTile(const char* const filename)
+INT32 GetCachedTile(ST::string const& filename)
 {
 	INT32 idx = -1;
 
@@ -144,7 +144,7 @@ INT32 GetCachedTile(const char* const filename)
 	tce->sHits = 1;
 
 	ST::string root_name(FileMan::getFileNameWithoutExt(filename));
-	STRUCTURE_FILE_REF* const sfr = GetCachedTileStructureRefFromFilename(root_name.c_str());
+	STRUCTURE_FILE_REF* const sfr = GetCachedTileStructureRefFromFilename(root_name);
 	tce->struct_file_ref = sfr;
 	if (sfr) AddZStripInfoToVObject(tce->pImagery->vo, sfr, TRUE, 0);
 
@@ -180,7 +180,7 @@ static STRUCTURE_FILE_REF* GetCachedTileStructureRef(INT32 const idx)
 }
 
 
-STRUCTURE_FILE_REF* GetCachedTileStructureRefFromFilename(char const* const filename)
+STRUCTURE_FILE_REF* GetCachedTileStructureRefFromFilename(ST::string const& filename)
 {
 	size_t const n = gpTileCacheStructInfo.size();
 	for (size_t i = 0; i != n; ++i)

--- a/src/game/TileEngine/Tile_Cache.h
+++ b/src/game/TileEngine/Tile_Cache.h
@@ -27,10 +27,10 @@ extern TILE_CACHE_ELEMENT* gpTileCache;
 void InitTileCache(void);
 void DeleteTileCache(void);
 
-INT32 GetCachedTile(const char* cFilename);
+INT32 GetCachedTile(ST::string const& filename);
 void  RemoveCachedTile(INT32 cached_tile);
 
-STRUCTURE_FILE_REF* GetCachedTileStructureRefFromFilename(const char* cFilename);
+STRUCTURE_FILE_REF* GetCachedTileStructureRefFromFilename(ST::string const& filename);
 
 void CheckForAndAddTileCacheStructInfo( LEVELNODE *pNode, INT16 sGridNo, UINT16 usIndex, UINT16 usSubIndex );
 void CheckForAndDeleteTileCacheStructInfo( LEVELNODE *pNode, UINT16 usIndex );

--- a/src/game/TileEngine/Tile_Surface.cc
+++ b/src/game/TileEngine/Tile_Surface.cc
@@ -36,7 +36,7 @@ try
 	{
 		SLOGD("loading tile {}", cStructureFilename);
 
-		pStructureFileRef = LoadStructureFile( cStructureFilename.c_str() );
+		pStructureFileRef = LoadStructureFile(cStructureFilename);
 
 		if (hVObject->SubregionCount() != pStructureFileRef->usNumberOfStructures)
 		{

--- a/src/sgp/SGPFile.cc
+++ b/src/sgp/SGPFile.cc
@@ -138,7 +138,7 @@ void SGPFile::write(void const *const pDest, size_t const uiBytesToWrite)
     if (!success)
     {
         RustPointer<char> err{getRustError()};
-        throw IoException(ST::format("SGPFile::write failed: {}", err.get()).c_str());
+        throw IoException(ST::format("SGPFile::write failed: {}", err.get()));
     }
 }
 
@@ -161,7 +161,7 @@ void SGPFile::seek(INT32 distance, FileSeekMode const how)
     if (!success)
     {
         RustPointer<char> err{getRustError()};
-        throw IoException(ST::format("SGPFile::seek failed: {}", err.get()).c_str());
+        throw IoException(ST::format("SGPFile::seek failed: {}", err.get()));
     }
 }
 
@@ -173,7 +173,7 @@ INT32 SGPFile::pos() const
     if (!success)
     {
         RustPointer<char> err{getRustError()};
-        throw IoException(ST::format("SGPFile::pos failed: {}", err.get()).c_str());
+        throw IoException(ST::format("SGPFile::pos failed: {}", err.get()));
     }
     if (position > INT32_MAX)
     {
@@ -192,7 +192,7 @@ UINT32 SGPFile::size() const
     if (!success)
     {
         RustPointer<char> err{getRustError()};
-        throw IoException(ST::format("SGPFile::size failed: {}", err.get()).c_str());
+        throw IoException(ST::format("SGPFile::size failed: {}", err.get()));
     }
     if (len > UINT32_MAX)
     {


### PR DESCRIPTION
• Several are no longer needed since PR #1713
• `JsonObject::AddMember` has a matching overload since PR #1045
• `IoException` always had ST::string as its parameter

This saves some ST string ➟ C string ➟ ST string round trips, which is just a convoluted way to create string copies that no one needs.