### PR TITLE
Fix RPK burst sound

### DIFF
--- a/assets/externalized/weapons.json
+++ b/assets/externalized/weapons.json
@@ -1726,6 +1726,7 @@
         "usRange": 500,
         "ubAttackVolume": 82,
         "ubHitVolume": 8,
+        "burstSound": "sounds/weapons/bursttype1.wav",
         "attachment_SniperScope": true,
         "attachment_LaserScope": true,
         "attachment_Bipod": true,


### PR DESCRIPTION
RPK was looking for a burst sound file that didn't exist so bursttype1 is now used for the RPK while other 5.45 weapons continue to use the sounds defined in calibres.json. Fixes the problem mentioned in #1714