### PR TITLE
Use more automatic memory manangement in ContentManager

### DIFF
--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -1,5 +1,9 @@
 #pragma once
 
+/* This header is somewhat private, unless you are constructing an instance
+ * of this class or inheriting from it there should not be any reason to
+ * include this file instead of ContentManager.h.
+ */
 #include "game/GameRes.h"
 
 #include "ContentManager.h"
@@ -173,17 +177,17 @@ protected:
 
 	GameVersion m_gameVersion;
 
-	std::vector<const ST::string*> m_newStrings;
-	std::vector<const ST::string*> m_landTypeStrings;
+	std::vector<ST::string> m_newStrings;
+	std::vector<ST::string> m_landTypeStrings;
 
 	std::vector<const ItemModel*> m_items;
 	std::vector<const MagazineModel*> m_magazines;
 
 	std::vector<const CalibreModel*> m_calibres;
-	std::vector<const ST::string*> m_calibreNames;
-	std::vector<const ST::string*> m_calibreNamesBobbyRay;
+	std::vector<ST::string> m_calibreNames;
+	std::vector<ST::string> m_calibreNamesBobbyRay;
 
-	std::vector<AmmoTypeModel*> m_ammoTypes;
+	std::vector<AmmoTypeModel const *> m_ammoTypes;
 
 	/** Mapping of calibre names to objects. */
 	std::map<ST::string, const AmmoTypeModel*> m_ammoTypeMap;
@@ -201,25 +205,25 @@ protected:
 	std::vector<ARMY_COMPOSITION> m_armyCompositions;
 
 	std::vector<const DealerInventory*> m_dealersInventory;
-	const DealerInventory *m_bobbyRayNewInventory;
-	const DealerInventory *m_bobbyRayUsedInventory;
+	std::unique_ptr<DealerInventory const> m_bobbyRayNewInventory;
+	std::unique_ptr<DealerInventory const> m_bobbyRayUsedInventory;
 
 	std::vector<const DealerModel*> m_dealers;
 
 	std::vector<const ShippingDestinationModel*> m_shippingDestinations;
-	std::vector<const ST::string*> m_shippingDestinationNames;
+	std::vector<ST::string> m_shippingDestinationNames;
 
 	std::map<Fact, const FactParamsModel*> m_factParams;
 	std::map<uint16_t, const NpcActionParamsModel*> m_npcActionParams;
 	std::map<uint8_t, const NpcPlacementModel*> m_npcPlacements;
 
-	const IMPPolicy *m_impPolicy;
-	const GamePolicy *m_gamePolicy;
-	const StrategicAIPolicy *m_strategicAIPolicy;
+	std::unique_ptr<IMPPolicy const> m_impPolicy;
+	std::unique_ptr<GamePolicy const> m_gamePolicy;
+	std::unique_ptr<StrategicAIPolicy const> m_strategicAIPolicy;
 
-	const CacheSectorsModel* m_cacheSectors;
-	const LoadingScreenModel* m_loadingScreenModel;
-	const MovementCostsModel* m_movementCosts;
+	std::unique_ptr<CacheSectorsModel const> m_cacheSectors;
+	std::unique_ptr<LoadingScreenModel const> m_loadingScreenModel;
+	std::unique_ptr<MovementCostsModel const> m_movementCosts;
 	std::map<SGPSector, uint8_t> m_sectorLandTypes;
 
 	std::vector<const BloodCatPlacementsModel*> m_bloodCatPlacements;
@@ -227,11 +231,11 @@ protected:
 	std::vector<const CreatureLairModel*> m_creatureLairs;
 	std::vector<const MineModel*> m_mines;
 	std::vector<const SamSiteModel*> m_samSites;
-	const SamSiteAirControlModel* m_samSitesAirControl;
+	std::unique_ptr<SamSiteAirControlModel const> m_samSitesAirControl;
 	std::vector<const StrategicMapSecretModel*> m_mapSecrets;
 	std::map<int8_t, const TownModel*> m_towns;
-	std::vector<const ST::string*> m_townNames;
-	std::vector<const ST::string*> m_townNameLocatives;
+	std::vector<ST::string> m_townNames;
+	std::vector<ST::string> m_townNameLocatives;
 	std::vector<const UndergroundSectorModel*> m_undergroundSectors;
 
 	std::map<uint8_t, const RPCSmallFaceModel*> m_rpcSmallFaces;
@@ -256,7 +260,7 @@ protected:
 
 	const DealerInventory * loadDealerInventory(const ST::string& fileName);
 	bool loadAllDealersAndInventory();
-	void loadStringRes(const ST::string& name, std::vector<const ST::string*> &strings) const;
+	void loadStringRes(const ST::string& name, std::vector<ST::string> &strings) const;
 
 	bool readWeaponTable(
 		const ST::string& fileName,

--- a/src/externalized/DefaultContentManagerUT.cc
+++ b/src/externalized/DefaultContentManagerUT.cc
@@ -9,11 +9,6 @@ DefaultContentManagerUT::DefaultContentManagerUT(RustPointer<EngineOptions> engi
 {
 }
 
-std::unique_ptr<rapidjson::Document> DefaultContentManagerUT::_readJsonDataFile(const char* fileName) const
-{
-	return DefaultContentManager::readJsonDataFile(fileName);
-}
-
 DefaultContentManagerUT* DefaultContentManagerUT::createDefaultCMForTesting()
 {
 	RustPointer<EngineOptions> engineOptions(EngineOptions_default());
@@ -22,7 +17,5 @@ DefaultContentManagerUT* DefaultContentManagerUT::createDefaultCMForTesting()
 
 	EngineOptions_setVanillaGameDir(engineOptions.get(), gameResRootPath.c_str());
 
-	DefaultContentManagerUT* cm = new DefaultContentManagerUT(std::move(engineOptions));
-
-	return cm;
+	return new DefaultContentManagerUT(std::move(engineOptions));
 }

--- a/src/externalized/DefaultContentManagerUT.h
+++ b/src/externalized/DefaultContentManagerUT.h
@@ -7,14 +7,9 @@ struct EngineOptions;
 
 class DefaultContentManagerUT : public DefaultContentManager
 {
-public:
 	DefaultContentManagerUT(RustPointer<EngineOptions> engineOptions);
 
-	// expose this method to unit tests
-	std::unique_ptr<rapidjson::Document> _readJsonDataFile(const char* fileName) const;
-
+public:
 	/** Create DefaultContentManager for usage in unit testing. */
 	static DefaultContentManagerUT* createDefaultCMForTesting();
 };
-
-

--- a/src/externalized/DefaultContentManager_unittests.cc
+++ b/src/externalized/DefaultContentManager_unittests.cc
@@ -1,6 +1,5 @@
 #ifdef WITH_UNITTESTS
 
-#include "DefaultContentManager.h"
 #include "DefaultContentManagerUT.h"
 #include "FileMan.h"
 #include "TestUtils.h"
@@ -124,7 +123,7 @@ TEST(ExternalizedData, readEveryFile)
 	for (ST::string f : results)
 	{
 		ST::string relativePath = f.substr(dataPath.size() + 1);
-		auto json = cm->_readJsonDataFile(relativePath.c_str());
+		auto json = cm->readJsonDataFile(relativePath);
 		ASSERT_FALSE(json.get() == NULL);
 	}
 

--- a/src/externalized/ShippingDestinationModel.cc
+++ b/src/externalized/ShippingDestinationModel.cc
@@ -41,7 +41,7 @@ ShippingDestinationModel* ShippingDestinationModel::deserialize(JsonObjectReader
 	);
 }
 
-void ShippingDestinationModel::validateData(std::vector<const ShippingDestinationModel*> destinations, std::vector<const ST::string*> destinationNames)
+void ShippingDestinationModel::validateData(std::vector<const ShippingDestinationModel*> destinations, std::vector<ST::string> const& destinationNames)
 {
 	int numPrimaryDestinations = 0;
 	for (size_t i = 0; i < destinations.size(); i++)

--- a/src/externalized/ShippingDestinationModel.h
+++ b/src/externalized/ShippingDestinationModel.h
@@ -20,7 +20,7 @@ public:
 	uint8_t getDeliverySector() const;
 
 	static ShippingDestinationModel* deserialize(JsonObjectReader& obj);
-	static void validateData(std::vector<const ShippingDestinationModel*> destinations, std::vector<const ST::string*> destinationNames);
+	static void validateData(std::vector<const ShippingDestinationModel*> destinations, std::vector<ST::string> const& destinationNames);
 
 	const uint8_t locationId;
 

--- a/src/game/Strategic/Strategic_Movement_Costs.cc
+++ b/src/game/Strategic/Strategic_Movement_Costs.cc
@@ -2,7 +2,7 @@
 #include "Strategic_Movement.h"
 #include "Strategic_Movement_Costs.h"
 #include "GameInstance.h"
-#include "DefaultContentManager.h"
+#include "ContentManager.h"
 #include "MovementCostsModel.h"
 
 
@@ -66,4 +66,3 @@ bool SectorIsPassable(INT16 const sSector)
 	const UINT8 t = SectorInfo[sSector].ubTraversability[THROUGH_STRATEGIC_MOVE];
 	return t != GROUNDBARRIER && t != EDGEOFWORLD;
 }
-


### PR DESCRIPTION
    • Use smart pointers for ContentManager members.
    • deleteElements templates no longer copy the map or vector
      they're deleting first.
    • Store ST::strings in vectors, not pointers to them.
    • Remove useless clear() calls of vectors that are about to be destructed.
    • DefaultContentManager::readJsonDataFile is already public, no need to
      "expose" anything in DefaultContentManagerUT

