### PR TITLE
Externalize Flo's weapon deals bonus

### DIFF
--- a/assets/externalized/mercs-profile-info.json
+++ b/assets/externalized/mercs-profile-info.json
@@ -13,7 +13,12 @@
  *        - "RPC": Recruitable characters - NPCs that can be recruited
  *        - "NPC": Non-playing characters, that can never be controlled by the player
  *        - "NOT_USED": Reserved slots that are not used anywhere
- */        
+ *   - weaponSaleModifier: what prices does this character get when buying or selling weapons?
+ *        This is specified in percent of the normal price: when selling, the normal price is
+          multiplied by 100 and divided by this value. When buying, the normal price is multiplied
+          by this value, then divided by 100.
+          In the original game, Flo is the only person who has an unique value.
+ */
 [
      /* A.I.M. soldiers */
      { "profileID": 0,  "internalName": "BARRY", "type": "AIM" }
@@ -61,7 +66,7 @@
     ,{ "profileID": 41, "internalName": "HAYWIRE", "type": "MERC" }
     ,{ "profileID": 42, "internalName": "GASKET", "type": "MERC" }
     ,{ "profileID": 43, "internalName": "RAZOR", "type": "MERC" }
-    ,{ "profileID": 44, "internalName": "FLO", "type": "MERC" }
+    ,{ "profileID": 44, "internalName": "FLO", "type": "MERC", "weaponSaleModifier": 110 }
     ,{ "profileID": 45, "internalName": "GUMPY", "type": "MERC" }
     ,{ "profileID": 46, "internalName": "LARRY_NORMAL", "type": "MERC" }
     ,{ "profileID": 47, "internalName": "LARRY_DRUNK", "type": "MERC" }

--- a/rust/stracciatella/src/schemas/yaml/mercs-profile-info.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/mercs-profile-info.schema.yaml
@@ -38,6 +38,17 @@ items:
       - IMP
       - MERC
       - AIM
+    weaponSaleModifier:
+      title: Weapon Sale Modifier
+      description: |
+        What prices does this character get when buying or selling weapons?
+        This is specified in percent of the normal price: when selling, the normal price is
+        multiplied by 100 and divided by this value. When buying, the normal price is multiplied
+        by this value, then divided by 100.
+        In the original game, Flo is the only person who has an unique value.
+      minimum: 10
+      maximum: 180
+      $ref: types/uint8.schema.yaml
   required:
   - profileID
   - internalName

--- a/src/externalized/mercs/MercProfile.h
+++ b/src/externalized/mercs/MercProfile.h
@@ -2,7 +2,7 @@
 #include "JA2Types.h"
 #include <functional>
 
-enum class MercType;
+enum class MercType : int8_t;
 class MercProfileInfo;
 struct MERCPROFILESTRUCT;
 

--- a/src/externalized/mercs/MercProfileInfo.cc
+++ b/src/externalized/mercs/MercProfileInfo.cc
@@ -4,6 +4,7 @@
 #include "Soldier_Profile_Type.h"
 #include <string_theory/format>
 #include <string_theory/string>
+#include <algorithm>
 #include <utility>
 
 
@@ -23,13 +24,13 @@ static MercType MercTypeFromString(const std::string& name)
 	throw std::runtime_error(err.to_std_string());
 }
 
-MercProfileInfo::MercProfileInfo(uint8_t profileID_, ST::string internalName_, MercType mercType_)
-	: profileID(profileID_), internalName(std::move(internalName_)), mercType(mercType_)
+MercProfileInfo::MercProfileInfo(uint8_t profileID_, ST::string internalName_, MercType mercType_, uint8_t weaponSaleModifier_)
+	: internalName(std::move(internalName_)), profileID(profileID_), mercType(mercType_), weaponSaleModifier(weaponSaleModifier_)
 {
 }
 
 MercProfileInfo::MercProfileInfo()
-	: profileID(NO_PROFILE), internalName(""), mercType(MercType::NOT_USED)
+	: internalName(""), weaponSaleModifier(100), profileID(NO_PROFILE), mercType(MercType::NOT_USED)
 {
 }
 
@@ -39,7 +40,8 @@ MercProfileInfo *MercProfileInfo::deserialize(const rapidjson::Value &json)
 	return new MercProfileInfo(
 		r.GetUInt("profileID"),
 		r.GetString("internalName"),
-		MercTypeFromString(r.GetString("type"))
+		MercTypeFromString(r.GetString("type")),
+		std::clamp(r.getOptionalInt("weaponSaleModifier", 100), 10, 180)
 		);
 }
 

--- a/src/externalized/mercs/MercProfileInfo.h
+++ b/src/externalized/mercs/MercProfileInfo.h
@@ -5,7 +5,7 @@
 #include <string_theory/string>
 #include <rapidjson/document.h>
 
-enum class MercType
+enum class MercType : int8_t
 {
 	NOT_USED,
 	AIM,
@@ -23,9 +23,10 @@ public:
 	// Creates an empty instance, of ID NO_PROFILE and type NOT_USED
 	MercProfileInfo();
 
-	const uint8_t profileID;
 	const ST::string internalName;
+	const uint8_t profileID;
 	const MercType mercType;
+	const uint8_t weaponSaleModifier;
 
 	// A function to provide MercProfileInfo by given ProfileIDs. This is to
 	// avoid a circular reference to ContentManager.
@@ -35,5 +36,5 @@ public:
 	static void validateData(const std::map<uint8_t, const MercProfileInfo*>& models);
 
 protected:
-	MercProfileInfo(uint8_t profileID_, ST::string internalName_, MercType mercType_);
+	MercProfileInfo(uint8_t profileID_, ST::string internalName_, MercType mercType_, uint8_t weaponSaleModifier_);
 };


### PR DESCRIPTION
Add a new field to mercs-profile-info.json which lets users specify a modifier when trading with arms dealers.

Always hiring Flo just to get more money from Tony is boring, so now others can get a bonus (or a handicap), too. Here is an overview of what's possible:

| Modifier | Buying a 100% dart gun | Selling a 100% MAC-10 |
| :---         |    ---:      |          ---: |
| 100  | 625 | 877 |
| 110 (Flo) | 563  | 964  |
| 10 (Minimum) | 1187 | 88 |
| 180 (Maximum) | 125 | 1578 |

I've never worked with the yaml schema files before, so it'd be good to have a closer look at these changes.