### PR TITLE
Add two missing usActionData assignments

### DIFF
--- a/src/game/TacticalAI/DecideAction.cc
+++ b/src/game/TacticalAI/DecideAction.cc
@@ -2204,6 +2204,7 @@ INT8 DecideActionRed(SOLDIERTYPE *pSoldier, UINT8 ubUnconsciousOK)
 				{
 					if (!gfTurnBasedAI || GetAPsToChangeStance( pSoldier, ANIM_CROUCH ) <= pSoldier->bActionPoints)
 					{
+						pSoldier->usActionData = ANIM_CROUCH;
 						return(AI_ACTION_CHANGE_STANCE);
 					}
 				}
@@ -2389,6 +2390,7 @@ INT8 DecideActionRed(SOLDIERTYPE *pSoldier, UINT8 ubUnconsciousOK)
 		{
 			if (!gfTurnBasedAI || GetAPsToChangeStance( pSoldier, ANIM_CROUCH ) <= pSoldier->bActionPoints)
 			{
+				pSoldier->usActionData = ANIM_CROUCH;
 				return(AI_ACTION_CHANGE_STANCE);
 			}
 		}


### PR DESCRIPTION
DecideActionRed had two code paths where it would return AI_ACTION_CHANGE_STANCE without setting the new stance in usActionData.

I found this rather by accident [here](https://github.com/hb029/JA-2-Stracciatella/commit/00936bcfa680f48fe1e0316b987edc4151892af0). The author claims this can cause an AI deadlock, if that's true then this is a quite important fix and it would have been nice if he had let us know about it.