### PR TITLE
- remove DequeueAllEvents from TileEngine/WorldDef.cc and name it DequeueAllInputEvents

### DIFF
--- a/src/game/MainMenuScreen.cc
+++ b/src/game/MainMenuScreen.cc
@@ -221,7 +221,7 @@ void InitMainMenu(void)
 
 	InitGameOptions();
 
-	DequeueAllEvents();
+	DequeueAllInputEvents();
 }
 
 

--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -2496,7 +2496,6 @@ void LoadWorldFromSGPFile(SGPFile *f)
 	GenerateBuildings();
 
 	RenderProgressBar(0, 100);
-	DequeueAllEvents();
 }
 
 

--- a/src/sgp/Input.cc
+++ b/src/sgp/Input.cc
@@ -584,7 +584,7 @@ void SimulateMouseMovement( UINT32 uiNewXPos, UINT32 uiNewYPos )
 }
 
 
-void DequeueAllEvents(void)
+void DequeueAllInputEvents(void)
 {
 	InputAtom InputEvent;
 	while (DequeueEvent(&InputEvent))

--- a/src/sgp/Input.h
+++ b/src/sgp/Input.h
@@ -44,7 +44,7 @@ struct InputAtom
 };
 
 
-extern BOOLEAN			DequeueEvent(InputAtom *Event);
+
 
 void MouseMove(const SDL_MouseMotionEvent*);
 void MouseButtonDown(const SDL_MouseButtonEvent*);
@@ -67,6 +67,8 @@ bool IsMainFingerDown();
 // TRUE = Last pointer device that was used was a touch device, FALSE = Last pointer device that was used was a mouse
 bool IsUsingTouch();
 
+void DequeueAllInputEvents(void);
+extern BOOLEAN DequeueEvent(InputAtom *Event);
 extern BOOLEAN DequeueSpecificEvent(InputAtom *Event, UINT32 uiMaskFlags );
 
 extern void					RestrictMouseToXYXY(UINT16 usX1, UINT16 usY1, UINT16 usX2, UINT16 usY2);
@@ -83,7 +85,6 @@ extern BOOLEAN 	 gfIsUsingTouch;
 extern UINT16    gusMouseXPos;       // X position of the mouse on screen
 extern UINT16    gusMouseYPos;       // y position of the mouse on screen
 
-void DequeueAllEvents(void);
 void HandleSingleClicksAndButtonRepeats();
 
 bool _KeyDown(SDL_Keycode);


### PR DESCRIPTION
- remove DequeueAllEvents from TileEngine/WorldDef.cc to make inputs while loading savegame

- rename DequeueAllEvents to DequeueAllInputEvents

Signed-off-by: Richard Fröhning <misanthropos@gmx.de>