### PR TITLE
Fix: Pressing ESC while the credits are playing no longer quits the game

### DIFF
--- a/src/game/Credits.cc
+++ b/src/game/Credits.cc
@@ -309,12 +309,10 @@ static void GetCreditScreenUserInput(void)
 	InputAtom Event;
 	while (DequeueSpecificEvent(&Event, KEYBOARD_EVENTS))
 	{
-		if (Event.usEvent == KEY_DOWN)
+		if (Event.usEvent == KEY_UP && Event.usParam == SDLK_ESCAPE)
 		{
-			switch (Event.usParam)
-			{
-				case SDLK_ESCAPE: g_credits_active = FALSE; break;
-			}
+			g_credits_active = FALSE;
+			// don't break here, dequeue all keyboard events.
 		}
 	}
 }


### PR DESCRIPTION
Currently the KEY_DOWN event from pressing the ESC key takes us back to the main screen where the corresponding KEY_UP event then makes us quit the game.