### PR TITLE
Restore the "Interrupt for ..." message from vanilla

### DIFF
--- a/src/game/Tactical/TeamTurns.cc
+++ b/src/game/Tactical/TeamTurns.cc
@@ -526,7 +526,6 @@ static void StartInterrupt(void)
 	if (first_interrupter->bTeam == OUR_TEAM)
 	{
 		// start interrupts for everyone on our side at once
-		ST::string sTemp;
 		UINT8   ubInterrupters = 0;
 
 		// build string for display of who gets interrupt
@@ -549,7 +548,7 @@ static void StartInterrupt(void)
 			}
 		}
 
-		sTemp = g_langRes->Message[ STR_INTERRUPT_FOR ];
+		ST::string sTemp = g_langRes->Message[STR_INTERRUPT_FOR];
 
 		// build string in separate loop here, want to linearly process squads...
 		for (INT32 iSquad = 0; iSquad < NUMBER_OF_SQUADS; ++iSquad)
@@ -578,6 +577,11 @@ static void StartInterrupt(void)
 				}
 				sTemp += s->name;
 			}
+		}
+
+		if (!sTemp.empty())
+		{
+			ScreenMsg(FONT_MCOLOR_LTYELLOW, MSG_INTERFACE, sTemp);
 		}
 
 		SLOGD("INTERRUPT: starting interrupt for {}", first_interrupter->ubID);


### PR DESCRIPTION
The function call for this message was probably unintentionally removed in a previous commit. Right now, we display the list only when there are more than six guys interrupting, so almost never.

[(This commit, if you're curious.)](https://github.com/ja2-stracciatella/ja2-stracciatella/commit/706477d84f95ab26095f7c022c488c9f7142de1b#diff-683714cce60d534b535dfdc2addbcb887374d604f05f72ccfa6a9f325e37af05L568)