### PR TITLE
Remove SGPVSurfaceAuto

### DIFF
--- a/src/game/GameScreen.cc
+++ b/src/game/GameScreen.cc
@@ -106,7 +106,8 @@ static void BlitMFont(VIDEO_OVERLAY* const ovr)
 void MainGameScreenInit(void)
 {
 	// all blit functions expect z-buffer pitch to match framebuffer pitch
-	gZBufferPitch = FRAME_BUFFER->surface_->pitch / FRAME_BUFFER->surface_->format->BytesPerPixel;
+	SDL_Surface const& surface = FRAME_BUFFER->GetSDLSurface();
+	gZBufferPitch = surface.pitch / surface.format->BytesPerPixel;
 	gpZBuffer = InitZBuffer(gZBufferPitch, SCREEN_HEIGHT);
 	gZBufferPitch *= sizeof(*gpZBuffer);
 	InitializeBackgroundRects();

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -834,7 +834,7 @@ static void ShadeMapElem(const SGPSector& sMap, const INT32 iColor)
 
 void InitializePalettesForMap(void)
 {
-	std::unique_ptr<SGPVSurfaceAuto> uiTempMap(AddVideoSurfaceFromFile(INTERFACEDIR "/b_map.pcx"));
+	std::unique_ptr<SGPVSurface> uiTempMap(AddVideoSurfaceFromFile(INTERFACEDIR "/b_map.pcx"));
 
 	SGPPaletteEntry const* const pal = uiTempMap->GetPalette();
 

--- a/src/game/Utils/MercTextBox.h
+++ b/src/game/Utils/MercTextBox.h
@@ -45,6 +45,7 @@ inline MercPopUpBox* PrepareMercPopupBox(MercPopUpBox* box, MercPopUpBackground 
 	return PrepareMercPopupBox(box, ubBackgroundIndex, ubBorderIndex, str.to_utf32(), usWidth, usMarginX, usMarginTopY, usMarginBottomY, pActualWidth, pActualHeight, flags);
 }
 
+// Now just another way to say 'delete box', so it is ok to call this with a nullptr
 void RemoveMercPopupBox(MercPopUpBox*);
 
 void RenderMercPopUpBox(MercPopUpBox const*, INT16 sDestX, INT16 sDestY, SGPVSurface* buffer);

--- a/src/sgp/Font.cc
+++ b/src/sgp/Font.cc
@@ -226,21 +226,6 @@ void SetFontDestBuffer(SGPVSurface* const dst)
 }
 
 
-/** Replace backbuffer if it is used by the font system. */
-void ReplaceFontBackBuffer(SGPVSurface* oldBackbuffer, SGPVSurface* newBackbuffer)
-{
-	if(FontDestBuffer == oldBackbuffer)
-	{
-		FontDestBuffer = newBackbuffer;
-	}
-
-	if(SaveFontDestBuffer == oldBackbuffer)
-	{
-		SaveFontDestBuffer = newBackbuffer;
-	}
-}
-
-
 void FindFontRightCoordinates(INT16 sLeft, INT16 sTop, INT16 sWidth, INT16 sHeight, const ST::utf32_buffer& codepoints, SGPFont font, INT16* psNewX, INT16* psNewY)
 {
 	// Compute the coordinates to right justify the text

--- a/src/sgp/Font.h
+++ b/src/sgp/Font.h
@@ -61,9 +61,6 @@ void SetFontDestBuffer(SGPVSurface* dst, INT32 x1, INT32 y1, INT32 x2, INT32 y2)
 /* Set the destination buffer for printing while using the whole surface. */
 void SetFontDestBuffer(SGPVSurface* dst);
 
-/** Replace backbuffer if it is used by the font system. */
-void ReplaceFontBackBuffer(SGPVSurface* oldBackbuffer, SGPVSurface* newBackbuffer);
-
 void SetFont(SGPFont);
 
 void SetFontAttributes(SGPFont, UINT8 foreground, UINT8 shadow = DEFAULT_SHADOW, UINT8 background = 0);


### PR DESCRIPTION
The only difference between SGPVSurfaceAuto and SGPVSurface is that the former frees the underlying SDL_Surface upon destruction while the latter does not. There is only one surface where we do not want this automatic free to happen: the screen buffer.

This behaviour was added back in 2013 to fix issue #45: crashes on MacOS. So why do we not need this special behaviour any more? Back then the wrapped surface for the screen buffer was obtained by a call to the SDL 1.2 function SDL_SetVideoMode, and that surface must not be freed by the application, similar how the surface obtained by a call to SDL_GetWindowSurface in SDL 2.0 must not be freed.

Nowadays Stracciatella uses CreateRGBSurface for the screen buffer, so the need for SGPVSurfaceAuto simply is not there any more. SGPVSurface can always free its surface.