### PR TITLE
Display correct information in sector popup boxes

### DIFF
--- a/src/game/Strategic/StrategicMap.cc
+++ b/src/game/Strategic/StrategicMap.cc
@@ -279,12 +279,6 @@ void InitStrategicEngine()
 }
 
 
-UINT8 GetTownIdForSector(UINT8 const sector)
-{
-	// return the name value of the town in this sector
-	return StrategicMap[SGPSector(sector).AsStrategicIndex()].bNameId;
-}
-
 UINT8 GetTownIdForSector(const SGPSector& sSector)
 {
 	return StrategicMap[sSector.AsStrategicIndex()].bNameId;

--- a/src/game/Strategic/StrategicMap.h
+++ b/src/game/Strategic/StrategicMap.h
@@ -51,7 +51,6 @@ extern Observable<> BeforePrepareSector;
 #define MAP_WORLD_Y				18
 
 // grab the town id value
-UINT8 GetTownIdForSector(UINT8 sector);
 UINT8 GetTownIdForSector(const SGPSector& sSector);
 
 void SetCurrentWorldSector(const SGPSector& sector);


### PR DESCRIPTION
Fixes the logic in AddCommonInfoToBox that got broken when SAM site locations were externalized. Also removes an unnecessary overload for GetTownIdForSector, the compiler will automatically convert an UINT8 to a SGPSector for us.