### PR TITLE
Some housekeeping

### DIFF
--- a/src/game/Strategic/Strategic_AI.cc
+++ b/src/game/Strategic/Strategic_AI.cc
@@ -2943,7 +2943,7 @@ static void RequestHighPriorityGarrisonReinforcements(size_t iGarrisonID, UINT8 
 			pGroup = GetGroup( gPatrolGroup[ i ].ubGroupID );
 			if( pGroup && pGroup->ubGroupSize >= ubSoldiersRequested )
 			{
-				ubDist = SectorDistance(pGroup->ubSector.AsByte(), gGarrisonGroup[iGarrisonID].ubSectorID);
+				ubDist = SectorDistance(pGroup->ubSector, gGarrisonGroup[iGarrisonID].ubSectorID);
 				if( ubDist < ubBestDist )
 				{
 					ubBestDist = ubDist;

--- a/src/game/Strategic/Town_Militia.cc
+++ b/src/game/Strategic/Town_Militia.cc
@@ -497,7 +497,7 @@ static void HandleInterfaceMessageForContinuingTrainingMilitia(SOLDIERTYPE* cons
 		if ( bTownId == BLANK_SECTOR )
 		{
 			// wilderness SAM site
-			sStringB = GetSectorIDString(sector, TRUE);
+			sStringB = GetSectorIDString(pSoldier->sSector, TRUE);
 			sString = st_format_printf(pMilitiaConfirmStrings[9], sStringB);
 		}
 		else
@@ -523,7 +523,7 @@ static void HandleInterfaceMessageForContinuingTrainingMilitia(SOLDIERTYPE* cons
 
 	// ok to continue, ask player
 
-	sStringB = GetSectorIDString(sector, TRUE);
+	sStringB = GetSectorIDString(pSoldier->sSector, TRUE);
 	sString = st_format_printf(pMilitiaConfirmStrings[ 3 ], sStringB, pMilitiaConfirmStrings[ 4 ], giTotalCostOfTraining);
 
 	// ask player whether he'd like to continue training

--- a/src/sgp/Random.cc
+++ b/src/sgp/Random.cc
@@ -48,7 +48,7 @@ void InitializeRandom(void)
 	UINT32 uiSeed2 = guiDistribution(randomDevice);
 
 	std::seed_seq seed = { uiSeed1, uiSeed2 };
-	gRandomEngine = std::mt19937(seed);
+	gRandomEngine.seed(seed);
 
 	// Pregenerate random numbers.
 	for (guiPreRandomIndex = 0; guiPreRandomIndex < MAX_PREGENERATED_NUMS; ++guiPreRandomIndex)

--- a/src/sgp/Random.h
+++ b/src/sgp/Random.h
@@ -22,6 +22,6 @@ extern BOOLEAN PreChance( UINT32 uiChance );
 extern UINT32 guiPreRandomIndex;
 extern UINT32 guiPreRandomNums[ MAX_PREGENERATED_NUMS ];
 
-#endif
-
 extern std::mt19937 gRandomEngine;
+
+#endif

--- a/src/sgp/SoundMan.cc
+++ b/src/sgp/SoundMan.cc
@@ -557,7 +557,6 @@ static int SoundServiceBuffers(void *_ptr)
 			}
 			fBuffersNeedService = FALSE;
 		}
-		lk.unlock();
 	}
 }
 
@@ -1024,7 +1023,6 @@ static BOOLEAN SoundInitHardware(void)
 			}
 		}
 
-		fShutdownBufferServiceThread = FALSE;
 		bufferServiceThread = SDL_CreateThread(SoundServiceBuffers, "SoundManBufferServiceThread", (void *)NULL);
 		if (bufferServiceThread == NULL) {
 			throw std::runtime_error(ST::format("SDL_CreateThread for SoundManBufferServiceThread returned error: {}", SDL_GetError()).c_str());

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -33,7 +33,6 @@
 
 #define VIDEO_OFF         0x00
 #define VIDEO_ON          0x01
-#define VIDEO_SUSPENDED   0x04
 
 #define RED_MASK 0xF800
 #define GREEN_MASK 0x07E0
@@ -54,7 +53,7 @@ static SDL_Rect MouseBackground = { 0, 0, 0, 0 };
 
 // Refresh thread based variables
 static UINT32 guiFrameBufferState;  // BUFFER_READY, BUFFER_DIRTY
-static UINT32 guiVideoManagerState; // VIDEO_ON, VIDEO_OFF, VIDEO_SUSPENDED
+static UINT32 guiVideoManagerState; // VIDEO_ON, VIDEO_OFF
 
 // Dirty rectangle management variables
 static SDL_Rect DirtyRegions[MAX_DIRTY_REGIONS];
@@ -295,11 +294,6 @@ void ShutdownVideoManager(void)
 	FreeMouseCursor();
 }
 
-
-void SuspendVideoManager(void)
-{
-	guiVideoManagerState = VIDEO_SUSPENDED;
-}
 
 void InvalidateRegion(INT32 iLeft, INT32 iTop, INT32 iRight, INT32 iBottom)
 {
@@ -648,14 +642,6 @@ static void GetRGBDistribution()
 	gusRedShift   = f.Rshift - f.Rloss;
 	gusGreenShift = f.Gshift - f.Gloss;
 	gusBlueShift  = f.Bshift - f.Bloss;
-}
-
-
-void GetPrimaryRGBDistributionMasks(UINT32* const  RedBitMask, UINT32* const GreenBitMask, UINT32* const BlueBitMask)
-{
-	*RedBitMask   = gusRedMask;
-	*GreenBitMask = gusGreenMask;
-	*BlueBitMask  = gusBlueMask;
 }
 
 

--- a/src/sgp/Video.h
+++ b/src/sgp/Video.h
@@ -18,10 +18,8 @@ using VideoScaleQuality = ScalingQuality;
 void         VideoSetFullScreen(BOOLEAN enable);
 void         InitializeVideoManager(VideoScaleQuality quality);
 void         ShutdownVideoManager(void);
-void         SuspendVideoManager(void);
 void         InvalidateRegion(INT32 iLeft, INT32 iTop, INT32 iRight, INT32 iBottom);
 void         InvalidateScreen(void);
-void         GetPrimaryRGBDistributionMasks(UINT32* RedBitMask, UINT32* GreenBitMask, UINT32* BlueBitMask);
 void         EndFrameBufferRender(void);
 
 void VideoSetBrightness(float brightness);


### PR DESCRIPTION
    Avoid unnecessary construction of SGPSector objects
    • Town_Militia: sector is the result of pSoldier->sSector.AsByte()
    * Strategic_AI: pGroup->ubSector is already a SGPSector

    • Remove two unused function in Video.cc
    • Reseed the existing mt19937 engine instead of creating a new one
    • Move one variable declaration into the include guard in Random.h
    • Remove an unnecessary assignment in SoundMan (CID 215563)
    • Do not unlock a unique_lock that is about to go out of scope

Just some assorted stuff I came across.
