### PR TITLE
Remove a check for profile ID 53 in HandleSuppressionFire

### DIFF
--- a/src/game/Tactical/Overhead.cc
+++ b/src/game/Tactical/Overhead.cc
@@ -5303,12 +5303,7 @@ static void HandleSuppressionFire(const SOLDIERTYPE* const targeted_merc, SOLDIE
 				{
 					pSoldier->usQuoteSaidFlags |= SOLDIER_QUOTE_SAID_BEING_PUMMELED;
 					// say we're under heavy fire!
-
-					// ATE: For some reason, we forgot #53!
-					if ( pSoldier->ubProfile != 53 )
-					{
-						TacticalCharacterDialogue( pSoldier, QUOTE_UNDER_HEAVY_FIRE );
-					}
+					TacticalCharacterDialogue(pSoldier, QUOTE_UNDER_HEAVY_FIRE);
 				}
 			}
 


### PR DESCRIPTION
It is true that drunk Larry does not have a quote for being under fire, however the dialogue system does not expect every merc to have a full set of quotes and handles this situation just fine. All this check does now is prevent modders from adding the missing quote.