### PR TITLE
Reduce the cost of Assert and AssertMsg

### DIFF
--- a/src/game/Laptop/Insurance_Contract.cc
+++ b/src/game/Laptop/Insurance_Contract.cc
@@ -1082,9 +1082,7 @@ static INT32 CalcStartDayOfInsurance(SOLDIERTYPE* pSoldier);
 
 void PurchaseOrExtendInsuranceForSoldier( SOLDIERTYPE *pSoldier, UINT32 uiInsuranceLength )
 {
-	INT32	iAmountOfMoneyTransfer = -1;
-
-	AssertMsg(pSoldier != NULL, "Soldier pointer is NULL!");
+	Assert(pSoldier);
 
 	//if the user doesnt have insruance already,
 	if( !(pSoldier->usLifeInsurance ) )
@@ -1095,7 +1093,8 @@ void PurchaseOrExtendInsuranceForSoldier( SOLDIERTYPE *pSoldier, UINT32 uiInsura
 	}
 
 	//transfer money
-	iAmountOfMoneyTransfer = CalculateInsuranceContractCost( uiInsuranceLength, pSoldier->ubProfile );
+	INT32 const iAmountOfMoneyTransfer =
+		CalculateInsuranceContractCost(uiInsuranceLength, pSoldier->ubProfile);
 
 	//if the user did have insruance already,
 	if( pSoldier->usLifeInsurance )

--- a/src/game/Strategic/Auto_Resolve.cc
+++ b/src/game/Strategic/Auto_Resolve.cc
@@ -1564,7 +1564,7 @@ static void CreateAutoResolveInterface(void)
 		cell->usIndex     = idx;
 		cell->uiVObjectID = ar->iFaces;
 
-		AssertMsg(s, "Failed to create militia soldier for autoresolve.");
+		Assert(s); // Failed to create militia soldier for autoresolve?
 		s->sSector = ar->ubSector;
 		s->name = gpStrategicString[STR_AR_MILITIA_NAME];
 	}

--- a/src/game/Strategic/Strategic_Movement.cc
+++ b/src/game/Strategic/Strategic_Movement.cc
@@ -610,7 +610,7 @@ static void PrepareForPreBattleInterface(GROUP* pPlayerDialogGroup, GROUP* pInit
 	}
 
 	// Pipe up with quote...
-	AssertMsg( pPlayerDialogGroup, "Didn't get a player dialog group for prebattle interface." );
+	Assert(pPlayerDialogGroup); // Didn't get a player dialog group for prebattle interface?
 
 	AssertMsg(pPlayerDialogGroup->pPlayerList, ST::format("Player group {} doesn't have *any* players in it!  (Finding dialog group)", pPlayerDialogGroup->ubGroupID));
 

--- a/src/game/TileEngine/SaveLoadMap.cc
+++ b/src/game/TileEngine/SaveLoadMap.cc
@@ -473,7 +473,7 @@ static void SetMapRevealedStatus(void)
 	UINT8		ubBitCnt;
 	UINT16	usMapIndex;
 
-	AssertMsg(gpRevealedMap != NULL, "gpRevealedMap is NULL.  DF 1");
+	Assert(gpRevealedMap);
 
 	ClearSlantRoofs( );
 

--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -946,7 +946,6 @@ STRUCTURE* SwapStructureForPartnerAndStoreChangeInMap(STRUCTURE* const s)
 
 STRUCTURE* FindStructure(INT16 const sGridNo, StructureFlags const flags)
 {
-	Assert(flags != 0);
 	for (STRUCTURE* i = gpWorldLevelData[sGridNo].pStructureHead;; i = i->pNext)
 	{
 		if (i == NULL || i->fFlags & flags) return i;
@@ -956,7 +955,6 @@ STRUCTURE* FindStructure(INT16 const sGridNo, StructureFlags const flags)
 
 STRUCTURE* FindNextStructure(STRUCTURE const* const s, StructureFlags const flags)
 {
-	Assert(flags != 0);
 	CHECKN(s);
 	for (STRUCTURE* i = s->pNext;; i = i->pNext)
 	{

--- a/src/game/Utils/Slider.cc
+++ b/src/game/Utils/Slider.cc
@@ -71,7 +71,7 @@ void InitSlider(void)
 
 void ShutDownSlider(void)
 {
-	AssertMsg(guiSliderBoxImage != NULL, "Trying to ShutDown the Slider System when it was never inited");
+	Assert(guiSliderBoxImage); // Trying to ShutDown the Slider System when it was never inited?
 
 	//Do a cehck to see if there are still active nodes
 	for (SLIDER* i = pSliderHead; i != NULL;)
@@ -96,7 +96,7 @@ static void SelectedSliderMovementCallBack(MOUSE_REGION* r, UINT32 reason);
 
 SLIDER* AddSlider(UINT8 ubStyle, UINT16 usCursor, UINT16 usPosX, UINT16 usPosY, UINT16 usWidth, UINT16 usNumberOfIncrements, INT8 sPriority, SLIDER_CHANGE_CALLBACK SliderChangeCallback)
 {
-	AssertMsg(guiSliderBoxImage != NULL, "Trying to Add a Slider Bar when the Slider System was never inited");
+	if (!guiSliderBoxImage) InitSlider();
 
 	if (ubStyle >= NUM_SLIDER_STYLES) throw std::logic_error("Invalid slider style");
 

--- a/src/game/Utils/Text_Input.cc
+++ b/src/game/Utils/Text_Input.cc
@@ -1153,7 +1153,7 @@ BOOLEAN TextInputMode()
 //calls.
 void SaveAndRemoveCurrentTextInputMode()
 {
-	AssertMsg(pSavedHead == NULL, "Attempting to save text input stack head, when one already exists.");
+	Assert(!pSavedHead); // Attempting to save text input stack head, when one already exists?
 	pSavedHead = gpTextInputHead;
 	pSavedColors = pColors;
 	if( pInputStack )
@@ -1170,7 +1170,7 @@ void SaveAndRemoveCurrentTextInputMode()
 
 void RestoreSavedTextInputMode()
 {
-	AssertMsg(pSavedHead != NULL, "Attempting to restore saved text input stack head, when one doesn't exist.");
+	Assert(pSavedHead); // Attempting to restore saved text input stack head, when one doesn't exist?
 	gpTextInputHead = pSavedHead;
 	pColors = pSavedColors;
 	pSavedHead = NULL;

--- a/src/sgp/Debug.h
+++ b/src/sgp/Debug.h
@@ -7,11 +7,12 @@
 #define DEBUG_PRINT_FPS                         (0)             /**< Flag telling to print FPS (Frames per second) counter. */
 #define DEBUG_PRINT_GAME_CYCLE_TIME             (0)             /**< Flag telling to print how much time every game cycle takes. */
 
+namespace SGP { inline ST::string const null{}; }
 // NOTE: on switching to c++20 investigate if this can be simplified in favour of std::source_location
-#define Assert(a) VerboseAssert(static_cast<bool>(a), "", __FILE__, __LINE__)
+#define Assert(a) VerboseAssert(static_cast<bool>(a), SGP::null, __FILE__, __LINE__)
 #define AssertMsg(a, b) VerboseAssert(static_cast<bool>(a), b, __FILE__, __LINE__)
 
-inline void VerboseAssert(bool condition, ST::string msg, ST::string file, uint16_t line)
+inline void VerboseAssert(bool condition, ST::string const& msg, char const * file, uint16_t line)
 {
 	if (!condition) SLOGA("Assertion failed in {}, line {}:\n{}", file, line, msg);
 }

--- a/src/sgp/MouseSystem.cc
+++ b/src/sgp/MouseSystem.cc
@@ -721,7 +721,7 @@ void MOUSE_REGION::ChangeCursor(UINT16 const crsr)
 
 void MSYS_RemoveRegion(MOUSE_REGION* const r)
 {
-	AssertMsg(r, "Attempting to remove a NULL mouse region.");
+	Assert(r); // Attempting to remove a NULL mouse region?
 
 	if (!r) return;
 


### PR DESCRIPTION
• Do not construct strings for the filename prematurely • Do not create a new instance of an empty string every time an Assert
  line is reached, use just one global instance instead.
• Use Assert instead of AssertMsg for null pointer checks, the message
  does not add anything useful.

I repeated my test from #1751 with this patch and this saved ~1.9 million allocations in four minutes, or ~7800 allocations every second.