### PR TITLE
Prevent mercs from swapping places when that make one of them unhittable

### DIFF
--- a/src/game/Tactical/Animation_Control.h
+++ b/src/game/Tactical/Animation_Control.h
@@ -66,10 +66,12 @@
 
 
 //ANIMATION HEIGHT VALUES
-#define ANIM_STAND			6
-#define ANIM_CROUCH			3
-#define ANIM_PRONE			1
-
+enum AnimationHeight : UINT8
+{
+	ANIM_STAND  = 6,
+	ANIM_CROUCH = 3,
+	ANIM_PRONE  = 1
+};
 #define INVALID_ANIMATION		0xFFF0
 #define FOUND_INVALID_ANIMATION	0xFFF1
 

--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -1923,10 +1923,10 @@ static void SetSoldierGridNo(SOLDIERTYPE& s, GridNo new_grid_no, BOOLEAN const f
 		InternalRemoveSoldierFromGridNo(s, fForceRemove);
 	}
 
-	s.sGridNo = new_grid_no;
-
 	// Check if our new gridno is valid, if not do not set!
 	if (!GridNoOnVisibleWorldTile(new_grid_no)) return;
+
+	s.sGridNo = new_grid_no;
 
 	// Alrighty, update UI for this guy, if he's the selected guy
 	if (GetSelectedMan() == &s && guiCurrentEvent == C_WAIT_FOR_CONFIRM)
@@ -2112,6 +2112,14 @@ static void SetSoldierGridNo(SOLDIERTYPE& s, GridNo new_grid_no, BOOLEAN const f
 
 	// Adjust speed based on terrain, etc
 	SetSoldierAniSpeed(&s);
+
+	if (!gpWorldLevelData[s.sGridNo].pMercHead ||
+	    !gpWorldLevelData[s.sGridNo].pMercHead->pStructureData)
+	{
+		// Debug help for issue #1681: set a break point here and check who
+		// is calling this function without calling InternalIsValidStance first.
+		SLOGW("SetSoldierGridNo: ID {} ({}) has no structure", s.ubID, s.name);
+	}
 }
 
 

--- a/src/game/Tactical/Soldier_Macros.h
+++ b/src/game/Tactical/Soldier_Macros.h
@@ -2,10 +2,12 @@
 #define SOLDIER_MACROS_H
 
 // MACROS FOR EASIER SOLDIER CONTROL
-#include "TeamTurns.h"
-#include "Soldier_Profile.h"
-#include "Assignments.h"
+#include "Animation_Control.h"
 #include "Animation_Data.h"
+#include "Assignments.h"
+#include "Soldier_Control.h"
+#include "Soldier_Profile.h"
+#include "TeamTurns.h"
 
 static inline bool RPC_RECRUITED(SOLDIERTYPE const* const s)
 {
@@ -38,6 +40,11 @@ constexpr bool IsHostileToOurTeam(SOLDIERTYPE const& s) noexcept
 static inline bool OK_ENEMY_MERC(SOLDIERTYPE const* const s)
 {
 	return IsHostileToOurTeam(*s) && s->bLife >= OKLIFE;
+}
+
+static inline AnimationHeight GetStance(SOLDIERTYPE const& s)
+{
+	return static_cast<AnimationHeight>(gAnimControl[s.usAnimState].ubEndHeight);
 }
 
 // Checks if our guy can be controllable .... checks bInSector, team, on duty, etc...

--- a/src/game/Tactical/Soldier_Tile.cc
+++ b/src/game/Tactical/Soldier_Tile.cc
@@ -23,6 +23,7 @@
 #include "OppList.h"
 #include "AI.h"
 #include "Faces.h"
+#include "Soldier_Macros.h"
 #include "Soldier_Profile.h"
 #include "Campaign.h"
 #include "Structure_Wrap.h"
@@ -703,6 +704,12 @@ BOOLEAN CanExchangePlaces( SOLDIERTYPE *pSoldier1, SOLDIERTYPE *pSoldier2, BOOLE
 			if ( ( gAnimControl[ pSoldier1->usAnimState ].uiFlags & ANIM_MOVING ) && !(gTacticalStatus.uiFlags & INCOMBAT) )
 			{
 				return( FALSE );
+			}
+
+			if (!InternalIsValidStance(pSoldier1, pSoldier2->bDirection, GetStance(*pSoldier2)) ||
+			    !InternalIsValidStance(pSoldier2, pSoldier1->bDirection, GetStance(*pSoldier1)))
+			{
+				return false;
 			}
 
 			if ( pSoldier2->bSide == 0 )


### PR DESCRIPTION
When a prone merc M1 swapped places with a not prone merc and M1's new grid and position didn't allow him to be prone there, he became unhittable.

This is not what is causing the enemies to become unhittable because the AI does not exchange places, but the added warning in `SetSoldierGridNo` should make it easier to figure out who's calling that function without proper checks.