### PR TITLE
Remove SDL_RenderClear

### DIFF
--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -620,8 +620,6 @@ void RefreshScreen(void)
 	SDL_UpdateTexture(ScreenTexture, &ScreenTextureUpdateRect,
 	                  SrcPixels, ScreenBuffer->pitch);
 
-	SDL_RenderClear(GameRenderer);
-
 	if (ScaleQuality == VideoScaleQuality::NEAR_PERFECT) {
 		SDL_SetRenderTarget(GameRenderer, ScaledScreenTexture);
 		SDL_RenderCopy(GameRenderer, ScreenTexture, nullptr, nullptr);


### PR DESCRIPTION
From the SDL 2 documentation:

SDL_RenderClear
Clear the current rendering target with the drawing color.

This means our use of this function is completely useless because our next next step is to fill the rendering target with the screen texture.

It's not a huge deal because `SDL_RenderPresent` is smart enough to figure out that it can just drop this request, so this removes just the little bit of overhead required to add and remove something from SDL's rendering queue.