### PR TITLE
BattleSnds maintenance

### DIFF
--- a/src/game/Tactical/LoadSaveSoldierType.cc
+++ b/src/game/Tactical/LoadSaveSoldierType.cc
@@ -446,7 +446,7 @@ void ExtractSoldierType(const BYTE* const data, SOLDIERTYPE* const s, bool strac
 	EXTR_I16(d, s->sBoundingBoxOffsetX)
 	EXTR_I16(d, s->sBoundingBoxOffsetY)
 	EXTR_U32(d, s->uiTimeSameBattleSndDone)
-	EXTR_I8(d, s->bOldBattleSnd)
+	EXTR_AUTO(d, s->bOldBattleSnd);
 	EXTR_SKIP(d, 1)
 	EXTR_BOOL(d, s->fContractPriceHasIncreased)
 	EXTR_SKIP(d, 1)
@@ -956,7 +956,7 @@ void InjectSoldierType(BYTE* const data, const SOLDIERTYPE* const s)
 	INJ_I16(d, s->sBoundingBoxOffsetX)
 	INJ_I16(d, s->sBoundingBoxOffsetY)
 	INJ_U32(d, s->uiTimeSameBattleSndDone)
-	INJ_I8(d, s->bOldBattleSnd)
+	INJ_AUTO(d, s->bOldBattleSnd);
 	INJ_SKIP(d, 1)
 	INJ_BOOL(d, s->fContractPriceHasIncreased)
 	INJ_SKIP(d, 1)

--- a/src/game/Tactical/Soldier_Control.h
+++ b/src/game/Tactical/Soldier_Control.h
@@ -25,7 +25,7 @@
 
 constexpr ProfileID NO_PROFILE = 200;
 
-#define BATTLE_SND_LOWER_VOLUME			1
+constexpr bool BATTLE_SND_LOWER_VOLUME = true;
 
 #define TAKE_DAMAGE_GUNFIRE				1
 #define TAKE_DAMAGE_BLADE				2
@@ -173,7 +173,7 @@ enum
 };
 
 // An enumeration for playing battle sounds
-enum BattleSound
+enum BattleSound : INT8
 {
 	BATTLE_SOUND_OK1,
 	BATTLE_SOUND_OK2,
@@ -187,9 +187,9 @@ enum BattleSound
 	BATTLE_SOUND_HUMM,
 	BATTLE_SOUND_NOTHING,
 	BATTLE_SOUND_GOTIT,
-	BATTLE_SOUND_LOWMARALE_OK1,
-	BATTLE_SOUND_LOWMARALE_OK2,
-	BATTLE_SOUND_LOWMARALE_ATTN1,
+	BATTLE_SOUND_LOWMORALE_OK1,
+	BATTLE_SOUND_LOWMORALE_OK2,
+	BATTLE_SOUND_LOWMORALE_ATTN1,
 	BATTLE_SOUND_LOCKED,
 	BATTLE_SOUND_ENEMY,
 	NUM_MERC_BATTLE_SOUNDS
@@ -713,15 +713,15 @@ struct SOLDIERTYPE
 	INT16 sBoundingBoxOffsetX;
 	INT16 sBoundingBoxOffsetY;
 	UINT32 uiTimeSameBattleSndDone;
-	INT8 bOldBattleSnd;
+	BattleSound bOldBattleSnd;
 	BOOLEAN fContractPriceHasIncreased;
 	UINT32 uiBurstSoundID;
 	BOOLEAN fFixingSAMSite;
 	BOOLEAN fFixingRobot;
 	INT8 bSlotItemTakenFrom;
 	BOOLEAN fSignedAnotherContract;
-	SOLDIERTYPE* auto_bandaging_medic;
 	BOOLEAN fDontChargeTurningAPs;
+	SOLDIERTYPE* auto_bandaging_medic;
 	SOLDIERTYPE* robot_remote_holder;
 	UINT32 uiTimeOfLastContractUpdate;
 	INT8 bTypeOfLastContract;
@@ -956,7 +956,7 @@ UINT16 GetStructureID(SOLDIERTYPE const *);
 
 void    MakeCharacterDialogueEventDoBattleSound(SOLDIERTYPE& s, BattleSound, UINT32 delay);
 BOOLEAN DoMercBattleSound(SOLDIERTYPE*, BattleSound);
-BOOLEAN InternalDoMercBattleSound(SOLDIERTYPE*, BattleSound, INT8 bSpecialCode);
+BOOLEAN InternalDoMercBattleSound(SOLDIERTYPE*, BattleSound, bool lowerVolume);
 
 
 UINT32 SoldierDressWound( SOLDIERTYPE *pSoldier, SOLDIERTYPE *pVictim, INT16 sKitPts, INT16 sStatus );

--- a/src/sgp/LoadSaveData.h
+++ b/src/sgp/LoadSaveData.h
@@ -182,6 +182,9 @@ protected:
 #define INJ_SKIP_U8(D)    (D).skip(1);
 #define INJ_SOLDIER(D, S) (D).write<SoldierID>(Soldier2ID((S)));
 #define INJ_VEC3(D, S) INJ_FLOAT(D, (S).x); INJ_FLOAT(D, (S).y); INJ_FLOAT(D, (S).z);
+// Could use auto as the type of S in C++20
+template<typename T>
+static inline void INJ_AUTO(DataWriter & D, T S) { D.write(S); }
 
 #define EXTR_STR(S, D, Size)  (S).readArray<char>((D), (Size));
 #define EXTR_BOOLA(S, D, Size) (S).readArray<BOOLEAN>((D), (Size));
@@ -207,5 +210,7 @@ protected:
 #define EXTR_SKIP_U8(S)    (S).skip(1);
 #define EXTR_SOLDIER(S, D) (D) = ID2Soldier((S).read<SoldierID>());
 #define EXTR_VEC3(S, D) EXTR_FLOAT(S, (D).x); EXTR_FLOAT(S, (D).y); EXTR_FLOAT(S, (D).z);
+template<typename T>
+static inline void EXTR_AUTO(DataReader & S, T & D) { D = S.read<std::remove_reference_t<decltype(D)>>(); }
 
 #endif


### PR DESCRIPTION
• Low morale confirmations restored (#1757), can be muted by game option
• BATTLESNDS BOOLEAN member had three different values
• Typos
• Changed SOLDIERTYPE::bOldBattleSnd from INT8 to enum