### PR TITLE
Fix visual artifacts when resizing the window or toggling fullscreen

### DIFF
--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -222,6 +222,8 @@ static void MainLoop(int msPerGameCycle)
 				case SDL_FINGERUP:     FingerUp(&event.tfinger); break;
 				case SDL_FINGERDOWN:   FingerDown(&event.tfinger); break;
 
+				case SDL_WINDOWEVENT: HandleWindowEvent(event); break;
+
 				case SDL_QUIT: deinitGameAndExit(); break;
 			}
 		}

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -114,6 +114,7 @@ void VideoToggleFullScreen(void)
 	{
 		SDL_SetWindowFullscreen(g_game_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
 	}
+	SDL_RenderClear(GameRenderer);
 }
 
 void VideoSetBrightness(float brightness)
@@ -720,5 +721,13 @@ void ShutdownVideoSurfaceManager(void)
 	while (gpVSurfaceHead)
 	{
 		delete gpVSurfaceHead;
+	}
+}
+
+
+void HandleWindowEvent(SDL_Event const& evt)
+{
+	if (evt.window.event == SDL_WINDOWEVENT_RESIZED) {
+		SDL_RenderClear(GameRenderer);
 	}
 }

--- a/src/sgp/Video.h
+++ b/src/sgp/Video.h
@@ -1,6 +1,7 @@
 #ifndef VIDEO_H
 #define VIDEO_H
 
+#include <SDL_events.h>
 #include <SDL_video.h>
 #include "Types.h"
 #include "stracciatella.h"
@@ -27,6 +28,8 @@ void VideoSetBrightness(float brightness);
 /* Toggle between fullscreen and window mode after initialising the video
  * manager */
 void VideoToggleFullScreen(void);
+
+void HandleWindowEvent(SDL_Event const&);
 
 void SetMouseCursorProperties(INT16 sOffsetX, INT16 sOffsetY, UINT16 usCursorHeight, UINT16 usCursorWidth);
 


### PR DESCRIPTION
I misunderstood the SDL documentation, `RenderCopy` only stretches the texture to fill the viewport, while `RenderClear` clears the entire window area. Fortunately it is still not necessary to clear everything every frame.