### PR TITLE
Proposal: Transition away from SGP::Buffer

### DIFF
--- a/src/game/TileEngine/Tile_Surface.cc
+++ b/src/game/TileEngine/Tile_Surface.cc
@@ -55,9 +55,8 @@ try
 	}
 	else if (hImage->uiAppDataSize == hVObject->SubregionCount() * sizeof(AuxObjectData))
 	{
-		// Valid auxiliary data, so make a copy of it for TileSurf
-		pTileSurf->pAuxData = new AuxObjectData[hVObject->SubregionCount()]{};
-		memcpy( pTileSurf->pAuxData, hImage->pAppData, hImage->uiAppDataSize );
+		// Valid auxiliary data, so move it to TileSurf
+		pTileSurf->pAuxData = reinterpret_cast<AuxObjectData *>(hImage->pAppData.Release());
 	}
 	else
 	{

--- a/src/sgp/Buffer.h
+++ b/src/sgp/Buffer.h
@@ -37,12 +37,12 @@ namespace SGP
 		private:
 			UniqueT ptr_;
 
-			Buffer(const Buffer&) = delete;          /* no copy */
+			Buffer(const Buffer&) = delete;         /* no copy */
 			void operator=(const Buffer&) = delete; /* no assignment */
 
 			// Moving a buffer would actually work, but to discourage use
 			// of this class, these two are deleted as well.
-			Buffer(Buffer &&) = delete;          /* no move */
+			Buffer(Buffer &&) = delete;         /* no move */
 			void operator=(Buffer &&) = delete; /* no move assignment */
 	};
 }

--- a/src/sgp/Buffer.h
+++ b/src/sgp/Buffer.h
@@ -2,42 +2,48 @@
 #define BUFFER_H
 
 #include <cstddef>
+#include <memory>
+#include <utility>
 
+/*
+ * Please do not use this class in new code, there is nothing it can do
+ * that unique_ptr or vector cannot do better. The only reason the
+ * deprecated attribute is commented out is for the sake of the existing
+ * Buffer users.
+ */
 namespace SGP
 {
-	template<typename T> class Buffer
+	/* [[deprecated]] */ template<typename T> class Buffer
 	{
+		using UniqueT = std::unique_ptr<T []>;
+
 		public:
-			explicit Buffer(T* const buf = 0) : buf_(buf) {}
+			explicit Buffer(T* const buf = nullptr) : ptr_{ buf } {}
 
-			explicit Buffer(size_t const n) : buf_(new T[n]{}) {}
+			explicit Buffer(std::size_t const n) { Allocate(n); }
 
-			~Buffer() { if (buf_) delete[] buf_; }
+			Buffer<T> & Allocate(std::size_t const n) { ptr_ = std::make_unique<T []>(n); return *this; }
 
-			Buffer& Allocate(size_t const n) { return *this = new T[n]{}; }
+			T* Release() noexcept { return ptr_.release(); }
 
-			T* Release()
-			{
-				T* const buf = buf_;
-				buf_ = 0;
-				return buf;
-			}
+			Buffer<T> & operator=(T * const buf) noexcept { ptr_.reset(buf); return *this; }
 
-			Buffer& operator =(T* const buf)
-			{
-				if (buf_) delete[] buf_;
-				buf_ = buf;
-				return *this;
-			}
+			// Small utility function to help ease the transition away from Buffer.
+			UniqueT moveToUnique() noexcept { return std::move(ptr_); }
 
-			operator T*()             { return buf_; }
-			operator T const*() const { return buf_; }
+			operator T*()             noexcept { return ptr_.get(); }
+			operator T const*() const noexcept { return ptr_.get(); }
 
 		private:
-			T* buf_;
+			UniqueT ptr_;
 
-			Buffer(const Buffer&);          /* no copy */
-			void operator =(const Buffer&); /* no assignment */
+			Buffer(const Buffer&) = delete;          /* no copy */
+			void operator=(const Buffer&) = delete; /* no assignment */
+
+			// Moving a buffer would actually work, but to discourage use
+			// of this class, these two are deleted as well.
+			Buffer(Buffer &&) = delete;          /* no move */
+			void operator=(Buffer &&) = delete; /* no move assignment */
 	};
 }
 

--- a/src/sgp/HImage.cc
+++ b/src/sgp/HImage.cc
@@ -290,24 +290,6 @@ UINT32 GetRGBColor(UINT16 Value16BPP)
 }
 
 
-void GetETRLEImageData(SGPImage const* const img, ETRLEData* const buf)
-{
-	Assert(img);
-	Assert(buf);
-
-	SGP::Buffer<ETRLEObject> etrle_objs(img->usNumberOfObjects);
-	memcpy(etrle_objs, img->pETRLEObject, sizeof(*etrle_objs) * img->usNumberOfObjects);
-
-	SGP::Buffer<UINT8> pix_data(img->uiSizePixData);
-	memcpy(pix_data, img->pImageData, sizeof(*pix_data) * img->uiSizePixData);
-
-	buf->pPixData          = pix_data.Release();
-	buf->uiSizePixData     = img->uiSizePixData;
-	buf->pETRLEObject      = etrle_objs.Release();
-	buf->usNumberOfObjects = img->usNumberOfObjects;
-}
-
-
 void ConvertRGBDistribution565To555( UINT16 * p16BPPData, UINT32 uiNumberOfPixels )
 {
 	for (UINT16* Px = p16BPPData; Px != p16BPPData + uiNumberOfPixels; ++Px)

--- a/src/sgp/HImage.h
+++ b/src/sgp/HImage.h
@@ -63,13 +63,6 @@ struct ETRLEObject
 	UINT16			usWidth;
 };
 
-struct ETRLEData
-{
-	PTR								pPixData;
-	UINT32						uiSizePixData;
-	ETRLEObject *			pETRLEObject;
-	UINT16						usNumberOfObjects;
-};
 
 // Image header structure
 struct SGPImage
@@ -109,9 +102,6 @@ SGPImage* CreateImage(const ST::string& ImageFile, UINT16 fContents);
 // This function will run the appropriate copy function based on the type of SGPImage object
 BOOLEAN CopyImageToBuffer(SGPImage const*, UINT32 fBufferType, BYTE* pDestBuf, UINT16 usDestWidth, UINT16 usDestHeight, UINT16 usX, UINT16 usY, SGPBox const* src_rect);
 
-
-// This function will create a buffer in memory of ETRLE data, excluding palette
-void GetETRLEImageData(SGPImage const*, ETRLEData*);
 
 // UTILITY FUNCTIONS
 

--- a/src/sgp/Types.h
+++ b/src/sgp/Types.h
@@ -52,7 +52,6 @@ typedef char            CHAR8;
 
 // other
 typedef unsigned char		BOOLEAN;
-typedef void *					PTR;
 typedef UINT8						BYTE;
 
 #ifndef TRUE

--- a/src/sgp/VObject.cc
+++ b/src/sgp/VObject.cc
@@ -50,14 +50,11 @@ SGPVObject::SGPVObject(SGPImage * const img) :
 
 	if (img->ubBitDepth == 8)
 	{
-		// create palette
-		const SGPPaletteEntry* const src_pal = img->pPalette;
-		Assert(src_pal != NULL);
+		// move palette data over
+		palette_ = img->pPalette.moveToUnique();
+		Assert(palette_);
 
-		SGPPaletteEntry* const pal = palette_.Allocate(256);
-		memcpy(pal, src_pal, sizeof(*pal) * 256);
-
-		palette16_     = Create16BPPPalette(pal);
+		palette16_     = Create16BPPPalette(palette_.get());
 		current_shade_ = palette16_;
 	}
 

--- a/src/sgp/VObject.h
+++ b/src/sgp/VObject.h
@@ -1,7 +1,6 @@
 #ifndef __VOBJECT_H
 #define __VOBJECT_H
 
-#include "Buffer.h"
 #include "Types.h"
 #include <memory>
 
@@ -34,7 +33,7 @@ class SGPVObject
 
 		UINT8 BPP() const { return bit_depth_; }
 
-		SGPPaletteEntry const* Palette() const { return palette_; }
+		SGPPaletteEntry const* Palette() const { return palette_.get(); }
 
 		UINT16 const* Palette16() const { return palette16_; }
 
@@ -67,7 +66,7 @@ class SGPVObject
 
 	private:
 		Flags                        flags_;                         // Special flags
-		SGP::Buffer<SGPPaletteEntry> palette_;                       // 8BPP Palette
+		std::unique_ptr<SGPPaletteEntry const []> palette_;          // 8BPP Palette
 		UINT16*                      palette16_;                     // A 16BPP palette used for 8->16 blits
 
 		std::unique_ptr<UINT8 const []> pix_data_;                   // ETRLE pixel data

--- a/src/sgp/VObject.h
+++ b/src/sgp/VObject.h
@@ -28,7 +28,8 @@ struct ZStripInfo
 class SGPVObject
 {
 	public:
-		SGPVObject(SGPImage const*);
+		// This modifies the SGPImage: relevant data is moved away from it
+		SGPVObject(SGPImage *);
 		~SGPVObject();
 
 		UINT8 BPP() const { return bit_depth_; }
@@ -66,12 +67,11 @@ class SGPVObject
 
 	private:
 		Flags                        flags_;                         // Special flags
-		UINT32                       pix_data_size_;                 // ETRLE data size
 		SGP::Buffer<SGPPaletteEntry> palette_;                       // 8BPP Palette
 		UINT16*                      palette16_;                     // A 16BPP palette used for 8->16 blits
 
-		UINT8*                       pix_data_;                      // ETRLE pixel data
-		ETRLEObject*                 etrle_object_;                  // Object offset data etc
+		std::unique_ptr<UINT8 const []> pix_data_;                   // ETRLE pixel data
+		std::unique_ptr<ETRLEObject const []> etrle_object_;         // Object offset data etc
 	public:
 		UINT16*                      pShades[HVOBJECT_SHADE_TABLES]; // Shading tables
 	private:


### PR DESCRIPTION
`SGP::Buffer` is essentially just a pre C++11 version of unique_ptr's array variant. It is less functional and certainly far less known than its modern successor.

This PR demonstrates a practical benefit of this approach: `SGPImages`  are short-lived (often unnamed and temporary) objects that are only created as a step in the creation of other things ike `SGPVObject`. It is therefore safe to move data away from `SGPImage` instead of copying it.