### PR TITLE
Undo damage from PR #1759

### DIFF
--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -1921,10 +1921,10 @@ static void SetSoldierGridNo(SOLDIERTYPE& s, GridNo new_grid_no, BOOLEAN const f
 		InternalRemoveSoldierFromGridNo(s, fForceRemove);
 	}
 
+	s.sGridNo = new_grid_no;
+
 	// Check if our new gridno is valid, if not do not set!
 	if (!GridNoOnVisibleWorldTile(new_grid_no)) return;
-
-	s.sGridNo = new_grid_no;
 
 	// Alrighty, update UI for this guy, if he's the selected guy
 	if (GetSelectedMan() == &s && guiCurrentEvent == C_WAIT_FOR_CONFIRM)
@@ -2111,8 +2111,9 @@ static void SetSoldierGridNo(SOLDIERTYPE& s, GridNo new_grid_no, BOOLEAN const f
 	// Adjust speed based on terrain, etc
 	SetSoldierAniSpeed(&s);
 
-	if (!gpWorldLevelData[s.sGridNo].pMercHead ||
-	    !gpWorldLevelData[s.sGridNo].pMercHead->pStructureData)
+	if (s.bTeam == ENEMY_TEAM &&
+		(!gpWorldLevelData[s.sGridNo].pMercHead ||
+	     !gpWorldLevelData[s.sGridNo].pMercHead->pStructureData))
 	{
 		// Debug help for issue #1681: set a break point here and check who
 		// is calling this function without calling InternalIsValidStance first.


### PR DESCRIPTION
Not setting `sGridNo` causes problems when NPCs leave a sector, for example when Fatima moves from A9 to A10.

Make the new warning appear less often, we only need it figure out the problem with the enemy AI.

I should have known better than to blindly trust code comments, this causes several error messages and OOB accesses in current builds.