### PR TITLE
Give CheckForGunJam and OKFireWeapon a proper return type

### DIFF
--- a/src/game/Tactical/Soldier_Ani.cc
+++ b/src/game/Tactical/Soldier_Ani.cc
@@ -657,8 +657,8 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 					else if (pSoldier->bDoBurst == 1)
 					{
 						// CHECK FOR GUN JAM
-						if (auto const weaponJammed = CheckForGunJam(pSoldier);
-						    weaponJammed == FireWeaponResult::JAMMED)
+						auto const weaponJammed = CheckForGunJam(pSoldier);
+						if (weaponJammed == FireWeaponResult::JAMMED)
 						{
 							fStop = TRUE;
 							// stop shooting!
@@ -1038,10 +1038,10 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 					return( TRUE );
 
 				case 470:
-
+				{
 					// CODE: CHECK FOR OK WEAPON SHOT!
-					if (auto const okFireWeapon = OKFireWeapon(pSoldier);
-					    okFireWeapon == FireWeaponResult::JAMMED)
+					auto const okFireWeapon = OKFireWeapon(pSoldier);
+					if (okFireWeapon == FireWeaponResult::JAMMED)
 					{
 						SLOGD("Fire Weapon: Gun Cannot fire, code 470");
 
@@ -1068,6 +1068,7 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 						}
 					}
 					break;
+				}
 
 				case 471:
 

--- a/src/game/Tactical/Soldier_Ani.cc
+++ b/src/game/Tactical/Soldier_Ani.cc
@@ -110,8 +110,6 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 	UINT16 usItem;
 	RANDOM_ANI_DEF *pAnimDef;
 	UINT8 ubDesiredHeight;
-	BOOLEAN bOKFireWeapon;
-	BOOLEAN bWeaponJammed;
 	UINT16 usUIMovementMode;
 
 	do
@@ -659,8 +657,8 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 					else if (pSoldier->bDoBurst == 1)
 					{
 						// CHECK FOR GUN JAM
-						bWeaponJammed = CheckForGunJam( pSoldier );
-						if ( bWeaponJammed == TRUE )
+						if (auto const weaponJammed = CheckForGunJam(pSoldier);
+						    weaponJammed == FireWeaponResult::JAMMED)
 						{
 							fStop = TRUE;
 							// stop shooting!
@@ -681,7 +679,7 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 							SLOGD("Freeing up attacker - aborting start of attack due to burst gun jam");
 							FreeUpAttacker(pSoldier);
 						}
-						else if ( bWeaponJammed == 255 )
+						else if (weaponJammed == FireWeaponResult::UNJAMMED)
 						{
 							// Play intermediate animation...
 							if ( HandleUnjamAnimation( pSoldier ) )
@@ -743,7 +741,6 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 					//CODE: FINISH BURST
 					pSoldier->fDoSpread = FALSE;
 					pSoldier->bDoBurst = 1;
-					//pSoldier->fBurstCompleted = TRUE;
 					break;
 
 				case 450:
@@ -1043,14 +1040,14 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 				case 470:
 
 					// CODE: CHECK FOR OK WEAPON SHOT!
-					bOKFireWeapon =  OKFireWeapon( pSoldier );
-
-					if ( bOKFireWeapon == FALSE )
+					if (auto const okFireWeapon = OKFireWeapon(pSoldier);
+					    okFireWeapon == FireWeaponResult::JAMMED)
 					{
 						SLOGD("Fire Weapon: Gun Cannot fire, code 470");
 
 						// OK, SKIP x # OF FRAMES
 						// Skip 3 frames, ( a third ia added at the end of switch.. ) For a total of 4
+						// XXX Code and comment do not match. Should we really skip 5 frames in total?
 						pSoldier->usAniCode += 4;
 
 						// Reduce by a bullet...
@@ -1062,7 +1059,7 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 						SLOGD("Freeing up attacker - gun failed to fire");
 						FreeUpAttacker(pSoldier);
 					}
-					else if ( bOKFireWeapon == 255 )
+					else if (okFireWeapon == FireWeaponResult::UNJAMMED)
 					{
 						// Play intermediate animation...
 						if ( HandleUnjamAnimation( pSoldier ) )

--- a/src/game/Tactical/Weapons.h
+++ b/src/game/Tactical/Weapons.h
@@ -160,6 +160,11 @@ struct EXPLOSIVETYPE
 	UINT8 ubAnimationID; // Animation enum to use
 };
 
+enum class FireWeaponResult
+{
+	FAILED, FIRED, FIREABLE, JAMMED, UNJAMMED
+};
+
 //GLOBALS
 
 extern ARMOURTYPE    const Armour[];
@@ -167,7 +172,7 @@ extern EXPLOSIVETYPE const Explosive[];
 
 INT8 EffectiveArmour(const OBJECTTYPE* pObj);
 extern INT8 ArmourVersusExplosivesPercent( SOLDIERTYPE * pSoldier );
-extern BOOLEAN FireWeapon( SOLDIERTYPE *pSoldier , INT16 sTargetGridNo );
+FireWeaponResult FireWeapon(SOLDIERTYPE * pSoldier, GridNo sTargetGridNo);
 void WeaponHit(SOLDIERTYPE* target, UINT16 usWeaponIndex, INT16 sDamage, INT16 sBreathLoss, UINT16 usDirection, INT16 sXPos, INT16 sYPos, INT16 sZPos, INT16 sRange, SOLDIERTYPE* attacker, UINT8 ubSpecial, UINT8 ubHitLocation);
 void StructureHit(BULLET* b, UINT16 usStructureID, INT32 iImpact, BOOLEAN fStopped);
 extern void WindowHit( INT16 sGridNo, UINT16 usStructureID, BOOLEAN fBlowWindowSouth, BOOLEAN fLargeForce );
@@ -188,8 +193,8 @@ INT8 ArmourPercent(const SOLDIERTYPE* pSoldier);
 
 extern void GetTargetWorldPositions( SOLDIERTYPE *pSoldier, INT16 sTargetGridNo, FLOAT *pdXPos, FLOAT *pdYPos, FLOAT *pdZPos );
 
-extern BOOLEAN	OKFireWeapon( SOLDIERTYPE *pSoldier );
-extern BOOLEAN CheckForGunJam( SOLDIERTYPE * pSoldier );
+FireWeaponResult OKFireWeapon(SOLDIERTYPE *);
+FireWeaponResult CheckForGunJam(SOLDIERTYPE *);
 
 INT32 CalcMaxTossRange(const SOLDIERTYPE* pSoldier, UINT16 usItem, BOOLEAN fArmed);
 extern UINT32 CalcThrownChanceToHit(SOLDIERTYPE *pSoldier, INT16 sGridNo, UINT8 ubAimTime, UINT8 ubAimPos );


### PR DESCRIPTION
These function used a BOOLEAN to express four different possible results. This commit also uses the new return type for `FireWeapon`, even though nobody is currently using the returned value. This adds a fifth possible result to the enum.

More code comments that contradict the actual code, lovely.