### PR TITLE
Do not add aim time to displayed # of APs when using the underhand launcher

### DIFF
--- a/src/game/Tactical/Overhead_Types.h
+++ b/src/game/Tactical/Overhead_Types.h
@@ -4,17 +4,24 @@
 
 #include "Types.h"
 
-
-#define REFINE_AIM_1					0
-#define REFINE_AIM_MID1				1
-#define REFINE_AIM_2					2
-#define REFINE_AIM_MID2				3
-#define REFINE_AIM_3					4
-#define REFINE_AIM_MID3				5
-#define REFINE_AIM_4					6
-#define REFINE_AIM_MID4				7
-#define REFINE_AIM_5					8
-#define REFINE_AIM_BURST				10
+// Possible values for SOLDIERTYPE::bShownAimTime
+enum RefineAim : INT8
+{
+	REFINE_AIM_1 = 0,
+	REFINE_AIM_MID1 = 1,
+	REFINE_AIM_2 = 2,
+	REFINE_AIM_MID2 = 3,
+	REFINE_AIM_3 = 4,
+	REFINE_AIM_MID3 = 5,
+	REFINE_AIM_4 = 6,
+	REFINE_AIM_MID4 = 7,
+	REFINE_AIM_5 = 8,
+	REFINE_AIM_BURST = 10,
+	REFINE_PUNCH_1 = 0,
+	REFINE_PUNCH_2 = 6,
+	REFINE_KNIFE_1 = 0,
+	REFINE_KNIFE_2 = 6
+};
 
 #define AIM_SHOT_RANDOM				0
 #define AIM_SHOT_HEAD					1

--- a/src/game/Tactical/Points.cc
+++ b/src/game/Tactical/Points.cc
@@ -875,11 +875,11 @@ UINT8 CalcTotalAPsToAttack(SOLDIERTYPE* const s, INT16 const grid_no, UINT8 cons
 		case IC_LAUNCHER:
 		case IC_TENTACLES:
 		case IC_THROWING_KNIFE:
-			ap_cost  = MinAPsToAttack(s, grid_no, ubAddTurningCost);
-			ap_cost +=
-				s->bDoBurst ? CalcAPsToBurst(CalcActionPoints(s), in_hand) :
-				aim_time;
-			break;
+			return MinAPsToAttack(s, grid_no, ubAddTurningCost) +
+				(s->bDoBurst ? CalcAPsToBurst(CalcActionPoints(s), in_hand) :
+				// WM_ATTACHED is already handled by MinAPsToAttack and the
+				// aim time cannot be refined further.
+				s->bWeaponMode == WM_ATTACHED ? 0 : aim_time);
 
 		case IC_GRENADE:
 		case IC_BOMB:

--- a/src/game/Tactical/Points.h
+++ b/src/game/Tactical/Points.h
@@ -2,6 +2,7 @@
 #define __POINTS_H_
 
 #include "Item_Types.h"
+#include "JA2Types.h"
 
 
 #define AP_MINIMUM			10 // no merc can have less for his turn

--- a/src/game/Tactical/UI_Cursors.cc
+++ b/src/game/Tactical/UI_Cursors.cc
@@ -1047,9 +1047,6 @@ void HandleRightClickAdjustCursor( SOLDIERTYPE *pSoldier, INT16 usMapPos )
 			}
 			else
 			{
-				sGridNo = usMapPos;
-				bTargetLevel = (INT8)gsInterfaceLevel;
-
 				// Look for a target here...
 				const SOLDIERTYPE* const tgt = gUIFullTarget;
 				if (tgt != NULL)

--- a/src/game/Tactical/UI_Cursors.h
+++ b/src/game/Tactical/UI_Cursors.h
@@ -4,13 +4,6 @@
 #include "Interface_Cursors.h"
 
 
-#define REFINE_PUNCH_1 0
-#define REFINE_PUNCH_2 6
-
-#define REFINE_KNIFE_1 0
-#define REFINE_KNIFE_2 6
-
-
 UICursorID GetProperItemCursor(SOLDIERTYPE*, GridNo map_pos, BOOLEAN activated);
 
 void HandleLeftClickCursor( SOLDIERTYPE *pSoldier );


### PR DESCRIPTION
Fixes #1765. This commit also merges the refine aim related constants that were split over two headers and adresses two issues pointed out by clang- tidy: dead stores in UI_Cursors.cc and Points.h needed other headers to be included before it.