### PR TITLE
Fix: IsThereASoldierInThisSector uses wrong SGPSector to index method

### DIFF
--- a/src/game/Strategic/Assignments.h
+++ b/src/game/Strategic/Assignments.h
@@ -112,7 +112,7 @@ void BuildSectorsWithSoldiersList( void );
 void InitSectorsWithSoldiersList( void );
 
 // is there a soldier in this sector?..only use after BuildSectorsWithSoldiersList is called
-BOOLEAN IsThereASoldierInThisSector(const SGPSector& sSector);
+bool IsThereASoldierInThisSector(const SGPSector& sSector);
 
 void CheckIfSoldierUnassigned( SOLDIERTYPE *pSoldier );
 


### PR DESCRIPTION
Fallout from the introduction of `SGPSector`: `fSectorsWithSoldiers` used the strategic index (0-323) as its array index, not the sector index (0-255). Changing this array to a bitset and adding a dedicated function to convert a `SGPSector` to a position should help to avoid this mistake in the future.

This function was only used once, but in the really important function `FindStratPath`, which probably caused the enemy troops to use incorrect routes.