### PR TITLE
OppList.cc maintenance

### DIFF
--- a/src/game/Tactical/Overhead.h
+++ b/src/game/Tactical/Overhead.h
@@ -123,6 +123,11 @@ static inline bool IsOnOurTeam(SOLDIERTYPE const& s)
 	return s.bTeam == OUR_TEAM;
 }
 
+constexpr bool IsOnOurOrMilitiaTeam(SOLDIERTYPE const& s)
+{
+	return s.bTeam == OUR_TEAM || s.bTeam == MILITIA_TEAM;
+}
+
 extern SOLDIERTYPE* g_selected_man;
 
 extern const char* const gzActionStr[];


### PR DESCRIPTION
• Remove the `HandleSight` warning about NOWHERE, it is no longer useful
• Remove the always defined `WE_SEE_WHAT_MILITIA_SEES_AND_VICE_VERSA` macro

Addresses #1801.