### PR TITLE
Keep JA2Clock in lockstep with SDL's clock

### DIFF
--- a/src/game/Utils/Timer_Control.h
+++ b/src/game/Utils/Timer_Control.h
@@ -63,11 +63,9 @@ extern CUSTOMIZABLE_TIMER_CALLBACK gpCustomizableTimerCallback;
 // MACROS
 // Check if new counter < 0        | set to 0 |        Decrement
 
-#define UPDATECOUNTER( c )		( ( giTimerCounters[ c ] - BASETIMESLICE ) < 0 ) ?  ( giTimerCounters[ c ] = 0 ) : ( giTimerCounters[ c ] -= BASETIMESLICE )
 #define RESETCOUNTER( c )		( giTimerCounters[ c ] = giTimerIntervals[ c ] )
 #define COUNTERDONE( c )		( giTimerCounters[ c ] == 0 ) ? TRUE : FALSE
 
-#define UPDATETIMECOUNTER( c )		( ( c - BASETIMESLICE ) < 0 ) ?  ( c = 0 ) : ( c -= BASETIMESLICE )
 #define RESETTIMECOUNTER( c, d )	( c = d )
 
 #ifdef BOUNDS_CHECKER


### PR DESCRIPTION
As of #1173, the game's built-in clock is incremented monotonically by an `SDL_AddTimer()` callback called every `ms_per_time_slice`, as part of the effort to address the issues surrounding #99. Unfortunately this has a significant problem: `SDL_AddTimer()` can't necessarily be counted on to have granularity beyond 10ms or so on all platforms, and on some (OpenBSD at the very least) the time often varies upwards by 10ms (one step!) in practice, with the practical effect that the game continues to run painfully slowly. One way to solve this would be to instead use the timer callback to synchronize the JA2Clock with SDL's internal clock via SDL_GetTicks64().

This (unfinished) patch is a quick and dirty attempt at doing just that; empirically, the game is *far* more playable on SDL platforms that won't reliably call a timer callback every 10ms with this patch. Unfortunately, it also breaks the clock's configurability: it always advances at the same overall rate as SDL's internal clock. (`ms_per_time_slice` only affects the frequency at which the game's clock is synchronized with SDL's, and is therefore more or less useless.) One way to address this might be to add a new setting that applies a multiplier (or perhaps a bitshift?) to the new `elapsed` value in `TimeProc()`, but this would still break `ms_per_time_slice`'s existing semantics: to double the rate, for example, one would need to set the multiplier to 2, instead of dividing `ms_per_time_slice` by 2.

Assuming there's interest in this idea, I'll work on it further to make the appropriate configuration changes, etc.