### PR TITLE
Proposal: Revamp calling of the game loop

### DIFF
--- a/assets/externalized/game.json
+++ b/assets/externalized/game.json
@@ -31,11 +31,11 @@
   //  vanilla setting: true
   "draw_item_shadow": true,
 
-  //  Number of milliseconds for one game cycle.
-  //  25 ms gives approx. 40 cycles per second (and 40 frames per second, since the screen is updated on every cycle).
-  //  Decreasing this value will increase the speed of the game (enemy movement, bullets speed, etc).
-  //  Stracciatella standard value: 25
-  "ms_per_game_cycle": 25,
+  //  Specifies how often the game tries to refresh the screen. Lower values reduce
+  //  power consumption, higher values can make the game appear to be more responsive.
+  //  Minimum: 1, Maximum: 144
+  //  Stracciatella default value: 40
+  "target_fps": 40,
 
   //  Number of milliseconds for one game time slice.
   //  Decreasing this value will speed up UI transitions and soldier animations.

--- a/rust/stracciatella/src/schemas/yaml/game.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/game.schema.yaml
@@ -38,18 +38,17 @@ properties:
       Automatically draw a shadow for all items in a merc's inventory.
 
       Vanilla setting: `true`
-  ms_per_game_cycle:
-    $ref: types/int32.schema.yaml
-    title: Milliseconds per game cycle
+  target_fps:
+    type: number
+    minimum: 1
+    maximum: 144
+    title: Target FPS
     description: |
-      Number of milliseconds for one game cycle.
+      Specifies how often the game tries to refresh the screen. Lower values reduce
+      power consumption, higher values can make the game appear to be more responsive.
 
-      25 ms gives approx. 40 cycles per second (and 40 frames per second, since the screen is updated on every cycle).
-      Decreasing this value will increase the speed of the game (enemy movement, bullets speed, etc).
-
-      Stracciatella default value: `25`
+      Stracciatella default value: `40`
   ms_per_time_slice:
-    $ref: types/int32.schema.yaml
     title: Milliseconds per time slice
     description: |
       Number of milliseconds for one game time slice.

--- a/rust/stracciatella/src/schemas/yaml/game.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/game.schema.yaml
@@ -49,6 +49,7 @@ properties:
 
       Stracciatella default value: `40`
   ms_per_time_slice:
+    $ref: types/int32.schema.yaml
     title: Milliseconds per time slice
     description: |
       Number of milliseconds for one game time slice.

--- a/rust/stracciatella/src/schemas/yaml/game.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/game.schema.yaml
@@ -496,7 +496,6 @@ required:
   - can_enter_turnbased
   - middle_mouse_look
   - draw_item_shadow
-  - ms_per_game_cycle
   - ms_per_time_slice
   - starting_cash_easy
   - starting_cash_medium

--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -10,7 +10,7 @@ DefaultGamePolicy::DefaultGamePolicy(const JsonValue& json)
 	middle_mouse_look = gp.getOptionalBool("middle_mouse_look", true);
 
 	f_draw_item_shadow = gp.getOptionalBool("draw_item_shadow", true);
-	ms_per_game_cycle = gp.getOptionalInt("ms_per_game_cycle", 25);
+	target_fps = gp.getOptionalInt("target_fps", 40);
 	ms_per_time_slice = gp.getOptionalInt("ms_per_time_slice", 10);
 
 	starting_cash_easy = gp.getOptionalInt("starting_cash_easy", 45000);

--- a/src/externalized/policy/GamePolicy.h
+++ b/src/externalized/policy/GamePolicy.h
@@ -29,7 +29,7 @@ public:
 
 	bool f_draw_item_shadow;              /**< Draw shadows from the inventory items. */
 
-	int32_t ms_per_game_cycle;            /**< Milliseconds per game cycle. */
+	int32_t target_fps;
 	int32_t ms_per_time_slice;            /**< Milliseconds per time slice. */
 
 	int32_t starting_cash_easy;

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -19,7 +19,6 @@
 #include "UILayout.h"
 #include "GameRes.h"
 #include "GameMode.h"
-#include "Timer.h"
 #include "Font.h"
 
 #include "DefaultContentManager.h"
@@ -119,7 +118,7 @@ void requestGameExit()
 	SDL_PushEvent(&event);
 }
 
-static void MainLoop(int msPerGameCycle)
+static void MainLoop()
 {
 	bool s_doGameCycles{true};
 
@@ -386,7 +385,7 @@ int main(int argc, char* argv[])
 		g_ui.recalculatePositions();
 
 		SLOGD("Initializing Video Manager");
-		InitializeVideoManager(scalingQuality);
+		InitializeVideoManager(scalingQuality, GCM->getGamePolicy()->target_fps);
 		VideoSetBrightness(brightness);
 
 		SLOGD("Initializing Video Object Manager");
@@ -425,7 +424,7 @@ int main(int argc, char* argv[])
 		/* At this point the SGP is set up, which means all I/O, Memory, tools, etc.
 		* are available. All we need to do is attend to the gaming mechanics
 		* themselves */
-		MainLoop(gamepolicy(ms_per_game_cycle));
+		MainLoop();
 
 		delete cm;
 		GCM = NULL;

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -19,7 +19,6 @@
 #include "UILayout.h"
 #include "GameRes.h"
 #include "GameMode.h"
-#include "Font.h"
 
 #include "DefaultContentManager.h"
 #include "GameInstance.h"

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -20,6 +20,7 @@
 #include "Font.h"
 #include "Icon.h"
 #include <algorithm>
+#include <chrono>
 #include <ctime>
 #include <stdexcept>
 
@@ -507,7 +508,7 @@ static void ScrollJA2Background(INT16 sScrollXIncrement, INT16 sScrollYIncrement
 	ExecuteVideoOverlaysToAlternateBuffer(BACKBUFFER);
 }
 
-
+static std::chrono::steady_clock::time_point gLastRefresh;
 void RefreshScreen(void)
 {
 	if (guiVideoManagerState != VIDEO_ON) return;
@@ -534,6 +535,13 @@ void RefreshScreen(void)
 	SDL_BlitSurface(FrameBuffer, &MouseBackground, ScreenBuffer, &MouseBackground);
 
 	const BOOLEAN scrolling = (gsScrollXIncrement != 0 || gsScrollYIncrement != 0);
+
+	auto const now = std::chrono::steady_clock::now();
+	if (!scrolling && now - gLastRefresh < std::chrono::milliseconds{25})
+	{
+		return;
+	}
+	gLastRefresh = now;
 
 	// This variable will hold the union of all modified regions.
 	struct rect : SDL_Rect {

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -536,8 +536,6 @@ void RefreshScreen(void)
 	}
 #endif
 
-	SDL_BlitSurface(FrameBuffer, &MouseBackground, ScreenBuffer, &MouseBackground);
-
 	const BOOLEAN scrolling = (gsScrollXIncrement != 0 || gsScrollYIncrement != 0);
 
 	auto const now = std::chrono::steady_clock::now();
@@ -546,6 +544,8 @@ void RefreshScreen(void)
 		return;
 	}
 	LastRefresh = now;
+
+	SDL_BlitSurface(FrameBuffer, &MouseBackground, ScreenBuffer, &MouseBackground);
 
 	// This variable will hold the union of all modified regions.
 	struct rect : SDL_Rect {

--- a/src/sgp/Video.h
+++ b/src/sgp/Video.h
@@ -17,7 +17,7 @@ extern SDL_Window* g_game_window;
 using VideoScaleQuality = ScalingQuality;
 
 void         VideoSetFullScreen(BOOLEAN enable);
-void         InitializeVideoManager(VideoScaleQuality quality);
+void         InitializeVideoManager(VideoScaleQuality quality, int32_t targetFPS);
 void         ShutdownVideoManager(void);
 void         InvalidateRegion(INT32 iLeft, INT32 iTop, INT32 iRight, INT32 iBottom);
 void         InvalidateScreen(void);


### PR DESCRIPTION
    Change how often GameLoop() gets called
    
    Before this commit, the duration between two GameLoop calls was
    configurable (ms_per_game_cycle, default 25ms). This is problematic
    because many of the predefined timecout counters use multiples of 5ms,
    and the delay between two soldier animations is even calculated with
    a resolution of 1ms.
    
    With this commit the game now tries to call GameLoop at a rate of
    144Hz (every ~7ms), corresponding to the refresh rate of modern
    monitors. To satisfy the needs of our users who do not need 144 FPS
    and would prefer a lower CPU usage, GameLoop()'s heaviest subfunction
    RefreshScreen() now has its own timeout.

This patch should make our timings be more in line with those originally intended by the JA2 developers. For example, `ExecuteOverhead` was supposed to run every 5ms, but with our current default settings it is limited to once every 25ms.