### PR TITLE
Stop ChangeSoldiersAssignment from clobbering just set repair values

### DIFF
--- a/src/game/Strategic/Assignments.h
+++ b/src/game/Strategic/Assignments.h
@@ -28,7 +28,8 @@ struct SOLDIERTYPE;
 
 
 // Assignments Defines
-enum{
+enum Assignments : int8_t
+{
 	SQUAD_1 =0,
 	SQUAD_2,
 	SQUAD_3,
@@ -207,7 +208,7 @@ void ReEvaluateEveryonesNothingToDo(void);
 void SetAssignmentForList( INT8 bAssignment, INT8 bParam );
 
 // function where we actually set someone's assignment so we can trap certain situations
-void ChangeSoldiersAssignment( SOLDIERTYPE *pSoldier, INT8 bAssignment );
+void ChangeSoldiersAssignment(SOLDIERTYPE *, Assignments);
 
 void UnEscortEPC( SOLDIERTYPE *pSoldier );
 

--- a/src/game/Tactical/Squads.cc
+++ b/src/game/Tactical/Squads.cc
@@ -192,7 +192,7 @@ BOOLEAN AddCharacterToSquad(SOLDIERTYPE* const s, INT8 const bSquadValue)
 		}
 
 		// set squad value
-		ChangeSoldiersAssignment(s, bSquadValue);
+		ChangeSoldiersAssignment(s, static_cast<Assignments>(bSquadValue));
 
 		// update selected squad if the old one is emptied
 		if (iCurrentTacticalSquad == NO_CURRENT_SQUAD || SquadIsEmpty(iCurrentTacticalSquad)) SetCurrentSquad(bSquadValue, TRUE);


### PR DESCRIPTION
Fixes #1813. Also clean up code duplication in RepairMenuBtnCallback.