### PR TITLE
Address several problems in Sound_Control.cc

### DIFF
--- a/src/game/Strategic/Auto_Resolve.cc
+++ b/src/game/Strategic/Auto_Resolve.cc
@@ -1919,7 +1919,7 @@ static void FinishButtonCallback(GUI_BUTTON* btn, UINT32 reason)
 		DepressAutoButton(FINISH_BUTTON);
 		gpAR->uiTimeSlice = 0xffffffff;
 		gpAR->fSound = FALSE;
-		PlayJA2StreamingSample(AUTORESOLVE_FINISHFX, HIGHVOLUME, 1, MIDDLEPAN);
+		PlayJA2Sample(AUTORESOLVE_FINISHFX, HIGHVOLUME, 1, MIDDLEPAN);
 	}
 }
 

--- a/src/game/Utils/Sound_Control.cc
+++ b/src/game/Utils/Sound_Control.cc
@@ -333,21 +333,11 @@ void ShutdownJA2Sound(void)
 }
 
 
-const char * getSoundSample(SoundID soundId)
-{
-	if(soundId == -1) {
-		return "";
-	}
-	else
-	{
-		return szSoundEffects[soundId];
-	}
-}
-
 UINT32 PlayJA2Sample(SoundID const usNum, UINT32 const ubVolume, UINT32 const ubLoops, UINT32 const uiPan)
 {
-	UINT32 const vol = CalculateSoundEffectsVolume(ubVolume);
-	return SoundPlay(szSoundEffects[usNum], vol, uiPan, ubLoops, NULL, NULL);
+	// Several of the szSoundEffects entries are NULL, this will be checked
+	// inside the following function call.
+	return PlayJA2Sample(szSoundEffects[usNum], ubVolume, ubLoops, uiPan);
 }
 
 
@@ -359,13 +349,6 @@ UINT32 PlayJA2Sample(const char *sample, UINT32 const ubVolume, UINT32 const ubL
 		return SoundPlay(sample, vol, uiPan, ubLoops, NULL, NULL);
 	}
 	return SOUND_ERROR;
-}
-
-
-UINT32 PlayJA2StreamingSample(SoundID const usNum, UINT32 const ubVolume, UINT32 const ubLoops, UINT32 const uiPan)
-{
-	UINT32 const vol = CalculateSoundEffectsVolume(ubVolume);
-	return SoundPlay(szSoundEffects[usNum], vol, uiPan, ubLoops, NULL, NULL);
 }
 
 
@@ -419,7 +402,7 @@ UINT32 PlayLocationJA2StreamingSample(UINT16 const grid_no, SoundID const idx, U
 {
 	UINT32 const vol = SoundVolume(base_vol, grid_no);
 	UINT32 const pan = SoundDir(grid_no);
-	return PlayJA2StreamingSample(idx, vol, loops, pan);
+	return PlayJA2Sample(idx, vol, loops, pan);
 }
 
 
@@ -436,7 +419,7 @@ UINT32 PlaySoldierJA2Sample(SOLDIERTYPE const* const s, SoundID const usNum, UIN
 		}
 	}
 
-	return( 0 );
+	return NO_SAMPLE;
 }
 
 

--- a/src/game/Utils/Sound_Control.h
+++ b/src/game/Utils/Sound_Control.h
@@ -324,19 +324,11 @@ enum SoundID
 };
 
 
-const char * getSoundSample(SoundID soundId);
-
-template<SoundID, SoundID, bool> struct SoundRangeHelper;
-template<SoundID first, SoundID last> struct SoundRangeHelper<first, last, true>
-{
-	operator SoundID() { return static_cast<SoundID>(first + Random(last - first + 1)); }
-};
-
-
 template<SoundID first, SoundID last> static inline SoundID SoundRange()
 {
-	return SoundRangeHelper<first, last, first < last>();
-}
+	static_assert(first < last);
+	return static_cast<SoundID>(first + Random(last - first + 1));
+};
 
 
 enum AmbientSoundID
@@ -365,7 +357,6 @@ typedef void (*SOUND_STOP_CALLBACK)( void *pData );
 void   ShutdownJA2Sound(void);
 UINT32 PlayJA2Sample(const char *sample, UINT32 const ubVolume, UINT32 const ubLoops, UINT32 const uiPan);
 UINT32 PlayJA2Sample(SoundID, UINT32 ubVolume, UINT32 ubLoops, UINT32 uiPan);
-UINT32 PlayJA2StreamingSample(SoundID, UINT32 ubVolume, UINT32 ubLoops, UINT32 uiPan);
 
 UINT32 PlayJA2SampleFromFile(const char* szFileName, UINT32 ubVolume, UINT32 ubLoops, UINT32 uiPan);
 UINT32 PlayJA2StreamingSampleFromFile(const char* szFileName, UINT32 ubVolume, UINT32 ubLoops, UINT32 uiPan, SOUND_STOP_CALLBACK EndsCallback);


### PR DESCRIPTION
• `getSoundSample()`: unused function that didn't do anything useful.
• `PlayJA2StreamingSample()`: exactly the same as `PlayJA2Sample`
• `PlayJA2Sample`: could call SoundPlay with a NULL filename
• `PlaySoldierJA2Sample`: wrong return value in case of an error
• simpler implementation of `SoundRange()`