### PR TITLE
Strategic-level modding support (Event, Quests and Facts)

### DIFF
--- a/src/externalized/scripting/FunctionsLibrary.cc
+++ b/src/externalized/scripting/FunctionsLibrary.cc
@@ -132,6 +132,36 @@ void AddStrategicEvent_(UINT8 const ubCallbackID, UINT32 const uiMinStampSeconds
 	}
 }
 
+void StartQuest(UINT8, const SGPSector &);
+void StartQuest_(UINT8 const ubQuestID, const std::string sectorID)
+{
+	if (!sectorID.empty())
+	{
+		SGPSector s = SGPSector::FromShortString(sectorID);
+		StartQuest(ubQuestID, s);
+	}
+	else
+	{
+		SGPSector s = SGPSector{-1, -1};
+		StartQuest(ubQuestID, s);
+	}
+}
+
+void EndQuest(UINT8, const SGPSector &);
+void EndQuest_(UINT8 const ubQuestID, const std::string sectorID)
+{
+	if (!sectorID.empty())
+	{
+		SGPSector s = SGPSector::FromShortString(sectorID);
+		EndQuest(ubQuestID, s);
+	}
+	else
+	{
+		SGPSector s = SGPSector{-1, -1};
+		EndQuest(ubQuestID, s);
+	}
+}
+
 void GuaranteeAtLeastXItemsOfIndex(ArmsDealerID, UINT16, UINT8);
 void GuaranteeAtLeastXItemsOfIndex_(INT8 const bDealerID, UINT16 const usItemIndex, UINT8 const ubNumItems)
 {

--- a/src/externalized/scripting/FunctionsLibrary.cc
+++ b/src/externalized/scripting/FunctionsLibrary.cc
@@ -1,6 +1,7 @@
 #include "FunctionsLibrary.h"
 #include "Arms_Dealer_Init.h"
 #include "Campaign_Types.h"
+#include "Game_Event_Hook.h"
 #include "Handle_Items.h"
 #include "Item_Types.h"
 #include "Items.h"
@@ -111,6 +112,24 @@ void PutGameStates(const std::string key, ExtraGameStatesTable const states)
 		else if (auto *f = std::get_if<float>(&v)) storables[k] = *f;
 	}
 	g_gameStates.Set(ST::format("scripts:{}", key), storables);
+}
+
+void AddEveryDayStrategicEvent_(UINT8 const ubCallbackID, UINT32 const uiStartMin, UINT32 const uiParam)
+{
+	BOOLEAN result = AddEveryDayStrategicEvent((StrategicEventKind)ubCallbackID, uiStartMin, uiParam);
+	if (!result)
+	{
+		SLOGW("Failed to add daily strategic event {}", ubCallbackID);
+	}
+}
+
+void AddStrategicEvent_(UINT8 const ubCallbackID, UINT32 const uiMinStampSeconds, UINT32 const uiParams)
+{
+	BOOLEAN result = AddStrategicEventUsingSeconds((StrategicEventKind)ubCallbackID, uiMinStampSeconds, uiParams);
+	if (!result)
+	{
+		SLOGW("Failed to add one time strategic event {}", ubCallbackID);
+	}
 }
 
 void GuaranteeAtLeastXItemsOfIndex(ArmsDealerID, UINT16, UINT8);

--- a/src/externalized/scripting/FunctionsLibrary.h
+++ b/src/externalized/scripting/FunctionsLibrary.h
@@ -233,7 +233,7 @@ OBJECTTYPE* CreateMoney(const UINT32 amt);
  */
 void PlaceItem(const INT16 sGridNo, OBJECTTYPE* const pObject, const INT8 bVisibility);
 /**
- * Adds a recurring events that happens at the same time every day.
+ * Adds a recurring event that happens at the same time every day.
  * @param ubCallbackID strategic event ID
  * @param uiStartMin the time (minutes of day) that the event
  * @param uiParam a parameter that will be passed to the event handler

--- a/src/externalized/scripting/FunctionsLibrary.h
+++ b/src/externalized/scripting/FunctionsLibrary.h
@@ -91,6 +91,12 @@ extern Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT8, BOOLEAN> OnStruc
 extern Observable<STRATEGICEVENT*, BOOLEAN_S*> OnStrategicEvent;
 
 /**
+ * Allows to override the player progress calculation.
+ * @param the progress percentage calculated by the base game. This can be adjusted or overridden.
+ */
+extern Observable<UINT8_S*> OnCalcPlayerProgress;
+
+/**
  * When the game about to be saved. This is the place to persist mod game states.
  * @ingroup observables
  */

--- a/src/externalized/scripting/FunctionsLibrary.h
+++ b/src/externalized/scripting/FunctionsLibrary.h
@@ -247,6 +247,9 @@ void AddEveryDayStrategicEvent_(UINT8 ubCallbackID, UINT32 uiStartMin, UINT32 ui
  * @param uiParam a parameter that will be passed to the event handler
  */
 void AddStrategicEvent_(UINT8 ubCallbackID, UINT32 uiMinStamp, UINT32);
+UINT32 GetWorldTotalMin();
+UINT32 GetWorldTotalSeconds();
+UINT32 GetWorldDay();
 void StartQuest_(UINT8 ubQuestID, std::string sectorID);
 void EndQuest_(UINT8 ubQuest, std::string sectorID);
 

--- a/src/externalized/scripting/FunctionsLibrary.h
+++ b/src/externalized/scripting/FunctionsLibrary.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Arms_Dealer.h"
+#include "Facts.h"
 #include "Item_Types.h"
 #include "Types.h"
 #include "Observable.h"
@@ -246,6 +247,13 @@ void AddEveryDayStrategicEvent_(UINT8 ubCallbackID, UINT32 uiStartMin, UINT32 ui
  * @param uiParam a parameter that will be passed to the event handler
  */
 void AddStrategicEvent_(UINT8 ubCallbackID, UINT32 uiMinStamp, UINT32);
+void StartQuest_(UINT8 ubQuestID, std::string sectorID);
+void EndQuest_(UINT8 ubQuest, std::string sectorID);
+
+void SetFactTrue(Fact);
+void SetFactFalse(Fact);
+BOOLEAN CheckFact(Fact, UINT8);
+
 
 /**
  * Gets the Merc Profile data object by profile ID

--- a/src/externalized/scripting/FunctionsLibrary.h
+++ b/src/externalized/scripting/FunctionsLibrary.h
@@ -231,6 +231,21 @@ OBJECTTYPE* CreateMoney(const UINT32 amt);
  * @ingroup funclib-items
  */
 void PlaceItem(const INT16 sGridNo, OBJECTTYPE* const pObject, const INT8 bVisibility);
+/**
+ * Adds a recurring events that happens at the same time every day.
+ * @param ubCallbackID strategic event ID
+ * @param uiStartMin the time (minutes of day) that the event
+ * @param uiParam a parameter that will be passed to the event handler
+ */
+void AddEveryDayStrategicEvent_(UINT8 ubCallbackID, UINT32 uiStartMin, UINT32 uiParam);
+
+/**
+ * Adds an one-off strategic event
+ * @param ubCallbackID strategic event ID
+ * @param uiMinStamp earliest time (in world-seconds) that this event will be processed
+ * @param uiParam a parameter that will be passed to the event handler
+ */
+void AddStrategicEvent_(UINT8 ubCallbackID, UINT32 uiMinStamp, UINT32);
 
 /**
  * Gets the Merc Profile data object by profile ID

--- a/src/externalized/scripting/FunctionsLibrary.h
+++ b/src/externalized/scripting/FunctionsLibrary.h
@@ -29,6 +29,8 @@ struct STRUCTURE;
     \brief Profile of a character in game; controls soldier's name, appearance and others */
 struct MERCPROFILESTRUCT;
 
+struct STRATEGICEVENT;
+
 /*! \defgroup funclib-dealers Shops and arms dealers
     \brief Manage behavior, inventory and prices of dealers */
 
@@ -80,6 +82,13 @@ extern Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT32, BOOLEAN_S*> Bef
   * @ingroup observables
   */
 extern Observable<INT16, INT16, INT8, INT16, STRUCTURE*, UINT8, BOOLEAN> OnStructureDamaged;
+
+/**
+ * Callback when an event is due and to be handled. Implement handlers here if custom strategic events are added.
+ * @param the event to be handled
+ * @param set to true if the event should not be further processed by the base game
+ */
+extern Observable<STRATEGICEVENT*, BOOLEAN_S*> OnStrategicEvent;
 
 /**
  * When the game about to be saved. This is the place to persist mod game states.

--- a/src/externalized/scripting/FunctionsLibrary.h
+++ b/src/externalized/scripting/FunctionsLibrary.h
@@ -97,6 +97,22 @@ extern Observable<STRATEGICEVENT*, BOOLEAN_S*> OnStrategicEvent;
 extern Observable<UINT8_S*> OnCalcPlayerProgress;
 
 /**
+ * Callback every morning to check quests' statuses..
+ * @param the current day
+ * @param set to true to skip base game checks
+ */
+extern Observable<UINT32, BOOLEAN_S*> OnCheckQuests;
+
+/**
+ * Callback when a quest is completed.
+ * @param the Quest ID
+ * @param sector X
+ * @param sector Y
+ * @param whether or not to write an update to the laptop history page
+ */
+extern Observable<UINT8, INT16, INT16, BOOLEAN> OnQuestEnded;
+
+/**
  * When the game about to be saved. This is the place to persist mod game states.
  * @ingroup observables
  */

--- a/src/externalized/scripting/ScriptingExtensionsLua.cc
+++ b/src/externalized/scripting/ScriptingExtensionsLua.cc
@@ -321,6 +321,8 @@ static void RegisterGlobals()
 	lua.set_function("ExecuteTacticalTextBox", ExecuteTacticalTextBox_);
 
 	lua.set_function("GetMercProfile", GetMercProfile);
+	lua.set_function("AddEveryDayStrategicEvent", AddEveryDayStrategicEvent_);
+	lua.set_function("AddStrategicEvent", AddStrategicEvent_);
 
 	lua.set_function("GetGameStates", GetGameStates);
 	lua.set_function("PutGameStates", PutGameStates);

--- a/src/externalized/scripting/ScriptingExtensionsLua.cc
+++ b/src/externalized/scripting/ScriptingExtensionsLua.cc
@@ -414,6 +414,7 @@ static void _RegisterListener(const std::string& observable, const std::string& 
 	else if (observable == "BeforePrepareSector")        BeforePrepareSector.addListener(key, wrap<>(luaFunc));
 	else if (observable == "OnSoldierCreated")           OnSoldierCreated.addListener(key, wrap<SOLDIERTYPE*>(luaFunc));
 	else if (observable == "OnStrategicEvent")           OnStrategicEvent.addListener(key, wrap<STRATEGICEVENT*, BOOLEAN_S*>(luaFunc));
+	else if (observable == "OnCalcPlayerProgress")       OnCalcPlayerProgress.addListener(key, wrap<UINT8_S*>(luaFunc));
 	else if (observable == "BeforeGameSaved")            BeforeGameSaved.addListener(key, wrap<>(luaFunc));
 	else if (observable == "OnGameLoaded")               OnGameLoaded.addListener(key, wrap<>(luaFunc));
 	else if (observable == "OnDealerInventoryUpdated")   OnDealerInventoryUpdated.addListener(key, wrap<>(luaFunc));

--- a/src/externalized/scripting/ScriptingExtensionsLua.cc
+++ b/src/externalized/scripting/ScriptingExtensionsLua.cc
@@ -321,6 +321,10 @@ static void RegisterGlobals()
 	lua.set_function("ExecuteTacticalTextBox", ExecuteTacticalTextBox_);
 
 	lua.set_function("GetMercProfile", GetMercProfile);
+
+	lua.set_function("GetWorldTotalMin", GetWorldTotalMin);
+	lua.set_function("GetWorldTotalSeconds", GetWorldTotalSeconds);
+	lua.set_function("GetWorldDay", GetWorldDay);
 	lua.set_function("AddEveryDayStrategicEvent", AddEveryDayStrategicEvent_);
 	lua.set_function("AddStrategicEvent", AddStrategicEvent_);
 

--- a/src/externalized/scripting/ScriptingExtensionsLua.cc
+++ b/src/externalized/scripting/ScriptingExtensionsLua.cc
@@ -415,6 +415,8 @@ static void _RegisterListener(const std::string& observable, const std::string& 
 	else if (observable == "OnSoldierCreated")           OnSoldierCreated.addListener(key, wrap<SOLDIERTYPE*>(luaFunc));
 	else if (observable == "OnStrategicEvent")           OnStrategicEvent.addListener(key, wrap<STRATEGICEVENT*, BOOLEAN_S*>(luaFunc));
 	else if (observable == "OnCalcPlayerProgress")       OnCalcPlayerProgress.addListener(key, wrap<UINT8_S*>(luaFunc));
+	else if (observable == "OnCheckQuests")              OnCheckQuests.addListener(key, wrap<UINT32, BOOLEAN_S*>(luaFunc));
+	else if (observable == "OnQuestEnded")               OnQuestEnded.addListener(key, wrap<UINT8, INT16, INT16, BOOLEAN>(luaFunc));
 	else if (observable == "BeforeGameSaved")            BeforeGameSaved.addListener(key, wrap<>(luaFunc));
 	else if (observable == "OnGameLoaded")               OnGameLoaded.addListener(key, wrap<>(luaFunc));
 	else if (observable == "OnDealerInventoryUpdated")   OnDealerInventoryUpdated.addListener(key, wrap<>(luaFunc));

--- a/src/externalized/scripting/ScriptingExtensionsLua.cc
+++ b/src/externalized/scripting/ScriptingExtensionsLua.cc
@@ -324,6 +324,12 @@ static void RegisterGlobals()
 	lua.set_function("AddEveryDayStrategicEvent", AddEveryDayStrategicEvent_);
 	lua.set_function("AddStrategicEvent", AddStrategicEvent_);
 
+	lua.set_function("StartQuest", StartQuest_);
+	lua.set_function("EndQuest", EndQuest_);
+	lua.set_function("SetFactTrue", SetFactTrue);
+	lua.set_function("SetFactFalse", SetFactFalse);
+	lua.set_function("CheckFact", CheckFact);
+
 	lua.set_function("GetGameStates", GetGameStates);
 	lua.set_function("PutGameStates", PutGameStates);
 

--- a/src/externalized/scripting/ScriptingExtensionsLua.cc
+++ b/src/externalized/scripting/ScriptingExtensionsLua.cc
@@ -401,7 +401,7 @@ static std::function<void(A...)> wrap(std::string luaFunc)
 	};
 }
 
-static void _RegisterListener(std::string observable, std::string luaFunc, ST::string key)
+static void _RegisterListener(const std::string& observable, const std::string& luaFunc, const ST::string& key)
 {
 	if (isLuaInitialized)
 	{
@@ -413,6 +413,7 @@ static void _RegisterListener(std::string observable, std::string luaFunc, ST::s
 	else if (observable == "OnAirspaceControlUpdated")   OnAirspaceControlUpdated.addListener(key, wrap<>(luaFunc));
 	else if (observable == "BeforePrepareSector")        BeforePrepareSector.addListener(key, wrap<>(luaFunc));
 	else if (observable == "OnSoldierCreated")           OnSoldierCreated.addListener(key, wrap<SOLDIERTYPE*>(luaFunc));
+	else if (observable == "OnStrategicEvent")           OnStrategicEvent.addListener(key, wrap<STRATEGICEVENT*, BOOLEAN_S*>(luaFunc));
 	else if (observable == "BeforeGameSaved")            BeforeGameSaved.addListener(key, wrap<>(luaFunc));
 	else if (observable == "OnGameLoaded")               OnGameLoaded.addListener(key, wrap<>(luaFunc));
 	else if (observable == "OnDealerInventoryUpdated")   OnDealerInventoryUpdated.addListener(key, wrap<>(luaFunc));

--- a/src/game/Strategic/Game_Event_Hook.cc
+++ b/src/game/Strategic/Game_Event_Hook.cc
@@ -34,10 +34,12 @@
 #include "Laptop.h"
 #include "Campaign.h"
 #include "Debug.h"
+#include "Observable.h"
 
 extern UINT32	guiTimeStampOfCurrentlyExecutingEvent;
 extern BOOLEAN gfPreventDeletionOfAnyEvent;
 
+Observable<STRATEGICEVENT*, BOOLEAN_S*> OnStrategicEvent;
 
 static BOOLEAN DelayEventIfBattleInProgress(STRATEGICEVENT* pEvent)
 {
@@ -66,6 +68,14 @@ BOOLEAN ExecuteStrategicEvent( STRATEGICEVENT *pEvent )
 	{
 		gfPreventDeletionOfAnyEvent = fOrigPreventFlag;
 		return FALSE;
+	}
+
+	BOOLEAN_S eventProcessed = false;
+	OnStrategicEvent(pEvent, &eventProcessed);
+	if (eventProcessed)
+	{
+		gfPreventDeletionOfAnyEvent = fOrigPreventFlag;
+		return true;
 	}
 
 	// Look at the ID of event and do stuff according to that!

--- a/src/game/Strategic/Quests.cc
+++ b/src/game/Strategic/Quests.cc
@@ -1131,6 +1131,8 @@ void InternalStartQuest(UINT8 ubQuest, const SGPSector& sector, BOOLEAN fUpdateH
 	}
 }
 
+Observable<UINT8, INT16, INT16, BOOLEAN> OnQuestEnded;
+
 void EndQuest(UINT8 ubQuest, const SGPSector& sector)
 {
 	InternalEndQuest(ubQuest, sector, TRUE);
@@ -1159,6 +1161,8 @@ void InternalEndQuest(UINT8 ubQuest, const SGPSector& sector, BOOLEAN fUpdateHis
 		gMercProfiles[ MADAME ].bNPCData = 0;
 		gMercProfiles[ MADAME ].bNPCData2 = 0;
 	}
+
+	OnQuestEnded(ubQuest, sector.x, sector.y, fUpdateHistory);
 }
 
 
@@ -1185,13 +1189,17 @@ void InitQuestEngine()
 	gfBoxersResting = FALSE;
 }
 
-
+Observable<UINT32, BOOLEAN_S*> OnCheckQuests;
 
 void CheckForQuests( UINT32 uiDay )
 {
 	// This function gets called at 8:00 AM time of the day
 
 	SLOGD("Checking For Quests, Day {}", uiDay);
+
+	BOOLEAN_S handled = false;
+	OnCheckQuests(uiDay, &handled);
+	if (handled) return;
 
 	// -------------------------------------------------------------------------------
 	// QUEST 0 : DELIVER LETTER

--- a/src/game/Tactical/Campaign.cc
+++ b/src/game/Tactical/Campaign.cc
@@ -1182,6 +1182,8 @@ static UINT8 CalcImportantSectorControl(void);
 #define PROGRESS_PORTION_INCOME		(100 * gamepolicy(progress_weight_income) / PROGRESS_PORTION_TOTAL)
 
 
+Observable<UINT8_S*> OnCalcPlayerProgress;
+
 // returns a number between 0-100, this is an estimate of how far a player has progressed through the game
 UINT8 CurrentPlayerProgressPercentage(void)
 {
@@ -1264,7 +1266,11 @@ UINT8 CurrentPlayerProgressPercentage(void)
 	// add control progress
 	ubCurrentProgress += usControlProgress;
 
-	return(ubCurrentProgress);
+	// allow override from mod scripts
+	UINT8_S progress = ubCurrentProgress;
+	OnCalcPlayerProgress(&progress);
+
+	return progress;
 }
 
 


### PR DESCRIPTION
Adding several more event hooks and Lua functions for mods to handle Strategic level events.

- Allowing mods to process, or ignore StrategicEvents - `OnStrategicEvent`
- Allowing mods to trigger  StrategicEvents - `AddEveryDayStrategicEvent`, `AddStrategicEvent`
- Allowing mods to override the current value of game progress (which affects weapons availability, enemy levels) - `OnCalcPlayerProgress`
- Allowing mods to process quests - `OnCheckQuests`, `OnQuestEnded`
- Allowing mods to process facts - `SetFactTrue`, `SetFactFalse`, `CheckFact`
- Mods can read the current game clock - `GetWorldTotalSeconds`, `GetWorldTotalMin`, `GetWorldDay`
---

Example: Disabling Meanwhile scenes from mod

```lua
require('enums.lua')
RegisterListener("OnStrategicEvent", "skip_meanwhile")

function skip_meanwhile(event, processed)
    if event.ubEventKind == StrategicEventKind.EVENT_MEANWHILE then
        log.debug('intercepted and cancelled MEANWHILE cutscene')
        processed.val = TRUE
    end
end
```