### PR TITLE
Remove three unnecessary functions handling video refresh

### DIFF
--- a/src/game/Credits.cc
+++ b/src/game/Credits.cc
@@ -180,8 +180,6 @@ ScreenID CreditScreenHandle(void)
 
 	GetCreditScreenUserInput();
 	HandleCreditScreen();
-	ExecuteBaseDirtyRectQueue();
-	EndFrameBufferRender();
 
 	if (!g_credits_active)
 	{

--- a/src/game/Editor/EditScreen.cc
+++ b/src/game/Editor/EditScreen.cc
@@ -425,7 +425,6 @@ static BOOLEAN EditModeShutdown(void)
 	}
 
 	InvalidateScreen( );
-	ExecuteBaseDirtyRectQueue();
 
 	gRadarRegion.Enable();
 	CreateCurrentTacticalPanelButtons( );
@@ -2377,7 +2376,6 @@ static ScreenID WaitForHelpScreenResponse(void)
 	}
 
 	InvalidateScreen( );
-	ExecuteBaseDirtyRectQueue();
 
 	return( EDIT_SCREEN );
 }
@@ -2424,13 +2422,11 @@ static ScreenID WaitForSelectionWindowResponse(void)
 				iDrawMode = DRAW_MODE_SLANTED_ROOF;
 		}
 		InvalidateScreen( );
-		ExecuteBaseDirtyRectQueue();
 	}
 	else
 	{
 		DisplaySelectionWindowGraphicalInformation();
 		InvalidateScreen( );
-		ExecuteBaseDirtyRectQueue();
 	}
 
 	return( EDIT_SCREEN );
@@ -3348,9 +3344,6 @@ ScreenID EditScreenHandle(void)
 	ExecuteVideoOverlays( );
 
 	ScrollString( );
-
-	ExecuteBaseDirtyRectQueue();
-	EndFrameBufferRender( );
 
 	return EDIT_SCREEN;
 }

--- a/src/game/Editor/LoadScreen.cc
+++ b/src/game/Editor/LoadScreen.cc
@@ -6,7 +6,6 @@
 #include "HImage.h"
 #include "Local.h"
 #include "RenderWorld.h"
-#include "Render_Dirty.h"
 #include "LoadScreen.h"
 #include "SelectWin.h"
 #include "EditorDefines.h"
@@ -361,8 +360,6 @@ ScreenID LoadSaveScreenHandle(void)
 	RenderAllTextFields();
 
 	InvalidateScreen();
-
-	ExecuteBaseDirtyRectQueue();
 
 	switch( iFDlgState )
 	{
@@ -1075,8 +1072,6 @@ BOOLEAN ExternalLoadMap(const ST::string& szFilename)
 	gFileForIO = szFilename;
 	gbCurrentFileIOStatus = INITIATE_MAP_LOAD;
 	ProcessFileIO(); //always returns loadsave_screen and changes iostatus to loading_map.
-	ExecuteBaseDirtyRectQueue();
-	EndFrameBufferRender();
 	RefreshScreen();
 	if( ProcessFileIO() == EDIT_SCREEN )
 		return TRUE;

--- a/src/game/Editor/MessageBox.cc
+++ b/src/game/Editor/MessageBox.cc
@@ -86,9 +86,6 @@ BOOLEAN MessageBoxHandled()
 	}
 	MarkButtonsDirty();
 	RenderButtons( );
-//	InvalidateScreen( );
-//	ExecuteBaseDirtyRectQueue();
-	EndFrameBufferRender( );
 	return gubMessageBoxStatus == MESSAGEBOX_DONE;
 }
 

--- a/src/game/Editor/PopupMenu.cc
+++ b/src/game/Editor/PopupMenu.cc
@@ -21,7 +21,6 @@
 #include "SelectWin.h"
 #include "PopupMenu.h"
 #include "EditorDefines.h"
-#include "Render_Dirty.h"
 #include "MouseSystem.h"
 #include "Cursors.h"
 #include "Overhead_Types.h"
@@ -504,7 +503,5 @@ BOOLEAN ProcessPopupMenuIfActive( )
 	PopupMenuHandle();
 	RenderPopupMenu();
 	InvalidateRegion( gPopup.usLeft, gPopup.usTop, gPopup.usRight, gPopup.usBottom );
-	ExecuteBaseDirtyRectQueue();
-	EndFrameBufferRender( );
 	return TRUE;
 }

--- a/src/game/GameInitOptionsScreen.cc
+++ b/src/game/GameInitOptionsScreen.cc
@@ -211,9 +211,6 @@ ScreenID GameInitOptionsScreenHandle(void)
 	RenderFastHelp();
 #endif
 
-	ExecuteBaseDirtyRectQueue();
-	EndFrameBufferRender();
-
 	if (HandleFadeOutCallback())
 	{
 		ClearMainMenu();

--- a/src/game/GameScreen.cc
+++ b/src/game/GameScreen.cc
@@ -544,14 +544,6 @@ ScreenID MainGameScreenHandle(void)
 
 	ScrollString( );
 
-	ExecuteBaseDirtyRectQueue( );
-
-	//KillBackgroundRects( );
-
-	/////////////////////////////////////////////////////
-	EndFrameBufferRender( );
-
-
 	if ( HandleFadeInCallback( ) )
 	{
 		// Re-render the scene!
@@ -702,10 +694,6 @@ static void HandleModalTactical(void)
 	SaveBackgroundRects( );
 	RenderFastHelp();
 	RenderPausedGameBox( );
-
-	ExecuteBaseDirtyRectQueue( );
-	EndFrameBufferRender( );
-
 }
 
 

--- a/src/game/HelpScreen.cc
+++ b/src/game/HelpScreen.cc
@@ -449,9 +449,6 @@ void HelpScreenHandler()
 	SaveBackgroundRects( );
 	RenderFastHelp();
 
-	ExecuteBaseDirtyRectQueue();
-	EndFrameBufferRender();
-
 	//if we are leaving the help screen
 	if( gfHelpScreenExit )
 	{

--- a/src/game/Intro.cc
+++ b/src/game/Intro.cc
@@ -15,7 +15,6 @@
 #include "MouseSystem.h"
 #include "Music_Control.h"
 #include "ContentMusic.h"
-#include "Render_Dirty.h"
 #include "Soldier_Profile.h"
 #include "SysUtil.h"
 #include "Text.h"
@@ -111,10 +110,6 @@ ScreenID IntroScreenHandle(void)
 	GetIntroScreenUserInput();
 
 	HandleIntroScreen();
-
-	ExecuteBaseDirtyRectQueue();
-	EndFrameBufferRender();
-
 
 	if( gfIntroScreenExit )
 	{

--- a/src/game/Laptop/Laptop.cc
+++ b/src/game/Laptop/Laptop.cc
@@ -1236,9 +1236,7 @@ ScreenID LaptopScreenHandle()
 	RenderFastHelp();
 
 	// ex SAVEBUFFER queue
-	ExecuteBaseDirtyRectQueue();
 	ResetInterface();
-	EndFrameBufferRender();
 	return (LAPTOP_SCREEN);
 }
 

--- a/src/game/Loading_Screen.cc
+++ b/src/game/Loading_Screen.cc
@@ -11,7 +11,6 @@
 #include "LoadingScreenModel.h"
 #include "Local.h"
 #include "Random.h"
-#include "Render_Dirty.h"
 #include "StrategicMap.h"
 #include "Strategic_Movement.h"
 #include "VSurface.h"
@@ -117,6 +116,5 @@ void DisplayLoadScreenWithID(UINT8 const id)
 
 	gubLastLoadingScreenID = id;
 	InvalidateScreen();
-	ExecuteBaseDirtyRectQueue();
 	RefreshScreen();
 }

--- a/src/game/MainMenuScreen.cc
+++ b/src/game/MainMenuScreen.cc
@@ -143,8 +143,6 @@ ScreenID MainMenuScreenHandle(void)
 
 	RenderButtons();
 
-	EndFrameBufferRender();
-
 	HandleMainMenuInput();
 	HandleMainMenuScreen();
 

--- a/src/game/MessageBoxScreen.cc
+++ b/src/game/MessageBoxScreen.cc
@@ -518,7 +518,6 @@ ScreenID MessageBoxScreenHandle(void)
 	}
 
 	RenderButtons();
-	EndFrameBufferRender();
 
 	// carter, need key shortcuts for clearing up message boxes
 	// Check for esc

--- a/src/game/Options_Screen.cc
+++ b/src/game/Options_Screen.cc
@@ -208,10 +208,6 @@ ScreenID OptionsScreenHandle()
 	RenderFastHelp();
 
 
-	ExecuteBaseDirtyRectQueue();
-	EndFrameBufferRender();
-
-
 	if( gfOptionsScreenExit )
 	{
 		ExitOptionsScreen();

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -82,7 +82,6 @@
 #include "Queen_Command.h"
 #include "Quests.h"
 #include "Random.h"
-#include "Render_Dirty.h"
 #include "RenderWorld.h"
 #include "SaveLoadGame.h"
 #include "SaveLoadGameStates.h"
@@ -256,7 +255,6 @@ BOOLEAN SaveGame(const ST::string& saveName, const ST::string& gameDesc)
 	}
 
 	InvalidateScreen();
-	ExecuteBaseDirtyRectQueue();
 	RefreshScreen();
 
 	// Make sure we redraw the screen when we are done

--- a/src/game/SaveLoadScreen.cc
+++ b/src/game/SaveLoadScreen.cc
@@ -268,9 +268,6 @@ ScreenID SaveLoadScreenHandle()
 	SaveBackgroundRects( );
 	RenderFastHelp();
 
-	ExecuteBaseDirtyRectQueue( );
-	EndFrameBufferRender( );
-
 	if ( HandleFadeOutCallback( ) )
 	{
 		return( guiSaveLoadExitScreen );

--- a/src/game/Strategic/Auto_Resolve.cc
+++ b/src/game/Strategic/Auto_Resolve.cc
@@ -513,8 +513,6 @@ ScreenID AutoResolveScreenHandle()
 	SaveBackgroundRects();
 	RenderButtons();
 	RenderFastHelp();
-	ExecuteBaseDirtyRectQueue();
-	EndFrameBufferRender();
 	return AUTORESOLVE_SCREEN;
 }
 

--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -2031,17 +2031,10 @@ ScreenID MapScreenHandle(void)
 		GlowItem( );
 	}
 
-
 	RenderFastHelp();
-
-	// execute dirty
-	ExecuteBaseDirtyRectQueue( );
 
 	// update cursor
 	UpdateCursorIfInLastSector( );
-
-	EndFrameBufferRender( );
-
 
 	// if not going anywhere else
 	if ( guiPendingScreen == NO_PENDING_SCREEN )
@@ -3249,8 +3242,6 @@ void EndMapScreen( BOOLEAN fDuringFade )
 		PlayJA2SampleFromFile(SOUNDSDIR "/initial power up (8-11).wav", HIGHVOLUME, 1, MIDDLEPAN);
 		BltVideoObjectOnce(FRAME_BUFFER, INTERFACEDIR "/laptopon.sti", 0, 465, 417);
 		InvalidateRegion( 465, 417, 480, 427 );
-		ExecuteBaseDirtyRectQueue( );
-		EndFrameBufferRender( );
 		RefreshScreen();
 	}
 

--- a/src/game/Strategic/PreBattle_Interface.cc
+++ b/src/game/Strategic/PreBattle_Interface.cc
@@ -594,7 +594,6 @@ static void DoTransitionFromMapscreenToPreBattleInterface(void)
 	BlitBufferToBuffer( guiEXTRABUFFER, FRAME_BUFFER, STD_SCREEN_X, STD_SCREEN_Y, 261, 359 );
 	PlayJA2SampleFromFile(SOUNDSDIR "/laptop power up (8-11).wav", HIGHVOLUME, 1, MIDDLEPAN);
 	InvalidateScreen();
-	RefreshScreen();
 
 	SGPBox const PBIRect = { STD_SCREEN_X, STD_SCREEN_Y, 261, 359 };
 	while( iPercentage < 100  )
@@ -978,8 +977,6 @@ static void AutoResolveBattleCallback(GUI_BUTTON* btn, UINT32 reason)
 					btn->uiFlags &= ~BUTTON_CLICKED_ON;
 					btn->Draw();
 					InvalidateRegion(btn->X(), btn->Y(), btn->BottomRightX(), btn->BottomRightY());
-					ExecuteBaseDirtyRectQueue();
-					EndFrameBufferRender( );
 					RefreshScreen();
 					KillPreBattleInterface();
 					StopTimeCompression();
@@ -1015,8 +1012,6 @@ static void GoToSectorCallback(GUI_BUTTON* btn, UINT32 reason)
 					btn->uiFlags &= ~BUTTON_CLICKED_ON;
 					btn->Draw();
 					InvalidateRegion(btn->X(), btn->Y(), btn->BottomRightX(), btn->BottomRightY());
-					ExecuteBaseDirtyRectQueue();
-					EndFrameBufferRender( );
 					RefreshScreen();
 					KillPreBattleInterface();
 					StopTimeCompression();
@@ -1033,8 +1028,6 @@ static void GoToSectorCallback(GUI_BUTTON* btn, UINT32 reason)
 			btn->uiFlags &= ~BUTTON_CLICKED_ON;
 			btn->Draw();
 			InvalidateRegion(btn->X(), btn->Y(), btn->BottomRightX(), btn->BottomRightY());
-			ExecuteBaseDirtyRectQueue();
-			EndFrameBufferRender( );
 			RefreshScreen();
 			SGPSector sector = gubPBSector;
 			// NOTE: remove this zeroing if we ever want to support underground auto battle resolution
@@ -1091,8 +1084,6 @@ static void RetreatMercsCallback(GUI_BUTTON* btn, UINT32 reason)
 			btn->uiFlags &= ~BUTTON_CLICKED_ON;
 			btn->Draw();
 			InvalidateRegion(btn->X(), btn->Y(), btn->BottomRightX(), btn->BottomRightY());
-			ExecuteBaseDirtyRectQueue();
-			EndFrameBufferRender( );
 			RefreshScreen();
 			KillPreBattleInterface();
 			StopTimeCompression();

--- a/src/game/Strategic/Quest_Debug_System.cc
+++ b/src/game/Strategic/Quest_Debug_System.cc
@@ -649,9 +649,6 @@ ScreenID QuestDebugScreenHandle()
 	SaveBackgroundRects( );
 	RenderFastHelp();
 
-	ExecuteBaseDirtyRectQueue();
-	EndFrameBufferRender();
-
 	if( gfQuestDebugExit )
 	{
 		ExitQuestDebugSystem();

--- a/src/game/Tactical/Auto_Bandage.cc
+++ b/src/game/Tactical/Auto_Bandage.cc
@@ -220,12 +220,9 @@ BOOLEAN HandleAutoBandage( )
 			//Shadow area
 			FRAME_BUFFER->ShadowRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
 			InvalidateScreen( );
-			RefreshScreen();
 		}
 
 		DisplayAutoBandageUpdatePanel( );
-
-		EndFrameBufferRender( );
 
 		// Handle strategic engine
 		HandleStrategicTurn( );

--- a/src/game/Tactical/ShopKeeper_Interface.cc
+++ b/src/game/Tactical/ShopKeeper_Interface.cc
@@ -488,9 +488,6 @@ ScreenID ShopKeeperScreenHandle()
 	SaveBackgroundRects( );
 	RenderFastHelp( );
 
-	ExecuteBaseDirtyRectQueue();
-	EndFrameBufferRender();
-
 	if( gfSKIScreenExit )
 	{
 		ExitShopKeeperInterface();

--- a/src/game/TileEngine/Overhead_Map.cc
+++ b/src/game/TileEngine/Overhead_Map.cc
@@ -364,8 +364,6 @@ void HandleOverheadMap(void)
 	RenderButtons();
 	SaveBackgroundRects();
 	RenderFastHelp();
-	ExecuteBaseDirtyRectQueue();
-	EndFrameBufferRender();
 	fInterfacePanelDirty = DIRTYLEVEL0;
 }
 

--- a/src/game/TileEngine/RenderWorld.cc
+++ b/src/game/TileEngine/RenderWorld.cc
@@ -28,6 +28,7 @@
 #include "TileDef.h"
 #include "Tile_Cache.h"
 #include "Timer_Control.h"
+#include "Video.h"
 #include "VObject.h"
 #include "VObject_Blitters.h"
 #include "VSurface.h"
@@ -1841,7 +1842,7 @@ void RenderStaticWorldRect(INT16 sLeft, INT16 sTop, INT16 sRight, INT16 sBottom,
 
 	ResetRenderParameters();
 
-	if (!gfDoVideoScroll) AddBaseDirtyRect(sLeft, sTop, sRight, sBottom);
+	if (!gfDoVideoScroll) InvalidateRegionEx(sLeft, sTop, sRight, sBottom);
 }
 
 
@@ -1881,7 +1882,7 @@ static void RenderStaticWorld(void)
 	sLevelIDs[1] = RENDER_STATIC_ONROOF;
 	RenderTiles(TILES_OBSCURED, gsLStartPointX_M, gsLStartPointY_M, gsLStartPointX_S, gsLStartPointY_S, gsLEndXS, gsLEndYS, 2, sLevelIDs);
 
-	AddBaseDirtyRect(gsVIEWPORT_START_X, gsVIEWPORT_WINDOW_START_Y, gsVIEWPORT_END_X, gsVIEWPORT_WINDOW_END_Y);
+	InvalidateRegionEx(gsVIEWPORT_START_X, gsVIEWPORT_WINDOW_START_Y, gsVIEWPORT_END_X, gsVIEWPORT_WINDOW_END_Y);
 	ResetRenderParameters();
 }
 
@@ -1920,7 +1921,7 @@ static void RenderMarkedWorld(void)
 	sLevelIDs[0] = RENDER_STATIC_TOPMOST;
 	RenderTiles(TILES_MARKED, gsStartPointX_M, gsStartPointY_M, gsStartPointX_S, gsStartPointY_S, gsEndXS, gsEndYS, 1, sLevelIDs);
 
-	AddBaseDirtyRect(gsVIEWPORT_START_X, gsVIEWPORT_WINDOW_START_Y, gsVIEWPORT_END_X, gsVIEWPORT_WINDOW_END_Y);
+	InvalidateRegionEx(gsVIEWPORT_START_X, gsVIEWPORT_WINDOW_START_Y, gsVIEWPORT_END_X, gsVIEWPORT_WINDOW_END_Y);
 
 	ResetRenderParameters();
 }

--- a/src/game/TileEngine/Render_Dirty.h
+++ b/src/game/TileEngine/Render_Dirty.h
@@ -50,11 +50,6 @@ struct VIDEO_OVERLAY
 inline SGPRect gDirtyClipRect;
 
 
-// DIRTY QUEUE
-void AddBaseDirtyRect(INT32 iLeft, INT32 iTop, INT32 iRight, INT32 iBottom);
-void ExecuteBaseDirtyRectQueue(void);
-
-
 // BACKGROUND RECT BUFFERING STUFF
 void             InitializeBackgroundRects(void);
 BACKGROUND_SAVE* RegisterBackgroundRect(BackgroundFlags, INT16 x, INT16 y, INT16 w, INT16 h);

--- a/src/game/Utils/Animated_ProgressBar.cc
+++ b/src/game/Utils/Animated_ProgressBar.cc
@@ -260,8 +260,6 @@ void RenderProgressBar( UINT8 ubID, UINT32 uiPercentage )
 			ColorFillVideoSurfaceArea(FRAME_BUFFER,	x + 2, y + 2, end, y + h - 2, Get16BPPColor(FROMRGB(72 , 155, 24)));
 		}
 		InvalidateRegion(x, y, x + w, y + h);
-		ExecuteBaseDirtyRectQueue();
-		EndFrameBufferRender();
 		RefreshScreen();
 	}
 

--- a/src/sgp/Video.h
+++ b/src/sgp/Video.h
@@ -21,7 +21,6 @@ void         InitializeVideoManager(VideoScaleQuality quality, int32_t targetFPS
 void         ShutdownVideoManager(void);
 void         InvalidateRegion(INT32 iLeft, INT32 iTop, INT32 iRight, INT32 iBottom);
 void         InvalidateScreen(void);
-void         EndFrameBufferRender(void);
 
 void VideoSetBrightness(float brightness);
 


### PR DESCRIPTION
ExecuteBaseDirtyRectQueue and EndFrameBufferRender just set two flags that the entire screen should be refreshed or that the frame buffer is dirty, something RefreshScreen() can figure out itself by looking at the state of three variables it needs to check anyway.
These changes turned made AddBaseDirtyRect just a synonym for InvalidateRegionEx, so it could be removed, too.