### PR TITLE
Fix division by 0 in CalcBestStab()

### DIFF
--- a/src/game/Tactical/Points.cc
+++ b/src/game/Tactical/Points.cc
@@ -865,7 +865,7 @@ UINT8 CalcAPsToBurst(INT8 const bBaseActionPoints, OBJECTTYPE const& o)
 }
 
 
-UINT8 CalcTotalAPsToAttack(SOLDIERTYPE* const s, INT16 const grid_no, UINT8 const ubAddTurningCost, INT8 const aim_time)
+UINT8 CalcTotalAPsToAttack(SOLDIERTYPE * const s, GridNo const grid_no, bool const add_turning_cost, INT8 const aim_time)
 {
 	UINT16            ap_cost = 0;
 	OBJECTTYPE const& in_hand = s->inv[HANDPOS];
@@ -875,7 +875,7 @@ UINT8 CalcTotalAPsToAttack(SOLDIERTYPE* const s, INT16 const grid_no, UINT8 cons
 		case IC_LAUNCHER:
 		case IC_TENTACLES:
 		case IC_THROWING_KNIFE:
-			return MinAPsToAttack(s, grid_no, ubAddTurningCost) +
+			return MinAPsToAttack(s, grid_no, add_turning_cost) +
 				(s->bDoBurst ? CalcAPsToBurst(CalcActionPoints(s), in_hand) :
 				// WM_ATTACHED is already handled by MinAPsToAttack and the
 				// aim time cannot be refined further.
@@ -950,7 +950,7 @@ UINT8 CalcTotalAPsToAttack(SOLDIERTYPE* const s, INT16 const grid_no, UINT8 cons
 				}
 				ap_cost += s->sWalkToAttackWalkToCost;
 			}
-			ap_cost += MinAPsToAttack(s, adjusted_grid_no, ubAddTurningCost);
+			ap_cost += MinAPsToAttack(s, adjusted_grid_no, add_turning_cost);
 			ap_cost += aim_time;
 			break;
 	}
@@ -962,7 +962,7 @@ UINT8 CalcTotalAPsToAttack(SOLDIERTYPE* const s, INT16 const grid_no, UINT8 cons
 static UINT8 MinAPsToPunch(SOLDIERTYPE const&, GridNo, bool add_turning_cost);
 
 
-UINT8 MinAPsToAttack(SOLDIERTYPE* const s, GridNo const grid_no, UINT8 const add_turning_cost)
+UINT8 MinAPsToAttack(SOLDIERTYPE * const s, GridNo const grid_no, bool const add_turning_cost)
 {
 	OBJECTTYPE const& in_hand = s->inv[HANDPOS];
 	UINT16            item    = in_hand.usItem;

--- a/src/game/Tactical/Points.h
+++ b/src/game/Tactical/Points.h
@@ -284,7 +284,7 @@ BOOLEAN EnoughPoints(const SOLDIERTYPE* pSoldier, INT16 sAPCost, INT16 sBPCost, 
 void DeductPoints( SOLDIERTYPE *pSoldier, INT16 sAPCost, INT16 sBPCost );
 void UnusedAPsToBreath(SOLDIERTYPE *pSold);
 INT16 TerrainBreathPoints(SOLDIERTYPE * pSoldier, INT16 sGridno,INT8 bDir, UINT16 usMovementMode);
-UINT8 MinAPsToAttack(SOLDIERTYPE*, GridNo, UINT8 add_turning_cost);
+UINT8 MinAPsToAttack(SOLDIERTYPE *, GridNo, bool add_turning_cost);
 INT8  MinPtsToMove(const SOLDIERTYPE* pSoldier);
 INT8 MinAPsToStartMovement(const SOLDIERTYPE* pSoldier, UINT16 usMovementMode);
 INT8 PtsToMoveDirection(const SOLDIERTYPE* pSoldier, UINT8 bDirection);
@@ -294,7 +294,7 @@ void DeductAmmo( SOLDIERTYPE *pSoldier, INT8 bInvPos );
 
 
 UINT16 GetAPsToPickupItem( SOLDIERTYPE *pSoldier, UINT16 usMapPos );
-UINT8 CalcTotalAPsToAttack( SOLDIERTYPE *pSoldier, INT16 sGridno, UINT8 ubAddTurningCost, INT8 bAimTime );
+UINT8 CalcTotalAPsToAttack(SOLDIERTYPE *, GridNo, bool add_turning_cost, INT8 bAimTime);
 UINT8 CalcAPsToBurst(INT8 bBaseActionPoints, OBJECTTYPE const&);
 UINT16 GetAPsToChangeStance(const SOLDIERTYPE* pSoldier, INT8 bDesiredHeight);
 
@@ -323,7 +323,6 @@ UINT16 GetAPsToUseRemote( SOLDIERTYPE *pSoldier );
 INT8 GetAPsToStealItem( SOLDIERTYPE *pSoldier, INT16 usMapPos );
 
 INT8 GetAPsToUseJar( SOLDIERTYPE *pSoldier, INT16 usMapPos );
-INT8 GetBPsTouseJar( SOLDIERTYPE *pSoldier );
 
 INT8 GetAPsToJumpOver(const SOLDIERTYPE* pSoldier);
 

--- a/src/game/TacticalAI/AIInternals.h
+++ b/src/game/TacticalAI/AIInternals.h
@@ -30,8 +30,8 @@ extern BOOLEAN gfTurnBasedAI;
 #define NOWATER         0
 #define WATEROK         1
 
-#define DONTADDTURNCOST 0
-#define ADDTURNCOST     1
+constexpr bool DONTADDTURNCOST = false;
+constexpr bool ADDTURNCOST     = true;
 
 enum
 {

--- a/src/game/TacticalAI/Attacks.cc
+++ b/src/game/TacticalAI/Attacks.cc
@@ -109,7 +109,7 @@ void CalcBestShot(SOLDIERTYPE *pSoldier, ATTACKTYPE *pBestShot)
 	INT32 iThreatValue;
 	INT32 iHitRate,iBestHitRate,iPercentBetter;
 	INT32 iEstDamage;
-	UINT8 ubRawAPCost,ubMinAPcost,ubMaxPossibleAimTime,ubAimTime,ubBestAimTime;
+	UINT8 ubMaxPossibleAimTime,ubAimTime,ubBestAimTime;
 	UINT8 ubChanceToHit,ubChanceToGetThrough,ubChanceToReallyHit,ubBestChanceToHit = 0;
 
 	ubBestChanceToHit = ubBestAimTime = ubChanceToHit = 0;
@@ -144,7 +144,7 @@ void CalcBestShot(SOLDIERTYPE *pSoldier, ATTACKTYPE *pBestShot)
 			continue;  // next opponent
 
 		// calculate minimum action points required to shoot at this opponent
-		ubMinAPcost = MinAPsToAttack(pSoldier,pOpponent->sGridNo,ADDTURNCOST);
+		UINT8 const ubMinAPcost = MinAPsToAttack(pSoldier, pOpponent->sGridNo, ADDTURNCOST);
 
 		// if we don't have enough APs left to shoot even a snap-shot at this guy
 		if (ubMinAPcost > pSoldier->bActionPoints)
@@ -153,8 +153,6 @@ void CalcBestShot(SOLDIERTYPE *pSoldier, ATTACKTYPE *pBestShot)
 		// calculate chance to get through the opponent's cover (if any)
 
 		ubChanceToGetThrough = AISoldierToSoldierChanceToGetThrough( pSoldier, pOpponent );
-
-		//   ubChanceToGetThrough = ChanceToGetThrough(pSoldier,pOpponent->sGridNo,NOTFAKE,ACTUAL,TESTWALLS,9999,M9PISTOL,NOT_FOR_LOS);
 
 		// if we can't possibly get through all the cover
 		if (ubChanceToGetThrough == 0)
@@ -185,7 +183,7 @@ void CalcBestShot(SOLDIERTYPE *pSoldier, ATTACKTYPE *pBestShot)
 		}
 
 		// calc next attack's minimum shooting cost (excludes readying & turning)
-		ubRawAPCost = MinAPsToShootOrStab(*pSoldier, pOpponent->sGridNo, FALSE);
+		UINT8 ubRawAPCost = MinAPsToShootOrStab(*pSoldier, pOpponent->sGridNo, DONTADDTURNCOST);
 
 		if (pOpponent->sGridNo != pSoldier->sLastTarget)
 		{
@@ -219,13 +217,11 @@ void CalcBestShot(SOLDIERTYPE *pSoldier, ATTACKTYPE *pBestShot)
 		// consider the various aiming times
 		for (ubAimTime = AP_MIN_AIM_ATTACK; ubAimTime <= ubMaxPossibleAimTime; ubAimTime++)
 		{
-			//HandleMyMouseCursor(KEYBOARDALSO);
 			UINT8 target = AIM_SHOT_TORSO;
 			if (gamepolicy(ai_better_aiming_choice)) {
 				target = pSoldier->bAimShotLocation;
 			}
 			ubChanceToHit = (UINT8) AICalcChanceToHitGun(pSoldier, pOpponent->sGridNo, ubAimTime, target);
-			// ExtMen[pOpponent->ubID].haveStats = TRUE;
 
 			iHitRate = (pSoldier->bActionPoints * ubChanceToHit) / (ubRawAPCost + ubAimTime);
 
@@ -385,7 +381,7 @@ static void CalcBestThrow(SOLDIERTYPE* pSoldier, ATTACKTYPE* pBestThrow)
 	UINT8 ubFriendCnt = 0;
 	UINT8 ubOpponentCnt = 0;
 	SOLDIERTYPE* opponents[MAXMERCS];
-	UINT8 ubRawAPCost,ubMinAPcost,ubMaxPossibleAimTime;
+	UINT8 ubRawAPCost,ubMaxPossibleAimTime;
 	UINT8 ubChanceToHit,ubChanceToGetThrough,ubChanceToReallyHit;
 	UINT32 uiPenalty;
 	UINT8 ubSearchRange;
@@ -746,7 +742,7 @@ static void CalcBestThrow(SOLDIERTYPE* pSoldier, ATTACKTYPE* pBestThrow)
 				}
 
 				// calculate minimum action points required to throw at this gridno
-				ubMinAPcost = MinAPsToAttack(pSoldier,sGridNo,ADDTURNCOST);
+				UINT8 const ubMinAPcost = MinAPsToAttack(pSoldier, sGridNo, ADDTURNCOST);
 
 				// if we don't have enough APs left to throw even without aiming
 				if (ubMinAPcost > pSoldier->bActionPoints)
@@ -908,13 +904,13 @@ static void CalcBestThrow(SOLDIERTYPE* pSoldier, ATTACKTYPE* pBestThrow)
 
 				if ( EXPLOSIVE_GUN( usInHand ) )
 				{
-					ubRawAPCost   = MinAPsToShootOrStab(*pSoldier, sGridNo, FALSE);
+					ubRawAPCost   = MinAPsToShootOrStab(*pSoldier, sGridNo, DONTADDTURNCOST);
 					ubChanceToHit = (UINT8) AICalcChanceToHitGun(pSoldier, sGridNo, ubMaxPossibleAimTime, AIM_SHOT_TORSO );
 				}
 				else
 				{
 					// NB grenade launcher is NOT a direct fire weapon!
-					ubRawAPCost   = MinAPsToThrow(*pSoldier, sGridNo, FALSE);
+					ubRawAPCost   = MinAPsToThrow(*pSoldier, sGridNo, DONTADDTURNCOST);
 					ubChanceToHit = (UINT8) CalcThrownChanceToHit( pSoldier, sGridNo, ubMaxPossibleAimTime, AIM_SHOT_TORSO );
 				}
 
@@ -1000,7 +996,7 @@ void CalcBestStab(SOLDIERTYPE *pSoldier, ATTACKTYPE *pBestStab, BOOLEAN fBladeAt
 	INT32 iAttackValue;
 	INT32 iThreatValue,iHitRate,iBestHitRate,iPercentBetter, iEstDamage;
 	BOOLEAN fSurpriseStab;
-	UINT8 ubRawAPCost,ubMinAPCost,ubMaxPossibleAimTime,ubAimTime;
+	UINT8 ubMinAPCost,ubMaxPossibleAimTime,ubAimTime;
 	UINT8 ubChanceToHit,ubChanceToReallyHit,ubBestChanceToHit = 0;
 	UINT16 usTrueMovementMode;
 
@@ -1043,8 +1039,6 @@ void CalcBestStab(SOLDIERTYPE *pSoldier, ATTACKTYPE *pBestStab, BOOLEAN fBladeAt
 		// calculate minimum action points required to stab at this opponent
 		ubMinAPCost = CalcTotalAPsToAttack( pSoldier,pOpponent->sGridNo,ADDTURNCOST, 0 );
 
-		//ubMinAPCost = MinAPsToAttack(pSoldier,pOpponent->sGridNo,ADDTURNCOST);
-
 		// Human: if I don't have enough APs left to get there & stab at this guy, skip 'im.
 		// Monster:  I'll do an extra check later on to see if I can reach the guy this turn.
 
@@ -1067,7 +1061,13 @@ void CalcBestStab(SOLDIERTYPE *pSoldier, ATTACKTYPE *pBestStab, BOOLEAN fBladeAt
 		}
 
 		// calc next attack's minimum stabbing cost (excludes movement & turning)
-		ubRawAPCost = MinAPsToAttack(pSoldier,pOpponent->sGridNo, FALSE) - AP_CHANGE_TARGET;
+		UINT8 ubRawAPCost = MinAPsToAttack(pSoldier, pOpponent->sGridNo, DONTADDTURNCOST);
+
+		if (pOpponent->sGridNo != pSoldier->sLastTarget)
+		{
+			// raw AP cost calculation included cost of changing target!
+			ubRawAPCost -= AP_CHANGE_TARGET;
+		}
 
 		// determine if this is a surprise stab (must be next to opponent & unseen)
 		fSurpriseStab = FALSE;        // assume it is not a surprise stab
@@ -1185,8 +1185,7 @@ void CalcTentacleAttack(SOLDIERTYPE *pSoldier, ATTACKTYPE *pBestStab )
 {
 	INT32 iAttackValue;
 	INT32 iThreatValue,iHitRate,iBestHitRate, iEstDamage;
-	BOOLEAN fSurpriseStab;
-	UINT8 ubRawAPCost,ubMinAPCost,ubMaxPossibleAimTime,ubAimTime;
+	UINT8 ubAimTime;
 	UINT8 ubChanceToHit,ubChanceToReallyHit,ubBestChanceToHit = 0;
 
 	UINT8 ubBestAimTime = (UINT8)-1; // XXX HACK000E
@@ -1222,33 +1221,30 @@ void CalcTentacleAttack(SOLDIERTYPE *pSoldier, ATTACKTYPE *pBestStab )
 		}
 
 		// calculate minimum action points required to stab at this opponent
-		ubMinAPCost = CalcTotalAPsToAttack( pSoldier,pOpponent->sGridNo,ADDTURNCOST, 0 );
-		//ubMinAPCost = MinAPsToAttack(pSoldier,pOpponent->sGridNo,ADDTURNCOST);
-
+		UINT8 const ubMinAPCost = CalcTotalAPsToAttack(pSoldier, pOpponent->sGridNo, ADDTURNCOST, 0);
 
 		// calc next attack's minimum stabbing cost (excludes movement & turning)
-		ubRawAPCost = MinAPsToAttack(pSoldier,pOpponent->sGridNo, FALSE) - AP_CHANGE_TARGET;
+		UINT8 ubRawAPCost = MinAPsToAttack(pSoldier, pOpponent->sGridNo, DONTADDTURNCOST);
+
+		if (pOpponent->sGridNo != pSoldier->sLastTarget)
+		{
+			// raw AP cost calculation included cost of changing target!
+			ubRawAPCost -= AP_CHANGE_TARGET;
+		}
 
 		// determine if this is a surprise stab (for tentacles, enemy must not see us, no dist limit)
-		fSurpriseStab = FALSE;        // assume it is not a surprise stab
-
-		// if opponent doesn't see the attacker
-		if (pOpponent->bOppList[pSoldier->ubID] != SEEN_CURRENTLY)
-		{
-			fSurpriseStab = TRUE;   // we got 'im lined up where we want 'im!
-		}
+		bool const fSurpriseStab = (pOpponent->bOppList[pSoldier->ubID] != SEEN_CURRENTLY);
 
 		iBestHitRate = 0;                     // reset best hit rate to minimum
 
 		// calculate the maximum possible aiming time
 
-		//ubMaxPossibleAimTime = std::min(AP_MAX_AIM_ATTACK,pSoldier->bActionPoints - ubMinAPCost);
-		ubMaxPossibleAimTime = 0;
+		// No additional aiming for tentacle attacks (as in Vanilla).
+		UINT8 const ubMaxPossibleAimTime = 0;
 
 		// consider the various aiming times
 		for (ubAimTime = AP_MIN_AIM_ATTACK; ubAimTime <= ubMaxPossibleAimTime; ubAimTime++)
 		{
-			//HandleMyMouseCursor(KEYBOARDALSO);
 			if (!fSurpriseStab)
 			{
 				ubChanceToHit = (UINT8) CalcChanceToStab(pSoldier,pOpponent,ubAimTime);
@@ -1638,8 +1634,6 @@ INT8 CanNPCAttack(SOLDIERTYPE *pSoldier)
 
 void CheckIfTossPossible(SOLDIERTYPE *pSoldier, ATTACKTYPE *pBestThrow)
 {
-	UINT8 ubMinAPcost;
-
 	if ( TANK( pSoldier ) )
 	{
 		pBestThrow->bWeaponIn = FindObj( pSoldier, TANK_CANNON );
@@ -1678,7 +1672,7 @@ void CheckIfTossPossible(SOLDIERTYPE *pSoldier, ATTACKTYPE *pBestThrow)
 		}
 
 		// get the minimum cost to attack with this tossable item
-		ubMinAPcost = MinAPsToAttack( pSoldier, pSoldier->sLastTarget, DONTADDTURNCOST);
+		UINT8 const ubMinAPcost = MinAPsToAttack(pSoldier, pSoldier->sLastTarget, DONTADDTURNCOST);
 
 		// if we can afford the minimum AP cost to throw this tossable item
 		if (pSoldier->bActionPoints >= ubMinAPcost)


### PR DESCRIPTION
MinAPsToAttack() can return 1 for extreme values of ubShotsPer4Turns in weapons.json, so always subtracting 1 AP for the cost of turning even if the soldier does not need to turn for the attack gave 0 for ubRawAPCost and a division by 0 followed when computing the hit rate.

CalcTentacleAttack() had the same problem.

Removed declaration of non-existant function GetBPsTouseJar().

Fixes #1840 (the crashing part, I didn't observe the unexpected item class warning while testing this).