### PR TITLE
Give special treatment to some keys used as shortcuts in tactical

### DIFF
--- a/src/game/Tactical/Turn_Based_Input.cc
+++ b/src/game/Tactical/Turn_Based_Input.cc
@@ -1363,6 +1363,7 @@ static void HandleModNone(UINT32 const key, UIEventKind* const new_event)
 			break;
 
 		case '*':
+		case ',':
 			gTacticalStatus.uiFlags ^= RED_ITEM_GLOW_ON;
 			break;
 

--- a/src/sgp/Input.cc
+++ b/src/sgp/Input.cc
@@ -332,6 +332,26 @@ static void KeyChange(SDL_Keysym const* const key_sym, bool const pressed)
 	SDL_Keycode      key = key_sym->sym;
 	SDL_Keymod const mod = (SDL_Keymod) key_sym->mod;
 	bool   const num = mod & KMOD_NUM;
+
+	// Special handling for some keys which often are used for different
+	// purposes for many keyboard layouts compared to the US keyboard layout
+	// and which otherwise wouldn't be usable as hotkeys in tactical mode.
+	//
+	// Note: it is still possible to use the key as intended by its
+	// keyboard layout when entering text like a save game description or
+	// the IMP name because we are using SDL_TextInput events for those,
+	// which are not affected by the KeyChange function. (Issue #1844)
+	if (mod == KMOD_NONE)
+	{
+		switch (key_sym->scancode)
+		{
+			case SDL_SCANCODE_EQUALS:      key = SDLK_EQUALS;           break;
+			case SDL_SCANCODE_SLASH:       key = SDLK_SLASH;            break;
+			case SDL_SCANCODE_GRAVE:       key = SDLK_BACKQUOTE;        break;
+			default:                                                    break;
+		}
+	}
+
 	switch (key)
 	{
 #if defined WITH_MAEMO


### PR DESCRIPTION
Treat the keys that are labeled with the grave, equals sign and slash on an US keyboard like those keys on all keyboard layouts so they can be used as shortcuts in tactical mode. Does not affect text input when entering save game descriptions.

Also add ',' as an alternative to '*' to toggle red item glow.

Fixes #1844.