### PR TITLE
AppVeyor: Cache sccache binary

### DIFF
--- a/.ci/ci-functions.sh
+++ b/.ci/ci-functions.sh
@@ -10,7 +10,7 @@ unix-install-rustup () {
 }
 
 linux-install-sccache () {
-    local SCCACHE_VERSION="0.2.13"
+    local SCCACHE_VERSION="v0.5.4"
     local SCCACHE_LINUX_PACKAGE="sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl"
 
     curl -sSfL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/${SCCACHE_LINUX_PACKAGE}.tar.gz" | sudo tar zx --strip-component=1 -C /usr/bin/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,8 +40,11 @@ cache:
   - '%USERPROFILE%\.cargo\registry\cache\ -> rust\Cargo.lock, rust\Cargo.toml'
   - '%USERPROFILE%\.cargo\git\db\ -> rust\Cargo.lock, rust\Cargo.toml'
   - '%USERPROFILE%\.rustup\ -> rust-toolchain'
-  # sccache
+  # sccache's cache
   - '%LOCALAPPDATA%\Mozilla\sccache'
+  # sccache binary
+  - C:\ProgramData\chocolatey\bin -> appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> appveyor.yml
 
 skip_commits:
   # appveyor only searches for tags in the first line by default


### PR DESCRIPTION
[skip actions]

After reading https://www.appveyor.com/docs/build-cache/#caching-chocolatey-packages I think we could make those builds faster and more reliable by caching the sccache binary itself, too.