### PR TITLE
Force a cursor mode switch when the current targt soldier dies

### DIFF
--- a/src/game/Tactical/Soldier_Create.cc
+++ b/src/game/Tactical/Soldier_Create.cc
@@ -964,7 +964,12 @@ static void InitSoldierStruct(SOLDIERTYPE& s)
 void InternalTacticalRemoveSoldier(SOLDIERTYPE& s, BOOLEAN const fRemoveVehicle)
 {
 	if (GetSelectedMan() == &s) SetSelectedMan(0);
-	if (gUIFullTarget    == &s) gUIFullTarget   = 0;
+	if (gUIFullTarget    == &s)
+	{
+		gUIFullTarget = nullptr;
+		// Force back cursor to move mode, otherwise it might get stuck.
+		guiPendingOverrideEvent = UIEventKind::A_CHANGE_TO_MOVE;
+	}
 	if (gpSMCurrentMerc  == &s) gpSMCurrentMerc = 0;
 
 	if (!s.bActive) return;


### PR DESCRIPTION
The cursor could get stuck in a no longer valid mode if the current gUIFullTarget died, for example from bleeding out. Fixes #1778.

Given the byzantine labyrinth of functions and global variables that are involved in handling the tactical cursor my confidence that this is the best way to fix this is fairly low. I believe the worst thing that could happen is that the cursor now changes to move mode when someone dies where this currently does not happen and might not be desirable, but right now I can't think of such a situation.