### PR TITLE
Correct documentation of minimum required SDL2 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ else()
         message(STATUS "Using local SDL from " "${CMAKE_CURRENT_SOURCE_DIR}/${LOCAL_SDL_LIB}")
         set(ENV{SDL2DIR} "${CMAKE_CURRENT_SOURCE_DIR}/${LOCAL_SDL_LIB}")
     endif()
-    find_package(SDL2 REQUIRED)
+    find_package(SDL2 2.0.5 REQUIRED)
 endif()
 message(STATUS "SDL2 Libraries: ${SDL2_LIBRARY}; SDL2 Include Dir: ${SDL2_INCLUDE_DIR}")
 

--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -2,7 +2,7 @@
 
 ## Dependencies
 
-- SDL2 >= `2.0.4` (version `2.0.20` is included in this repo for Windows and macOS).
+- SDL2 >= `2.0.5` (version `2.0.20` is included in this repo for Windows and macOS).
   __WARNING__: There is an issue with SDL in version `2.0.6` that causes segfaults when playing sounds.
   Please ensure that you run the game with a different version of the SDL2 library otherwise sound will be
   disabled.

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -167,7 +167,7 @@ void InitializeVideoManager(const VideoScaleQuality quality,
 	if (ScaleQuality == VideoScaleQuality::PERFECT)
 	{
 		SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
-#if SDL_VERSION_ATLEAST(2,0,5)
+
 		if (!IsDesktopLargeEnough())
 		{
 			// Pixel-perfect mode cannot handle scaling down, and will
@@ -178,10 +178,6 @@ void InitializeVideoManager(const VideoScaleQuality quality,
 		}
 		SDL_SetWindowMinimumSize(g_game_window, SCREEN_WIDTH, SCREEN_HEIGHT);
 		SDL_RenderSetIntegerScale(GameRenderer, SDL_TRUE);
-#else
-		SLOGW("Pixel-perfect scaling is not available");
-		ScaleQuality = VideoScaleQuality::NEAR_PERFECT;
-#endif
 	}
 	else if (ScaleQuality == VideoScaleQuality::NEAR_PERFECT)
 	{


### PR DESCRIPTION
I unintentionally raised this when I used SDL_CreateRGBSurfaceWithFormat in 67654996626ea5ceb20abe5236f4d625e6063b42. So far nobody has complained and I don't believe requiring your SDL version to be less than seven years old is too much too ask.

