### PR TITLE
Do not dereference a null pointer in RebuildWayPointsForGroupPath

### DIFF
--- a/src/game/Strategic/Strategic_Movement.cc
+++ b/src/game/Strategic/Strategic_Movement.cc
@@ -398,18 +398,22 @@ BOOLEAN AddWaypointToPGroup(GROUP *g, const SGPSector& sMap)
 	{
 		if (n_aligned_axes == 0)
 		{
-			AssertMsg(FALSE, ST::format("Invalid DIAGONAL waypoint being added for groupID {}. AM-0", g->ubGroupID));
+			SLOGE("Invalid DIAGONAL waypoint being added for groupID {}. AM-0", g->ubGroupID);
 			return FALSE;
 		}
 
 		if (n_aligned_axes >= 2)
 		{
-			AssertMsg(FALSE, ST::format("Invalid IDENTICAL waypoint being added for groupID {}. AM-0", g->ubGroupID));
+			SLOGE("Invalid IDENTICAL waypoint being added for groupID {}. AM-0", g->ubGroupID);
 			return FALSE;
 		}
 
 		// Has to be different in exactly 1 axis to be a valid new waypoint
-		Assert(n_aligned_axes == 1);
+		if (n_aligned_axes != 1)
+		{
+			SLOGE("n_aligned_axes should be 1, is {}", n_aligned_axes);
+			return false;
+		}
 	}
 
 	WAYPOINT* const new_wp = new WAYPOINT{};

--- a/src/game/Strategic/Strategic_Pathing.cc
+++ b/src/game/Strategic/Strategic_Pathing.cc
@@ -794,7 +794,6 @@ void RebuildWayPointsForGroupPath(PathSt* const pHeadOfPath, GROUP& g)
 	INT32 iOldDelta = 0;
 	BOOLEAN fFirstNode = TRUE;
 	PathSt* pNode = pHeadOfPath;
-	WAYPOINT *wp = NULL;
 
 	//KRIS!  Added this because it was possible to plot a new course to the same destination, and the
 	//       group would add new arrival events without removing the existing one(s).
@@ -868,10 +867,18 @@ void RebuildWayPointsForGroupPath(PathSt* const pHeadOfPath, GROUP& g)
 	AddWaypointStrategicIDToPGroup(&g, pNode->uiSectorId);
 
 	// at this point, the final sector in the path must be identical to this group's last waypoint
-	wp = GetFinalWaypoint(&g);
-	AssertMsg( wp, "Path exists, but no waypoints were added!  AM-0" );
-	AssertMsg(pNode->uiSectorId == (UINT32) wp->sSector.AsStrategicIndex(), "Last waypoint differs from final path sector!  AM-0");
+	{
+		auto * const wp = GetFinalWaypoint(&g);
 
+		if (wp == nullptr)
+		{
+			SLOGE("Path exists, but no waypoints were added!  AM-0" );
+		}
+		else if (pNode->uiSectorId != static_cast<UINT32>(wp->sSector.AsStrategicIndex()))
+		{
+			SLOGE("Last waypoint differs from final path sector!  AM-0");
+		}
+	}
 
 	// see if we've already reached the first sector in the path (we never actually left the sector and reversed back to it)
 	if (g.uiArrivalTime == GetWorldTotalMin())


### PR DESCRIPTION
Also change a couple of assertions to SLOGE messages. This avoids the crash with the save game provided in issue #1871.

The strategic pathfinding problem is still there, that's why I'd leave 1871 open, it has a nice testcase. This is what it looks like with this commit:

```
2023-08-10T09:14:16.024072348Z [ERROR] game/Strategic/Strategic_Movement.cc: Invalid DIAGONAL waypoint being added for groupID 30. AM-0
2023-08-10T09:14:16.024268076Z [ERROR] game/Strategic/Strategic_Movement.cc: Invalid DIAGONAL waypoint being added for groupID 30. AM-0
2023-08-10T09:14:16.024369941Z [ERROR] game/Strategic/Strategic_Movement.cc: Invalid DIAGONAL waypoint being added for groupID 30. AM-0
2023-08-10T09:14:16.024461411Z [ERROR] game/Strategic/Strategic_Pathing.cc: Path exists, but no waypoints were added!  AM-0
```