### PR TITLE
Add the filename to SGPFile

### DIFF
--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -81,7 +81,8 @@ public:
 	virtual SGPFile* openMapForReading(const ST::string& mapName) const = 0;
 
 	/* Open a game resource file for reading. */
-	virtual SGPFile* openGameResForReading(const ST::string& filename) const = 0;
+	/* Note: filename is passed by value here, it will be moved to SGPFile. */
+	virtual SGPFile* openGameResForReading(ST::string filename) const = 0;
 
 	/* Checks if a game resource exists. */
 	virtual bool doesGameResExists(const ST::string& filename) const = 0;

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -311,7 +311,7 @@ std::vector<ST::string> DefaultContentManager::getAllTilecache() const
  * settings directory) and file is present.
  * If file is not found, try to find it relatively to 'Data' directory.
  * If file is not found, try to find the file in libraries located in 'Data' directory; */
-SGPFile* DefaultContentManager::openGameResForReading(const ST::string& filename) const
+SGPFile* DefaultContentManager::openGameResForReading(ST::string filename) const
 {
 	RustPointer<VFile> vfile(VfsFile_open(m_vfs.get(), filename.c_str()));
 	if (!vfile)
@@ -320,7 +320,7 @@ SGPFile* DefaultContentManager::openGameResForReading(const ST::string& filename
 		throw std::runtime_error(ST::format("openGameResForReading: {}", err.get()).to_std_string());
 	}
 	SLOGD("Opened resource file from VFS: '{}'", filename);
-	return new SGPFile(vfile.release());
+	return new SGPFile(vfile.release(), std::move(filename));
 }
 
 /* Checks if a game resource exists. */
@@ -362,7 +362,7 @@ ST::string* DefaultContentManager::loadDialogQuoteFromFile(const ST::string& fil
 	{
 		SLOGW("DefaultContentManager::loadDialogQuoteFromFile '{}' {}: {}", fileName, quote_number, err_msg);
 	}
-	return new ST::string(quote);
+	return new ST::string{std::move(quote)};
 }
 
 /** Load all dialogue quotes for a character. */
@@ -380,7 +380,7 @@ void DefaultContentManager::loadAllDialogQuotes(STRING_ENC_TYPE encType, const S
 		{
 			SLOGW("DefaultContentManager::loadAllDialogQuotes '{}' {}: {}", fileName, i, err);
 		}
-		quotes.push_back(new ST::string(quote));
+		quotes.push_back(new ST::string{std::move(quote)});
 	}
 }
 

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -60,7 +60,7 @@ public:
 	virtual DirFs* tempFiles() const override;
 
 	/* Open a game resource file for reading. */
-	virtual SGPFile* openGameResForReading(const ST::string& filename) const override;
+	virtual SGPFile* openGameResForReading(ST::string filename) const override;
 
 	/* Checks if a game resource exists. */
 	virtual bool doesGameResExists(const ST::string& filename) const override;

--- a/src/sgp/FileMan.cc
+++ b/src/sgp/FileMan.cc
@@ -8,6 +8,7 @@
 
 #include <stdexcept>
 #include <regex>
+#include <utility>
 
 ST::string FileMan::cleanBasename(const ST::string& pathSegment)
 {
@@ -95,7 +96,7 @@ ST::string FileMan::resolveExistingComponents(const ST::string& path)
 /** Open file for writing.
  * If file is missing it will be created.
  * If file exists, it's content will be removed. */
-SGPFile* FileMan::openForWriting(const ST::string& filename, bool truncate)
+SGPFile* FileMan::openForWriting(ST::string filename, bool truncate)
 {
 	uint8_t open_options = FILE_OPEN_WRITE | FILE_OPEN_CREATE;
 	if (truncate)
@@ -109,13 +110,13 @@ SGPFile* FileMan::openForWriting(const ST::string& filename, bool truncate)
 		RustPointer<char> err{getRustError()};
 		throw IoException(ST::format("FileMan::openForWriting('{}') failed: {}", filename, err.get()));
 	}
-	return new SGPFile(file.release());
+	return new SGPFile(file.release(), std::move(filename));
 }
 
 
 /** Open file for appending data.
  * If file doesn't exist, it will be created. */
-SGPFile* FileMan::openForAppend(const ST::string& filename)
+SGPFile* FileMan::openForAppend(ST::string filename)
 {
 	RustPointer<VFile> file{File_open(filename.c_str(), FILE_OPEN_APPEND | FILE_OPEN_CREATE)};
 	if (!file)
@@ -123,13 +124,13 @@ SGPFile* FileMan::openForAppend(const ST::string& filename)
 		RustPointer<char> err{getRustError()};
 		throw IoException(ST::format("FileMan::openForAppend('{}') failed: {}", filename, err.get()));
 	}
-	return new SGPFile(file.release());
+	return new SGPFile(file.release(), std::move(filename));
 }
 
 
 /** Open file for reading and writing.
  * If file doesn't exist, it will be created. */
-SGPFile* FileMan::openForReadWrite(const ST::string& filename)
+SGPFile* FileMan::openForReadWrite(ST::string filename)
 {
 	RustPointer<VFile> file{File_open(filename.c_str(), FILE_OPEN_READ | FILE_OPEN_WRITE | FILE_OPEN_CREATE)};
 	if (!file)
@@ -137,11 +138,11 @@ SGPFile* FileMan::openForReadWrite(const ST::string& filename)
 		RustPointer<char> err{getRustError()};
 		throw IoException(ST::format("FileMan::openForReadWrite('{}') failed: {}", filename, err.get()));
 	}
-	return new SGPFile(file.release());
+	return new SGPFile(file.release(), std::move(filename));
 }
 
 /** Open file for reading. */
-SGPFile* FileMan::openForReading(const ST::string &filename)
+SGPFile* FileMan::openForReading(ST::string filename)
 {
 	RustPointer<VFile> file{File_open(filename.c_str(), FILE_OPEN_READ)};
 	if (!file)
@@ -149,7 +150,7 @@ SGPFile* FileMan::openForReading(const ST::string &filename)
 		RustPointer<char> err{getRustError()};
 		throw IoException(ST::format("FileMan::openForReading('{}') failed: {}", filename, err.get()));
 	}
-	return new SGPFile(file.release());
+	return new SGPFile(file.release(), std::move(filename));
 }
 
 std::vector<ST::string>

--- a/src/sgp/FileMan.h
+++ b/src/sgp/FileMan.h
@@ -1,11 +1,9 @@
 #pragma once
 
-#include "sgp/SGPFile.h"
-#include "sgp/Types.h"
-
-#include <string_theory/string>
-
+#include "SGPFile.h"
+#include <stdint.h>
 #include <vector>
+#include <string_theory/string>
 
 /***
  * The file manager namespace provides functions to interact with files
@@ -19,18 +17,18 @@ namespace FileMan
 	/** Open file for writing.
 	 * If file is missing it will be created.
 	 * If file exists, it's content will be removed. */
-	SGPFile* openForWriting(const ST::string& filename, bool truncate=true);
+	SGPFile* openForWriting(ST::string filename, bool truncate=true);
 
 	/** Open file for appending data.
 	 * If file doesn't exist, it will be created. */
-	SGPFile* openForAppend(const ST::string& filename);
+	SGPFile* openForAppend(ST::string filename);
 
 	/** Open file for reading and writing.
 	 * If file doesn't exist, it will be created. */
-	SGPFile* openForReadWrite(const ST::string& filename);
+	SGPFile* openForReadWrite(ST::string filename);
 
 	/** Open file for reading. */
-	SGPFile* openForReading(const ST::string &filename);
+	SGPFile* openForReading(ST::string filename);
 
 	/* Delete the file at path. */
 	void deleteFile(const ST::string &path);

--- a/src/sgp/SGPFile.h
+++ b/src/sgp/SGPFile.h
@@ -2,22 +2,10 @@
 
 #include <stdint.h>
 
-#include <Types.h>
-#include "sgp/AutoObj.h"
-
+#include "AutoObj.h"
+#include "Types.h"
+#include <string_theory/string>
 #include <SDL_rwops.h>
-
-struct SGP_FILETIME
-{
-	uint32_t Lo;
-	uint32_t Hi;
-};
-
-enum SGPFileFlags
-{
-	SGPFILE_NONE = 0U,
-	SGPFILE_REAL = 1U << 0
-};
 
 enum FileSeekMode
 {
@@ -26,18 +14,20 @@ enum FileSeekMode
 	FILE_SEEK_FROM_CURRENT
 };
 
-struct File;
 struct VfsFile;
 
 class SGPFile
 {
 private:
-	SGPFileFlags flags;
 	VFile *file;
+	ST::string name;
 
 public:
 	/** Create a SGP file from a file on disk. */
-	SGPFile(VFile *file);
+	/* The filename is only needed for diagnostic purposes. */
+	SGPFile(VFile *file, ST::string const& filename);
+	SGPFile(VFile *file, ST::string && filename);
+
 	/** Closes file. */
 	~SGPFile();
 


### PR DESCRIPTION
This is optional (not needed to open the file), but enables better diagnostics.
Remove unused SGP_FILETIME and SGPFileFlags.

Failure to open a file already logs the filename. Actual file operations should do the same, it would help in cases like #1873.