### PR TITLE
Force a switch to the team panel when necessary.

### DIFF
--- a/src/game/Tactical/Soldier_Create.cc
+++ b/src/game/Tactical/Soldier_Create.cc
@@ -970,7 +970,13 @@ void InternalTacticalRemoveSoldier(SOLDIERTYPE& s, BOOLEAN const fRemoveVehicle)
 		// Force back cursor to move mode, otherwise it might get stuck.
 		guiPendingOverrideEvent = UIEventKind::A_CHANGE_TO_MOVE;
 	}
-	if (gpSMCurrentMerc  == &s) gpSMCurrentMerc = 0;
+	if (gpSMCurrentMerc  == &s)
+	{
+		SetCurrentInterfacePanel(InterfacePanelKind::TEAM_PANEL);
+		// SetCurrentInterfacePanel still needs the old value
+		// of gpSMCurrentMerc so it must be cleared afterwards.
+		gpSMCurrentMerc = nullptr;
+	}
 
 	if (!s.bActive) return;
 


### PR DESCRIPTION
Having a zero gmSMCurrentMerc pointer while the SM panel is open is pretty bad. All the panel's mouse regions and their callbacks are still active and many of them expect a valid pointer.

There is not enough information in #1870 to say that this is the cause of that crash, but I've definitely seen an ASAN violation when the current merc left, so something like this is needed in any case.