### PR TITLE
Fix bug in two FindGridNoFromSweetSpot* functions

### DIFF
--- a/src/game/Tactical/Soldier_Add.cc
+++ b/src/game/Tactical/Soldier_Add.cc
@@ -311,7 +311,8 @@ UINT16 FindGridNoFromSweetSpotWithStructData( SOLDIERTYPE *pSoldier, UINT16 usAn
 
 							if (uiRange == 0 )
 							{
-								uiRange = 999;
+								// If we don't have a path, this cannot be the best gridno!
+								continue;
 							}
 						}
 						else
@@ -460,7 +461,8 @@ static UINT16 FindGridNoFromSweetSpotWithStructDataUsingGivenDirectionFirst(SOLD
 
 							if (uiRange == 0 )
 							{
-								uiRange = 999;
+								// If we don't have a path, this cannot be the best gridno!
+								continue;
 							}
 						}
 						else


### PR DESCRIPTION
The method these functions used to filter out gridnos without a path to the sweet spot was broken: uiRange was set to 999 and then compared to uiLowestRange. However, since uiLowestRange initial value is 999999, this invalid gridno could be considered as the best, and if there are no gridnos with a valid path in the search range, it could be returned as the result.

I believe this bug is not very likely to happen, but it could potentially the source (or one of the sources) of the path finding warnings we get occasionally.