### PR TITLE
Address new Coverity defects

### DIFF
--- a/src/game/TileEngine/Ambient_Control.cc
+++ b/src/game/TileEngine/Ambient_Control.cc
@@ -18,8 +18,8 @@
 static BOOLEAN LoadAmbientControlFile(UINT8 ubAmbientID)
 try
 {
-	ST::string zFilename = ST::format("{}/{}.bad", AMBIENTDIR, ubAmbientID);
-	AutoSGPFile hFile(GCM->openGameResForReading(zFilename));
+	AutoSGPFile hFile{GCM->openGameResForReading(
+		ST::format("{}/{}.bad", AMBIENTDIR, ubAmbientID))};
 
 	// READ #
 	hFile->read(&gsNumAmbData, sizeof(INT16));

--- a/src/sgp/FileMan_unittest.cc
+++ b/src/sgp/FileMan_unittest.cc
@@ -1,8 +1,7 @@
 #include "gtest/gtest.h"
-
 #include "FileMan.h"
-
-#include "externalized/TestUtils.h"
+#include "TestUtils.h"
+#include <utility>
 
 TEST(FileManTest, joinPaths)
 {
@@ -125,9 +124,9 @@ TEST(FileManTest, RemoveAllFilesInDir)
 	ST::string pathA = FileMan::joinPaths(tempPath.get(), "foo.txt");
 	ST::string pathB = FileMan::joinPaths(tempPath.get(), "bar.txt");
 
-	SGPFile* fileA = FileMan::openForWriting(pathA);
+	SGPFile* fileA = FileMan::openForWriting(std::move(pathA));
 	ASSERT_NE(fileA, nullptr);
-	SGPFile* fileB = FileMan::openForWriting(pathB);
+	SGPFile* fileB = FileMan::openForWriting(std::move(pathB));
 	ASSERT_NE(fileB, nullptr);
 
 	fileA->write("foo", 3);

--- a/src/sgp/LoadSaveData_unittest.cc
+++ b/src/sgp/LoadSaveData_unittest.cc
@@ -1,12 +1,10 @@
 // -*-coding: utf-8-unix;-*-
 
 #include "gtest/gtest.h"
-
 #include "LoadSaveData.h"
-
-#include "externalized/RustInterface.h"
-#include "externalized/TestUtils.h"
-
+#include "RustInterface.h"
+#include "TestUtils.h"
+#include <utility>
 
 TEST(LoadSaveData, integers)
 {
@@ -175,7 +173,7 @@ TEST(LoadSaveData, floatAndDoubleFormat)
 	ASSERT_EQ(sizeof(double), 8u);
 
 	{
-		AutoSGPFile file{FileMan::openForReading(floatsPath)};
+		AutoSGPFile file{FileMan::openForReading(std::move(floatsPath))};
 		std::vector<uint8_t> buf = file->readToEnd();
 		ASSERT_EQ(buf.size(), sizeof(float) * 5);
 		float f;
@@ -190,7 +188,7 @@ TEST(LoadSaveData, floatAndDoubleFormat)
 	}
 
 	{
-		AutoSGPFile file{FileMan::openForReading(doublesPath)};
+		AutoSGPFile file{FileMan::openForReading(std::move(doublesPath))};
 		std::vector<uint8_t> buf = file->readToEnd();
 		ASSERT_EQ(buf.size(), sizeof(double) * 5);
 		double d;


### PR DESCRIPTION
5 new COPY_INSTEAD_OF_MOVE complaints, caused by #1874. CID 323024-323028

I felt obligated to fix these because I caused them, but in general I believe all these performance defects that Coverity is now reporting would best be handled automatically by a tool like clang-tidy.