### PR TITLE
Statically allocate the gpWorldLevelData array

### DIFF
--- a/src/game/TileEngine/Lighting.cc
+++ b/src/game/TileEngine/Lighting.cc
@@ -315,8 +315,6 @@ static BOOLEAN LightTileBlocked(INT16 iSrcX, INT16 iSrcY, INT16 iX, INT16 iY)
 {
 	UINT16 usTileNo, usSrcTileNo;
 
-	Assert(gpWorldLevelData!=NULL);
-
 	usTileNo=MAPROWCOLTOPOS(iY, iX);
 	usSrcTileNo=MAPROWCOLTOPOS(iSrcY, iSrcX);
 
@@ -356,14 +354,10 @@ static BOOLEAN LightTileBlocked(INT16 iSrcX, INT16 iSrcY, INT16 iX, INT16 iY)
 // Returns TRUE/FALSE if the tile at the specified coordinates contains a wall.
 static BOOLEAN LightTileHasWall(INT16 iSrcX, INT16 iSrcY, INT16 iX, INT16 iY)
 {
-	//LEVELNODE *pStruct;
 	UINT16 usTileNo;
 	UINT16 usSrcTileNo;
 	INT8		bDirection;
 	UINT8		ubTravelCost;
-	//INT8		bWallCount = 0;
-
-	Assert(gpWorldLevelData!=NULL);
 
 	usTileNo=MAPROWCOLTOPOS(iY, iX);
 	usSrcTileNo=MAPROWCOLTOPOS(iSrcY, iSrcX);
@@ -591,8 +585,6 @@ static BOOLEAN LightAddTile(const INT16 iSrcX, const INT16 iSrcY, const INT16 iX
 	BOOLEAN fLitWall=FALSE;
 	BOOLEAN fFake;
 
-	Assert(gpWorldLevelData!=NULL);
-
 	uiTile= MAPROWCOLTOPOS( iY, iX );
 
 	if ( uiTile >= GRIDSIZE )
@@ -725,8 +717,6 @@ static BOOLEAN LightSubtractTile(const INT16 iSrcX, const INT16 iSrcY, const INT
 	UINT32 uiTile;
 	BOOLEAN fLitWall=FALSE;
 	BOOLEAN fFake; // only passed in to land and roof layers; others get fed FALSE
-
-	Assert(gpWorldLevelData != NULL);
 
 	uiTile= MAPROWCOLTOPOS( iY, iX );
 
@@ -1594,8 +1584,6 @@ BOOLEAN LightDraw(const LIGHT_SPRITE* const l)
 
 static BOOLEAN LightHideWall(const INT16 sX, const INT16 sY, const INT16 sSrcX, const INT16 sSrcY)
 {
-	Assert(gpWorldLevelData != NULL);
-
 	UINT32     const uiTile = MAPROWCOLTOPOS(sY, sX);
 	LEVELNODE* const head   = gpWorldLevelData[uiTile].pStructHead;
 

--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -97,7 +97,6 @@ void SetAllNewTileSurfacesLoaded( BOOLEAN fNew )
 
 
 // Global Variables
-MAP_ELEMENT			*gpWorldLevelData;
 UINT8						gubWorldMovementCosts[ WORLD_MAX ][MAXDIR][2];
 
 // set to nonzero (locs of base gridno of structure are good) to have it defined by structure code
@@ -170,11 +169,6 @@ void InitializeWorld()
 	// Init default surface list
 	std::fill(std::begin(gbDefaultSurfaceUsed), std::end(gbDefaultSurfaceUsed), 0);
 
-
-	// Initialize world data
-
-	gpWorldLevelData = new MAP_ELEMENT[WORLD_MAX]{};
-
 	// Init room database
 	InitRoomDatabase( );
 
@@ -189,12 +183,6 @@ static void DestroyTileSurfaces(void);
 void DeinitializeWorld( )
 {
 	TrashWorld();
-
-	if ( gpWorldLevelData != NULL )
-	{
-		delete[] gpWorldLevelData;
-		gpWorldLevelData = nullptr;
-	}
 
 	DestroyTileSurfaces( );
 	FreeAllStructureFiles( );

--- a/src/game/TileEngine/WorldDef.h
+++ b/src/game/TileEngine/WorldDef.h
@@ -237,7 +237,7 @@ struct TILE_SURFACE_RESOURCE
 };
 
 // World Data
-extern MAP_ELEMENT* gpWorldLevelData;
+inline MAP_ELEMENT gpWorldLevelData[WORLD_MAX];
 
 #define FOR_EACH_WORLD_TILE(iter) \
 	for (MAP_ELEMENT* iter = gpWorldLevelData, * const iter##__end = gpWorldLevelData + WORLD_MAX; iter != iter##__end; ++iter)


### PR DESCRIPTION
This array was allocated with new once during the program's initialization phase and only released during shutdown. This made little sense because much of the codebase expects it to be always present in memory.

This makes the array a bit faster to access and saves a couple of KB code size in a release build.