### PR TITLE
Fix crash when opening email box after save and load

### DIFF
--- a/src/game/Laptop/EMail.cc
+++ b/src/game/Laptop/EMail.cc
@@ -279,6 +279,9 @@ void GameInitEmail()
 	pEmailList=NULL;
 	pPageList=NULL;
 
+	CurrentMail = NULL;
+	PreviousMail = NULL;
+
 	iLastPage=-1;
 
 	iCurrentPage=0;

--- a/src/game/LoadSaveEMail.cc
+++ b/src/game/LoadSaveEMail.cc
@@ -43,6 +43,8 @@ void LoadEmailFromSavedGame(HWFILE const File)
 {
 	ShutDownEmailList();
 
+	GameInitEmail();
+
 	UINT32 uiNumOfEmails;
 	File->read(&uiNumOfEmails, sizeof(UINT32));
 


### PR DESCRIPTION
`CurrentMail` was not zeroed during load, so it pointed to the deleted object. Results can vary, but one of them is an assert firing in the string theory library:

```
string_theory/st_utf_conv.h:263: String data buffer is too large
```

fixes #1591