### PR TITLE
Make the editor crash less often

### DIFF
--- a/src/game/Editor/EditorMercs.cc
+++ b/src/game/Editor/EditorMercs.cc
@@ -220,6 +220,7 @@ static SoldierBodyType const bRebelArray[]    = { BODY_RANDOM, FATCIV, MANCIV, R
 static SoldierBodyType const bCivArray[]      = { BODY_RANDOM, FATCIV, MANCIV, MINICIV, DRESSCIV, HATKIDCIV, KIDCIV, REGMALE, BIGMALE, STOCKYMALE, REGFEMALE, HUMVEE, ELDORADO, ICECREAMTRUCK, JEEP, CRIPPLECIV, ROBOTNOWEAPON, COW };
 static SoldierBodyType gbCurrCreature = BLOODCAT;
 
+constexpr UINT8 NO_PAL_REP = 0xff;
 
 void GameInitEditorMercsInfo()
 {
@@ -304,7 +305,13 @@ void ProcessMercEditing(void)
 			return;
 	}
 
-	UINT8 ubPaletteRep = GetPaletteRepIndexFromID(*soldier_pal);
+	auto const paletteRep = GetPaletteRepIndexFromID(*soldier_pal);
+	if (!paletteRep)
+	{
+		return;
+	}
+	auto ubPaletteRep = *paletteRep;
+
 	const INT32 start = iEditColorStart[ubType];
 	const UINT8 range = gubpNumReplacementsPerRange[ubType];
 	if (iEditWhichStat & 1)
@@ -647,7 +654,7 @@ static void ShowEditMercPalettes(SOLDIERTYPE* pSoldier)
 		if (pSoldier->HeadPal.empty())
 			ubPaletteRep = 0xff;
 		else
-			ubPaletteRep = GetPaletteRepIndexFromID(pSoldier->HeadPal);
+			ubPaletteRep = GetPaletteRepIndexFromID(pSoldier->HeadPal).value_or(NO_PAL_REP);
 	}
 	ShowEditMercColorSet( ubPaletteRep, 0 );
 
@@ -656,7 +663,7 @@ static void ShowEditMercPalettes(SOLDIERTYPE* pSoldier)
 		if (pSoldier->SkinPal.empty())
 			ubPaletteRep = 0xff;
 		else
-			ubPaletteRep = GetPaletteRepIndexFromID(pSoldier->SkinPal);
+			ubPaletteRep = GetPaletteRepIndexFromID(pSoldier->SkinPal).value_or(NO_PAL_REP);
 	}
 	ShowEditMercColorSet( ubPaletteRep, 1 );
 
@@ -665,7 +672,7 @@ static void ShowEditMercPalettes(SOLDIERTYPE* pSoldier)
 		if (pSoldier->VestPal.empty())
 			ubPaletteRep = 0xff;
 		else
-			ubPaletteRep = GetPaletteRepIndexFromID(pSoldier->VestPal);
+			ubPaletteRep = GetPaletteRepIndexFromID(pSoldier->VestPal).value_or(NO_PAL_REP);
 	}
 	ShowEditMercColorSet( ubPaletteRep, 2 );
 
@@ -674,7 +681,7 @@ static void ShowEditMercPalettes(SOLDIERTYPE* pSoldier)
 		if (pSoldier->PantsPal.empty())
 			ubPaletteRep = 0xff;
 		else
-			ubPaletteRep = GetPaletteRepIndexFromID(pSoldier->PantsPal);
+			ubPaletteRep = GetPaletteRepIndexFromID(pSoldier->PantsPal).value_or(NO_PAL_REP);
 	}
 	ShowEditMercColorSet( ubPaletteRep, 3 );
 }
@@ -689,7 +696,7 @@ static void ShowEditMercColorSet(UINT8 ubPaletteRep, INT16 sSet)
 	INT16 sUnitSize;
 	INT16  sLeft, sTop, sRight, sBottom;
 
-	if( ubPaletteRep == 0xff )
+	if (ubPaletteRep == NO_PAL_REP)
 		ubSize = 16;
 	else
 		ubSize = gpPalRep[ ubPaletteRep ].ubPaletteSize;

--- a/src/game/JAScreens.cc
+++ b/src/game/JAScreens.cc
@@ -253,7 +253,13 @@ static void PalEditRenderHook(void)
 
 static void CyclePaletteReplacement(SOLDIERTYPE& s, ST::string& pal)
 {
-	UINT8 ubPaletteRep = GetPaletteRepIndexFromID(pal);
+	auto const paletteRep = GetPaletteRepIndexFromID(pal);
+	if (!paletteRep)
+	{
+		return;
+	}
+
+	auto ubPaletteRep = *paletteRep;
 	const UINT8 ubType = gpPalRep[ubPaletteRep].ubType;
 
 	ubPaletteRep++;

--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -5035,16 +5035,19 @@ void LoadPaletteData()
 void SetPaletteReplacement(SGPPaletteEntry* p8BPPPalette, const ST::string& aPalRep)
 {
 	UINT32 cnt2;
-	UINT8  ubType;
 
-	const UINT8 ubPalIndex = GetPaletteRepIndexFromID(aPalRep);
+	auto const ubPalIndex = GetPaletteRepIndexFromID(aPalRep);
+	if (!ubPalIndex)
+	{
+		return;
+	}
 
 	// Get range type
-	ubType = gpPalRep[ ubPalIndex ].ubType;
+	auto const ubType = gpPalRep[*ubPalIndex].ubType;
 
 	for ( cnt2 = gpPaletteSubRanges[ ubType ].ubStart; cnt2 <= gpPaletteSubRanges[ ubType ].ubEnd; cnt2++ )
 	{
-		p8BPPPalette[cnt2] = gpPalRep[ubPalIndex].rgb[cnt2 - gpPaletteSubRanges[ubType].ubStart];
+		p8BPPPalette[cnt2] = gpPalRep[*ubPalIndex].rgb[cnt2 - gpPaletteSubRanges[ubType].ubStart];
 	}
 }
 
@@ -5081,7 +5084,7 @@ void DeletePaletteData()
 }
 
 
-UINT8 GetPaletteRepIndexFromID(const ST::string& pal_rep)
+std::optional<UINT8> GetPaletteRepIndexFromID(const ST::string& pal_rep)
 {
 	// Check if type exists
 	for (UINT32 i = 0; i < guiNumReplacements; ++i)
@@ -5089,7 +5092,7 @@ UINT8 GetPaletteRepIndexFromID(const ST::string& pal_rep)
 		if (pal_rep.compare(gpPalRep[i].ID) == 0) return i;
 	}
 
-	throw std::logic_error("Invalid Palette Replacement ID given");
+	return {};
 }
 
 

--- a/src/game/Tactical/Soldier_Control.h
+++ b/src/game/Tactical/Soldier_Control.h
@@ -14,6 +14,7 @@
 #include "Timer_Control.h"
 
 #include <string_theory/string>
+#include <optional>
 
 
 // ANDREW: these are defines for OKDestanation usage - please move to approprite file
@@ -934,7 +935,7 @@ void ReviveSoldier( SOLDIERTYPE *pSoldier );
 
 // Palette functions for soldiers
 void  CreateSoldierPalettes(SOLDIERTYPE&);
-UINT8 GetPaletteRepIndexFromID(const ST::string& pal_rep);
+std::optional<UINT8> GetPaletteRepIndexFromID(const ST::string& pal_rep);
 void SetPaletteReplacement(SGPPaletteEntry* p8BPPPalette, const ST::string& aPalRep);
 void  LoadPaletteData(void);
 void  DeletePaletteData(void);

--- a/src/game/Tactical/Soldier_Init_List.cc
+++ b/src/game/Tactical/Soldier_Init_List.cc
@@ -1419,14 +1419,14 @@ void AddSoldierInitListCreatures(BOOLEAN fQueen, UINT8 ubNumLarvae, UINT8 ubNumI
 }
 
 
-SOLDIERINITNODE* FindSoldierInitNodeWithID( UINT16 usID )
+SOLDIERINITNODE* FindSoldierInitNodeWithID(SoldierID const soldierID)
 {
 	FOR_EACH_SOLDIERINITNODE(curr)
 	{
-		if( curr->pSoldier->ubID == usID )
+		if (curr->pSoldier && curr->pSoldier->ubID == soldierID)
 			return curr;
 	}
-	return NULL;
+	return nullptr;
 }
 
 
@@ -1436,7 +1436,7 @@ SOLDIERINITNODE* FindSoldierInitNodeBySoldier(SOLDIERTYPE const& s)
 	{
 		if (i->pSoldier == &s) return i;
 	}
-	return 0;
+	return nullptr;
 }
 
 

--- a/src/game/Tactical/Soldier_Init_List.h
+++ b/src/game/Tactical/Soldier_Init_List.h
@@ -45,7 +45,7 @@ void InitSoldierInitList(void);
 void KillSoldierInitList(void);
 SOLDIERINITNODE* AddBasicPlacementToSoldierInitList(BASIC_SOLDIERCREATE_STRUCT const&);
 void RemoveSoldierNodeFromInitList( SOLDIERINITNODE *pNode );
-SOLDIERINITNODE* FindSoldierInitNodeWithID( UINT16 usID );
+SOLDIERINITNODE* FindSoldierInitNodeWithID(SoldierID soldierID);
 SOLDIERINITNODE* FindSoldierInitNodeBySoldier(SOLDIERTYPE const&);
 
 void AddSoldierInitListTeamToWorld(INT8 team);

--- a/src/game/Utils/Utilities.cc
+++ b/src/game/Utils/Utilities.cc
@@ -45,15 +45,18 @@ void DisplayPaletteRep(const ST::string& aPalRep, UINT8 ubXPos, UINT8 ubYPos, SG
 {
 	UINT16 us16BPPColor;
 	UINT32 cnt1;
-	UINT8  ubSize;
 	INT16  sTLX, sTLY, sBRX, sBRY;
 
 	// Create 16BPP Palette
-	const UINT8 ubPaletteRep = GetPaletteRepIndexFromID(aPalRep);
+	auto const ubPaletteRep = GetPaletteRepIndexFromID(aPalRep);
+	if (!ubPaletteRep)
+	{
+		return;
+	}
 
 	SetFont( LARGEFONT1 );
 
-	ubSize = gpPalRep[ ubPaletteRep ].ubPaletteSize;
+	auto const ubSize = gpPalRep[*ubPaletteRep].ubPaletteSize;
 
 	for ( cnt1 = 0; cnt1 < ubSize; cnt1++ )
 	{
@@ -62,11 +65,11 @@ void DisplayPaletteRep(const ST::string& aPalRep, UINT8 ubXPos, UINT8 ubYPos, SG
 		sBRX = sTLX + 20;
 		sBRY = sTLY + 20;
 
-		const SGPPaletteEntry* Clr = &gpPalRep[ubPaletteRep].rgb[cnt1];
+		auto const * const Clr = &gpPalRep[*ubPaletteRep].rgb[cnt1];
 		us16BPPColor = Get16BPPColor(FROMRGB(Clr->r, Clr->g, Clr->b));
 
 		ColorFillVideoSurfaceArea(dst, sTLX, sTLY, sBRX, sBRY, us16BPPColor);
 	}
 
-	GPrint(ubXPos + 16 * 20, ubYPos, ST::format("{}", gpPalRep[ubPaletteRep].ID));
+	GPrint(ubXPos + 16 * 20, ubYPos, gpPalRep[*ubPaletteRep].ID);
 }


### PR DESCRIPTION
• Fix null pointer deref in FindSoldierInitNodeWithID when trying to
  add a soldier to an already full team
• GetPaletteRepIndexFromID does no longer throw an exception; the editor
  uses this function to determine if there is a valid replacement

The first one is a vanilla bug; the exception was added in 71bd4e296a11e46dbe8593f67359cbd388c9e2ea  but I think this change failed to take the editor's needs into account.