### PR TITLE
Handle attempts to promote militia better

### DIFF
--- a/src/game/Strategic/Auto_Resolve.cc
+++ b/src/game/Strategic/Auto_Resolve.cc
@@ -1752,12 +1752,14 @@ static void RemoveAutoResolveInterface(bool const delete_for_good)
 	{
 		if (!gpCivs[i].pSoldier) continue;
 		SOLDIERTYPE& s = *gpCivs[i].pSoldier;
+		// The soldiers in the gpCivs array should all be regular militia
+		// members. Thr might get promoted before they're removed.
+		auto const rank = SoldierClassToMilitiaRank(s.ubSoldierClass);
 
-		UINT8 current_rank = SoldierClassToMilitiaRank(s.ubSoldierClass);
-		if (current_rank >= MAX_MILITIA_LEVELS) throw std::runtime_error(ST::format("Removing autoresolve militia with invalid ubSoldierClass {}.", s.ubSoldierClass).to_std_string());
-
-		if (delete_for_good)
+		if (rank && delete_for_good)
 		{
+			auto current_rank = *rank;
+
 			if (s.bLife < OKLIFE / 2)
 			{
 				AddDeadSoldierToUnLoadedSector(arSector, &s, RandomGridNo(), ADD_DEAD_SOLDIER_TO_SWEETSPOT);

--- a/src/game/Strategic/Town_Militia.cc
+++ b/src/game/Strategic/Town_Militia.cc
@@ -189,14 +189,14 @@ void TownMilitiaTrainingCompleted(SOLDIERTYPE *pTrainer, const SGPSector& sector
 }
 
 
-INT8 SoldierClassToMilitiaRank(UINT8 const soldier_class)
+std::optional<UINT8> SoldierClassToMilitiaRank(UINT8 const soldier_class)
 {
 	switch (soldier_class)
 	{
 		case SOLDIER_CLASS_GREEN_MILITIA: return GREEN_MILITIA;
 		case SOLDIER_CLASS_REG_MILITIA:   return REGULAR_MILITIA;
 		case SOLDIER_CLASS_ELITE_MILITIA: return ELITE_MILITIA;
-		default:                          return -1;
+		default:                          return {};
 	}
 }
 

--- a/src/game/Strategic/Town_Militia.h
+++ b/src/game/Strategic/Town_Militia.h
@@ -6,6 +6,7 @@
 #include "JA2Types.h"
 
 #include <string_theory/string>
+#include <optional>
 
 
 // how many militia of all ranks can be in any one sector at once
@@ -25,8 +26,8 @@
 // this handles what happens when a new militia unit is finishes getting trained
 void TownMilitiaTrainingCompleted(SOLDIERTYPE *pTrainer, const SGPSector& sector);
 
-// Given a SOLDIER_CLASS_ returns a _MITILIA rank or -1 if it is not militia
-INT8 SoldierClassToMilitiaRank(UINT8 soldier_class);
+// Given a SOLDIER_CLASS_ returns a _MITILIA rank if it is militia
+std::optional<UINT8> SoldierClassToMilitiaRank(UINT8 soldier_class);
 
 // remove militias of a certain rank
 void StrategicRemoveMilitiaFromSector(const SGPSector& sMap, UINT8 ubRank, UINT8 ubHowMany);

--- a/src/game/Tactical/Militia_Control.cc
+++ b/src/game/Tactical/Militia_Control.cc
@@ -73,8 +73,11 @@ void HandleMilitiaPromotions()
 		if (s.bLife <= 0)          continue;
 		if (s.ubMilitiaKills == 0) continue;
 
-		UINT8 militia_rank = SoldierClassToMilitiaRank(s.ubSoldierClass);
-		if (militia_rank >= MAX_MILITIA_LEVELS)      throw std::logic_error("invalid militia rank");
+		// Is this a regular militia or a "rebel" (the editor kind, not the
+		// A10 basement kind? Only regular milita can be promoted.
+		auto const rank = SoldierClassToMilitiaRank(s.ubSoldierClass);
+		if (!rank) continue;
+		auto militia_rank = *rank;
 
 		UINT8 const promotions   = CheckOneMilitiaForPromotion(gWorldSector, militia_rank, s.ubMilitiaKills);
 		if (promotions != 0)

--- a/src/game/Tactical/Overhead.cc
+++ b/src/game/Tactical/Overhead.cc
@@ -2520,11 +2520,11 @@ void HandleNPCTeamMemberDeath(SOLDIERTYPE* const pSoldierOld)
 	}
 	else if (pSoldierOld->bTeam == MILITIA_TEAM)
 	{
-		const INT8 bMilitiaRank = SoldierClassToMilitiaRank(pSoldierOld->ubSoldierClass);
-		if (bMilitiaRank != -1)
+		auto const militiaRank = SoldierClassToMilitiaRank(pSoldierOld->ubSoldierClass);
+		if (militiaRank)
 		{
 			// remove this militia from the strategic records
-			StrategicRemoveMilitiaFromSector(gWorldSector, bMilitiaRank, 1);
+			StrategicRemoveMilitiaFromSector(gWorldSector, *militiaRank, 1);
 		}
 
 		// also treat this as murder - but player will never be blamed for militia death he didn't cause


### PR DESCRIPTION
Not all members of the militia team are trainable militia as in vanilla; the editor also allows to add so-called "rebels" to this team. Mods should be able to use these rebels without crashing the game when we try to promote militia after a successful fight.

Fixes #1886.