### PR TITLE
Fix editing of keys

### DIFF
--- a/src/game/Editor/EditorBuildings.cc
+++ b/src/game/Editor/EditorBuildings.cc
@@ -1,7 +1,9 @@
 #include "Button_System.h"
 #include "Cursor_Modes.h"
 #include "Directories.h"
+#include "EditScreen.h"
 #include "Font.h"
+#include "Handle_UI.h"
 #include "Isometric_Utils.h"
 #include "Edit_Sys.h"
 #include "Font_Control.h"
@@ -506,6 +508,11 @@ void InitDoorEditing(INT32 const map_idx)
 {
 	if (!DoorAtGridNo(map_idx) && !OpenableAtGridNo(map_idx)) return;
 
+	// Let HandleMouseClicksInGameScreen() know it should ignore clicks,
+	// otherwise it would call this function for every mouse click. We
+	// restore the old value in KillDoorEditing().
+	iDrawMode = DRAW_MODE_NOTHING;
+
 	gfEditingDoor = TRUE;
 	iDoorMapIndex = map_idx;
 	DisableEditorTaskbar();
@@ -637,6 +644,8 @@ void KillDoorEditing()
 	MSYS_RemoveRegion(&DoorRegion);
 	FOR_EACH(GUIButtonRef, i, iDoorButton) RemoveButton(*i);
 	gfEditingDoor = FALSE;
+	// Restore the draw mode that we changed in InitDoorEditing().
+	iDrawMode = DRAW_MODE_DOORKEYS;
 	KillTextInputMode();
 }
 


### PR DESCRIPTION
HandleMouseClicksInGameScreen() could call InitDoorEditing() again and again, leading to a stack of buttons and text input fields on top of each other that were impossible to get rid of completely.

Also Text_Input.cc didn't properly update all its pointers when pushing or popping an editing context.

Fixes #1892.