### PR TITLE
Fix compilation failures due to missing headers

### DIFF
--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -56,7 +56,7 @@ struct GARRISON_GROUP;
 class ContentManager : public ItemSystem, public MercSystem
 {
 public:
-	virtual ~ContentManager() noexcept(false) {};
+	virtual ~ContentManager() = default;
 
 	virtual void logConfiguration() const = 0;
 
@@ -121,7 +121,7 @@ public:
 	virtual const std::vector<ARMY_COMPOSITION>& getArmyCompositions() const = 0;
 
 	virtual const DealerModel* getDealer(uint8_t dealerID) const = 0;
-	virtual const std::vector<const DealerModel*> getDealers() const = 0;
+	virtual const std::vector<const DealerModel*>& getDealers() const = 0;
 
 	virtual const DealerInventory* getDealerInventory(int dealerId) const = 0;
 	virtual const DealerInventory* getBobbyRayNewInventory() const = 0;

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -142,11 +142,10 @@ void deleteElements(std::map<K, const V*> & map)
 	}
 }
 
-DefaultContentManager::~DefaultContentManager() noexcept(false)
+DefaultContentManager::~DefaultContentManager()
 {
 	// Deconstruction of vectors containing non-pointer types
 	// is left to the compiler, no need to clear() them.
-	SLOGD("Shutting Down Content Manager");
 
 	deleteElements(m_items);
 	deleteElements(m_calibres);
@@ -170,10 +169,6 @@ DefaultContentManager::~DefaultContentManager() noexcept(false)
 	deleteElements(m_mercProfileInfo);
 	deleteElements(m_mercProfiles);
 	deleteElements(m_vehicles);
-
-	m_vfs.reset();
-	m_tempDir.reset();
-	m_engineOptions.reset();
 }
 
 const DealerInventory* DefaultContentManager::getBobbyRayNewInventory() const
@@ -191,7 +186,7 @@ const DealerModel* DefaultContentManager::getDealer(uint8_t dealerID) const
 	return m_dealers[dealerID];
 }
 
-const std::vector<const DealerModel*> DefaultContentManager::getDealers() const
+const std::vector<const DealerModel*>& DefaultContentManager::getDealers() const
 {
 	return m_dealers;
 }
@@ -246,7 +241,7 @@ const FactParamsModel* DefaultContentManager::getFactParams(Fact fact) const
 /** Get map file path. */
 ST::string DefaultContentManager::getMapPath(const ST::string& mapName) const
 {
-	ST::string const result = MAPSDIR "/" + mapName;
+	ST::string result = MAPSDIR "/" + mapName;
 
 	SLOGD("map file {}", result);
 
@@ -256,7 +251,7 @@ ST::string DefaultContentManager::getMapPath(const ST::string& mapName) const
 /** Get radar map resource name. */
 ST::string DefaultContentManager::getRadarMapResourceName(const ST::string &mapName) const
 {
-	ST::string const result = RADARMAPSDIR "/" + mapName;
+	ST::string result = RADARMAPSDIR "/" + mapName;
 
 	SLOGD("map file {}", result);
 
@@ -856,7 +851,7 @@ std::vector<ST::string> DefaultContentManager::getAllSmallInventoryGraphicPaths(
 	return v;
 }
 
-const std::map<uint16_t, uint16_t> DefaultContentManager::getMapItemReplacements() const
+const std::map<uint16_t, uint16_t>& DefaultContentManager::getMapItemReplacements() const
 {
 	return m_mapItemReplacements;
 }

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -25,7 +25,7 @@ class DefaultContentManager : public ContentManager, public IGameDataLoader
 public:
 	DefaultContentManager(RustPointer<EngineOptions> engineOptions);
 
-	virtual ~DefaultContentManager() noexcept(false) override;
+	virtual ~DefaultContentManager() override;
 
 	void logConfiguration() const override;
 
@@ -92,7 +92,7 @@ public:
 	virtual const ItemModel* getItemByName(const ST::string &internalName) const override;
 	virtual const ItemModel* getKeyItemForKeyId(uint16_t usKeyItem) const override;
 	virtual std::vector<ST::string> getAllSmallInventoryGraphicPaths() const override;
-	virtual const std::map<uint16_t, uint16_t> getMapItemReplacements() const override;
+	virtual const std::map<uint16_t, uint16_t>& getMapItemReplacements() const override;
 
 	virtual const std::vector<std::vector<const WeaponModel*> > & getNormalGunChoice() const override;
 	virtual const std::vector<std::vector<const WeaponModel*> > & getExtendedGunChoice() const override;
@@ -105,7 +105,7 @@ public:
 	virtual const DealerInventory* getBobbyRayUsedInventory() const override;
 
 	virtual const DealerModel* getDealer(uint8_t dealerID) const override;
-	virtual const std::vector<const DealerModel*> getDealers() const override;
+	virtual const std::vector<const DealerModel*> & getDealers() const override;
 
 	virtual const std::vector<const ShippingDestinationModel*>& getShippingDestinations() const override;
 	virtual const ShippingDestinationModel* getShippingDestination(uint8_t locationId) const override;

--- a/src/externalized/ItemSystem.h
+++ b/src/externalized/ItemSystem.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "stdint.h"
 #include <string_theory/string>
 #include <vector>
 #include <map>
@@ -19,7 +20,7 @@ public:
 	virtual std::vector<ST::string> getAllSmallInventoryGraphicPaths() const = 0;
 
 	// Returns item replacements for maps
-	virtual const std::map<uint16_t, uint16_t> getMapItemReplacements() const = 0;
+	virtual const std::map<uint16_t, uint16_t>& getMapItemReplacements() const = 0;
 
 	// Returns a key for
 	virtual const ItemModel* getKeyItemForKeyId(uint16_t usKeyItem) const = 0;

--- a/src/game/Strategic/QuestText.h
+++ b/src/game/Strategic/QuestText.h
@@ -1,6 +1,7 @@
 #ifndef _QUEST_TEXT_H_
 #define _QUEST_TEXT_H_
 
+#include "stdint.h"
 #include <string_theory/string>
 
 

--- a/src/game/Tactical/Arms_Dealer_Init.cc
+++ b/src/game/Tactical/Arms_Dealer_Init.cc
@@ -451,7 +451,7 @@ static void LimitArmsDealersInventory(ArmsDealerID, UINT32 uiDealerItemType, UIN
 
 static void AdjustCertainDealersInventory(void)
 {
-	auto dealers = GCM->getDealers();
+	auto const& dealers = GCM->getDealers();
 
 	//Adjust Tony's items (this restocks *instantly* 1/day, doesn't use the reorder system)
 	GuaranteeAtLeastOneItemOfType( ARMS_DEALER_TONY, ARMS_DEALER_BIG_GUNS );

--- a/src/game/Tactical/World_Items.cc
+++ b/src/game/Tactical/World_Items.cc
@@ -237,7 +237,7 @@ void LoadWorldItemsFromMap(HWFILE const f)
 
 	// Read the number of items that were saved in the map
 	UINT32 n_world_items;
-	auto itemReplacements = GCM->getMapItemReplacements();
+	auto const& itemReplacements = GCM->getMapItemReplacements();
 	f->read(&n_world_items, sizeof(n_world_items));
 
 	if (gTacticalStatus.uiFlags & LOADING_SAVED_GAME && !gfEditMode)

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -68,6 +68,7 @@ static void shutdownGame()
 		ShutdownGame();
 	}
 
+	SLOGD("Shutting Down Content Manager");
 	delete GCM;
 	GCM = NULL;
 


### PR DESCRIPTION
Compilation failed with GCC13 when precompiled headers were disabled. Also addresses some other minor issues:
• Unnecessary copy of a map and a vector
• move SLOGD out of DefaultContentManager's destructor so it
  can be noexcept
• Pointed out by clangd: const keyword prevents return value
  optimization