### PR TITLE
Cursor hides on action, reselects targets.

### DIFF
--- a/src/game/Tactical/Handle_UI.cc
+++ b/src/game/Tactical/Handle_UI.cc
@@ -598,6 +598,10 @@ ScreenID HandleTacticalUI(void)
 		}
 	}
 
+	if ( gCurrentUIMode == CONFIRM_ACTION_MODE || gCurrentUIMode == LOCKOURTURN_UI_MODE ) {
+		RefreshMouseRegions();
+	}
+
 	return( ReturnVal );
 }
 
@@ -2706,6 +2710,7 @@ BOOLEAN UIHandleOnMerc( BOOLEAN fMovementMode )
 						gUIActionModeChangeDueToMouseOver = TRUE;
 
 						guiPendingOverrideEvent = M_CHANGE_TO_ACTION;
+						gfUIForceReExamineCursorData = TRUE;
 						// Return FALSE
 						return( FALSE );
 					}

--- a/src/game/Tactical/Handle_UI.cc
+++ b/src/game/Tactical/Handle_UI.cc
@@ -598,10 +598,6 @@ ScreenID HandleTacticalUI(void)
 		}
 	}
 
-	if ( gCurrentUIMode == CONFIRM_ACTION_MODE || gCurrentUIMode == LOCKOURTURN_UI_MODE ) {
-		RefreshMouseRegions();
-	}
-
 	return( ReturnVal );
 }
 
@@ -905,6 +901,9 @@ static void SetUIMouseCursor(void)
 				guiCurrentUICursor = guiNewUICursor;
 			}
 		}
+	}
+	if ( gCurrentUIMode == CONFIRM_ACTION_MODE || gCurrentUIMode == LOCKOURTURN_UI_MODE ) {
+		RefreshMouseRegions();
 	}
 }
 


### PR DESCRIPTION
Reintroduces pre-touch screen behavior of the cursor disappearing during an action in turn-based mode as well as no longer requiring a double-click or moving the cursor off a target for follow up shots as the cursor is re-examined after an action.  Solves issue #1735 