### PR TITLE
Workaround for the Z-Blitter address sanitizer problem

### DIFF
--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -1708,21 +1708,12 @@ void AddZStripInfoToVObject(HVOBJECT const hVObject, STRUCTURE_FILE_REF const* c
 
 					// now create the array!
 					pCurr->ubNumberOfZChanges = ubNumIncreasing + ubNumStable + ubNumDecreasing;
-					pCurr->pbZChange = new INT8[pCurr->ubNumberOfZChanges]{};
+					Assert(pCurr->ubNumberOfZChanges <= std::size(pCurr->pbZChange));
+					auto end = std::fill_n(pCurr->pbZChange, ubNumIncreasing, 1);
+					     end = std::fill_n(end, ubNumStable, 0);
+					     end = std::fill_n(end, ubNumDecreasing, -1);
+					std::fill(end, std::end(pCurr->pbZChange), 0);
 
-					UINT8 ubLoop2;
-					for (ubLoop2 = 0; ubLoop2 < ubNumIncreasing; ubLoop2++)
-					{
-						pCurr->pbZChange[ubLoop2] = 1;
-					}
-					for (; ubLoop2 < ubNumIncreasing + ubNumStable; ubLoop2++)
-					{
-						pCurr->pbZChange[ubLoop2] = 0;
-					}
-					for (; ubLoop2 < pCurr->ubNumberOfZChanges; ubLoop2++)
-					{
-						pCurr->pbZChange[ubLoop2] = -1;
-					}
 					if (ubNumIncreasing > 0)
 					{
 						pCurr->bInitialZChange = -ubNumIncreasing;

--- a/src/sgp/VObject.cc
+++ b/src/sgp/VObject.cc
@@ -78,7 +78,6 @@ SGPVObject::~SGPVObject()
 		{
 			if (ppZStripInfo[usLoop] != NULL)
 			{
-				delete[] ppZStripInfo[usLoop]->pbZChange;
 				delete ppZStripInfo[usLoop];
 			}
 		}

--- a/src/sgp/VObject.h
+++ b/src/sgp/VObject.h
@@ -12,10 +12,10 @@
 // Z-buffer info structure for properly assigning Z values
 struct ZStripInfo
 {
+	INT8  pbZChange[16];      // change to the Z value in each strip (after the first)
 	INT8  bInitialZChange;    // difference in Z value between the leftmost and base strips
 	UINT8 ubFirstZStripWidth; // # of pixels in the leftmost strip
 	UINT8 ubNumberOfZChanges; // number of strips (after the first)
-	INT8* pbZChange;          // change to the Z value in each strip (after the first)
 };
 
 // This definition mimics what is found in WINDOWS.H ( for Direct Draw compatiblity )


### PR DESCRIPTION
The Z-Blitter functions disagree with AddZStripInfoToVObject about the format of the zchange array in a ZStripInfo, which leads to constant complaints (with valgrind) or crashes (in ASAN builds) when blitting some multitile VObjects. Since nobody seems to fully understand what this code is supposed to do, this commit changes the zchange array to a fixed size of 16 bytes. Each byte is supposed to represent the z change of 20 pixels, so this is enough for multitile VObjects up to 320 pixels wide. AFAIK the biggest asset in the original game data is the queen monster, which requires a zchange array of 10 bytes, so 16 bytes should be plenty.