### PR TITLE
Rework burst sound logic

### DIFF
--- a/assets/externalized/weapons.json
+++ b/assets/externalized/weapons.json
@@ -1726,7 +1726,6 @@
         "usRange": 500,
         "ubAttackVolume": 82,
         "ubHitVolume": 8,
-        "burstSound": "sounds/weapons/bursttype1.wav",
         "attachment_SniperScope": true,
         "attachment_LaserScope": true,
         "attachment_Bipod": true,


### PR DESCRIPTION
This should fix the problem of the missing sound for CAWS buckshot ammo and the RPK74 using the generic sound even when the 5.45 burst sound is available (when we have four or less shots left). Issues #1730 and #1764.

This could definitely use more testing, I'd appreciate help here. This is what I found with two known problematic weapons:


|CAWS, CAWS buckshot magazine||
|---|---|
|>=3 bullets left| bursttype1.wav|
|2 bullets left| bursttype1.wav|
|1 bullet left| bursttype1.wav|

|CAWS, CAWS magazine||
|---|---|
|>=3 bullets left| shotgun burst 3.wav|
|2 bullets left| shotgun burst 2.wav|
|1 bullet left| shotgun single shot.wav|

|RPK74||
|---|---|
|>=5 bullets left:|bursttype1.wav|
|4 bullets left| 5,45 burst 4.wav|
|3 bullets left| 5,45 burst 3.wav|
|2 bullets left| 5,45 burst 2.wav|
|1 bullet left| 5,45 burst 1.wav|

Does that  seem reasonable?

Save game for testing, so you don't have to set things up yourself: 
[2023-09-29t11-29-13z-burst-sound-test.zip](https://github.com/ja2-stracciatella/ja2-stracciatella/files/12765552/2023-09-29t11-29-13z-burst-sound-test.zip)
