### PR TITLE
Change configuration directory on Windows to AppData

### DIFF
--- a/rust/stracciatella/src/config/stracciatella_home.rs
+++ b/rust/stracciatella/src/config/stracciatella_home.rs
@@ -1,10 +1,15 @@
+use crate::fs::resolve_existing_components;
 use std::path::PathBuf;
 
-/// Find ja2 stracciatella configuration directory inside the user's home directory
-pub fn find_stracciatella_home() -> Result<PathBuf, String> {
-    use crate::fs::resolve_existing_components;
+#[cfg(not(windows))]
+const STRACCIATELLA_HOME_DIR_NAME: &str = ".ja2";
+#[cfg(windows)]
+const STRACCIATELLA_HOME_DIR_NAME: &str = "JA2";
 
-    #[cfg(all(not(windows), not(target_os = "android")))]
+#[cfg(not(windows))]
+/// Find ja2 stracciatella configuration directory inside the user's home directory or the android app dir
+pub fn find_stracciatella_home() -> Result<PathBuf, String> {
+    #[cfg(not(target_os = "android"))]
     let base = dirs::home_dir();
     #[cfg(target_os = "android")]
     let base = match crate::android::get_android_app_dir() {
@@ -14,20 +19,48 @@ pub fn find_stracciatella_home() -> Result<PathBuf, String> {
             None
         }
     };
-    #[cfg(windows)]
-    let base = dirs::document_dir();
-    #[cfg(not(windows))]
-    let dir = ".ja2";
-    #[cfg(windows)]
-    let dir = "JA2";
 
     match base {
         Some(mut path) => {
-            path.push(dir);
+            path.push(STRACCIATELLA_HOME_DIR_NAME);
             Ok(resolve_existing_components(&path, None, true))
         }
         None => Err(String::from("Could not find home directory")),
     }
+}
+
+#[cfg(windows)]
+/// Find ja2 stracciatella configuration directory
+/// First try the new one inside the appdata directory. If that does not exist and the old one does, return the old one. Otherwise return the new one.
+pub fn find_stracciatella_home() -> Result<PathBuf, String> {
+    use std::borrow::Cow;
+
+    let get_dir_info = |p: PathBuf| {
+        let p = resolve_existing_components(&p.join(STRACCIATELLA_HOME_DIR_NAME), None, true);
+        let exists = p.exists();
+        (p, exists)
+    };
+    let old = dirs::document_dir().map(get_dir_info);
+    let new = dirs::config_dir().map(get_dir_info);
+
+    if let Some((new, true)) = new {
+        // New one already exists, use this one
+        return Ok(new);
+    }
+    if let Some((old, true)) = old {
+        // Old one exists, warn and use this one
+        log::warn!(
+            "The old configuration directory `{}` is deprecated. Please move your data to the new one: `{}`.",
+            old.to_string_lossy(),
+            new.as_ref().map(|(p, _)| p.to_string_lossy()).unwrap_or_else(|| Cow::Borrowed("<failed to find new directory>")),
+        );
+        return Ok(old);
+    }
+    if let Some((new, _)) = new {
+        // None of them exists, use new one
+        return Ok(new);
+    }
+    Err(String::from("Could not find home directory"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The new dir should be: `C:\Users\Alice\AppData\Roaming\JA2`, which is not influenced by MS Defender on Windows.

Closes https://github.com/ja2-stracciatella/ja2-stracciatella/issues/1864.

I need someone to test this though, as I dont have a Windows system available to me.