### PR TITLE
Remove remove_dir_all rust dependency

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -988,19 +988,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "remove_dir_all"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882f368737489ea543bc5c340e6f3d34a28c39980bd9a979e47322b26f60ac40"
-dependencies = [
- "libc",
- "log",
- "num_cpus",
- "rayon",
- "winapi",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,7 +1117,6 @@ dependencies = [
  "ndk-sys",
  "rayon",
  "regex",
- "remove_dir_all 0.7.0",
  "send_wrapper",
  "serde",
  "serde_json",
@@ -1194,7 +1180,7 @@ dependencies = [
  "fastrand",
  "libc",
  "redox_syscall",
- "remove_dir_all 0.5.3",
+ "remove_dir_all",
  "winapi",
 ]
 

--- a/rust/stracciatella/Cargo.toml
+++ b/rust/stracciatella/Cargo.toml
@@ -30,7 +30,6 @@ lru = "0.8"
 rayon = "1.6"
 dunce = "1.0"
 regex = "1.7"
-remove_dir_all = "0.7"
 tempfile = "3.3"
 slug = "0.1.4"
 

--- a/rust/stracciatella/src/fs.rs
+++ b/rust/stracciatella/src/fs.rs
@@ -29,10 +29,6 @@ pub use tempfile::{Builder as TempBuilder, NamedTempFile, TempDir};
 // replacements
 //--------------
 
-/// A reliable implementation of remove_dir_all for Windows.
-/// For other systems it re-exports std::fs::remove_dir_all.
-pub use remove_dir_all::remove_dir_all;
-
 /// Returns the canonical, absolute form of a path with all intermediate
 /// components normalized and symbolic links resolved.
 ///

--- a/rust/stracciatella/src/vfs/mod.rs
+++ b/rust/stracciatella/src/vfs/mod.rs
@@ -412,7 +412,7 @@ mod tests {
         let mut vfs = Vfs::new();
         vfs.init(&engine_options, &mod_manager).unwrap();
 
-        crate::fs::remove_dir_all(&engine_options.stracciatella_home.join("mods/test-mod/data"))
+        std::fs::remove_dir_all(&engine_options.stracciatella_home.join("mods/test-mod/data"))
             .expect("remove `test-mod/data` dir");
         std::fs::create_dir_all(&engine_options.stracciatella_home.join("mods/test-mod/dAtA"))
             .expect("create `test-mod/dAtA` dir");

--- a/rust/stracciatella_c_api/src/c/fs/mod.rs
+++ b/rust/stracciatella_c_api/src/c/fs/mod.rs
@@ -142,19 +142,6 @@ pub extern "C" fn Fs_modifiedSecs(path: *const c_char, modified_secs: *mut f64) 
     no_rust_error()
 }
 
-/// Removes a directory and all it's contents.
-/// Sets the rust error.
-/// @see https://doc.rust-lang.org/std/fs/fn.remove_dir_all.html
-#[no_mangle]
-pub extern "C" fn Fs_removeDirAll(dir: *const c_char) -> bool {
-    forget_rust_error();
-    let dir = path_buf_from_c_str_or_panic(unsafe_c_str(dir));
-    if let Err(err) = fs::remove_dir_all(&dir) {
-        remember_rust_error(format!("Fs_removeDirAll {:?}: {}", dir, err));
-    }
-    no_rust_error()
-}
-
 /// Removes a file.
 /// Sets the rust error.
 /// @see https://doc.rust-lang.org/std/fs/fn.remove_file.html


### PR DESCRIPTION
Some linking issues with the new version still exist, but we dont even use it, except for one test where the directory is empty anyways.