### PR TITLE
Upgrade string_theory to 3.8

### DIFF
--- a/dependencies/lib-string_theory/builder/CMakeLists.txt.in
+++ b/dependencies/lib-string_theory/builder/CMakeLists.txt.in
@@ -12,8 +12,8 @@ project(builder NONE)
 
 include(ExternalProject)
 externalproject_add(string_theory
-    URL "https://github.com/zrax/string_theory/archive/3.7.tar.gz"
-    URL_MD5 "08908b927d1b26e00b61cb6f32e5beb4"
+    URL "https://github.com/zrax/string_theory/archive/3.8.tar.gz"
+    URL_MD5 "910af6773498c6064e9d14d935d2603d"
     CMAKE_ARGS
         "-G@CMAKE_GENERATOR@"
         "-C@CACHE_FILE@"


### PR DESCRIPTION
Closes the overflow bug reported by @momoko-h  https://github.com/zrax/string_theory/issues/29.

Also closes the stdint include issues.