### PR TITLE
Load the big map of Arulco just once

### DIFF
--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -1308,9 +1308,6 @@ static void RefreshMapScreen()
 // THIS IS STUFF THAT RUNS *ONCE* DURING APPLICATION EXECUTION, AT INITIAL STARTUP
 void MapScreenInit(void)
 {
-	// init palettes for big map
-	InitializePalettesForMap( );
-
 	InitMapScreenInterfaceMap();
 
 	// set up leave list arrays for dismissed mercs
@@ -1326,8 +1323,6 @@ void MapScreenShutdown(void)
 {
 	// free up alloced mapscreen messages
 	FreeGlobalMessageList( );
-
-	ShutDownPalettesForMap( );
 
 	// free memory for leave list arrays for dismissed mercs
 	ShutDownLeaveList( );

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -832,11 +832,10 @@ static void ShadeMapElem(const SGPSector& sMap, const INT32 iColor)
 	map->p16BPPPalette = org_pal;
 }
 
-void InitializePalettesForMap(void)
-{
-	std::unique_ptr<SGPVSurface> uiTempMap(AddVideoSurfaceFromFile(INTERFACEDIR "/b_map.pcx"));
 
-	SGPPaletteEntry const* const pal = uiTempMap->GetPalette();
+static void InitializePalettesForMap(SGPPaletteEntry const * const pal)
+{
+	if (pMapDKGreenPalette) return;
 
 	pMapLTRedPalette   = Create16BPPPaletteShaded(pal, 400,   0, 0, TRUE);
 	pMapDKRedPalette   = Create16BPPPaletteShaded(pal, 200,   0, 0, TRUE);
@@ -845,7 +844,7 @@ void InitializePalettesForMap(void)
 }
 
 
-void ShutDownPalettesForMap(void)
+static void ShutDownPalettesForMap()
 {
 	delete[] pMapLTRedPalette;
 	delete[] pMapDKRedPalette;
@@ -2722,6 +2721,8 @@ void LoadMapScreenInterfaceMapGraphics()
 			gSecretSiteIcons[path] = AddVideoObjectFromFile(path);
 		}
 	}
+
+	InitializePalettesForMap(guiBIGMAP->GetPalette());
 }
 
 
@@ -2750,6 +2751,8 @@ void DeleteMapScreenInterfaceMapGraphics()
 		DeleteVideoObject(pair.second);
 	}
 	gSecretSiteIcons.clear();
+
+	ShutDownPalettesForMap();
 }
 
 

--- a/src/game/Strategic/Map_Screen_Interface_Map.h
+++ b/src/game/Strategic/Map_Screen_Interface_Map.h
@@ -15,9 +15,6 @@ void DrawMap(void);
 
 void GetScreenXYFromMapXY(const SGPSector& sMap, INT16 *psX, INT16 *psY);
 
-void InitializePalettesForMap(void);
-void ShutDownPalettesForMap( void );
-
 // plot path for helicopter
 void PlotPathForHelicopter(const SGPSector& sector);
 


### PR DESCRIPTION
b_map.pcx was loaded twice and copied to a surface twice during startup, once just to compute the green and red alternative palettes for the map. The palettes are now generated later, from the surface that is actually used during the game.

Not really a big deal, modern CPUs are just too fast to care about loading a ~450k PCX file.