### PR TITLE
Clarify Lua 5.3 version dependency

### DIFF
--- a/dependencies/lib-lua/CMakeLists.txt
+++ b/dependencies/lib-lua/CMakeLists.txt
@@ -3,7 +3,7 @@
 option(LOCAL_LUA_LIB "Download and build Lua instead of searching the system" ON)
 if (NOT LOCAL_LUA_LIB)
     message(STATUS "Using system Lua")
-    find_package(Lua "5.3" REQUIRED)
+    find_package(Lua "5.3" REQUIRED EXACT)
     if (NOT LUA_FOUND)
         message(FATAL_ERROR "Lua 5.3 not found")
     endif()


### PR DESCRIPTION
The project needs exactly lua 5.3 to build.
Add EXACT to lib-lia's CMakeLists.txt.