### PR TITLE
Fix memory leak in DrawMercsFaceToScreen

### DIFF
--- a/src/game/Laptop/AIMFacialIndex.cc
+++ b/src/game/Laptop/AIMFacialIndex.cc
@@ -246,7 +246,11 @@ static void DrawMercsFaceToScreen(const UINT8 ubMercID, const UINT16 usPosX, con
 	if (IsMercDead(p))
 	{
 		// the merc is dead, so shade the face red
-		face->pShades[0] = Create16BPPPaletteShaded(face->Palette(), DEAD_MERC_COLOR_RED, DEAD_MERC_COLOR_GREEN, DEAD_MERC_COLOR_BLUE, TRUE);
+		if (face->pShades[0] == nullptr)
+		{
+			face->pShades[0] = Create16BPPPaletteShaded(face->Palette(),
+				DEAD_MERC_COLOR_RED, DEAD_MERC_COLOR_GREEN, DEAD_MERC_COLOR_BLUE, TRUE);
+		}
 		face->CurrentShade(0);
 		shaded = FALSE;
 		text   = AimFiText[AIM_FI_DEAD];


### PR DESCRIPTION
The red shade of dead mercs was constantly recreated and leaked while moving the cursor around over these faces.

Probably a copy and paste bug; there's very similar code in Merc_Files.cc, AIMMembers.cc and Insurance_Contract.cc, but in those cases we don't leak because we're always using new SGPVObjects.