### PR TITLE
Warn about 1.13 modified game files in launcher

### DIFF
--- a/android/app/src/main/java/io/github/ja2stracciatella/GameDir.kt
+++ b/android/app/src/main/java/io/github/ja2stracciatella/GameDir.kt
@@ -1,0 +1,73 @@
+package io.github.ja2stracciatella
+
+import android.app.AlertDialog
+import android.content.Context
+import java.io.File
+
+class GameDir {
+    companion object {
+        fun checkGameDirectoryForCommonMistakes(
+            context: Context,
+            dir: String?,
+            callback: () -> Unit
+        ) {
+            if (dir != null) {
+                val gameDir = File(dir)
+                checkForDataDir(context, gameDir) { dataDirSegment ->
+                    val dataDir = File(dir, dataDirSegment)
+                    checkFor1Dot13(context, dataDir, callback)
+                }
+            } else {
+                AlertDialog.Builder(context)
+                    .setTitle(R.string.common_mistakes_no_game_dir_selected_title)
+                    .setMessage(R.string.common_mistakes_no_game_dir_selected_description)
+                    .setPositiveButton(android.R.string.cancel) { _, _ -> }
+                    .show()
+            }
+        }
+
+        private fun checkForDataDir(context: Context, gameDir: File, callback: (String) -> Unit) {
+            // Check for missing data dir
+            val searchFor = "Data"
+            val found = checkForExistenceCaseInsensitive(gameDir, searchFor)
+            if (found == null) {
+                AlertDialog.Builder(context)
+                    .setTitle(R.string.common_mistakes_no_data_dir_found_title)
+                    .setMessage(R.string.common_mistakes_no_data_dir_found_description)
+                    .setPositiveButton(android.R.string.cancel) { _, _ -> }
+                    .setNegativeButton(R.string.continue_action) { _, _ -> callback(searchFor) }
+                    .show()
+            } else {
+                callback(found)
+            }
+        }
+
+        private fun checkFor1Dot13(context: Context, dataDir: File, callback: () -> Unit) {
+            // Check for 1.13 installation
+            val file = checkForExistenceCaseInsensitive(dataDir, "Ja2Set.dat.xml")
+            if (file != null) {
+                AlertDialog.Builder(context)
+                    .setTitle(R.string.common_mistakes_one_dot_thirteen_detected_title)
+                    .setMessage(R.string.common_mistakes_one_dot_thirteen_detected_description)
+                    .setPositiveButton(android.R.string.cancel) { _, _ -> }
+                    .setNegativeButton(R.string.continue_action) { _, _ -> callback() }
+                    .show()
+            } else {
+                callback()
+            }
+        }
+
+        private fun checkForExistenceCaseInsensitive(
+            parent: File,
+            fileOrDirectory: String
+        ): String? {
+            val contents = parent.listFiles()
+            if (contents != null) {
+                return contents.firstOrNull { c ->
+                    c.name.equals(fileOrDirectory, true)
+                }?.name
+            }
+            return null
+        }
+    }
+}

--- a/android/app/src/main/java/io/github/ja2stracciatella/LauncherActivity.kt
+++ b/android/app/src/main/java/io/github/ja2stracciatella/LauncherActivity.kt
@@ -1,5 +1,6 @@
 package io.github.ja2stracciatella
 
+import android.app.AlertDialog
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
@@ -130,10 +131,15 @@ class LauncherActivity : AppCompatActivity() {
     private fun startGame() {
         try {
             getPermissionsIfNecessaryForAction {
-                saveJA2Json()
-                NativeExceptionContainer.resetException()
-                val intent = Intent(this@LauncherActivity, StracciatellaActivity::class.java)
-                startActivity(intent)
+                GameDir.checkGameDirectoryForCommonMistakes(
+                    this,
+                    configurationModel.vanillaGameDir.value
+                ) {
+                    saveJA2Json()
+                    NativeExceptionContainer.resetException()
+                    val intent = Intent(this@LauncherActivity, StracciatellaActivity::class.java)
+                    startActivity(intent)
+                }
             }
         } catch (e: IOException) {
             val message = "Could not write ${ja2JsonPath}: ${e.message}"

--- a/android/app/src/main/java/io/github/ja2stracciatella/ui/main/DataTabFragment.kt
+++ b/android/app/src/main/java/io/github/ja2stracciatella/ui/main/DataTabFragment.kt
@@ -13,6 +13,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.codekidlabs.storagechooser.StorageChooser
 import io.github.ja2stracciatella.ConfigurationModel
+import io.github.ja2stracciatella.GameDir
 import io.github.ja2stracciatella.R
 import io.github.ja2stracciatella.VanillaVersion
 import io.github.ja2stracciatella.databinding.FragmentLauncherDataTabBinding
@@ -27,6 +28,7 @@ class DataTabFragment : Fragment() {
 
     // Request permissions for game dir
     private val requestPermissionsCodeGameDir = 1001
+
     // Request permissions for save dir
     private val requestPermissionsCodeSaveGameDir = 1002
 
@@ -47,7 +49,8 @@ class DataTabFragment : Fragment() {
         _binding = FragmentLauncherDataTabBinding.inflate(inflater, container, false)
 
         val spinnerLabels = versions.map { v: VanillaVersion -> v.getLabel() }
-        val adapter: ArrayAdapter<String> = ArrayAdapter(this.requireContext(), R.layout.launcher_spinner_item, spinnerLabels)
+        val adapter: ArrayAdapter<String> =
+            ArrayAdapter(this.requireContext(), R.layout.launcher_spinner_item, spinnerLabels)
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         binding.gameVersionSpinner.adapter = adapter
 
@@ -113,8 +116,10 @@ class DataTabFragment : Fragment() {
                 .setType(StorageChooser.DIRECTORY_CHOOSER)
                 .build()
             directoryChooser.setOnSelectListener { path ->
-                configurationModel.apply {
-                    setVanillaGameDir(path)
+                GameDir.checkGameDirectoryForCommonMistakes(requireContext(), path) {
+                    configurationModel.apply {
+                        setVanillaGameDir(path)
+                    }
                 }
             }
             directoryChooser.show()
@@ -142,9 +147,17 @@ class DataTabFragment : Fragment() {
     }
 
     private fun getPermissionsIfNecessaryForAction(permissionsCode: Int, action: () -> Unit) {
-        val permissions = arrayOf(android.Manifest.permission.READ_EXTERNAL_STORAGE, android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
-        val hasAllPermissions = permissions.all { ContextCompat.checkSelfPermission(requireContext(), android.Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED }
-        if (hasAllPermissions)  {
+        val permissions = arrayOf(
+            android.Manifest.permission.READ_EXTERNAL_STORAGE,
+            android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+        )
+        val hasAllPermissions = permissions.all {
+            ContextCompat.checkSelfPermission(
+                requireContext(),
+                android.Manifest.permission.READ_EXTERNAL_STORAGE
+            ) == PackageManager.PERMISSION_GRANTED
+        }
+        if (hasAllPermissions) {
             action()
         } else {
             requestPermissions(permissions, permissionsCode)
@@ -160,14 +173,22 @@ class DataTabFragment : Fragment() {
             if (grantResults.all { r -> r == PackageManager.PERMISSION_GRANTED }) {
                 showGameDirChooser()
             } else {
-                Toast.makeText(requireContext(), "Cannot select game directory without proper permissions", Toast.LENGTH_SHORT).show()
+                Toast.makeText(
+                    requireContext(),
+                    "Cannot select game directory without proper permissions",
+                    Toast.LENGTH_SHORT
+                ).show()
             }
         }
         if (requestCode == requestPermissionsCodeSaveGameDir) {
             if (grantResults.all { r -> r == PackageManager.PERMISSION_GRANTED }) {
                 showSaveGameDirChooser()
             } else {
-                Toast.makeText(requireContext(), "Cannot select save game directory without proper permissions", Toast.LENGTH_SHORT).show()
+                Toast.makeText(
+                    requireContext(),
+                    "Cannot select save game directory without proper permissions",
+                    Toast.LENGTH_SHORT
+                ).show()
             }
         }
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -35,4 +35,11 @@
     <string name="debug_mode_info_title_text">Debug Mode</string>
     <string name="debug_mode_info_text">In case you run into issues, you can enable debug mode. This will result in more logs being written in order to be able to debug issues.</string>
     <string name="debug_mode_label">Enable Debug Mode</string>
+    <string name="continue_action">Continue</string>
+    <string name="common_mistakes_no_game_dir_selected_title">No game directory selected</string>
+    <string name="common_mistakes_no_game_dir_selected_description">You have not selected a game directory yet. Please set a game directory containing an unmodified Jagged Alliance 2 installation.</string>
+    <string name="common_mistakes_no_data_dir_found_title">Incorrect game directory detected</string>
+    <string name="common_mistakes_no_data_dir_found_description">The Data directory was not found within game directory. This means the chosen directory does not contain a Jagged Alliance 2 installation.</string>
+    <string name="common_mistakes_one_dot_thirteen_detected_title">Modified game directory detected</string>
+    <string name="common_mistakes_one_dot_thirteen_detected_description">We detected that the game directory contains the 1.13 patch. JA2 Stracciatella will not work properly with the modified files. Please use a clean installation of Jagged Alliance 2.</string>
 </resources>

--- a/rust/stracciatella/src/vfs/mod.rs
+++ b/rust/stracciatella/src/vfs/mod.rs
@@ -78,6 +78,7 @@ static MODS_DIR: &str = "mods";
 static DATA_DIR: &str = "data";
 static EXTERNALIZED_DIR: &str = "externalized";
 static EDITOR_SLF_NAME: &str = "editor.slf";
+static ONE_DOT_THIRTEEN_MARKER: &str = "Ja2Set.dat.xml";
 
 impl Vfs {
     /// Creates a new virtual filesystem.
@@ -175,6 +176,16 @@ impl Vfs {
         let vanilla_game_dir = engine_options.vanilla_game_dir.clone();
         let vanilla_data_dir =
             fs::resolve_existing_components(Path::new(DATA_DIR), Some(&vanilla_game_dir), true);
+
+        let one_dot_thirteen_marker = fs::resolve_existing_components(
+            Path::new(ONE_DOT_THIRTEEN_MARKER),
+            Some(&vanilla_data_dir),
+            true,
+        );
+        if one_dot_thirteen_marker.exists() {
+            log::error!("The game directory seems to be modified by a 1.13 installation, the game might crash at any point in time.")
+        }
+
         let home_data_dir = fs::resolve_existing_components(
             &PathBuf::from(DATA_DIR),
             Some(&engine_options.stracciatella_home),

--- a/src/launcher/Launcher.h
+++ b/src/launcher/Launcher.h
@@ -44,6 +44,7 @@ private:
 	void updateLogs();
 	void showModDetails(const ST::string& modName);
 	void hideModDetails();
+	static bool checkGameDirectoryForCommonMistakes(const ST::string& gameDir);
 	static void openGameDirectorySelector(Fl_Widget *btn, void *userdata);
 	static void openSaveGameDirectorySelector(Fl_Widget *btn, void *userdata);
 	static void startGame(Fl_Widget* btn, void* userdata);


### PR DESCRIPTION
Now a warning is shown after three user interactions

- Selecting a game directory
- Autoguessing version
- Starting the game

whenever one of the following conditions is true:

- Game directory does not contain `Data` dir
- Game directory contains a 1.13 data file

The user has the choice to continue anyways or cancel the action.

As discussed in #1693.

![image](https://github.com/ja2-stracciatella/ja2-stracciatella/assets/848854/d5dcf180-41c8-4cc6-892a-1ae8e5371dd3)
