### PR TITLE
Fix bug in InternalTacticalRemoveSoldier panel logic

### DIFF
--- a/src/game/Tactical/Soldier_Create.cc
+++ b/src/game/Tactical/Soldier_Create.cc
@@ -967,7 +967,10 @@ void InternalTacticalRemoveSoldier(SOLDIERTYPE& s, BOOLEAN const fRemoveVehicle)
 	}
 	if (gpSMCurrentMerc  == &s)
 	{
-		SetCurrentInterfacePanel(InterfacePanelKind::TEAM_PANEL);
+		if (guiCurrentScreen == ScreenID::GAME_SCREEN)
+		{
+			SetCurrentInterfacePanel(InterfacePanelKind::TEAM_PANEL);
+		}
 		// SetCurrentInterfacePanel still needs the old value
 		// of gpSMCurrentMerc so it must be cleared afterwards.
 		gpSMCurrentMerc = nullptr;


### PR DESCRIPTION
We can have a non-null gpSMCurrentMerc even when the current screen is not the game screen. Calling SetCurrentInterfacePanel() in that situation leads to all the interface elements of the panel being created, so you could for example end up with a Change Squad button on the main menu screen.

To reproduce this bug: in Tactical, have the Single Merc Panel open, the press O to go to the options screen. Choose Quit to go back to the main menu then move the mouse over the region where the three buttons left of the radar area are.