### PR TITLE
Use smart pointers to manage ZStripInfo structs

### DIFF
--- a/src/game/TileEngine/RenderWorld.cc
+++ b/src/game/TileEngine/RenderWorld.cc
@@ -2512,8 +2512,8 @@ static void Blt8BPPDataTo16BPPBufferTransZIncClip(UINT16* pBuffer, UINT32 uiDest
 		return;
 	}
 	// setup for the z-column blitting stuff
-	const ZStripInfo* const pZInfo = hSrcVObject->ppZStripInfo[usIndex];
-	if (pZInfo == NULL)
+	auto const& pZInfo = hSrcVObject->ppZStripInfo[usIndex];
+	if (!pZInfo)
 	{
 		SLOGW("Missing Z-Strip info on multi-Z object");
 		return;
@@ -2775,8 +2775,8 @@ static void Blt8BPPDataTo16BPPBufferTransZIncClipZSameZBurnsThrough(UINT16* pBuf
 		return;
 	}
 	// setup for the z-column blitting stuff
-	const ZStripInfo* const pZInfo = hSrcVObject->ppZStripInfo[usIndex];
-	if (pZInfo == NULL)
+	auto const& pZInfo = hSrcVObject->ppZStripInfo[usIndex];
+	if (!pZInfo)
 	{
 		SLOGW("Missing Z-Strip info on multi-Z object");
 		return;
@@ -3042,8 +3042,8 @@ static void Blt8BPPDataTo16BPPBufferTransZIncObscureClip(UINT16* pBuffer, UINT32
 		return;
 	}
 	// setup for the z-column blitting stuff
-	const ZStripInfo* const pZInfo = hSrcVObject->ppZStripInfo[usIndex];
-	if (pZInfo == NULL)
+	auto const& pZInfo = hSrcVObject->ppZStripInfo[usIndex];
+	if (!pZInfo)
 	{
 		SLOGW("Missing Z-Strip info on multi-Z object");
 		return;
@@ -3304,8 +3304,8 @@ static void Blt8BPPDataTo16BPPBufferTransZTransShadowIncObscureClip(UINT16* pBuf
 		return;
 	}
 	// setup for the z-column blitting stuff
-	const ZStripInfo* const pZInfo = hSrcVObject->ppZStripInfo[sZIndex];
-	if (pZInfo == NULL)
+	auto const& pZInfo = hSrcVObject->ppZStripInfo[sZIndex];
+	if (!pZInfo)
 	{
 		SLOGW("Missing Z-Strip info on multi-Z object");
 		return;
@@ -3570,8 +3570,8 @@ static void Blt8BPPDataTo16BPPBufferTransZTransShadowIncClip(UINT16* pBuffer, UI
 		return;
 	}
 	// setup for the z-column blitting stuff
-	const ZStripInfo* const pZInfo = hSrcVObject->ppZStripInfo[sZIndex];
-	if (pZInfo == NULL)
+	auto const& pZInfo = hSrcVObject->ppZStripInfo[sZIndex];
+	if (!pZInfo)
 	{
 		SLOGW("Missing Z-Strip info on multi-Z object");
 		return;

--- a/src/game/TileEngine/TileDef.cc
+++ b/src/game/TileEngine/TileDef.cc
@@ -69,7 +69,7 @@ void CreateTileDatabase()
 			TileElement.sBuddyNum			= -1;
 
 			// Check for multi-z stuff
-			ZStripInfo* const* const zsi = TileSurf->vo->ppZStripInfo;
+			auto const& zsi = TileSurf->vo->ppZStripInfo;
 			if (zsi && zsi[cnt2]) TileElement.uiFlags |= MULTI_Z_TILE;
 
 			// Structure database stuff!

--- a/src/sgp/VObject.cc
+++ b/src/sgp/VObject.cc
@@ -35,7 +35,6 @@ SGPVObject::SGPVObject(SGPImage * const img) :
 	pix_data_{ img->pImageData.moveToUnique() },
 	etrle_object_{ img->pETRLEObject.moveToUnique() },
 	current_shade_(),
-	ppZStripInfo(),
 	subregion_count_{ img->usNumberOfObjects },
 	bit_depth_{ img->ubBitDepth },
 	next_(gpVObjectHead)
@@ -71,18 +70,6 @@ SGPVObject::~SGPVObject()
 	}
 
 	DestroyPalettes();
-
-	if (ppZStripInfo != NULL)
-	{
-		for (UINT32 usLoop = 0; usLoop < SubregionCount(); usLoop++)
-		{
-			if (ppZStripInfo[usLoop] != NULL)
-			{
-				delete ppZStripInfo[usLoop];
-			}
-		}
-		delete[] ppZStripInfo;
-	}
 }
 
 

--- a/src/sgp/VObject.h
+++ b/src/sgp/VObject.h
@@ -76,7 +76,8 @@ class SGPVObject
 	private:
 		UINT16 const*                current_shade_;
 	public:
-		ZStripInfo**                 ppZStripInfo;                   // Z-value strip info arrays
+		// Smart pointer to an array of smart pointers to ZStripInfo structs.
+		std::unique_ptr<std::unique_ptr<ZStripInfo> []> ppZStripInfo;// Z-value strip info arrays
 
 	private:
 		UINT16                       subregion_count_;               // Total number of objects


### PR DESCRIPTION
This removes some boilerplate cleanup code.

You have probably heard this all before; raw owning pointers bad, smart pointers good, etc.

Obviously this is a really low priority change that can easily wait until the 0.21 release.