### PR TITLE
RFC: Stop hiding the SDL surface

### DIFF
--- a/src/game/Laptop/BobbyRMailOrder.cc
+++ b/src/game/Laptop/BobbyRMailOrder.cc
@@ -7,6 +7,7 @@
 #include "BobbyRMailOrder.h"
 #include "BobbyR.h"
 #include "MessageBoxScreen.h"
+#include "SDL_render.h"
 #include "Text.h"
 #include "VObject.h"
 #include "WordWrap.h"
@@ -1464,20 +1465,20 @@ static void DrawGoldRectangle(INT8 bCityNum)
 	if( usPosY >= temp )
 		usPosY = BOBBYR_SCROLL_AREA_Y + BOBBYR_SCROLL_AREA_HEIGHT - BOBBYR_SCROLL_ARROW_HEIGHT - usHeight - 5;
 
-	ColorFillVideoSurfaceArea( FRAME_BUFFER, BOBBYR_SCROLL_AREA_X, usPosY, BOBBYR_SCROLL_AREA_X+usWidth,	usPosY+usHeight, Get16BPPColor( FROMRGB( 186, 165, 68 ) ) );
+	FRAME_BUFFER->SetDrawColor(186, 165, 68)
+	.FillRect({ BOBBYR_SCROLL_AREA_X, usPosY, usWidth, usHeight })
 
 	//display the line
-	SGPVSurface::Lock l(FRAME_BUFFER);
-	UINT16* const pDestBuf = l.Buffer<UINT16>();
-	SetClippingRegionAndImageWidth(l.Pitch(), 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
 
 	// draw the gold highlite line on the top and left
-	LineDraw(FALSE, usPosX, usPosY, usPosX+usWidth, usPosY, Get16BPPColor( FROMRGB( 235, 222, 171 ) ), pDestBuf);
-	LineDraw(FALSE, usPosX, usPosY, usPosX, usPosY+usHeight, Get16BPPColor( FROMRGB( 235, 222, 171 ) ), pDestBuf);
+	.SetDrawColor(235, 222, 171)
+	.LineDraw(usPosX, usPosY, usPosX + usWidth, usPosY)
+	.LineDraw(usPosX, usPosY, usPosX, usPosY + usHeight)
 
 	// draw the shadow line on the bottom and right
-	LineDraw(FALSE, usPosX, usPosY+usHeight, usPosX+usWidth, usPosY+usHeight, Get16BPPColor( FROMRGB( 65, 49, 6 ) ), pDestBuf);
-	LineDraw(FALSE, usPosX+usWidth, usPosY, usPosX+usWidth, usPosY+usHeight, Get16BPPColor( FROMRGB( 65, 49, 6 ) ), pDestBuf);
+	.SetDrawColor(65, 49, 6)
+	.LineDraw(usPosX, usPosY + usHeight, usPosX + usWidth, usPosY + usHeight)
+	.LineDraw(usPosX + usWidth, usPosY, usPosX + usWidth, usPosY + usHeight);
 }
 
 

--- a/src/game/Laptop/Insurance.cc
+++ b/src/game/Laptop/Insurance.cc
@@ -4,6 +4,7 @@
 #include "Laptop.h"
 #include "Insurance.h"
 #include "Insurance_Contract.h"
+#include "SDL_render.h"
 #include "VObject.h"
 #include "WordWrap.h"
 #include "Cursors.h"
@@ -294,17 +295,13 @@ void RemoveInsuranceDefaults()
 
 void DisplaySmallRedLineWithShadow( UINT16 usStartX, UINT16 usStartY, UINT16 EndX, UINT16 EndY)
 {
-	SGPVSurface::Lock l(FRAME_BUFFER);
-
-	SetClippingRegionAndImageWidth(l.Pitch(), 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
-
-	UINT16* const pDestBuf = l.Buffer<UINT16>();
-
 	// draw the red line
-	LineDraw(FALSE, usStartX, usStartY, EndX, EndY, Get16BPPColor( FROMRGB( 255, 0, 0 ) ), pDestBuf);
+	FRAME_BUFFER->SetDrawColor(255, 0, 0)
+		.LineDraw(usStartX, usStartY, EndX, EndY)
 
 	// draw the black shadow line
-	LineDraw(FALSE, usStartX+1, usStartY+1, EndX+1, EndY+1, Get16BPPColor( FROMRGB( 0, 0, 0 ) ), pDestBuf);
+		.SetDrawColor(0, 0, 0)
+		.LineDraw(usStartX + 1, usStartY + 1, EndX + 1, EndY + 1);
 }
 
 

--- a/src/game/Strategic/Quest_Debug_System.cc
+++ b/src/game/Strategic/Quest_Debug_System.cc
@@ -27,6 +27,9 @@
 #include "QuestText.h"
 #include "Random.h"
 #include "Render_Dirty.h"
+#include "SDL_pixels.h"
+#include "SDL_render.h"
+#include "SDL_surface.h"
 #include "SGP.h"
 #include "Soldier_Add.h"
 #include "Soldier_Control.h"
@@ -385,8 +388,6 @@ static BOOLEAN gfQuestDebugExit  = FALSE;
 
 static BOOLEAN gfRedrawQuestDebugSystem = TRUE;
 
-static UINT16 gusQuestDebugBlue;
-
 
 static SCROLL_BOX gNpcListBox;  // The Npc Scroll box
 static SCROLL_BOX gItemListBox;
@@ -498,8 +499,6 @@ void QuestDebugScreenInit()
 
 	//Set so next time we come in, we can set up
 	gfQuestDebugEntry = TRUE;
-
-	gusQuestDebugBlue = Get16BPPColor( FROMRGB(  65,  79,  94 ) );
 
 	//Initialize which facts are at the top of the list
 	gusFactAtTopOfList = 0;
@@ -961,7 +960,8 @@ static void DisplaySectionLine(void);
 
 static void RenderQuestDebugSystem(void)
 {
-	ButtonDestBuffer->Fill(gusQuestDebugBlue);
+	auto * surface = &ButtonDestBuffer->GetSDLSurface();
+	SDL_FillRect(surface, nullptr, SDL_MapRGB(surface->format, 65, 79, 94));
 
 	//display the title
 	DisplayWrappedString(0, 5, SCREEN_WIDTH, 2, QUEST_DBS_FONT_TITLE, QUEST_DBS_COLOR_TITLE, QuestDebugText[QUEST_DBS_TITLE], FONT_MCOLOR_BLACK, CENTER_JUSTIFIED);
@@ -1240,23 +1240,22 @@ static void DisplaySectionLine(void)
 	usStartY = QUEST_DBS_FIRST_COL_NUMBER_Y;
 	usEndY = 475;
 
-	SGPVSurface::Lock l(FRAME_BUFFER);
-	UINT16* const pDestBuf = l.Buffer<UINT16>();
+	auto * renderer = FRAME_BUFFER->GetRenderer();
 
 	// draw the line in b/n the first and second section
-	SetClippingRegionAndImageWidth(l.Pitch(), 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
-	LineDraw(FALSE, usStartX, usStartY, usEndX, usEndY, Get16BPPColor( FROMRGB( 255, 255, 255 ) ), pDestBuf);
+	SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+	SDL_RenderDrawLine(renderer, usStartX, usStartY, usEndX, usEndY);
 
 	// draw the line in b/n the second and third section
 	usStartX = usEndX = QUEST_DBS_FIRST_SECTION_WIDTH + QUEST_DBS_SECOND_SECTION_WIDTH;
-	LineDraw(FALSE, usStartX, usStartY, usEndX, usEndY, Get16BPPColor( FROMRGB( 255, 255, 255 ) ), pDestBuf);
+	SDL_RenderDrawLine(renderer, usStartX, usStartY, usEndX, usEndY);
 
 
 	//draw the horizopntal line under the title
 	usStartX = 0;
 	usEndX   = SCREEN_WIDTH - 1;
 	usStartY = usEndY = 75;
-	LineDraw(FALSE, usStartX, usStartY, usEndX, usEndY, Get16BPPColor( FROMRGB( 255, 255, 255 ) ), pDestBuf);
+	SDL_RenderDrawLine(renderer, usStartX, usStartY, usEndX, usEndY);
 }
 
 

--- a/src/game/Tactical/Interface_Panels.cc
+++ b/src/game/Tactical/Interface_Panels.cc
@@ -47,6 +47,8 @@
 #include "Points.h"
 #include "Radar_Screen.h"
 #include "Render_Dirty.h"
+#include "SDL_pixels.h"
+#include "SDL_surface.h"
 #include "ScreenIDs.h"
 #include "ShopKeeper_Interface.h"
 #include "Soldier_Functions.h"
@@ -1174,25 +1176,16 @@ static void SetStatsHelp(MOUSE_REGION& r, SOLDIERTYPE const& s)
 
 void ProgressBarBackgroundRect(const INT16 sLeft, const INT16 sTop, const INT16 sWidth, const INT16 sHeight, const UINT32 rgb, const UINT8 scale_rgb)
 {
-	SGPVSurface::Lock l(guiSAVEBUFFER);
-
 	#define s(a)				((a) / 2) + ((a) / 2) * (scale_rgb) / 100
 
 	const int r = s(0xff & rgb >> 16);
 	const int g = s(0xff & rgb >> 8);
 	const int b = s(0xff & rgb);
 
-	const UINT16 fill_color = Get16BPPColor((b << 16) + (g << 8) + r);
+	auto & surface = guiSAVEBUFFER->GetSDLSurface();
+	SDL_Rect rect{ 0, 0, sWidth, sHeight };
 
-	UINT16* const dst = l.Buffer<UINT16>();
-
-	for (int y = 0; y < sHeight; ++y)
-	{
-		for(int x = 0; x < sWidth; ++x)
-		{
-			dst[(y + sTop)*l.Pitch() / 2 + sLeft + x] = fill_color;
-		}
-	}
+	SDL_FillRect(&surface, &rect, SDL_MapRGB(surface.format, r, g, b));
 }
 
 static void PrintStat(UINT32 const change_time, UINT16 const stat_bit, INT8 const stat_val, INT16 const x, INT16 const y, INT32 const progress)

--- a/src/sgp/VSurface.cc
+++ b/src/sgp/VSurface.cc
@@ -4,6 +4,7 @@
 #include "VObject_Blitters.h"
 #include "VSurface.h"
 #include "Logger.h"
+#include "SDL_render.h"
 
 #include <string_theory/format>
 #include <string_theory/string>
@@ -96,6 +97,20 @@ void SGPVSurface::SetTransparency(const COLORVAL colour)
 void SGPVSurface::Fill(const UINT16 colour)
 {
 	SDL_FillRect(surface_.get(), NULL, colour);
+}
+
+
+SDL_Renderer * SGPVSurface::GetRenderer()
+{
+	if (!renderer_)
+	{
+		renderer_.reset(SDL_CreateSoftwareRenderer(surface_.get()));
+		if (!renderer_)
+		{
+			throw std::runtime_error("Could not create software renderer");
+		}
+	}
+	return renderer_.get();
 }
 
 


### PR DESCRIPTION
As you know, a SGPVSurface is just a thin wrapper around a SDL surface. SGPVSurface tries to hide this fact by making the pointer to the SDL surface a private field. This approach probably made sense when this project started and made the transition from DirectDraw to SDL; this is pure speculation on my part, but I may have been done to keep the option open to use something else other than SDL.

IMO nowadays this design just hurts us. We're just denying ourselves easy access to tons of functionality SDL has to offer; instead we're stuck with terrible APIs from vanilla like LineDraw.

This PR doesn't really do all that much:
1. Allow getting the SDL surface pointer non-const
2. Create a SDL software renderer for the surface
3. Add four convenience methods for this renderer

This small change already lays the foundation to move Line.cc to the trashcan. You'll notice that a nice side effect of this change: it removes our dependency on the pixel format of the surface, something that hurts us so much in #738. We would get 32-bit line drawing for free.

I'd welcome input on this idea. Am I missing something here, some downside I'm not seeing? 

IMO the upcoming release would be a great opportunity to make this change. I don't foresee any huge problems, but it is invasive; new bugs could certainly happen.
