### PR TITLE
Correct bottom coordinate of an editor mouse region

### DIFF
--- a/src/game/Editor/EditorMercs.cc
+++ b/src/game/Editor/EditorMercs.cc
@@ -1987,7 +1987,7 @@ void UpdateMercsInfo()
 //is called by the region callback functions to handle these cases.  The event types are defined
 //in Editor Taskbar Utils.h.  Here are the internal functions...
 
-SGPRect mercRects[9] =
+static SGPRect const mercRects[9]
 {
 	{  75,  0, 104, 19 }, //head
 	{  75, 22, 104, 41 }, //body
@@ -2001,13 +2001,13 @@ SGPRect mercRects[9] =
 };
 
 
-static BOOLEAN PointInRect(SGPRect* pRect, INT32 x, INT32 y)
+static bool PointInRect(SGPRect const * pRect, INT32 x, INT32 y)
 {
 	return( x >= pRect->iLeft && x <= pRect->iRight && y >= pRect->iTop && y <= pRect->iBottom );
 }
 
 
-static void DrawRect(SGPRect* pRect, INT16 color)
+static void DrawRect(SGPRect const * pRect, INT16 color)
 {
 	SGPVSurface::Lock l(FRAME_BUFFER);
 	SetClippingRegionAndImageWidth(l.Pitch(), 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);

--- a/src/game/Editor/Editor_Taskbar_Utils.cc
+++ b/src/game/Editor/Editor_Taskbar_Utils.cc
@@ -51,7 +51,6 @@
 #include <string_theory/format>
 #include <string_theory/string>
 
-#include <stdarg.h>
 
 
 //editor icon storage vars
@@ -139,11 +138,17 @@ static void InitEditorRegions()
 	gfShowTerrainTileButtons = FALSE;
 
 	// Create the region for the items selection window.
+	// Ends above the secondary row of tabs.
 	MSYS_DefineRegion(&ItemsRegion, 100, EDITOR_TASKBAR_POS_Y, 540, EDITOR_TASKBAR_POS_Y + 80, MSYS_PRIORITY_NORMAL, 0, MouseMovedInItemsRegion, MouseClickedInItemsRegion);
 	ItemsRegion.Disable();
 
 	// Create the region for the merc inventory panel.
-	MSYS_DefineRegion(&MercRegion, 175, EDITOR_TASKBAR_POS_Y + 1, 450, EDITOR_TASKBAR_POS_Y + 80, MSYS_PRIORITY_NORMAL, 0, MouseMovedInMercRegion, MouseClickedInMercRegion);
+	// Ends directly above the main row of tabs.
+	MSYS_DefineRegion(&MercRegion,
+		175, EDITOR_TASKBAR_POS_Y + 1,
+		450, EDITOR_TASKBAR_POS_Y + 100,
+		MSYS_PRIORITY_NORMAL, 0,
+		MouseMovedInMercRegion, MouseClickedInMercRegion);
 	MercRegion.Disable();
 }
 


### PR DESCRIPTION
This made an area of the merc inventory panel hard to reach, issue #1946.