### PR TITLE
Fix crash in HandleTextInput()

### DIFF
--- a/src/game/Utils/Text_Input.cc
+++ b/src/game/Utils/Text_Input.cc
@@ -1132,6 +1132,7 @@ void EnableAllTextFields()
 		i->fEnabled = TRUE;
 	}
 	if (!gpActive) gpActive = gpTextInputHead;
+	SetEditingStatus(gpActive != nullptr);
 }
 
 
@@ -1144,6 +1145,7 @@ void DisableAllTextFields()
 		i->region.Disable();
 		i->fEnabled = FALSE;
 	}
+	SetEditingStatus(false);
 }
 
 


### PR DESCRIPTION
This function still tried to handle input even when there was no active input field, for example after calling DisableAllTextFields(), which could lead to a access violation when trying to dereference a NULL gpActive pointer.

STR if you want to see the crash for yourself:
1. Open the editor
2. Load sector A9
3. Click on the Mercs tab
4. Find Pacos or Fatima and right click on them
5. Click the "Merc Att" button to see their stats in disabled text fields
6. Press the right arrow or the End key