### PR TITLE
Fix ODR violation in pathing code

### DIFF
--- a/src/game/Strategic/Strategic_Pathing.cc
+++ b/src/game/Strategic/Strategic_Pathing.cc
@@ -24,6 +24,15 @@ static BOOLEAN gfPlotToAvoidPlayerInfuencedSectors = FALSE;
 
 
 // Globals
+
+namespace StrategicPathing
+{
+// These type definitions were placed inside a namespace to avoid a collision
+// with their counterparts in Tactical/PathAI.cc which caused a violation of
+// the C++ One Definition Rule, issue #1963.
+
+using TRAILCELLTYPE = UINT32;
+
 struct path_t
 {
 	INT16 nextLink;           //2
@@ -40,6 +49,9 @@ struct trail_t
 	short diStratDelta;
 };
 
+}
+using namespace StrategicPathing;
+
 #define MAXTRAILTREE	(4096)
 #define MAXpathQ			(512)
 #define MAP_WIDTH 18
@@ -49,7 +61,6 @@ struct trail_t
 //#define ISWATER(t)	(((t)==TRAVELCOST_KNEEDEEP) || ((t)==TRAVELCOST_DEEPWATER))
 //#define NOPASS (TRAVELCOST_OBSTACLE)
 //#define VEINCOST TRAVELCOST_FLAT     //actual cost for bridges and doors and such
-#define TRAILCELLTYPE UINT32
 #define TRAILCELLMAX 0xFFFFFFFF
 
 static path_t        pathQB[MAXpathQ];

--- a/src/game/Strategic/Strategic_Pathing.h
+++ b/src/game/Strategic/Strategic_Pathing.h
@@ -13,18 +13,6 @@
 #define SOUTH_MOVE  18
 
 
-// Movement speed defines
-#define NORMAL_MVT 1
-#define SLOW_MVT   0
-
-
-// movment modes
-enum{
-	MVT_MODE_AIR,
-	MVT_MODE_VEHICLE,
-	MVT_MODE_FOOT,
-};
-
 INT32 FindStratPath(INT16 sStart, INT16 sDestination, GROUP const&, BOOLEAN fTacticalTraversal);
 
 // build a stategic path


### PR DESCRIPTION
PathAI.cc and Strategic_Pathing.cc both had global definitions of the types path_t and trail_t. Fixed by placing the strategic variants in a new namespace.

This commit also removes some old crud from the header.

Fixes #1963.