### PR TITLE
Allow total weight of objects to exceed 25.5 kilograms

### DIFF
--- a/src/externalized/ItemModel.cc
+++ b/src/externalized/ItemModel.cc
@@ -61,8 +61,6 @@ ItemModel::ItemModel(uint16_t   itemIndex,
 	this->fFlags                = fFlags;
 }
 
-ItemModel::~ItemModel() = default;
-
 const ST::string& ItemModel::getInternalName() const   { return internalName;          }
 
 const ST::string& ItemModel::getShortName() const      { return shortName; }

--- a/src/externalized/ItemModel.h
+++ b/src/externalized/ItemModel.h
@@ -33,7 +33,7 @@ struct ItemModel
 		ItemCursor ubCursor,
 		InventoryGraphicsModel inventoryGraphics,
 		TilesetTileIndexModel tileGraphic,
-		uint8_t    ubWeight,
+		uint8_t    ubWeight, // In hectogram, so f.e. ubWeight==4 means 400 grams.
 		uint8_t    ubPerPocket,
 		uint16_t   usPrice,
 		uint8_t    ubCoolness,
@@ -41,8 +41,7 @@ struct ItemModel
 		int8_t     bRepairEase,
 		uint16_t   fFlags);
 
-	// This could be default in C++11
-	virtual ~ItemModel();
+	virtual ~ItemModel() = default;
 
 	const virtual ST::string& getInternalName() const;
 	const virtual ST::string& getShortName() const;

--- a/src/game/JA2Types.h
+++ b/src/game/JA2Types.h
@@ -33,4 +33,6 @@ struct TILE_IMAGERY;
 struct VEHICLETYPE;
 struct VIDEO_OVERLAY;
 
+using grams = int;
+
 #endif

--- a/src/game/Strategic/Map_Screen_Interface_Map_Inventory.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map_Inventory.cc
@@ -801,10 +801,7 @@ static BOOLEAN GetObjFromInventoryStashSlot(OBJECTTYPE* pInventorySlot, OBJECTTY
 		// find first unempty slot
 		pItemPtr->bStatus[0] = pInventorySlot->bStatus[0];
 		pItemPtr->ubNumberOfObjects = 1;
-		pItemPtr->ubWeight = CalculateObjectWeight( pItemPtr );
 		RemoveObjFrom( pInventorySlot, 0 );
-		pInventorySlot->ubWeight = CalculateObjectWeight( pInventorySlot );
-
 	}
 
 	return ( TRUE );

--- a/src/game/Tactical/Interface_Items.cc
+++ b/src/game/Tactical/Interface_Items.cc
@@ -155,7 +155,7 @@ static const SGPBox g_map_itemdesc_item_status_box = { 18,  54,   2, 42 };
 #define ITEM_FONT					TINYFONT1
 
 #define EXCEPTIONAL_DAMAGE				30
-#define EXCEPTIONAL_WEIGHT				20
+constexpr grams EXCEPTIONAL_WEIGHT = 2000;
 #define EXCEPTIONAL_RANGE				300
 #define EXCEPTIONAL_MAGAZINE				30
 #define EXCEPTIONAL_AP_COST				7
@@ -458,7 +458,7 @@ static void GenerateProsString(ST::string& zItemPros, const OBJECTTYPE& o, UINT3
 
 	zItemPros.clear();
 
-	if (GCM->getItem(usItem)->getWeight() <= EXCEPTIONAL_WEIGHT)
+	if (GCM->getItem(usItem)->getWeight() * 100 <= EXCEPTIONAL_WEIGHT)
 	{
 		zTemp = g_langRes->Message[STR_LIGHT];
 		if ( ! AttemptToAddSubstring( zItemPros, zTemp, &uiStringLength, uiPixLimit ) )
@@ -2388,9 +2388,11 @@ void RenderItemDescriptionBox(void)
 	}
 
 	// Calculate total weight of item and attachments
-	float fWeight = CalculateObjectWeight(&obj) / 10.f;
-	if (!gGameSettings.fOptions[TOPTION_USE_METRIC_SYSTEM]) fWeight *= 2.2f;
-	if (fWeight < 0.1) fWeight = 0.1f;
+	grams const objectWeight = Weight(obj);
+	double const convertedWeight = objectWeight /
+		(gGameSettings.fOptions[TOPTION_USE_METRIC_SYSTEM]
+		? 1000.0      // Weight in kilograms
+		: 453.59237); // Weight in pounds
 
 	SetFontShadow(DEFAULT_SHADOW);
 
@@ -2431,8 +2433,8 @@ void RenderItemDescriptionBox(void)
 		MPrint(usX, usY, pStr);
 
 		//Weight
-		HighlightIf(fWeight <= EXCEPTIONAL_WEIGHT / 10);
-		pStr = ST::format("{1.1f}", fWeight);
+		HighlightIf(objectWeight <= EXCEPTIONAL_WEIGHT);
+		pStr = ST::format("{1.1f}", convertedWeight);
 		FindFontRightCoordinates(dx + ids[0].sX + ids[0].sValDx, dy + ids[0].sY, ITEM_STATS_WIDTH, ITEM_STATS_HEIGHT, pStr, BLOCKFONT2, &usX, &usY);
 		MPrint(usX, usY, pStr);
 
@@ -2584,7 +2586,7 @@ void RenderItemDescriptionBox(void)
 		}
 
 		//Weight
-		pStr = ST::format("{1.1f}", fWeight);
+		pStr = ST::format("{1.1f}", convertedWeight);
 		FindFontRightCoordinates(dx + ids[0].sX + ids[0].sValDx, dy + ids[0].sY, ITEM_STATS_WIDTH, ITEM_STATS_HEIGHT, pStr, BLOCKFONT2, &usX, &usY);
 		MPrint(usX, usY, pStr);
 

--- a/src/game/Tactical/Item_Types.h
+++ b/src/game/Tactical/Item_Types.h
@@ -1,7 +1,7 @@
 #ifndef ITEM_TYPES_H
 #define ITEM_TYPES_H
 
-#include "Types.h"
+#include "JA2Types.h"
 
 enum ItemCursor
 {
@@ -129,6 +129,10 @@ struct OBJECTTYPE
 	UINT8  ubMission;
 	INT8   bTrap; // 1-10 exp_lvl to detect
 	UINT8  ubImprintID; // ID of merc that item is imprinted on
+
+	// Was the weight of object in multiples of 0.1kg
+	// (including attachments and ammo, if applicable)
+	// no longer used, this is now computed on demand.
 	UINT8  ubWeight;
 	UINT8  fUsed; // flags for whether the item is used or not
 };
@@ -607,5 +611,7 @@ enum ITEMDEFINE
 
 	MAXITEMS
 };
+
+grams Weight(OBJECTTYPE const& object);
 
 #endif

--- a/src/game/Tactical/Items.h
+++ b/src/game/Tactical/Items.h
@@ -1,13 +1,10 @@
 #ifndef ITEMS_H
 #define ITEMS_H
 
-#include <vector>
-
 #include "Item_Types.h"
 #include "JA2Types.h"
 
 struct CalibreModel;
-struct ItemModel;
 struct WeaponModel;
 
 void DamageObj(OBJECTTYPE* pObj, INT8 bAmount);
@@ -42,7 +39,7 @@ extern void GetObjFrom( OBJECTTYPE * pObj, UINT8 ubGetIndex, OBJECTTYPE * pDest 
 bool AttachObject(SOLDIERTYPE* const s, OBJECTTYPE* const pTargetObj, OBJECTTYPE* const pAttachment, UINT8 const ubIndexInStack = 0);
 extern BOOLEAN RemoveAttachment( OBJECTTYPE * pObj, INT8 bAttachPos, OBJECTTYPE * pNewObj );
 
-UINT8	CalculateObjectWeight(const OBJECTTYPE* pObject);
+// Returns (in percent) how much of his carrying capacity this soldier uses.
 UINT32 CalculateCarriedWeight(const SOLDIERTYPE* pSoldier);
 
 extern UINT16 TotalPoints(const OBJECTTYPE*);

--- a/src/game/Tactical/LoadSaveObjectType.cc
+++ b/src/game/Tactical/LoadSaveObjectType.cc
@@ -5,6 +5,7 @@
 #include "ContentManager.h"
 #include "GameInstance.h"
 #include "ItemModel.h"
+#include <algorithm>
 
 
 static void ReplaceInvalidItem(UINT16 & usItem)
@@ -199,7 +200,7 @@ inject_status:
 	INJ_U8(d, o->ubMission)
 	INJ_I8(d, o->bTrap)
 	INJ_U8(d, o->ubImprintID)
-	INJ_U8(d, o->ubWeight)
+	d.writeU8(static_cast<UINT8>(std::clamp(Weight(*o), 1, 255)));
 	INJ_U8(d, o->fUsed)
 	INJ_SKIP(d, 2)
 	Assert(d.getConsumed() == start + 36);

--- a/src/game/Tactical/Rotting_Corpses.cc
+++ b/src/game/Tactical/Rotting_Corpses.cc
@@ -1314,7 +1314,6 @@ void ReduceAmmoDroppedByNonPlayerSoldiers(SOLDIERTYPE const& s, OBJECTTYPE& o)
 	// Don't drop all the clips, just a random # of them between 1 and how
 	// many there are
 	o.ubNumberOfObjects = 1 + Random(o.ubNumberOfObjects);
-	o.ubWeight          = CalculateObjectWeight(&o);
 }
 
 


### PR DESCRIPTION
The member OBJECTTYPE::ubWeight is kept for savegame compatibility but no longer used; instead the object's current weight is calculated when needed.

Converting from hectograms to kilograms and pounds gave me a headache so the new function Weight() returns the object's weight in grams (currently the return value is always a multiple of 100).