### PR TITLE
Fix bug returning to the game screen from the load screen

### DIFF
--- a/src/game/Tactical/Turn_Based_Input.cc
+++ b/src/game/Tactical/Turn_Based_Input.cc
@@ -2162,7 +2162,7 @@ void GetKeyboardInput(UIEventKind* const puiNewEvent)
 		{
 			gfSaveGame              = FALSE;
 			gfCameDirectlyFromGame  = TRUE;
-			guiPreviousOptionScreen = SAVE_LOAD_SCREEN;
+			guiPreviousOptionScreen = GAME_SCREEN;
 			LeaveTacticalScreen( SAVE_LOAD_SCREEN );
 		}
 


### PR DESCRIPTION
Pressing Ctrl+L to go to the Load screen during the AI's turn is a Straciatella feature not present in Vanilla, however cancelling the load screen did not work, it took you to the Options screen instead.

Fixes #1972.