### PR TITLE
Clean up MessageBoxScreen a bit

### DIFF
--- a/src/game/MessageBoxScreen.h
+++ b/src/game/MessageBoxScreen.h
@@ -50,7 +50,8 @@ enum MessageBoxStyleID
 	MSG_BOX_BLUE_ON_GREY,
 	MSG_BOX_BASIC_SMALL_BUTTONS,
 	MSG_BOX_IMP_STYLE,
-	MSG_BOX_LAPTOP_DEFAULT
+	MSG_BOX_LAPTOP_DEFAULT,
+	NUMBER_OF_MSG_BOX_STYLES
 };
 
 
@@ -86,12 +87,12 @@ extern ST::string gzUserDefinedButton1;
 extern ST::string gzUserDefinedButton2;
 
 /* ubStyle:       Determines the look of graphics including buttons
- * zString:       16-bit string
+ * str:           The message box text.
  * uiExitScreen   The screen to exit to
  * ubFlags        Some flags for button style
- * ReturnCallback Callback for return. Can be NULL. Returns any above return value
+ * ReturnCallback Callback for return. Can be NULL. Receives a MessageBoxReturnValue defined above.
  * pCenteringRect Rect to center in. Can be NULL */
-void DoMessageBox(MessageBoxStyleID ubStyle, const ST::string str, ScreenID uiExitScreen, MessageBoxFlags usFlags, MSGBOX_CALLBACK ReturnCallback, const SGPBox* centering_rect);
+void DoMessageBox(MessageBoxStyleID ubStyle, const ST::string& str, ScreenID uiExitScreen, MessageBoxFlags usFlags, MSGBOX_CALLBACK ReturnCallback = nullptr, const SGPBox* centering_rect = nullptr);
 void DoScreenIndependantMessageBox(const ST::string& msg, MessageBoxFlags flags, MSGBOX_CALLBACK callback);
 
 //wrappers for other screens
@@ -99,9 +100,9 @@ void DoMapMessageBoxWithRect(MessageBoxStyleID ubStyle, const ST::string& str, S
 void DoOptionsMessageBoxWithRect(const ST::string& str, ScreenID uiExitScreen, MessageBoxFlags usFlags, MSGBOX_CALLBACK ReturnCallback, const SGPBox* centering_rect);
 void DoSaveLoadMessageBoxWithRect(const ST::string& str, ScreenID uiExitScreen, MessageBoxFlags usFlags, MSGBOX_CALLBACK ReturnCallback, const SGPBox* centering_rect);
 
-extern BOOLEAN gfInMsgBox;
+inline bool gfInMsgBox{ false };
 
-ScreenID MessageBoxScreenHandle(void);
+ScreenID MessageBoxScreenHandle();
 void     MessageBoxScreenShutdown();
 
 #endif


### PR DESCRIPTION
• Pass the message box by const reference. A missing &
  caused us to do unnecessary string copies in ~70 places.
• Remove the unused default message box style. This style
  could only be reached by doing something really silly
  like DoMessageBox((MessageBoxStyleID)9, ...).
• MakeButton is now a lambda so we do not have to always
  pass the same constant arguments to it
• Combined the six seperate callback handlers that only
  differed by their return value into one common handler

If you are wondering what the deleted default style looked like, here it is: 
![Screenshot_20240428_211238](https://github.com/ja2-stracciatella/ja2-stracciatella/assets/25463312/892183d9-3068-41e4-8618-2dcf5a9c33b8)
