### PR TITLE
Put the content of the primary hand in the secondary (not a pocket) when assigning doctor/repair tasks 

### DIFF
--- a/src/game/Strategic/Assignments.cc
+++ b/src/game/Strategic/Assignments.cc
@@ -3332,6 +3332,10 @@ static void MakeSureToolKitIsInHand(SOLDIERTYPE* pSoldier)
 			if( pSoldier -> inv[ bPocket ].usItem == TOOLKIT )
 			{
 				SwapObjs( &pSoldier -> inv[ HANDPOS ], &pSoldier -> inv[ bPocket ] );
+				if (pSoldier->inv[SECONDHANDPOS].usItem == NOTHING && pSoldier->inv[bPocket].usItem != NOTHING)
+				{
+					SwapObjs(&pSoldier->inv[SECONDHANDPOS], &pSoldier->inv[bPocket]);
+				}
 				break;
 			}
 		}
@@ -3358,6 +3362,10 @@ static BOOLEAN MakeSureMedKitIsInHand(SOLDIERTYPE* pSoldier)
 		{
 			fCharacterInfoPanelDirty = TRUE;
 			SwapObjs( &pSoldier -> inv[ HANDPOS ], &pSoldier -> inv[ bPocket ] );
+			if (pSoldier->inv[SECONDHANDPOS].usItem == NOTHING && pSoldier->inv[bPocket].usItem != NOTHING)
+			{
+				SwapObjs(&pSoldier->inv[SECONDHANDPOS], &pSoldier->inv[bPocket]);
+			}
 			return(TRUE);
 		}
 	}


### PR DESCRIPTION
Currently when a task is assigned, equipped one-handed guns are put in a pocket when swapped with a toolkit or medkit, which then makes it a bit of a hassle to open every soldier's inventory and equip them back. The proposed enhancement puts items in the secondary hand so that we can quickly swap them by right clicking on team panel in tactical mode.