### PR TITLE
Fix disabled yellow highlight of those in the selected sector

### DIFF
--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -1241,7 +1241,7 @@ static void DisplayCharacterList(void)
 			CharacterIsGettingPathPlotted(i) ? FONT_LTBLUE    :
 			/* Not in current sector? */
 			s.sSector.x != sSelMap.x ||
-			s.sSector.x != sSelMap.y ||
+			s.sSector.y != sSelMap.y ||
 			s.sSector.z != iCurrentMapSectorZ ? 5              :
 			/* Mobile? */
 			s.bAssignment < ON_DUTY ||


### PR DESCRIPTION
A one-character typo in #1479 disabled yellow highlighting of the soldiers in a selected sector.
![mercsInSectorHighlight](https://github.com/ja2-stracciatella/ja2-stracciatella/assets/65758182/cadd1e24-f1ea-4324-9d88-0bd0d86b4d37)
