### PR TITLE
Fix tile path-blocking on roofs due to nearby explosion

### DIFF
--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -987,7 +987,7 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 			}
 			else
 			{
-				if (!(pStructure->fFlags & STRUCTURE_PASSABLE || pStructure->fFlags & STRUCTURE_NORMAL_ROOF))
+				if (!(pStructure->fFlags & (STRUCTURE_PASSABLE|STRUCTURE_NORMAL_ROOF|STRUCTURE_PERSON)))
 				{
 					fStructuresOnRoof = TRUE;
 				}


### PR DESCRIPTION
PROBLEM (in vanilla too)

Structure-destroying explosions make nearby roof tiles obstacle-blocked if occupied by soldiers at the moment of the explosion.
Steps to reproduce:
1. Load this savefile: https://disk.yandex.ru/d/NhSrPal-hll_zw
2. End turn
3. The enemy soldier will attack Gus with a LAW, destroying some ground level structures in the process:
![LAWattack](https://github.com/ja2-stracciatella/ja2-stracciatella/assets/65758182/0b8f48f5-53e9-4cb7-b8d6-7e63609eb013)
(LAW missiles going through roofs unimpeded is an unrelated bug)
4. Within a certain radius the roof tiles occupied at the moment of the explosion by soldiers will be blocked for travel:
![scullyBlocked](https://github.com/ja2-stracciatella/ja2-stracciatella/assets/65758182/f4b942c0-8b4f-45d3-ba12-6f654b9d27a1)
![gusBlocked](https://github.com/ja2-stracciatella/ja2-stracciatella/assets/65758182/68697083-3800-41b4-9701-2bcc907a2b37)
![clownBlocked](https://github.com/ja2-stracciatella/ja2-stracciatella/assets/65758182/b8768bf0-3e72-4ea7-b350-3fe0a7d45c9d)
5. The same story will be with destruction by TNT, for example.

SOLUTION

Add a check excluding anything flagged STRUCTURE_PERSON (which includes monsters and bloodcats, by the way) from explosion-induced travel cost recompilation.

TESTING

People structures are supposed to block travel into a tile by WhoIsThere2 test anyway, not by assigning travel costs to the world, so I don't expect any complications from this.