### PR TITLE
Attempt to work around crashes with the MSVC build

### DIFF
--- a/src/externalized/strings/EDT.h
+++ b/src/externalized/strings/EDT.h
@@ -51,7 +51,7 @@ class EDTFile
 		IEDT::column_list    columns;
 	};
 
-	static constexpr EDTFilesTable EDTFilesTable[]
+	static inline EDTFilesTable const EDTFilesTable[]
 	{
 		/* Description strings of the A.I.M. members screen.
 		   One row per merc (40 in total) with two columns each:

--- a/src/externalized/strings/IEDT.h
+++ b/src/externalized/strings/IEDT.h
@@ -20,6 +20,6 @@ struct IEDT
 #else
 	// Microsoft's STL implementation of initializer_list seems broken,
 	// we have to use vector as a workaround.
-	using column_list = std::vector<std::uint16_t>
+	using column_list = std::vector<std::uint16_t>;
 #endif
 };

--- a/src/externalized/strings/IEDT.h
+++ b/src/externalized/strings/IEDT.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <cstdint>
+#ifndef _MSC_VER
 #include <initializer_list>
+#else
+#include <vector>
+#endif
 #include <memory>
 #include <string_theory/string>
 
@@ -11,5 +15,11 @@ struct IEDT
 	virtual ~IEDT() = default;
 
 	using uptr = std::unique_ptr<IEDT const>;
+#ifndef _MSC_VER
 	using column_list = std::initializer_list<std::uint16_t>;
+#else
+	// Microsoft's STL implementation of initializer_list seems broken,
+	// we have to use vector as a workaround.
+	using column_list = std::vector<std::uint16_t>
+#endif
 };


### PR DESCRIPTION
Apparently MSVC's STL does not like how we use initializer_list so see if we can replace them with vectors to get a working build.