### PR TITLE
Fix building without magic_enum

### DIFF
--- a/src/game/Tactical/Handle_UI.h
+++ b/src/game/Tactical/Handle_UI.h
@@ -7,7 +7,6 @@
 #include "MouseSystem.h"
 #include "ScreenIDs.h"
 #include "Soldier_Find.h"
-#include <magic_enum.hpp>
 
 
 #define UIEVENT_SINGLEEVENT		0x00000002

--- a/src/game/Tactical/Interface_Dialogue.cc
+++ b/src/game/Tactical/Interface_Dialogue.cc
@@ -3805,7 +3805,7 @@ action_punch_pc:
 			case NPC_ACTION_REMOVE_MERC_FOR_MARRIAGE:
 			{
 				SOLDIERTYPE* pSoldier = FindSoldierByProfileID(ubTargetNPC);
-				assert(pSoldier);
+				Assert(pSoldier);
 
 				pSoldier = ChangeSoldierTeam(pSoldier, CIV_TEAM);
 				// remove profile from map


### PR DESCRIPTION
Remove unnecessary include of magic_enum.hpp
Also fixes use of wrong version of assert which could cause a compilation failure if nothing includes cassert.