### PR TITLE
Fix jump location validation

### DIFF
--- a/src/game/Tactical/Handle_UI.cc
+++ b/src/game/Tactical/Handle_UI.cc
@@ -5264,10 +5264,13 @@ BOOLEAN IsValidJumpLocation(const SOLDIERTYPE* pSoldier, INT16 sGridNo, BOOLEAN 
 	UINT8 sDirs[4] = { NORTH, EAST, SOUTH, WEST };
 	UINT8 cnt;
 	UINT8 ubMovementCost;
+	UINT8 ubOppMovementCost;
 
 	// First check that action point cost is zero so far
 	// ie: NO PATH!
-	if ( gsCurrentActionPoints != 0 && fCheckForPath )
+	// Or the cursor is in "select currently non-selected soldier" mode
+	if (gsSelectedGridNo == sGridNo ||
+		(gsCurrentActionPoints != 0 && guiCurrentUICursor != NO_UICURSOR && fCheckForPath))
 	{
 		return( FALSE );
 	}
@@ -5280,13 +5283,18 @@ BOOLEAN IsValidJumpLocation(const SOLDIERTYPE* pSoldier, INT16 sGridNo, BOOLEAN 
 
 		// ATE: Check our movement costs for going through walls!
 		ubMovementCost = gubWorldMovementCosts[ sIntSpot ][ sDirs[ cnt ] ][ pSoldier->bLevel ];
+		ubOppMovementCost = gubWorldMovementCosts[sIntSpot][OppositeDirection(sDirs[cnt])][pSoldier->bLevel];
 		if ( IS_TRAVELCOST_DOOR( ubMovementCost ) )
 		{
 			ubMovementCost = DoorTravelCost(pSoldier, sIntSpot, ubMovementCost, pSoldier->bTeam == OUR_TEAM, NULL);
 		}
+		if (IS_TRAVELCOST_DOOR(ubOppMovementCost))
+		{
+			ubOppMovementCost = DoorTravelCost(pSoldier, sIntSpot, ubOppMovementCost, pSoldier->bTeam == OUR_TEAM, NULL);
+		}
 
 		// If we have hit an obstacle, STOP HERE
-		if ( ubMovementCost >= TRAVELCOST_BLOCKED )
+		if (ubMovementCost >= TRAVELCOST_BLOCKED || ubOppMovementCost >= TRAVELCOST_BLOCKED)
 		{
 			// no good, continue
 			continue;


### PR DESCRIPTION
PROBLEM

1. Jumping over the base tile of a soldier is too tricky. First you have to trigger blocked path cursor over their legs, then move it to the jump location in the pattern shown in this pic:
![jump1](https://github.com/ja2-stracciatella/ja2-stracciatella/assets/65758182/cbb5e84f-a136-459e-bec8-c97e9cd5d418)
2. You can't even jump over someone facing west, because their "extended" structure is flagged as passable, so there is no blocked path cursor to take advantage of:
![jump2](https://github.com/ja2-stracciatella/ja2-stracciatella/assets/65758182/37370beb-1e6d-473f-b6cc-9ab70ca51b3e)
3. There is no block test for jumper's source tile, only for destination, which allows you to phase through walls and doors:
![jump3](https://github.com/ja2-stracciatella/ja2-stracciatella/assets/65758182/235e01ff-a7c3-4c28-be86-b484318c8f36)

SOLUTION

Add a check that takes into account selection cursor.
Add a test for jumper's source tile block.
