### PR TITLE
Fix militia resetting their positions during battle or not showing up in the tactical screen

### DIFF
--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -66,6 +66,7 @@
 #include "Mercs.h"
 #include "MercTextBox.h"
 #include "Message.h"
+#include "Militia_Control.h"
 #include "Music_Control.h"
 #include "NPC.h"
 #include "NpcPlacementModel.h"
@@ -107,7 +108,6 @@
 #include "Video.h"
 #include "VSurface.h"
 #include "WorldDef.h"
-#include "Militia_Control.h"
 
 #include "policy/GamePolicy.h"
 

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -107,6 +107,7 @@
 #include "Video.h"
 #include "VSurface.h"
 #include "WorldDef.h"
+#include "Militia_Control.h"
 
 #include "policy/GamePolicy.h"
 
@@ -1878,7 +1879,8 @@ static void SaveGeneralInfo(HWFILE const f)
 	INJ_I32(  d, giHospitalRefund)
 	INJ_I8(   d, gfPlayerTeamSawJoey)
 	INJ_I8(   d, gfMikeShouldSayHi)
-	INJ_SKIP( d, 550)
+	INJ_BOOL( d, gfStrategicMilitiaChangesMade)
+	INJ_SKIP( d, 549)
 	Assert(d.getConsumed() == lengthof(data));
 
 	f->write(data, sizeof(data));
@@ -2036,7 +2038,8 @@ static void LoadGeneralInfo(HWFILE const f, UINT32 const savegame_version)
 	EXTR_I32(  d, giHospitalRefund)
 	EXTR_I8(   d, gfPlayerTeamSawJoey)
 	EXTR_I8(   d, gfMikeShouldSayHi)
-	EXTR_SKIP( d, 550)
+	EXTR_BOOL( d, gfStrategicMilitiaChangesMade)
+	EXTR_SKIP( d, 549)
 	Assert(d.getConsumed() == lengthof(data));
 }
 


### PR DESCRIPTION
Closes #292

PROBLEM

In relation to the following code:
```c++
void ResetMilitia()
{
	if( gfStrategicMilitiaChangesMade || gTacticalStatus.uiFlags & LOADING_SAVED_GAME )
	{
		...
	}
}
``` 

1. The value of gfStrategicMilitiaChangesMade is not stored in savefiles and not reset on savegame load, allowing it to be "inherited" either from other playthroughs or from the default FALSE value set on game launch.
2. There is no execution path where (gTacticalStatus.uiFlags & LOADING_SAVED_GAME) is TRUE, because:
```c++
	/* CJC January 13: we can't do this because (a) it resets militia IN THE
	 * MIDDLE OF COMBAT, and (b) if we add militia to the teams while
	 * LOADING_SAVED_GAME is set, the team counters will not be updated properly!
	 */
//	ResetMilitia();
``` 
Steps to reproduce the case, when gfStrategicMilitiaChangesMade being FALSE causes a bug:
1. Load this savefile: https://disk.yandex.ru/d/04a-bpvDSd0wJw (the sector in it is already loaded which is important)
2. While staying in the strategic screen, advance time for several minutes
3. Once the new batch of militia has been trained, save to another file
4. Go to the tactical screen (Or relaunch the game without loading any savefiles)
5. Load the savefile you created
6. The freshly trained militia will be shown strategically and absent tactically, until you reload the sector

Steps to reproduce the case, when gfStrategicMilitiaChangesMade being TRUE causes a bug:
1. Load the same savefile
2. While staying in the strategic screen, advance time for several minutes
3. Once the new batch of militia has been trained, load another savefile, where there is battle in progress in a sector with militia: https://disk.yandex.ru/d/PhwcPDlKJS6SlA
4. Go to the strategic screen
5. Then back to the tactical: all the militia in the sector will be insta-teleported to their initial positions

SOLUTION

Include gfStrategicMilitiaChangesMade in savefiles.
I didn't increment SAVE_GAME_VERSION, because, when loading old savefiles, setting gfStrategicMilitiaChangesMade to zero is exactly what we want. It will happen anyway without any version checks.