### PR TITLE
Make IsTheCursorAllowedToHighLightThisSector() more robust

### DIFF
--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -1961,7 +1961,11 @@ void DisplayThePotentialPathForHelicopter(const SGPSector& sMap)
 
 bool IsTheCursorAllowedToHighLightThisSector(const SGPSector& sMap)
 {
-	return SectorInfo[sMap.AsByte()].ubTraversability[THROUGH_STRATEGIC_MOVE] != EDGEOFWORLD;
+	return
+		sMap.IsValid() &&
+		sMap.z == 0 &&
+		(SectorInfo[sMap.AsByte()].ubTraversability[THROUGH_STRATEGIC_MOVE]
+			!= EDGEOFWORLD);
 }
 
 


### PR DESCRIPTION
This function can sometimes be called with an invalid sector which caused an assertion failure and a incorrect read of the SectorInfo array. Fixes #2005.