### PR TITLE
Fix Larry's profiles swapping incorrectly

### DIFF
--- a/src/game/Tactical/Soldier_Profile.cc
+++ b/src/game/Tactical/Soldier_Profile.cc
@@ -990,7 +990,7 @@ SOLDIERTYPE* SwapLarrysProfiles(SOLDIERTYPE* const s)
 */
 
 	memcpy(dst.bInvStatus, src.bInvStatus, sizeof(dst.bInvStatus));
-	memcpy(dst.bInvNumber, src.bInvStatus, sizeof(dst.bInvNumber));
+	memcpy(dst.bInvNumber, src.bInvNumber, sizeof(dst.bInvNumber));
 	memcpy(dst.inv,        src.inv,        sizeof(dst.inv));
 
 	DeleteSoldierFace(s);


### PR DESCRIPTION
Fixes an obvious typo that's been present since vanilla.
Closes #1956.