### PR TITLE
Fix several compiler warnings

### DIFF
--- a/dependencies/lib-smacker/CMakeLists.txt
+++ b/dependencies/lib-smacker/CMakeLists.txt
@@ -10,5 +10,5 @@ target_include_directories(smacker PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/libsmacke
 
 if(NOT MSVC)
     # Compilation flags copied from the Makefile
-    target_compile_options(smacker PRIVATE -pipe -Wall -Wextra -ansi -pedantic)
+    target_compile_options(smacker PRIVATE -pipe -Wall -Wextra -ansi -pedantic -fsigned-char)
 endif()

--- a/src/game/Laptop/Finances.cc
+++ b/src/game/Laptop/Finances.cc
@@ -48,14 +48,11 @@ struct FinanceUnit
 #define BLOCK_HEIGHT 10
 #define TOP_DIVLINE_Y (102 + STD_SCREEN_Y)
 #define DIVLINE_X (130 + STD_SCREEN_X)
-#define MID_DIVLINE_Y (205 + STD_SCREEN_Y)
 #define BOT_DIVLINE_Y (180 + STD_SCREEN_Y)
 #define MID_DIVLINE_Y2 (263 + 20 + STD_SCREEN_Y)
-#define BOT_DIVLINE_Y2 MID_DIVLINE_Y2 + MID_DIVLINE_Y - BOT_DIVLINE_Y
 #define TITLE_X (140 + STD_SCREEN_X)
 #define TITLE_Y (33 + STD_SCREEN_Y)
 #define TEXT_X (140 + STD_SCREEN_X)
-#define PAGE_SIZE 17
 
 // yesterdyas/todays income and balance text positions
 #define YESTERDAYS_INCOME               (STD_SCREEN_Y + 114)
@@ -70,7 +67,7 @@ struct FinanceUnit
 #define TODAYS_CURRENT_FORCAST_BALANCE  (STD_SCREEN_Y + 354)
 #define FINANCE_HEADER_FONT FONT14ARIAL
 #define FINANCE_TEXT_FONT FONT12ARIAL
-#define NUM_RECORDS_PER_PAGE PAGE_SIZE
+#define NUM_RECORDS_PER_PAGE (17)
 
 // records text positions
 #define RECORD_CREDIT_WIDTH (106-47)
@@ -384,10 +381,8 @@ static void DrawSummaryLines(void)
 	// blit summary LINE object to screen
 	BltVideoObject(FRAME_BUFFER, guiLINE, 0,DIVLINE_X, TOP_DIVLINE_Y);
 	BltVideoObject(FRAME_BUFFER, guiLINE, 0,DIVLINE_X, TOP_DIVLINE_Y+2);
-	//BltVideoObject(FRAME_BUFFER, guiLINE, 0,DIVLINE_X, MID_DIVLINE_Y);
 	BltVideoObject(FRAME_BUFFER, guiLINE, 0,DIVLINE_X, BOT_DIVLINE_Y);
 	BltVideoObject(FRAME_BUFFER, guiLINE, 0,DIVLINE_X, MID_DIVLINE_Y2);
-	//BltVideoObject(FRAME_BUFFER, guiLINE, 0,DIVLINE_X, BOT_DIVLINE_Y2);
 }
 
 

--- a/src/game/Laptop/History.cc
+++ b/src/game/Laptop/History.cc
@@ -44,9 +44,7 @@ struct HistoryUnit
 #define TOP_DIVLINE_Y			(STD_SCREEN_Y + 101)
 #define TITLE_X				(STD_SCREEN_X + 140)
 #define TITLE_Y				(STD_SCREEN_Y + 33 )
-#define PAGE_SIZE			22
 #define RECORD_Y			TOP_DIVLINE_Y
-#define RECORD_HISTORY_WIDTH		200
 #define PAGE_NUMBER_X			TOP_X+20
 #define PAGE_NUMBER_Y			TOP_Y+33
 #define HISTORY_DATE_X			PAGE_NUMBER_X+85
@@ -60,7 +58,7 @@ struct HistoryUnit
 #define RECORD_HEADER_Y			(STD_SCREEN_Y + 90)
 
 
-#define NUM_RECORDS_PER_PAGE		PAGE_SIZE
+#define NUM_RECORDS_PER_PAGE		(22)
 #define SIZE_OF_HISTORY_FILE_RECORD	( sizeof( UINT8 ) + sizeof( UINT8 ) + sizeof( UINT32 ) + sizeof( UINT16 ) + sizeof( UINT16 ) + sizeof( UINT8 ) + sizeof( UINT8 ) )
 
 // button positions

--- a/src/game/TileEngine/TileDef.cc
+++ b/src/game/TileEngine/TileDef.cc
@@ -124,7 +124,7 @@ void CreateTileDatabase()
 				if (TileElement.usRegionIndex == 0 && (TileElement.pDBStructureRef->pDBStructure->fFlags & (STRUCTURE_DDOOR_RIGHT|STRUCTURE_DDOOR_LEFT)))
 				{
 					// if a door in an open state takes up 1 tile and is flagged as outside-oriented...
-					if (TileElement.usWallOrientation = OUTSIDE_TOP_RIGHT && TileElement.pDBStructureRef[4].pDBStructure->ubNumberOfTiles == 1)
+					if (TileElement.usWallOrientation == OUTSIDE_TOP_RIGHT && TileElement.pDBStructureRef[4].pDBStructure->ubNumberOfTiles == 1)
 					{
 						// ... we found our problematic tile surface to be fixed
 						TileElement.usWallOrientation = INSIDE_TOP_RIGHT;
@@ -152,8 +152,7 @@ void CreateTileDatabase()
 		// Handle underflow
 		for (; cnt2 < gNumTilesPerType[cnt1]; ++cnt2)
 		{
-			TILE_ELEMENT TileElement;
-			TileElement = TILE_ELEMENT{};
+			TILE_ELEMENT TileElement{};
 			TileElement.usRegionIndex  = 0;
 			TileElement.hTileSurface   = TileSurf->vo;
 			TileElement.fType          = (UINT16)TileSurf->fType;

--- a/src/game/Utils/Cinematics.cc
+++ b/src/game/Utils/Cinematics.cc
@@ -35,7 +35,7 @@ struct SMKFLIC
 	UINT32 start_tick;
 	UINT32 frame_no;
 	double milliseconds_per_frame;
-	char status;
+	signed char status;
 };
 
 
@@ -285,7 +285,7 @@ static void SmkBlitVideoFrame(SMKFLIC* const sf, SGPVSurface* surface)
 	if (src == nullptr) return;
 	src_palette = smk_get_palette(sf->smacker);
 	if (src_palette == nullptr) return;
-	if (smk_info_video(sf->smacker, &src_width, &src_height, nullptr) < 0) return;
+	if (static_cast<signed char>(smk_info_video(sf->smacker, &src_width, &src_height, nullptr)) < 0) return;
 
 	// convert palette
 	UINT16 palette[256];


### PR DESCRIPTION
• Default signedness of char is platform-dependent, which leads to compiler warnings while compiling libsmacker
• Assignment in TileDef should be a comparison
• PAGE_SIZE macro is already defined on some platforms
• Unused macros warnings