### PR TITLE
Fix empty crepitus' lair bug

### DIFF
--- a/src/game/Strategic/Auto_Resolve.cc
+++ b/src/game/Strategic/Auto_Resolve.cc
@@ -414,6 +414,8 @@ static void DoTransitionFromPreBattleInterfaceToAutoResolve(void)
 
 void EnterAutoResolveMode(const SGPSector& ubSector)
 {
+	//fix empty creatures' lair bug
+	gubCreatureBattleCode = CREATURE_BATTLE_CODE_NONE;
 	//Set up mapscreen for removal
 	SetPendingNewScreen( AUTORESOLVE_SCREEN );
 	CreateDestroyMapInvButton();


### PR DESCRIPTION
Closes #1228

PROBLEM

The global variable gubCreatureBattleCode is not reset properly after an auto-resolved battle with the town-attacking crepitus.
Steps to reproduce:
1. Load this savefile: https://disk.yandex.ru/d/pA6Ay02ON3BDgQ
2. Advance time until an auto-resolved Drassen creature attack happens (since it's random, you'll want to reload if the night passes without an attack)
3. Go to the Drassen mine. It'll be empty all the way down.
4. Alternatively you can load the savefile from the original issue ([savegame.tar.gz](https://github.com/ja2-stracciatella/ja2-stracciatella/files/5245693/savegame.tar.gz)) and go to the mine there. The result will be the same.

The only ways to reset gubCreatureBattleCode: 
- Relaunch ja2.exe
- Wait for another creature attack while having your mercs in the sector and resolve it tactically
- Wait for another creature attack while having your mercs in the sector and auto-resolve it. You'll have to load any underground creture sector 2 times for this to work

SOLUTION

Once an auto-resolved battle has started, we can safely reset gubCreatureBattleCode to default, since any other value no longer serves any purpose.
