### PR TITLE
Bug fix: underground levels no longer accessible on map screen

### DIFF
--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -2097,7 +2097,7 @@ void DrawStringRight(const ST::string& str, UINT16 x, UINT16 y, UINT16 w, UINT16
 }
 
 
-static void RenderMapHighlight(const SGPSector& sMap, UINT16 usLineColor, BOOLEAN fStationary);
+static void RenderMapHighlight(const SGPSector& sMap, UINT16 usLineColor);
 static void RestoreMapSectorCursor(const SGPSector& sMap);
 
 
@@ -2137,7 +2137,7 @@ static void RenderMapCursorsIndexesAnims(void)
 			}
 
 			// draw WHITE highlight rectangle
-			RenderMapHighlight(gsHighlightSector, Get16BPPColor(RGB_WHITE), FALSE);
+			RenderMapHighlight(gsHighlightSector, Get16BPPColor(RGB_WHITE));
 
 			sPrevHighlightedMap = gsHighlightSector;
 			fHighlightChanged = TRUE;
@@ -2189,7 +2189,7 @@ static void RenderMapCursorsIndexesAnims(void)
 		}
 
 		// always render this one, it's too much of a pain detecting overlaps with the white cursor otherwise
-		RenderMapHighlight(sSelMap, usCursorColor, TRUE);
+		RenderMapHighlight(sSelMap, usCursorColor);
 
 		if (sPrevSelectedMap != sSelMap)
 		{
@@ -3252,10 +3252,8 @@ static SGPSector GetSectorAtXY(INT16 relX, INT16 relY)
 }
 
 
-static void RenderMapHighlight(const SGPSector& sMap, UINT16 usLineColor, BOOLEAN fStationary)
+static void RenderMapHighlight(const SGPSector& sMap, UINT16 usLineColor)
 {
-	Assert(sMap.IsValid());
-
 	// if we are not allowed to highlight, leave
 	if (!IsTheCursorAllowedToHighLightThisSector(sMap))
 	{

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -51,7 +51,6 @@
 #include "VObject.h"
 #include "VObject_Blitters.h"
 #include "VSurface.h"
-#include <memory>
 #include <stdexcept>
 #include <string_theory/format>
 #include <string_theory/string>
@@ -260,7 +259,6 @@ static SGPVObject* guiBULLSEYE;
 
 #define POPUP_MILITIA_ICONS_PER_ROW 5 // max 6 rows gives the limit of 30 militia
 #define MEDIUM_MILITIA_ICON_SPACING 5
-#define LARGE_MILITIA_ICON_SPACING  6
 
 #define MILITIA_BTN_OFFSET_X 26
 #define MILITIA_BTN_HEIGHT 11
@@ -410,8 +408,7 @@ void InitMapScreenInterfaceMap()
 	pTownPoints.clear();
 	pTownPoints.push_back(SGPPoint());
 
-	auto towns = GCM->getTowns();
-	for (auto& pair : GCM->getTowns())
+	for (auto const& pair : GCM->getTowns())
 	{
 		auto town = pair.second;
 		sBaseSectorList.push_back(town->getBaseSector());
@@ -1955,11 +1952,14 @@ void DisplayThePotentialPathForHelicopter(const SGPSector& sMap)
 
 bool IsTheCursorAllowedToHighLightThisSector(const SGPSector& sMap)
 {
+	// It is not strictly necessary to construct a new SGPSector above because
+	// AsByte() would ignore the z member anyway. It is done here to avoid
+	// possible confusion; accessing the SectorInfo array with only covers
+	// ground level sectors with an underground SGPSector may look wrong.
 	return
 		sMap.IsValid() &&
-		sMap.z == 0 &&
-		(SectorInfo[sMap.AsByte()].ubTraversability[THROUGH_STRATEGIC_MOVE]
-			!= EDGEOFWORLD);
+		(SectorInfo[SGPSector{ sMap.x, sMap.y, 0 }.AsByte()]
+			.ubTraversability[THROUGH_STRATEGIC_MOVE] != EDGEOFWORLD);
 }
 
 


### PR DESCRIPTION
Introduced by #2009. Also remove unused parameter fStationary of RenderMapHighlight(), the unused variable towns in RenderMapHighlight() and the unused macro LARGE_MILITIA_ICON_SPACING.

Fixes #2018.