### PR TITLE
Change signatures of GetMousePos and GetCursorPos

### DIFF
--- a/src/game/GameLoop.cc
+++ b/src/game/GameLoop.cc
@@ -114,8 +114,7 @@ try
 	InputAtom InputEvent;
 	ScreenID uiOldScreen = guiCurrentScreen;
 
-	SGPPoint MousePos;
-	GetMousePos(&MousePos);
+	auto const MousePos{ GetMousePos() };
 	// Hook into mouse stuff for MOVEMENT MESSAGES
 	MouseSystemHook(MOUSE_POS, 0, MousePos.iX, MousePos.iY);
 	MusicPoll();

--- a/src/game/MessageBoxScreen.cc
+++ b/src/game/MessageBoxScreen.cc
@@ -87,7 +87,7 @@ static_assert(NUMBER_OF_MSG_BOX_STYLES == std::size(g_msg_box_style));
 
 void DoMessageBox(MessageBoxStyleID ubStyle, const ST::string& str, ScreenID uiExitScreen, MessageBoxFlags usFlags, MSGBOX_CALLBACK ReturnCallback, const SGPBox* centering_rect)
 {
-	GetMousePos(&pOldMousePosition);
+	pOldMousePosition = GetMousePos();
 
 	//this variable can be unset if ur in a non gamescreen and DONT want the msg box to use the save buffer
 	gfDontOverRideSaveBuffer = TRUE;
@@ -350,8 +350,7 @@ static ScreenID ExitMsgBox(MessageBoxReturnValue const ubExitCode)
 
 	if (fCursorLockedToArea)
 	{
-		SGPPoint pPosition;
-		GetMousePos(&pPosition);
+		auto const pPosition{ GetMousePos() };
 
 		if (pPosition.iX > MessageBoxRestrictedCursorRegion.iRight ||
 				(pPosition.iX > MessageBoxRestrictedCursorRegion.iLeft && pPosition.iY < MessageBoxRestrictedCursorRegion.iTop && pPosition.iY > MessageBoxRestrictedCursorRegion.iBottom))

--- a/src/game/Tactical/UI_Cursors.cc
+++ b/src/game/Tactical/UI_Cursors.cc
@@ -466,8 +466,7 @@ static void DetermineCursorBodyLocation(SOLDIERTYPE* const s, BOOLEAN const disp
 
 	if (recalc)
 	{
-		SGPPoint cursorPosition{};
-		GetCursorPos(cursorPosition);
+		auto const cursorPosition{ GetCursorPos() };
 
 		// Always set aim location to nothing
 		s->bAimShotLocation = AIM_SHOT_RANDOM;

--- a/src/game/TileEngine/Interactive_Tiles.cc
+++ b/src/game/TileEngine/Interactive_Tiles.cc
@@ -317,8 +317,7 @@ void LogMouseOverInteractiveTile(INT16 const sGridNo)
 	ConvertGridNoToCellXY(sGridNo, &sXMapPos, &sYMapPos);
 
 	// Set mouse stuff
-	SGPPoint cursorPosition = {};
-	GetCursorPos(cursorPosition);
+	auto const cursorPosition{ GetCursorPos() };
 
 	for (LEVELNODE const* n = gpWorldLevelData[sGridNo].pStructHead; n; n = n->pNext)
 	{

--- a/src/game/TileEngine/Isometric_Utils.cc
+++ b/src/game/TileEngine/Isometric_Utils.cc
@@ -183,8 +183,7 @@ BOOLEAN GetMouseWorldCoords( INT16 *psMouseX, INT16 *psMouseY )
 		return( FALSE );
 	}
 
-	SGPPoint cursorPosition;
-	GetCursorPos(cursorPosition);
+	auto const cursorPosition{ GetCursorPos() };
 	sOffsetX = cursorPosition.iX - ( g_ui.m_tacticalMapCenterX ); // + gsRenderWorldOffsetX;
 	sOffsetY = cursorPosition.iY - ( g_ui.m_tacticalMapCenterY ) + 10;// + gsRenderWorldOffsetY;
 

--- a/src/sgp/Cursor_Control.cc
+++ b/src/sgp/Cursor_Control.cc
@@ -38,14 +38,9 @@ static MOUSEBLT_HOOK gMouseBltOverride = NULL;
 
 std::optional<SGPPoint> gManualCursorPos = std::nullopt;
 
-void GetCursorPos(SGPPoint& point)
+SGPPoint GetCursorPos()
 {
-	if (gManualCursorPos) {
-		point.iX = gManualCursorPos->iX;
-		point.iY = gManualCursorPos->iY;
-		return;
-	}
-	GetMousePos(&point);
+	return gManualCursorPos ? *gManualCursorPos : GetMousePos();
 }
 
 void SetManualCursorPos(SGPPoint point) {

--- a/src/sgp/Cursor_Control.h
+++ b/src/sgp/Cursor_Control.h
@@ -69,7 +69,7 @@ extern INT16 gsGlobalCursorYOffset;
 extern UINT16 gsCurMouseHeight;
 extern UINT16 gsCurMouseWidth;
 
-void GetCursorPos(SGPPoint& Point);
+SGPPoint GetCursorPos();
 
 // Sets an override for the cursor position
 void SetManualCursorPos(SGPPoint Point);

--- a/src/sgp/Input.cc
+++ b/src/sgp/Input.cc
@@ -493,10 +493,9 @@ void TextInput(const SDL_TextInputEvent* TextEv) {
 }
 
 
-void GetMousePos(SGPPoint* Point)
+SGPPoint GetMousePos()
 {
-	Point->iX = gusMouseXPos;
-	Point->iY = gusMouseYPos;
+	return { gusMouseXPos, gusMouseYPos };
 }
 
 bool IsMouseButtonDown(UINT32 mouseButton) {

--- a/src/sgp/Input.h
+++ b/src/sgp/Input.h
@@ -59,7 +59,7 @@ void FingerMove(const SDL_TouchFingerEvent*);
 void FingerDown(const SDL_TouchFingerEvent*);
 void FingerUp(const SDL_TouchFingerEvent*);
 
-void GetMousePos(SGPPoint *Point);
+SGPPoint GetMousePos();
 // TRUE = specified mouse button is down, FALSE = specified mouse button is up
 bool IsMouseButtonDown(UINT32 mouseButton);
 // TRUE = Main finger is down. Multitouch gesture is not detected, FALSE = Main finger is up or multitouch gesture is in progress

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -548,8 +548,7 @@ void RefreshScreen(void)
 		gfIgnoreScrollDueToCenterAdjust = FALSE;
 	}
 
-	SGPPoint cursorPos;
-	GetCursorPos(cursorPos);
+	auto const cursorPos{ GetCursorPos() };
 	SDL_Rect src;
 	src.x = 0;
 	src.y = 0;


### PR DESCRIPTION
Return the position directly as a SGPPoint instead of through a pointer or reference to SGPPoint.