### PR TITLE
github-ci.yml: upload-artifact@v4 requires unique names

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -134,7 +134,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: artifacts
+        name: artifacts ${{ matrix.cfg.name }}
         path: ${{ github.workspace }}/artifacts
 
   ci-lint:


### PR DESCRIPTION
https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md

This is basically just for PR builds, if one wants to look at the artifacts directly. We upload to our infra in a previous step already.