### PR TITLE
Fix EPCs unescort functionality

### DIFF
--- a/src/game/Strategic/Map_Screen_Helicopter.cc
+++ b/src/game/Strategic/Map_Screen_Helicopter.cc
@@ -646,7 +646,6 @@ void SetUpHelicopterForPlayer(const SGPSector& sMap)
 		SetUpHelicopterForMovement( );
 		UpdateRefuelSiteAvailability( );
 		fSkyRiderSetUp = TRUE;
-		gMercProfiles[ SKYRIDER ].fUseProfileInsertionInfo = FALSE;
 	}
 }
 

--- a/src/game/Tactical/Interface_Dialogue.cc
+++ b/src/game/Tactical/Interface_Dialogue.cc
@@ -2589,6 +2589,26 @@ void HandleNPCDoAction( UINT8 ubTargetNPC, UINT16 usActionCode, UINT8 ubQuoteNum
 					case JOHN:
 						UnRecruitEPC( MARY );
 						break;
+					case SKYRIDER:
+						if (ubQuoteNum == 15) // quote triggered by proximity to the helicopter
+						{
+							// make him always appear at his map editor placement spot in the airport sector
+							gMercProfiles[SKYRIDER].fUseProfileInsertionInfo = FALSE;
+						}
+						break;
+					case JOEY:
+						if (ubQuoteNum == 9) // quote triggered by proximity to Martha
+						{
+							// since he has no map editor placement in Cambria, make him spawn in the room he was sent to
+							gMercProfiles[JOEY].usStrategicInsertionData = 18326;
+						}
+						break;
+				}
+				if ((ubTargetNPC == JOHN || ubTargetNPC == MARY) && ubQuoteNum == 13) // quote triggered by proximity to the airplane
+				{
+					// make them disappear after unloading the sector
+					gMercProfiles[JOHN].sSector = SGPSector();
+					gMercProfiles[MARY].sSector = SGPSector();
 				}
 				break;
 

--- a/src/game/Tactical/Soldier_Profile.cc
+++ b/src/game/Tactical/Soldier_Profile.cc
@@ -43,6 +43,7 @@
 #include "content/ContentMercs.h"
 #include "WeaponModels.h"
 #include "MercProfile.h"
+#include "Strategic.h"
 
 extern BOOLEAN gfProfileDataLoaded;
 
@@ -801,23 +802,12 @@ BOOLEAN UnRecruitEPC(ProfileID const pid)
 	p.ubMiscFlags &= ~PROFILE_MISC_FLAG_EPCACTIVE;
 
 	// update sector values to current
+	p.sSector = s->sSector;
 
-	// check to see if this person should disappear from the map after this
-	if ((pid == JOHN || pid == MARY) &&
-			s->sSector.x == 13            &&
-			s->sSector.y == MAP_ROW_B     &&
-			s->sSector.z == 0)
-	{
-		p.sSector = SGPSector();
-	}
-	else
-	{
-		p.sSector = s->sSector;
-	}
-
-	// how do we decide whether or not to set this?
-	p.fUseProfileInsertionInfo  = TRUE;
-	p.ubMiscFlags3             |= PROFILE_MISC_FLAG3_PERMANENT_INSERTION_CODE;
+	gMercProfiles[pid].ubMiscFlags3 |= PROFILE_MISC_FLAG3_PERMANENT_INSERTION_CODE;
+	gMercProfiles[pid].ubStrategicInsertionCode = INSERTION_CODE_GRIDNO;
+	gMercProfiles[pid].usStrategicInsertionData = s->sGridNo;
+	gMercProfiles[pid].fUseProfileInsertionInfo = TRUE;
 
 	ChangeSoldierTeam(s, CIV_TEAM);
 	UpdateTeamPanelAssignments();

--- a/src/game/Tactical/Soldier_Profile.cc
+++ b/src/game/Tactical/Soldier_Profile.cc
@@ -804,10 +804,10 @@ BOOLEAN UnRecruitEPC(ProfileID const pid)
 	// update sector values to current
 	p.sSector = s->sSector;
 
-	gMercProfiles[pid].ubMiscFlags3 |= PROFILE_MISC_FLAG3_PERMANENT_INSERTION_CODE;
-	gMercProfiles[pid].ubStrategicInsertionCode = INSERTION_CODE_GRIDNO;
-	gMercProfiles[pid].usStrategicInsertionData = s->sGridNo;
-	gMercProfiles[pid].fUseProfileInsertionInfo = TRUE;
+	p.ubMiscFlags3 |= PROFILE_MISC_FLAG3_PERMANENT_INSERTION_CODE;
+	p.ubStrategicInsertionCode = INSERTION_CODE_GRIDNO;
+	p.usStrategicInsertionData = s->sGridNo;
+	p.fUseProfileInsertionInfo = TRUE;
 
 	ChangeSoldierTeam(s, CIV_TEAM);
 	UpdateTeamPanelAssignments();


### PR DESCRIPTION
Closes #478

Fixed (or circumvented) issues:
1. Doesn't matter, if unescorted manually or by a proximity trigger (quest completion), NPCs are always put on the north entry point after a sector reload. From now on they'll be at the exact tile the player left them, if unescorted manually.
2. There's map editor placement info for Skyrider in the airport sector, but it's ignored.
3. There's no map editor placement info for Joey in his home sector.
4. Unescort-related placement/disappearance code is a bit scattered all over the place.