### PR TITLE
Use MacOS 12 for the mac runner

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -22,7 +22,7 @@ jobs:
           target: linux-mingw64
 
         - name: Mac
-          os: macos-11
+          os: macos-12
           target: mac
 
         - name: Android


### PR DESCRIPTION
MacOS 11 is no longer supported since 2024-06-28. Compare the [Github docs page](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).