### PR TITLE
Fix Android build by upgrading minimum Android SDK to 21

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,14 +6,10 @@ android {
     compileSdkVersion 31
     ndkVersion "25.0.8775105"
 
-    lintOptions {
-        disable 'NewApi'
-        disable 'ExpiredTargetSdkVersion'
-    }
 
     defaultConfig {
         applicationId "io.github.ja2stracciatella"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 26
 
         // Version name is the semver version
@@ -82,6 +78,10 @@ android {
                 srcDirs = [ "../../assets" ]
             }
         }
+    }
+    namespace 'io.github.ja2stracciatella'
+    lint {
+        disable 'NewApi', 'ExpiredTargetSdkVersion'
     }
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.github.ja2stracciatella">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip


### PR DESCRIPTION
We introduced a dependency on some functions which only become available with the Android SDK 21 (equivalent to Android 5). As Android 4 (the previous equivalent minimum version) is already > 10 years old I think this requirement should be fine (covers 99.5% of all running Android devices according to https://apilevels.com/).