### PR TITLE
Fix moddability of Walter's bribe amount

### DIFF
--- a/src/game/Tactical/Interface_Dialogue.cc
+++ b/src/game/Tactical/Interface_Dialogue.cc
@@ -1,7 +1,6 @@
 #include "Interface_Dialogue.h"
 
 #include "AI.h"
-#include "AIInternals.h"
 #include "Animation_Control.h"
 #include "Animation_Data.h"
 #include "Arms_Dealer_Init.h"
@@ -1558,6 +1557,23 @@ static BOOLEAN NPCOpenThing(SOLDIERTYPE* pSoldier, BOOLEAN fDoor);
 static void DoneFadeOutActionBasement(void);
 static void DoneFadeOutActionLeaveBasement(void);
 static void CarmenLeavesSectorCallback(void);
+
+namespace {
+// Handles both NPC_ACTION_WALTER_GIVEN_MONEY_INITIALLY and
+// NPC_ACTION_WALTER_GIVEN_MONEY.
+void WalterGivenMoney(NPCAction actionCode, NpcActionParamsModel const& params)
+{
+	if (gMercProfiles[WALTER].iBalance >= params.getAmount(WALTER_BRIBE_AMOUNT))
+	{
+		TriggerNPCRecord(WALTER, 16);
+	}
+	else
+	{
+		TriggerNPCRecord(WALTER,
+			actionCode == NPC_ACTION_WALTER_GIVEN_MONEY_INITIALLY ? 14 : 15);
+	}
+}
+}
 
 
 void HandleNPCDoAction( UINT8 ubTargetNPC, UINT16 usActionCode, UINT8 ubQuoteNum )
@@ -4046,24 +4062,8 @@ add_log:
 			}
 
 			case NPC_ACTION_WALTER_GIVEN_MONEY_INITIALLY:
-				if ( gMercProfiles[ WALTER ].iBalance >= params->getGridNo(WALTER_BRIBE_AMOUNT) )
-				{
-					TriggerNPCRecord( WALTER, 16 );
-				}
-				else
-				{
-					TriggerNPCRecord( WALTER, 14 );
-				}
-				break;
 			case NPC_ACTION_WALTER_GIVEN_MONEY:
-				if ( gMercProfiles[ WALTER ].iBalance >= params->getGridNo(WALTER_BRIBE_AMOUNT) )
-				{
-					TriggerNPCRecord( WALTER, 16 );
-				}
-				else
-				{
-					TriggerNPCRecord( WALTER, 15 );
-				}
+				WalterGivenMoney(static_cast<NPCAction>(usActionCode), *params);
 				break;
 			default:
 				SLOGD("No code support for NPC action {}", usActionCode);

--- a/src/game/Tactical/Interface_Dialogue.h
+++ b/src/game/Tactical/Interface_Dialogue.h
@@ -82,7 +82,7 @@ bool ProfileCurrentlyTalkingInDialoguePanel(UINT8 ubProfile);
 void InternalInitTalkingMenu(UINT8 ubCharacterNum, INT16 sX, INT16 sY);
 
 
-enum
+enum NPCAction : UINT16
 {
 	NPC_ACTION_NONE = 0,
 	NPC_ACTION_DONT_ACCEPT_ITEM,


### PR DESCRIPTION
The amount specified in tactical-npc-action-params.json had no effect because the code used the wrong NpcActionParamsModel method (getGridNo instead of getAmount).

I moved the code to handle these two cases into a new function because HandleNPCDoAction() is the worst function in the sense of code complexity measurements.