### PR TITLE
Refactor iteration over items

### DIFF
--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -804,6 +804,11 @@ bool DefaultContentManager::loadAllDealersAndInventory()
 	return true;
 }
 
+ItemRange DefaultContentManager::getItems() const
+{
+	return ItemRange(m_items.begin() + 1, m_items.end());
+}
+
 const ItemModel* DefaultContentManager::getItem(uint16_t itemIndex) const
 {
 	if(itemIndex >= m_items.size())

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -89,6 +89,7 @@ public:
 
 	virtual const AmmoTypeModel* getAmmoType(uint8_t index) override;
 
+	virtual ItemRange getItems() const override;
 	virtual const ItemModel* getItem(uint16_t index) const override;
 	virtual const ItemModel* getItemByName(const ST::string &internalName) const override;
 	virtual const ItemModel* getKeyItemForKeyId(uint16_t usKeyItem) const override;

--- a/src/externalized/ItemRange.h
+++ b/src/externalized/ItemRange.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <vector>
+#include "ItemModel.h"
+
+class ItemRange {
+	using Iterator = std::vector<ItemModel const *>::const_iterator;
+
+	public:
+		ItemRange(Iterator begin, Iterator end) noexcept : m_begin(begin), m_end(end) {};
+		Iterator begin() const noexcept {
+			return m_begin;
+		};
+		Iterator end() const noexcept {
+			return m_end;
+		};
+
+	private:
+		Iterator m_begin;
+		Iterator m_end;
+};

--- a/src/externalized/ItemSystem.h
+++ b/src/externalized/ItemSystem.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ItemRange.h>
+
 #include "stdint.h"
 #include <string_theory/string>
 #include <vector>
@@ -10,6 +12,9 @@ struct ItemModel;
 class ItemSystem
 {
 public:
+	// Returns a range that can be iterated over, without the NOTHING item
+	virtual ItemRange getItems() const = 0;
+
 	// Returns an item by internal name
 	virtual const ItemModel* getItemByName(const ST::string &internalName) const = 0;
 

--- a/src/game/Editor/EditorItems.cc
+++ b/src/game/Editor/EditorItems.cc
@@ -105,7 +105,6 @@ EditorItemsInfo eInfo;
 //isn't calculated every time a player changes categories.
 void EntryInitEditorItemsInfo()
 {
-	INT32 i;
 	eInfo.uiBuffer = 0;
 	eInfo.fActive = 0;
 	eInfo.sScrollIndex = 0;
@@ -120,29 +119,24 @@ void EntryInitEditorItemsInfo()
 		eInfo.uiItemType = TBAR_MODE_ITEM_WEAPONS;
 		//Pre-calculate the number of each item type.
 		eInfo.sNumTriggers = NUMBER_TRIGGERS;
-		for( i=0; i < MAXITEMS; i++ )
+		for (auto item : GCM->getItems())
 		{
-			const ItemModel* item = GCM->getItem(i);
-			if( GCM->getItem(i)->getFlags() & ITEM_NOT_EDITOR )
-				continue;
-			if( i == SWITCH || i == ACTION_ITEM )
-			{
+			const auto itemIdx = item->getItemIndex();
 
-			}
-			else switch( item->getItemClass() )
+			if( item->getFlags() & ITEM_NOT_EDITOR )
+				continue;
+			if( itemIdx == SWITCH || itemIdx == ACTION_ITEM )
+				continue;
+
+			switch( item->getItemClass() )
 			{
 				case IC_GUN:
 				case IC_BLADE:
 				case IC_THROWN:
 				case IC_LAUNCHER:
 				case IC_THROWING_KNIFE:
-					eInfo.sNumWeapons++;
-					break;
 				case IC_PUNCH:
-					if ( i != NOTHING )
-					{
-						eInfo.sNumWeapons++;
-					}
+					eInfo.sNumWeapons++;
 					break;
 				case IC_AMMO:
 					eInfo.sNumAmmo++;

--- a/src/game/Editor/Sector_Summary.cc
+++ b/src/game/Editor/Sector_Summary.cc
@@ -583,7 +583,6 @@ static void RenderItemDetails(void)
 {
 	FLOAT dAvgExistChance, dAvgStatus;
 	OBJECTTYPE *pItem;
-	INT32 index, i;
 	UINT32 uiQuantity, uiExistChance, uiStatus;
 	UINT32 xp, yp;
 	INT8 bFreqIndex;
@@ -599,13 +598,14 @@ static void RenderItemDetails(void)
 		UINT32 uiActionQuantity[8] {};
 		UINT32 uiTriggerExistChance[8] {};
 		UINT32 uiActionExistChance[8] {};
-		for( index = 1; index < MAXITEMS; index++ )
+		for (auto item : GCM->getItems())
 		{
+			const auto index = item->getItemIndex();
 			uiQuantity = 0;
 			uiExistChance = 0;
 			uiStatus = 0;
 			Assert(gpWorldItemsSummaryArray.size() <= INT32_MAX);
-			for (i = 0; i < static_cast<INT32>(gpWorldItemsSummaryArray.size()); i++)
+			for (INT32 i = 0; i < static_cast<INT32>(gpWorldItemsSummaryArray.size()); i++)
 			{
 				if( index == SWITCH || index == ACTION_ITEM )
 				{
@@ -669,7 +669,7 @@ static void RenderItemDetails(void)
 				dAvgExistChance = (FLOAT)(uiExistChance / 100.0);
 				dAvgStatus = uiStatus / (FLOAT)uiQuantity;
 				//Display stats.
-				MPrint(xp, yp, GCM->getItem(index)->getShortName());
+				MPrint(xp, yp, item->getShortName());
 				MPrint( xp + 85, yp, ST::format("{3.02f}", dAvgExistChance) );
 				MPrint( xp + 110, yp, ST::format("@ {3.02f}%", dAvgStatus) );
 				yp += 10;
@@ -687,7 +687,7 @@ static void RenderItemDetails(void)
 			}
 		}
 		//Now list the number of actions/triggers of each type
-		for( i = 0; i < 8; i++ )
+		for(INT32 i = 0; i < 8; i++ )
 		{
 			if( uiTriggerQuantity[i] || uiActionQuantity[i] )
 			{
@@ -749,12 +749,14 @@ static void RenderItemDetails(void)
 			MPrint(xp, yp, "None");
 			yp += 10;
 		}
-		else for( index = 1; index < MAXITEMS; index++ )
+		else for (auto item : GCM->getItems())
 		{
+			const auto index = item->getItemIndex();
+
 			uiQuantity = 0;
 			uiExistChance = 0;
 			uiStatus = 0;
-			for( i = 0; i < gusPEnemyItemsSummaryArraySize; i++ )
+			for(INT32 i = 0; i < gusPEnemyItemsSummaryArraySize; i++ )
 			{
 				if( gpPEnemyItemsSummaryArray[ i ].usItem == index )
 				{
@@ -774,7 +776,7 @@ static void RenderItemDetails(void)
 				dAvgExistChance = (FLOAT)(uiExistChance / 100.0);
 				dAvgStatus = uiStatus / (FLOAT)uiQuantity;
 				//Display stats.
-				MPrint(xp, yp, GCM->getItem(index)->getShortName());
+				MPrint(xp, yp, item->getShortName());
 				MPrint( xp + 85, yp, ST::format("{3.02f}", dAvgExistChance) );
 				MPrint( xp + 110, yp, ST::format("@ {3.02f}%", dAvgStatus) );
 				yp += 10;
@@ -816,12 +818,14 @@ static void RenderItemDetails(void)
 			MPrint(xp, yp, "None");
 			yp += 10;
 		}
-		for( index = 1; index < MAXITEMS; index++ )
+		for (auto item : GCM->getItems())
 		{
+			const auto index = item->getItemIndex();
+
 			uiQuantity = 0;
 			uiExistChance = 0;
 			uiStatus = 0;
-			for( i = 0; i < gusNEnemyItemsSummaryArraySize; i++ )
+			for(INT32 i = 0; i < gusNEnemyItemsSummaryArraySize; i++ )
 			{
 				if( gpNEnemyItemsSummaryArray[ i ].usItem == index )
 				{
@@ -841,7 +845,7 @@ static void RenderItemDetails(void)
 				dAvgExistChance = (FLOAT)(uiExistChance / 100.0);
 				dAvgStatus = uiStatus / (FLOAT)uiQuantity;
 				//Display stats.
-				MPrint(xp, yp, GCM->getItem(index)->getShortName());
+				MPrint(xp, yp, item->getShortName());
 				MPrint( xp + 85, yp, ST::format("{3.02f}", dAvgExistChance) );
 				MPrint( xp + 110, yp, ST::format("@ {3.02f}%", dAvgStatus) );
 				yp += 10;

--- a/src/game/Laptop/BobbyR.cc
+++ b/src/game/Laptop/BobbyR.cc
@@ -437,20 +437,20 @@ void InitBobbyRayInventory()
 
 static void InitBobbyRayNewInventory(void)
 {
-	UINT16	i;
 	UINT16	usBobbyrIndex = 0;
 
 
 	std::fill_n(LaptopSaveInfo.BobbyRayInventory, static_cast<size_t>(MAXITEMS), STORE_INVENTORY{});
 
 	// add all the NEW items he can ever sell into his possible inventory list, for now in order by item #
-	for( i = 0; i < MAXITEMS; i++ )
+	for (auto item : GCM->getItems())
 	{
-		const ItemModel *item = GCM->getItem(i);
+		const auto itemIndex = item->getItemIndex();
+
 		//if Bobby Ray sells this, it can be sold, and it's allowed into this game (some depend on e.g. gun-nut option)
-		if( (GCM->getBobbyRayNewInventory()->getMaxItemAmount(item) != 0) && !(item->getFlags() & ITEM_NOT_BUYABLE) && ItemIsLegal( i ) )
+		if( (GCM->getBobbyRayNewInventory()->getMaxItemAmount(item) != 0) && !(item->getFlags() & ITEM_NOT_BUYABLE) && ItemIsLegal(itemIndex) )
 		{
-			LaptopSaveInfo.BobbyRayInventory[ usBobbyrIndex ].usItemIndex = i;
+			LaptopSaveInfo.BobbyRayInventory[ usBobbyrIndex ].usItemIndex = itemIndex;
 			usBobbyrIndex++;
 		}
 	}
@@ -471,24 +471,23 @@ static void InitBobbyRayNewInventory(void)
 
 static void InitBobbyRayUsedInventory(void)
 {
-	UINT16	i;
 	UINT16	usBobbyrIndex = 0;
 
 
 	std::fill_n(LaptopSaveInfo.BobbyRayUsedInventory, static_cast<size_t>(MAXITEMS), STORE_INVENTORY{});
 
 	// add all the NEW items he can ever sell into his possible inventory list, for now in order by item #
-	for( i = 0; i < MAXITEMS; i++ )
+	for (auto item : GCM->getItems())
 	{
-		const ItemModel *item = GCM->getItem(i);
+		const auto itemIndex = item->getItemIndex();
 
 		//if Bobby Ray sells this, it can be sold, and it's allowed into this game (some depend on e.g. gun-nut option)
-		if( (GCM->getBobbyRayUsedInventory()->getMaxItemAmount(item) != 0) && !(item->getFlags() & ITEM_NOT_BUYABLE) && ItemIsLegal( i ) )
+		if( (GCM->getBobbyRayUsedInventory()->getMaxItemAmount(item) != 0) && !(item->getFlags() & ITEM_NOT_BUYABLE) && ItemIsLegal(itemIndex) )
 		{
 			// in case his store inventory list is wrong, make sure this category of item can be sold used
-			if ( CanDealerItemBeSoldUsed( i ) )
+			if ( CanDealerItemBeSoldUsed(itemIndex) )
 			{
-				LaptopSaveInfo.BobbyRayUsedInventory[ usBobbyrIndex ].usItemIndex = i;
+				LaptopSaveInfo.BobbyRayUsedInventory[ usBobbyrIndex ].usItemIndex = itemIndex;
 				usBobbyrIndex++;
 			}
 		}

--- a/src/game/Tactical/Arms_Dealer_Init.cc
+++ b/src/game/Tactical/Arms_Dealer_Init.cc
@@ -85,7 +85,6 @@ static void ArmsDealerGetsFreshStock(ArmsDealerID, UINT16 usItemIndex, UINT8 ubN
 
 static void InitializeOneArmsDealer(ArmsDealerID const ubArmsDealer)
 {
-	UINT16 usItemIndex;
 	UINT8  ubNumItems=0;
 
 
@@ -104,8 +103,9 @@ static void InitializeOneArmsDealer(ArmsDealerID const ubArmsDealer)
 
 
 	//loop through all the item types
-	for( usItemIndex = 1; usItemIndex < MAXITEMS; usItemIndex++ )
+	for (auto item : GCM->getItems())
 	{
+		const auto usItemIndex = item->getItemIndex();
 		//Can the item be sold by the arms dealer
 		if( CanDealerTransactItem( ubArmsDealer, usItemIndex, FALSE ) )
 		{
@@ -133,7 +133,7 @@ void ShutDownArmsDealers()
 	for (ArmsDealerID ubArmsDealer = ARMS_DEALER_FIRST; ubArmsDealer < NUM_ARMS_DEALERS; ++ubArmsDealer)
 	{
 
-		//loop through all the item types
+		//loop through all the special items
 		for( usItemIndex = 1; usItemIndex < MAXITEMS; usItemIndex++ )
 		{
 			if (gArmsDealersInventory[ ubArmsDealer ][ usItemIndex ].SpecialItem.size() > 0)
@@ -264,7 +264,6 @@ void DailyUpdateOfArmsDealersInventory()
 // Once a day, loop through each dealer's inventory items and possibly sell some
 static void SimulateArmsDealerCustomer(void)
 {
-	UINT16 usItemIndex;
 	UINT8  ubItemsSold=0;
 	UINT8  ubElement;
 	SPECIAL_ITEM_INFO SpclItemInfo;
@@ -280,8 +279,9 @@ static void SimulateArmsDealerCustomer(void)
 			continue;
 
 		//loop through all items of the same type
-		for( usItemIndex = 1; usItemIndex < MAXITEMS; usItemIndex++ )
+		for (auto item : GCM->getItems())
 		{
+			const auto usItemIndex = item->getItemIndex();
 			//if there are some of these in stock
 			if( gArmsDealersInventory[ ubArmsDealer ][ usItemIndex ].ubTotalItems > 0)
 			{
@@ -326,7 +326,6 @@ static void SimulateArmsDealerCustomer(void)
 
 void DailyCheckOnItemQuantities()
 {
-	UINT16  usItemIndex;
 	UINT8   ubMaxSupply;
 	UINT8   ubNumItems;
 	UINT32  uiArrivalDay;
@@ -348,8 +347,10 @@ void DailyCheckOnItemQuantities()
 
 
 		//loop through all items of the same type
-		for( usItemIndex = 1; usItemIndex < MAXITEMS; usItemIndex++ )
+		for (auto item : GCM->getItems())
 		{
+			const auto usItemIndex = item->getItemIndex();
+
 			//if the dealer can sell the item type
 			if( CanDealerTransactItem( ubArmsDealer, usItemIndex, FALSE ) )
 			{
@@ -499,7 +500,6 @@ void RemoveRandomItemFromArmsDealerInventory(ArmsDealerID, UINT16 usItemIndex, U
 
 static void LimitArmsDealersInventory(ArmsDealerID const ubArmsDealer, UINT32 uiDealerItemType, UINT8 ubMaxNumberOfItemType)
 {
-	UINT16 usItemIndex=0;
 	UINT32 uiItemsToRemove=0;
 	SPECIAL_ITEM_INFO SpclItemInfo;
 
@@ -515,8 +515,9 @@ static void LimitArmsDealersInventory(ArmsDealerID const ubArmsDealer, UINT32 ui
 		return;
 
 	//loop through all items of the same class and count the number in stock
-	for( usItemIndex = 1; usItemIndex < MAXITEMS; usItemIndex++ )
-	{
+	for (auto item : GCM->getItems()) {
+		const auto usItemIndex = item->getItemIndex();
+
 		//if there is some items in stock
 		if( gArmsDealersInventory[ ubArmsDealer ][ usItemIndex ].ubTotalItems > 0)
 		{
@@ -556,7 +557,7 @@ static void LimitArmsDealersInventory(ArmsDealerID const ubArmsDealer, UINT32 ui
 			{
 				if ( uiRandomChoice <= ubNumberOfAvailableItem[ uiIndex ] )
 				{
-					usItemIndex = usAvailableItem[ uiIndex ];
+					const auto usItemIndex = usAvailableItem[ uiIndex ];
 					if ( uiDealerItemType == ARMS_DEALER_AMMO )
 					{
 						// remove all of them, since each ammo item counts as only one "item" here
@@ -633,7 +634,6 @@ static void LimitArmsDealersInventory(ArmsDealerID const ubArmsDealer, UINT32 ui
 
 static void GuaranteeAtLeastOneItemOfType(ArmsDealerID const ubArmsDealer, UINT32 uiDealerItemType)
 {
-	UINT16 usItemIndex;
 	UINT8  ubChance;
 	UINT16 usAvailableItem[ MAXITEMS ] = { NOTHING };
 	UINT8  ubChanceForAvailableItem[ MAXITEMS ] = { 0 };
@@ -647,8 +647,9 @@ static void GuaranteeAtLeastOneItemOfType(ArmsDealerID const ubArmsDealer, UINT3
 		return;
 
 	//loop through all items of the same type
-	for( usItemIndex = 1; usItemIndex < MAXITEMS; usItemIndex++ )
-	{
+	for (auto item : GCM->getItems()) {
+		const auto usItemIndex = item->getItemIndex();
+
 		//if the item is of the same dealer item type
 		if( uiDealerItemType & GetArmsDealerItemTypeFromItemNumber( usItemIndex ) )
 		{
@@ -911,7 +912,6 @@ BOOLEAN RepairmanIsFixingItemsButNoneAreDoneYet( UINT8 ubProfileID )
 {
 	BOOLEAN fHaveOnlyUnRepairedItems=FALSE;
 	UINT8   ubElement;
-	UINT16  usItemIndex;
 
 	ArmsDealerID const bArmsDealer = GetArmsDealerIDFromMercID( ubProfileID );
 	if (bArmsDealer == ARMS_DEALER_INVALID) return FALSE;
@@ -921,8 +921,9 @@ BOOLEAN RepairmanIsFixingItemsButNoneAreDoneYet( UINT8 ubProfileID )
 		return( FALSE );
 
 	//loop through the dealers inventory and check if there are only unrepaired items
-	for( usItemIndex = 1; usItemIndex < MAXITEMS; usItemIndex++ )
-	{
+	for (auto item : GCM->getItems()) {
+		const auto usItemIndex = item->getItemIndex();
+
 		//if there is some items in stock
 		if( gArmsDealersInventory[ bArmsDealer ][ usItemIndex ].ubTotalItems )
 		{
@@ -1159,11 +1160,11 @@ static UINT8 CountActiveSpecialItemsInArmsDealersInventory(ArmsDealerID, UINT16 
 UINT32 CountDistinctItemsInArmsDealersInventory(ArmsDealerID const ubArmsDealer)
 {
 	UINT32	uiNumOfItems=0;
-	UINT16	usItemIndex;
 
 
-	for( usItemIndex = 1; usItemIndex < MAXITEMS; usItemIndex++ )
-	{
+	for (auto item : GCM->getItems()) {
+		const auto usItemIndex = item->getItemIndex();
+
 		//if there are any items
 		if( gArmsDealersInventory[ ubArmsDealer ][ usItemIndex ].ubTotalItems > 0 )
 		{
@@ -1221,7 +1222,6 @@ static UINT8 CountSpecificItemsRepairDealerHasInForRepairs(ArmsDealerID, UINT16 
 
 UINT16 CountTotalItemsRepairDealerHasInForRepairs(ArmsDealerID const ubArmsDealer)
 {
-	UINT16	usItemIndex;
 	UINT16	usHowManyInForRepairs = 0;
 
 	//if the dealer is not a repair dealer, no need to count, return 0
@@ -1229,8 +1229,8 @@ UINT16 CountTotalItemsRepairDealerHasInForRepairs(ArmsDealerID const ubArmsDeale
 		return( 0 );
 
 	//loop through the dealers inventory and count the number of items in for repairs
-	for( usItemIndex=0; usItemIndex < MAXITEMS; usItemIndex++ )
-	{
+	for (auto item : GCM->getItems()) {
+		const auto usItemIndex = item->getItemIndex();
 		usHowManyInForRepairs += CountSpecificItemsRepairDealerHasInForRepairs( ubArmsDealer, usItemIndex );
 	}
 
@@ -1649,7 +1649,6 @@ void RemoveSpecialItemFromArmsDealerInventoryAtElement(ArmsDealerID const ubArms
 
 BOOLEAN AddDeadArmsDealerItemsToWorld(SOLDIERTYPE const* const pSoldier)
 {
-	UINT16 usItemIndex;
 	UINT8  ubElement;
 	UINT8  ubHowManyMaxAtATime;
 	UINT8  ubLeftToDrop;
@@ -1672,8 +1671,9 @@ BOOLEAN AddDeadArmsDealerItemsToWorld(SOLDIERTYPE const* const pSoldier)
 
 	//loop through all the items in the dealer's inventory, and drop them all where the dealer was set up.
 
-	for( usItemIndex = 1; usItemIndex < MAXITEMS; usItemIndex++ )
-	{
+	for (auto item : GCM->getItems()) {
+		const auto usItemIndex = item->getItemIndex();
+
 		//if the dealer has any items of this type
 		if( gArmsDealersInventory[ bArmsDealer ][ usItemIndex ].ubTotalItems > 0)
 		{
@@ -1890,7 +1890,6 @@ static void GiveItemToArmsDealerforRepair(ArmsDealerID const ubArmsDealer, UINT1
 static UINT32 WhenWillRepairmanBeAllDoneRepairing(ArmsDealerID const ubArmsDealer)
 {
 	UINT32 uiWhenFree;
-	UINT16 usItemIndex;
 	UINT8  ubElement;
 
 	Assert( DoesDealerDoRepairs( ubArmsDealer ) );
@@ -1899,8 +1898,9 @@ static UINT32 WhenWillRepairmanBeAllDoneRepairing(ArmsDealerID const ubArmsDeale
 	uiWhenFree = GetWorldTotalMin();
 
 	//loop through the dealers inventory
-	for( usItemIndex = 1; usItemIndex < MAXITEMS; usItemIndex++ )
-	{
+	for (auto item : GCM->getItems()) {
+		const auto usItemIndex = item->getItemIndex();
+
 		//if there is some items in stock
 		if( gArmsDealersInventory[ ubArmsDealer ][ usItemIndex ].ubTotalItems > 0 )
 		{

--- a/src/game/Tactical/Inventory_Choosing.cc
+++ b/src/game/Tactical/Inventory_Choosing.cc
@@ -525,7 +525,6 @@ static UINT16 SelectStandardArmyGun(UINT8 uiGunLevel);
 static void ChooseWeaponForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bWeaponClass, INT8 bAmmoClips, INT8 bAttachClass, BOOLEAN fAttachment)
 {
 	OBJECTTYPE Object;
-	UINT16 i;
 	UINT16 usRandom;
 	UINT16 usNumMatches = 0;
 	UINT16 usGunIndex = 0;
@@ -543,7 +542,7 @@ static void ChooseWeaponForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bW
 	{
 		//Linda has added a specific gun to the merc's inventory, but no ammo.  So, we
 		//will choose ammunition that works with the gun.
-		for( i = 0; i < NUM_INV_SLOTS; i++ )
+		for( UINT16 i = 0; i < NUM_INV_SLOTS; i++ )
 		{
 			if( GCM->getItem(pp->Inv[ i ].usItem)->getItemClass() == IC_GUN )
 			{
@@ -610,10 +609,8 @@ static void ChooseWeaponForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bW
 		while( bAttachClass && !usNumMatches )
 		{
 			//Count the number of valid attachments.
-			for( i = 0; i < MAXITEMS; i++ )
-			{
-				const ItemModel * pItem = GCM->getItem(i);
-				if( pItem->getItemClass() == IC_MISC && pItem->getCoolness() == bAttachClass && ValidAttachment( i, usGunIndex ) )
+			for (auto pItem : GCM->getItems()) {
+				if( pItem->getItemClass() == IC_MISC && pItem->getCoolness() == bAttachClass && ValidAttachment( pItem->getItemIndex(), usGunIndex ) )
 					usNumMatches++;
 			}
 			if( !usNumMatches )
@@ -624,16 +621,14 @@ static void ChooseWeaponForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bW
 		if( usNumMatches )
 		{
 			usRandom = (UINT16)Random( usNumMatches );
-			for( i = 0; i < MAXITEMS; i++ )
-			{
-				const ItemModel * pItem = GCM->getItem(i);
-				if( pItem->getItemClass() == IC_MISC && pItem->getCoolness() == bAttachClass && ValidAttachment( i, usGunIndex ) )
+			for (auto pItem : GCM->getItems()) {
+				if( pItem->getItemClass() == IC_MISC && pItem->getCoolness() == bAttachClass && ValidAttachment( pItem->getItemIndex(), usGunIndex ) )
 				{
 					if( usRandom )
 						usRandom--;
 					else
 					{
-						usAttachIndex = i;
+						usAttachIndex = pItem->getItemIndex();
 						break;
 					}
 				}
@@ -961,7 +956,6 @@ static void ChooseGrenadesForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 
 
 static void ChooseArmourForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bHelmetClass, INT8 bVestClass, INT8 bLeggingsClass)
 {
-	UINT16 i;
 	UINT16 usRandom;
 	UINT16 usNumMatches;
 	INT8 bOrigVestClass = bVestClass;
@@ -974,9 +968,7 @@ static void ChooseArmourForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bH
 		while( bHelmetClass && !usNumMatches )
 		{ //First step is to count the number of helmets in the helmet class range.  If we
 			//don't find one, we keep lowering the class until we do.
-			for( i = 0; i < MAXITEMS; i++ )
-			{
-				const ItemModel * pItem = GCM->getItem(i);
+			for (auto pItem : GCM->getItems()) {
 				// NOTE: This relies on treated armor to have a coolness of 0 in order for enemies not to be equipped with it
 				if( pItem->getItemClass() == IC_ARMOUR && pItem->getCoolness() == bHelmetClass )
 				{
@@ -990,9 +982,7 @@ static void ChooseArmourForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bH
 		if( usNumMatches )
 		{ //There is a helmet that we can choose.
 			usRandom = (UINT16)Random( usNumMatches );
-			for( i = 0; i < MAXITEMS; i++ )
-			{
-				const ItemModel * pItem = GCM->getItem(i);
+			for (auto pItem : GCM->getItems()) {
 				if( pItem->getItemClass() == IC_ARMOUR && pItem->getCoolness() == bHelmetClass )
 				{
 					if( Armour[ pItem->getClassIndex() ].ubArmourClass == ARMOURCLASS_HELMET )
@@ -1003,7 +993,7 @@ static void ChooseArmourForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bH
 						{
 							if( !(pp->Inv[ HELMETPOS ].fFlags & OBJECT_NO_OVERWRITE) )
 							{
-								CreateItem( i, (INT8)(70+Random(31)), &(pp->Inv[ HELMETPOS ]) );
+								CreateItem( pItem->getItemIndex(), (INT8)(70+Random(31)), &(pp->Inv[ HELMETPOS ]) );
 								pp->Inv[ HELMETPOS ].fFlags |= OBJECT_UNDROPPABLE;
 							}
 							break;
@@ -1021,13 +1011,13 @@ static void ChooseArmourForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bH
 		{
 			//First step is to count the number of armours in the armour class range.  If we
 			//don't find one, we keep lowering the class until we do.
-			for( i = 0; i < MAXITEMS; i++ )
-			{
+			for (auto pItem : GCM->getItems()) {
+				auto itemIndex = pItem->getItemIndex();
+
 				// these 3 have a non-zero coolness, and would otherwise be selected, so skip them
-				if ( ( i == TSHIRT ) || ( i == LEATHER_JACKET ) || ( i == TSHIRT_DEIDRANNA ) )
+				if ( ( itemIndex == TSHIRT ) || ( itemIndex == LEATHER_JACKET ) || ( itemIndex == TSHIRT_DEIDRANNA ) )
 					continue;
 
-				const ItemModel * pItem = GCM->getItem(i);
 				// NOTE: This relies on treated armor to have a coolness of 0 in order for enemies not to be equipped with it
 				if( pItem->getItemClass() == IC_ARMOUR && pItem->getCoolness() == bVestClass )
 				{
@@ -1042,13 +1032,13 @@ static void ChooseArmourForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bH
 		{
 			//There is an armour that we can choose.
 			usRandom = (UINT16)Random( usNumMatches );
-			for( i = 0; i < MAXITEMS; i++ )
-			{
+			for (auto pItem : GCM->getItems()) {
+				auto itemIndex = pItem->getItemIndex();
+
 				// these 3 have a non-zero coolness, and would otherwise be selected, so skip them
-				if ( ( i == TSHIRT ) || ( i == LEATHER_JACKET ) || ( i == TSHIRT_DEIDRANNA ) )
+				if ( ( itemIndex == TSHIRT ) || ( itemIndex == LEATHER_JACKET ) || ( itemIndex == TSHIRT_DEIDRANNA ) )
 					continue;
 
-				const ItemModel * pItem = GCM->getItem(i);
 				if( pItem->getItemClass() == IC_ARMOUR && pItem->getCoolness() == bVestClass )
 				{
 					if( Armour[ pItem->getClassIndex() ].ubArmourClass == ARMOURCLASS_VEST )
@@ -1059,10 +1049,10 @@ static void ChooseArmourForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bH
 						{
 							if( !(pp->Inv[ VESTPOS ].fFlags & OBJECT_NO_OVERWRITE) )
 							{
-								CreateItem( i, (INT8)(70+Random(31)), &(pp->Inv[ VESTPOS ]) );
+								CreateItem( itemIndex, (INT8)(70+Random(31)), &(pp->Inv[ VESTPOS ]) );
 								pp->Inv[ VESTPOS ].fFlags |= OBJECT_UNDROPPABLE;
 
-								if ( ( i == KEVLAR_VEST ) || ( i == SPECTRA_VEST ) )
+								if ( ( itemIndex == KEVLAR_VEST ) || ( itemIndex == SPECTRA_VEST ) )
 								{
 									// roll to see if he gets a CERAMIC PLATES, too.
 									// Higher chance the higher his entitled vest class is
@@ -1088,9 +1078,7 @@ static void ChooseArmourForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bH
 		while( bLeggingsClass && !usNumMatches )
 		{ //First step is to count the number of Armours in the Armour class range.  If we
 			//don't find one, we keep lowering the class until we do.
-			for( i = 0; i < MAXITEMS; i++ )
-			{
-				const ItemModel * pItem = GCM->getItem(i);
+			for (auto pItem : GCM->getItems()) {
 				// NOTE: This relies on treated armor to have a coolness of 0 in order for enemies not to be equipped with it
 				if( pItem->getItemClass() == IC_ARMOUR && pItem->getCoolness() == bLeggingsClass )
 				{
@@ -1105,9 +1093,7 @@ static void ChooseArmourForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bH
 		{
 			//There is a legging that we can choose.
 			usRandom = (UINT16)Random( usNumMatches );
-			for( i = 0; i < MAXITEMS; i++ )
-			{
-				const ItemModel * pItem = GCM->getItem(i);
+			for (auto pItem : GCM->getItems()) {
 				if( pItem->getItemClass() == IC_ARMOUR && pItem->getCoolness() == bLeggingsClass )
 				{
 					if( Armour[ pItem->getClassIndex() ].ubArmourClass == ARMOURCLASS_LEGGINGS )
@@ -1118,7 +1104,7 @@ static void ChooseArmourForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bH
 						{
 							if( !(pp->Inv[ LEGPOS ].fFlags & OBJECT_NO_OVERWRITE) )
 							{
-								CreateItem( i, (INT8)(70+Random(31)), &(pp->Inv[ LEGPOS ]) );
+								CreateItem( pItem->getItemIndex(), (INT8)(70+Random(31)), &(pp->Inv[ LEGPOS ]) );
 								pp->Inv[ LEGPOS ].fFlags |= OBJECT_UNDROPPABLE;
 								break;
 							}
@@ -1133,7 +1119,6 @@ static void ChooseArmourForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bH
 
 static void ChooseSpecialWeaponsForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bKnifeClass, BOOLEAN fGrenadeLauncher, BOOLEAN fLAW, BOOLEAN fMortar)
 {
-	UINT16 i;
 	UINT16 usRandom;
 	UINT16 usNumMatches = 0;
 	UINT16 usKnifeIndex = 0;
@@ -1144,10 +1129,10 @@ static void ChooseSpecialWeaponsForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp,
 	{
 		//First step is to count the number of weapons in the weapon class range.  If we
 		//don't find one, we keep lowering the class until we do.
-		for( i = 0; i < MAXITEMS; i++ )
-		{
-			const ItemModel * pItem = GCM->getItem(i);
-			if( ( pItem->getItemClass() == IC_BLADE || pItem->getItemClass() == IC_THROWING_KNIFE ) && pItem->getCoolness() == bKnifeClass )
+		for (auto pItem : GCM->getItems()) {
+			auto itemClass = pItem->getItemClass();
+
+			if( ( itemClass == IC_BLADE || itemClass == IC_THROWING_KNIFE ) && pItem->getCoolness() == bKnifeClass )
 			{
 				usNumMatches++;
 			}
@@ -1159,16 +1144,16 @@ static void ChooseSpecialWeaponsForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp,
 	{
 		//There is a knife that we can choose.
 		usRandom = (UINT16)Random( usNumMatches );
-		for( i = 0; i < MAXITEMS; i++ )
-		{
-			const ItemModel * pItem = GCM->getItem(i);
-			if( ( pItem->getItemClass() == IC_BLADE || pItem->getItemClass() == IC_THROWING_KNIFE ) && pItem->getCoolness() == bKnifeClass )
+		for (auto pItem : GCM->getItems()) {
+			auto itemClass = pItem->getItemClass();
+
+			if( ( itemClass == IC_BLADE || itemClass == IC_THROWING_KNIFE ) && pItem->getCoolness() == bKnifeClass )
 			{
 				if( usRandom )
 					usRandom--;
 				else
 				{
-					usKnifeIndex = i;
+					usKnifeIndex = pItem->getItemIndex();
 					break;
 				}
 			}
@@ -1293,7 +1278,6 @@ static void ChooseFaceGearForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp)
 
 static void ChooseKitsForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bKitClass)
 {
-	UINT16 i;
 	UINT16 usRandom;
 	UINT16 usNumMatches = 0;
 	OBJECTTYPE Object;
@@ -1313,11 +1297,9 @@ static void ChooseKitsForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bKit
 	else
 	{
 		// count how many non-medical KITS are eligible ( of sufficient or lower coolness)
-		for( i = 0; i < MAXITEMS; i++ )
-		{
-			const ItemModel * pItem = GCM->getItem(i);
+		for (auto pItem : GCM->getItems()) {
 			// skip toolkits
-			if( ( pItem->getItemClass() == IC_KIT ) && ( pItem->getCoolness() > 0 ) && pItem->getCoolness() <= bKitClass && ( i != TOOLKIT ) )
+			if( ( pItem->getItemClass() == IC_KIT ) && ( pItem->getCoolness() > 0 ) && pItem->getCoolness() <= bKitClass && ( pItem->getItemIndex() != TOOLKIT ) )
 			{
 				usNumMatches++;
 			}
@@ -1327,18 +1309,18 @@ static void ChooseKitsForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bKit
 		if( usNumMatches )
 		{
 			usRandom = (UINT16)Random( usNumMatches );
-			for( i = 0; i < MAXITEMS; i++ )
-			{
-				const ItemModel * pItem = GCM->getItem(i);
+			for (auto pItem : GCM->getItems()) {
+				auto itemIndex = pItem->getItemIndex();
+
 				// skip toolkits
 				if((pItem->getItemClass() == IC_KIT) && (pItem->getCoolness() > 0) &&
-					pItem->getCoolness() <= bKitClass && (i != TOOLKIT))
+					pItem->getCoolness() <= bKitClass && (itemIndex != TOOLKIT))
 				{
 					if( usRandom )
 						usRandom--;
 					else
 					{
-						usKitItem = i;
+						usKitItem = itemIndex;
 						break;
 					}
 				}
@@ -1420,15 +1402,12 @@ static void ChooseMiscGearForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 
 
 static void ChooseBombsForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bBombClass)
 {
-	UINT16 i;
 	UINT16 usRandom;
 	UINT16 usNumMatches = 0;
 	OBJECTTYPE Object;
 
 	// count how many are eligible
-	for( i = 0; i < MAXITEMS; i++ )
-	{
-		const ItemModel * pItem = GCM->getItem(i);
+	for (auto pItem : GCM->getItems()) {
 		if( ( pItem->getItemClass() == IC_BOMB ) && ( pItem->getCoolness() > 0 ) && ( pItem->getCoolness() <= bBombClass ) )
 		{
 			usNumMatches++;
@@ -1440,16 +1419,14 @@ static void ChooseBombsForSoldierCreateStruct(SOLDIERCREATE_STRUCT* pp, INT8 bBo
 	if( usNumMatches )
 	{
 		usRandom = (UINT16)Random( usNumMatches );
-		for( i = 0; i < MAXITEMS; i++ )
-		{
-			const ItemModel * pItem = GCM->getItem(i);
+		for (auto pItem : GCM->getItems()) {
 			if( ( pItem->getItemClass() == IC_BOMB ) && ( pItem->getCoolness() > 0 ) && ( pItem->getCoolness() <= bBombClass ) )
 			{
 				if( usRandom )
 					usRandom--;
 				else
 				{
-					CreateItem( i, (INT8)(80 + Random( 21 )), &Object );
+					CreateItem( pItem->getItemIndex(), (INT8)(80 + Random( 21 )), &Object );
 					Object.fFlags |= OBJECT_UNDROPPABLE;
 					PlaceObjectInSoldierCreateStruct( pp, &Object );
 					break;


### PR DESCRIPTION
This changes the way items are iterated over in most of the places. `GCM` has a new method, which returns a new class called `ItemRange`, which is a range over the items vector.

It can be used where we need iteration over items instead of the loop over the item ids.

I've used this in most places where we do iterations over item ids, except for two cases:

- When the thing we are iterating over is not really the items vector but something different (e.g. the arms dealer inventory)
- When the iteration logic is not a straight forward iteration over all items.

NB: This would be a place where we actually would benefit from the C++20, as it supports ranges and views over the items vector.