### PR TITLE
Fix warnings when running the unit tests

### DIFF
--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -1,6 +1,7 @@
 #include "DefaultContentManager.h"
 
 #include "Exceptions.h"
+#include "ItemStrings.h"
 #include "game/Directories.h"
 #include "game/Strategic/Strategic_Status.h"
 
@@ -671,17 +672,18 @@ void DefaultContentManager::loadStringRes(const ST::string& name, std::vector<ST
 	}
 }
 
-/** Load the game data. */
+
+/** Load the game data and the item descriptions from the original game resources. */
 bool DefaultContentManager::loadGameData()
 {
-	VanillaItemStrings vanillaItemStrings = {};
-	try {
-		AutoSGPFile f(openGameResForReading(VanillaItemStrings::filename()));
-		vanillaItemStrings = VanillaItemStrings::deserialize(f);
-	} catch (const std::runtime_error& err) {
-		SLOGE("Could not read vanilla item strings from {}: {}", VanillaItemStrings::filename(), err.what());
-	}
+	return loadGameData(VanillaItemStrings::deserialize(
+		AutoSGPFile{ openGameResForReading(VanillaItemStrings::filename()) }));
+}
 
+
+/** Load the game data. */
+bool DefaultContentManager::loadGameData(VanillaItemStrings const& vanillaItemStrings)
+{
 	m_items.resize(MAXITEMS);
 	bool result = loadItems(vanillaItemStrings)
 		&& loadCalibres()

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -10,9 +10,9 @@
 #include "ContentMusic.h"
 #include "IEDT.h"
 #include "IGameDataLoader.h"
-#include "StringEncodingTypes.h"
-#include "RustInterface.h"
 #include "ItemStrings.h"
+#include "RustInterface.h"
+#include "StringEncodingTypes.h"
 
 #include <string_theory/string>
 
@@ -31,7 +31,7 @@ public:
 	void logConfiguration() const override;
 
 	/** Load the game data. */
-	bool loadGameData();
+	virtual bool loadGameData();
 
 	/** Get map file path. */
 	virtual ST::string getMapPath(const ST::string& mapName) const override;
@@ -255,6 +255,7 @@ protected:
 
 	RustPointer<Vfs> m_vfs;
 
+	bool loadGameData(const VanillaItemStrings& vanillaItemStrings);
 	bool loadWeapons(const VanillaItemStrings& vanillaItemStrings);
 	bool loadItems(const VanillaItemStrings& vanillaItemStrings);
 	bool loadMagazines(const VanillaItemStrings& vanillaItemStrings);

--- a/src/externalized/DefaultContentManagerUT.cc
+++ b/src/externalized/DefaultContentManagerUT.cc
@@ -1,5 +1,7 @@
 #include "DefaultContentManagerUT.h"
 
+#include "DefaultContentManager.h"
+#include "ItemStrings.h"
 #include "sgp/FileMan.h"
 #include "externalized/TestUtils.h"
 #include <utility>
@@ -18,4 +20,9 @@ DefaultContentManagerUT* DefaultContentManagerUT::createDefaultCMForTesting()
 	EngineOptions_setVanillaGameDir(engineOptions.get(), gameResRootPath.c_str());
 
 	return new DefaultContentManagerUT(std::move(engineOptions));
+}
+
+bool DefaultContentManagerUT::loadGameData()
+{
+	return DefaultContentManager::loadGameData(VanillaItemStrings{});
 }

--- a/src/externalized/DefaultContentManagerUT.h
+++ b/src/externalized/DefaultContentManagerUT.h
@@ -11,4 +11,6 @@ class DefaultContentManagerUT : public DefaultContentManager
 public:
 	/** Create DefaultContentManager for usage in unit testing. */
 	static DefaultContentManagerUT* createDefaultCMForTesting();
+
+	bool loadGameData() override;
 };


### PR DESCRIPTION
During unit testing the file itemdesc.edt from the original game resources is not available which caused several irritiating warning messages in DefaultContentManager:: loadGameData(). This method is now virtual and overridden by the unit test content manager. The new loadGameData method simply uses an empty VanillaItemStrings instance because the unit tests do not need the actual item descriptions.