### PR TITLE
Change getItem() to throw an exception in case of failure

### DIFF
--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -818,11 +818,12 @@ ItemRange DefaultContentManager::getItems() const
 
 const ItemModel* DefaultContentManager::getItem(uint16_t itemIndex) const
 {
-	if(itemIndex >= m_items.size())
-	{
-		return nullptr;
-	}
-	return m_items[itemIndex];
+	return m_items.at(itemIndex);
+}
+
+const ItemModel* DefaultContentManager::getItem(uint16_t itemIndex, ItemSystem::nothrow_t const&) const noexcept
+{
+	return itemIndex < m_items.size() ? m_items[itemIndex] : nullptr;
 }
 
 const ItemModel* DefaultContentManager::getItemByName(const ST::string &internalName) const

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -91,6 +91,7 @@ public:
 
 	virtual ItemRange getItems() const override;
 	virtual const ItemModel* getItem(uint16_t index) const override;
+	virtual const ItemModel* getItem(uint16_t itemIndex, ItemSystem::nothrow_t const&) const noexcept override;
 	virtual const ItemModel* getItemByName(const ST::string &internalName) const override;
 	virtual const ItemModel* getKeyItemForKeyId(uint16_t usKeyItem) const override;
 	virtual std::vector<ST::string> getAllSmallInventoryGraphicPaths() const override;

--- a/src/externalized/ItemSystem.h
+++ b/src/externalized/ItemSystem.h
@@ -12,6 +12,11 @@ struct ItemModel;
 class ItemSystem
 {
 public:
+	// Similar to std::nothrow and nothrow_t, defined here so we do not have
+	// to include <new> almost everywhere.
+	struct nothrow_t{ explicit nothrow_t() = default; };
+	static inline nothrow_t const nothrow{};
+
 	// Returns a range that can be iterated over, without the NOTHING item
 	virtual ItemRange getItems() const = 0;
 
@@ -19,7 +24,12 @@ public:
 	virtual const ItemModel* getItemByName(const ST::string &internalName) const = 0;
 
 	// Returns an item by numeric id
+	// Throws an exception if itemIndex is invalid
 	virtual const ItemModel* getItem(uint16_t itemIndex) const = 0;
+
+	// Returns an item by numeric id
+	// Returns nullptr if itemIndex is invalid
+	virtual const ItemModel* getItem(uint16_t itemIndex, nothrow_t const&) const noexcept = 0;
 
 	// Returns all paths to small inventory images
 	virtual std::vector<ST::string> getAllSmallInventoryGraphicPaths() const = 0;

--- a/src/externalized/VanillaWeapons_unittests.cc
+++ b/src/externalized/VanillaWeapons_unittests.cc
@@ -191,4 +191,23 @@ TEST(Items, CompatibleFaceItem)
 	}
 }
 
+TEST(Items, Invalid_ItemIndex_Exception)
+{
+	std::unique_ptr<DefaultContentManager> cm(DefaultContentManagerUT::createDefaultCMForTesting());
+	ASSERT_TRUE(cm->loadGameData());
+	auto const oldGCM = std::exchange(GCM, cm.release());
+
+	EXPECT_NO_THROW(GCM->getItem(MAXITEMS - 1));
+	for (uint16_t i = UINT16_MAX; i >= MAXITEMS; --i)
+	{
+		EXPECT_THROW(GCM->getItem(i), std::out_of_range);
+	}
+
+	EXPECT_NO_THROW(GCM->getItem(57000, ItemSystem::nothrow));
+	EXPECT_EQ(GCM->getItem(38000, ItemSystem::nothrow), nullptr);
+
+	delete GCM;
+	GCM = oldGCM;
+}
+
 #endif

--- a/src/game/Laptop/BobbyR.cc
+++ b/src/game/Laptop/BobbyR.cc
@@ -528,8 +528,6 @@ void DailyUpdateOfBobbyRaysNewInventory()
 		usItemIndex = LaptopSaveInfo.BobbyRayInventory[ i ].usItemIndex;
 		const ItemModel *item = GCM->getItem(usItemIndex);
 
-		Assert(usItemIndex < MAXITEMS);
-
 		// make sure this item is still sellable in the latest version of the store inventory
 		if (GCM->getBobbyRayNewInventory()->getMaxItemAmount(item) == 0 )
 		{
@@ -632,7 +630,6 @@ static UINT8 HowManyBRItemsToOrder(UINT16 usItemIndex, UINT8 ubCurrentlyOnHand, 
 	const DealerInventory *inv = ubBobbyRayNewUsed ? GCM->getBobbyRayUsedInventory() : GCM->getBobbyRayNewInventory();
 	const ItemModel *item = GCM->getItem(usItemIndex);
 
-	Assert(usItemIndex < MAXITEMS);
 	// formulas below will fail if there are more items already in stock than optimal
 	Assert(ubCurrentlyOnHand <= inv->getMaxItemAmount(item));
 	Assert(ubBobbyRayNewUsed < BOBBY_RAY_LISTS);

--- a/src/game/Tactical/Items.cc
+++ b/src/game/Tactical/Items.cc
@@ -674,7 +674,7 @@ static const AttachmentInfoStruct* GetAttachmentInfo(const UINT16 usItem)
 
 bool ValidAttachment(UINT16 const attachment, UINT16 const item)
 {
-	const ItemModel *itemModel = GCM->getItem(item);
+	auto * itemModel{ GCM->getItem(item, ItemSystem::nothrow) };
 	if (itemModel && itemModel->canBeAttached(attachment))
 	{
 		return true;

--- a/src/game/Tactical/LoadSaveObjectType.cc
+++ b/src/game/Tactical/LoadSaveObjectType.cc
@@ -10,7 +10,7 @@
 
 static void ReplaceInvalidItem(UINT16 & usItem)
 {
-	const ItemModel* item = GCM->getItem(usItem);
+	auto * item{ GCM->getItem(usItem, ItemSystem::nothrow) };
 	if (!item)
 	{
 		SLOGW("Item (index {}) is not defined and will be ignored. Maybe the file was saved for a different game version", usItem);

--- a/src/game/Tactical/Points.cc
+++ b/src/game/Tactical/Points.cc
@@ -1678,7 +1678,7 @@ INT16 MinAPsToThrow(SOLDIERTYPE const& s, GridNo gridno, bool const add_turning_
 
 	// Make sure the guy's actually got a throwable item in his hand
 	UINT16 const in_hand = s.inv[HANDPOS].usItem;
-	const ItemModel *item = GCM->getItem(in_hand);
+	auto * item{ GCM->getItem(in_hand, ItemSystem::nothrow) };
 	if (!item)
 	{
 		SLOGW("MinAPsToThrow - in-hand item is missing");


### PR DESCRIPTION
getItem returned NULL if the item index was invalid but almost all callers assume a valid pointer.

This commit changes getitem to throw out_of_range exception and adds a new overload with the old behavior for the few cases that actually check the result.