### PR TITLE
Reduce the number of unnecessary vector copies

### DIFF
--- a/src/game/Laptop/Mercs.cc
+++ b/src/game/Laptop/Mercs.cc
@@ -627,7 +627,7 @@ ProfileID GetProfileIDFromMERCListing(const MERCListingModel* listing)
 //Gets the actual merc id from the array
 ProfileID GetProfileIDFromMERCListingIndex(UINT8 ubMercIndex)
 {
-	auto mercsListing = GCM->getMERCListings();
+	auto && mercsListing{ GCM->getMERCListings() };
 	return GetProfileIDFromMERCListing(mercsListing.at(ubMercIndex));
 }
 
@@ -958,7 +958,7 @@ static void MakeBiffAwayForCoupleOfDays(void);
 
 static BOOLEAN IsSpeckTryingToRecruit()
 {
-	auto listings = GCM->getMERCListings();
+	auto && listings{ GCM->getMERCListings() };
 	if (LaptopSaveInfo.gubLastMercIndex >= (listings.size() - 1))
 	{
 		// we have got all mercs already
@@ -1333,7 +1333,7 @@ static BOOLEAN ShouldSpeckStartTalkingDueToActionOnSubPage(void)
 	//if the merc came from the hire screen
 	if( gfJustHiredAMercMerc )
 	{
-		auto listing = GCM->getMERCListings();
+		auto && listing{ GCM->getMERCListings() };
 		HandlePlayerHiringMerc(listing[gubCurMercIndex]);
 
 		//get speck to say the thank you

--- a/src/game/Strategic/Map_Screen_Helicopter.cc
+++ b/src/game/Strategic/Map_Screen_Helicopter.cc
@@ -759,7 +759,7 @@ static void HandleSkyRiderMonologueAboutDrassenSAMSite(UINT32 const uiSpecialCod
 			SkyriderDialogue(MENTION_DRASSEN_SAM_SITE);
 			SkyriderDialogueWithSpecialEvent(SKYRIDER_MONOLOGUE_EVENT_DRASSEN_SAM_SITE, 1);
 
-			auto samList = GCM->getSamSites();
+			auto && samList{ GCM->getSamSites() };
 			if (StrategicMap[SGPSector(samList[SAM_SITE_TWO]->sectorId).AsStrategicIndex()].fEnemyControlled)
 			{
 				SkyriderDialogue(SECOND_HALF_OF_MENTION_DRASSEN_SAM_SITE);
@@ -893,7 +893,7 @@ void HandleAnimationOfSectors( void )
 	static BOOLEAN fOldShowEstoniRefuelHighLight = FALSE;
 	static BOOLEAN fOldShowOtherSAMHighLight = FALSE;
 
-	auto samList = GCM->getSamSites();
+	auto && samList{ GCM->getSamSites() };
 
 	// find out which mode we are in and animate for that mode
 

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -563,7 +563,7 @@ void DrawMap(void)
 		ShowSAMSitesOnStrategicMap();
 
 		// draw mine icons and descriptive text
-		auto mines = GCM->getMines();
+		auto && mines{ GCM->getMines() };
 		for (UINT32 i = 0; i < mines.size(); ++i)
 		{
 			SGPSector sMap(mines[i]->entranceSector);

--- a/src/game/Strategic/Meanwhile.cc
+++ b/src/game/Strategic/Meanwhile.cc
@@ -439,7 +439,7 @@ bool AreInMeanwhile()
 
 static void ProcessImplicationsOfMeanwhile()
 {
-	auto samList = GCM->getSamSites();
+	auto && samList{ GCM->getSamSites() };
 	switch( gCurrentMeanwhileDef.ubMeanwhileID )
 	{
 		case END_OF_PLAYERS_FIRST_BATTLE:

--- a/src/game/Strategic/SAM_Sites.cc
+++ b/src/game/Strategic/SAM_Sites.cc
@@ -65,7 +65,7 @@ void UpdateSAMDoneRepair(const SGPSector& sec)
 
 void UpdateAirspaceControl()
 {
-	auto samList = GCM->getSamSites();
+	auto && samList{ GCM->getSamSites() };
 	SGPSector sMap;
 	for (sMap.x = 1; sMap.x < (MAP_WORLD_X - 1); sMap.x++)
 	{

--- a/src/game/Strategic/Strategic_AI.cc
+++ b/src/game/Strategic/Strategic_AI.cc
@@ -369,9 +369,8 @@ void InitStrategicAI()
 	gubPatrolReinforcementsDenied = new UINT8[gPatrolGroup.size()]{};
 
 	// Initialize the garrison group definitions
-	auto origGarrisonGroups = GCM->getGarrisonGroups();
-	size_t uiGarrisonArraySize = origGarrisonGroups.size();
-	gGarrisonGroup = origGarrisonGroups;
+	gGarrisonGroup = GCM->getGarrisonGroups();
+	size_t uiGarrisonArraySize = gGarrisonGroup.size();
 
 	gubGarrisonReinforcementsDenied = new UINT8[uiGarrisonArraySize]{};
 
@@ -2189,7 +2188,7 @@ void LoadStrategicAI(HWFILE const hFile)
 		EvolveQueenPriorityPhase( TRUE );
 
 		//Recreate the patrol desired sizes
-		auto origPatrolGroup = GCM->getPatrolGroups();
+		auto && origPatrolGroup{ GCM->getPatrolGroups() };
 		for( i = 0; i < gPatrolGroup.size(); i++ )
 		{
 			gPatrolGroup[ i ].bSize = origPatrolGroup[ i ].bSize;

--- a/src/game/Strategic/Strategic_Mines.cc
+++ b/src/game/Strategic/Strategic_Mines.cc
@@ -96,7 +96,7 @@ void InitializeMines( void )
 			return;
 	}
 
-	auto minesData = GCM->getMines();
+	auto && minesData{ GCM->getMines() };
 	while (ubMineProductionIncreases > 0)
 	{
 		// pick a producing mine at random and increase its production


### PR DESCRIPTION
Several ContentManager methods return a reference to a vector. Simply calling this methods with` auto v = GCM-> methodName() `creates a new copy of the vector in v but in most of this cases we simply want to read from the vector.