### PR TITLE
Fix crash on cash deposit

### DIFF
--- a/src/game/Tactical/Arms_Dealer_Init.cc
+++ b/src/game/Tactical/Arms_Dealer_Init.cc
@@ -887,7 +887,7 @@ ArmsDealerID GetArmsDealerIDFromMercID(UINT8 const ubMercID)
 
 ArmsDealerType GetTypeOfArmsDealer(ArmsDealerID ubDealerID)
 {
-	if (ubDealerID >= NUM_ARMS_DEALERS)
+	if (ubDealerID < 0 || ubDealerID >= NUM_ARMS_DEALERS)
 	{
 		return ArmsDealerType::NOT_VALID_DEALER;
 	}


### PR DESCRIPTION
Closes #2040.

Fixes an oversight regarding implicit conversion from signed argument -1 to the unsigned int parameter `ubDealerID`. Had no effect until #2031.