### PR TITLE
Auto resolve cleanup

### DIFF
--- a/src/game/Strategic/Auto_Resolve.cc
+++ b/src/game/Strategic/Auto_Resolve.cc
@@ -466,7 +466,7 @@ void EnterAutoResolveMode(const SGPSector& ubSector)
 
 static void CalculateAttackValues(void);
 static void CalculateAutoResolveInfo(void);
-static void CalculateSoldierCells(BOOLEAN fReset);
+static void CalculateSoldierCells();
 static void CreateAutoResolveInterface(void);
 static void DetermineTeamLeader(BOOLEAN fFriendlyTeam);
 static void HandleAutoResolveInput(void);
@@ -491,7 +491,7 @@ ScreenID AutoResolveScreenHandle()
 		BltVideoSurface(guiSAVEBUFFER, FRAME_BUFFER, 0, 0, NULL);
 		KillPreBattleInterface();
 		CalculateAutoResolveInfo();
-		CalculateSoldierCells( FALSE );
+		CalculateSoldierCells();
 		CreateAutoResolveInterface();
 		DetermineTeamLeader( TRUE ); //friendly team
 		DetermineTeamLeader( FALSE ); //enemy team
@@ -522,20 +522,6 @@ ScreenID AutoResolveScreenHandle()
 	RenderButtons();
 	RenderFastHelp();
 	return AUTORESOLVE_SCREEN;
-}
-
-
-static void RefreshMerc(SOLDIERTYPE* pSoldier)
-{
-	pSoldier->bLife = pSoldier->bLifeMax;
-	pSoldier->bBleeding = 0;
-	pSoldier->bBreath = pSoldier->bBreathMax = 100;
-	pSoldier->sBreathRed = 0;
-	if( gpAR->pRobotCell)
-	{
-		UpdateRobotControllerGivenRobot( gpAR->pRobotCell->pSoldier );
-	}
-	//gpAR->fUnlimitedAmmo = TRUE;
 }
 
 
@@ -633,7 +619,7 @@ static void MercCellMouseClickCallback(MOUSE_REGION* reg, UINT32 reason);
 static void MercCellMouseMoveCallback(MOUSE_REGION* reg, UINT32 reason);
 
 
-static void CalculateSoldierCells(BOOLEAN fReset)
+static void CalculateSoldierCells()
 {
 	INT32 i, x, y;
 	INT32 index, iStartY, iTop, gapStartRow;
@@ -691,8 +677,6 @@ static void CalculateSoldierCells(BOOLEAN fReset)
 				MSYS_PRIORITY_HIGH, CURSOR_NORMAL,
 				MercCellMouseMoveCallback, MercCellMouseClickCallback);
 			c.pRegion->SetUserPtr(&c);
-			if( fReset )
-				RefreshMerc( gpMercs[ index ].pSoldier );
 			if( !gpMercs[ index ].pSoldier->bLife )
 				gpAR->ubAliveMercs--;
 		}

--- a/src/game/Strategic/Auto_Resolve.cc
+++ b/src/game/Strategic/Auto_Resolve.cc
@@ -61,11 +61,6 @@
 #include <string_theory/string>
 
 
-struct BUTTON_PICS;
-
-
-//#define INVULNERABILITY
-
 BOOLEAN gfTransferTacticalOppositionToAutoResolve = FALSE;
 
 //button images
@@ -3075,11 +3070,7 @@ static void AttackTarget(SOLDIERCELL* pAttacker, SOLDIERCELL* pTarget)
 		if( !pTarget->pSoldier->bLife )
 		{
 			gpAR->fRenderAutoResolve = TRUE;
-			#ifdef INVULNERABILITY
-			if( 1 )
-				RefreshMerc( pTarget->pSoldier );
-			else
-			#endif
+
 			if( pTarget->uiFlags & CELL_MERC )
 			{
 				gpAR->usPlayerAttack -= pTarget->usAttack;
@@ -3248,10 +3239,6 @@ static void TargetHitCallback(SOLDIERCELL* pTarget, INT32 index)
 				DoMercBattleSound( pTarget->pSoldier, BATTLE_SOUND_DIE1 );
 			}
 		}
-		#ifdef INVULNERABILITY
-			RefreshMerc( pTarget->pSoldier );
-			return;
-		#endif
 	}
 	//Adjust the soldiers stats based on the damage.
 	pTarget->pSoldier->bLife = (INT8)std::max(iNewLife, 0);


### PR DESCRIPTION
- Remove three unused functions in Auto_Resolve

    
    Previously auto resolve had several cheat keys but these
    all got removed as part of the JA2BETAVERSION removal.
    Since then these function could only be reached through
    a debugger (I didn't test whether they'd still work).

-   Clean up RemoveAutoResolveInterface()
    
    The removed debug code was the only place that called
    this function with a false argument for delete_for_good.

-   Allocate SOLDIERCELL arrays together with AUTORESOLVE_STRUCT
    
    These arrays and the AR struct now have the same lifetime so
    it makes no sense to allocate them seperately.

-   Remove INVULNERABILITY

-   Remove CalculateSoldierCells's parameter
    
    Was now always false; this also made RefreshMerc obsolete.

-   Remove iActualMercFaces
    
    This variable was also only used when the AR screen still
    had cheat keys and it was possible to add more mercs to
    the team.
