### PR TITLE
Fix NPCs getting stuck on diagonal travel through closed sliding door

### DIFF
--- a/src/game/Tactical/PathAI.cc
+++ b/src/game/Tactical/PathAI.cc
@@ -1092,6 +1092,9 @@ INT32 FindBestPath(SOLDIERTYPE* s, INT16 sDestination, INT8 ubLevel, INT16 usMov
 						if (pDoorStructure)
 						{
 							fDoorIsOpen = (pDoorStructure->fFlags & STRUCTURE_OPEN) != 0;
+							// disallow diagonal travel through closed sliding door
+							if (pDoorStructure->fFlags & STRUCTURE_SLIDINGDOOR && !fDoorIsOpen && ubCnt & 1)
+								goto NEXTDIR;
 						}
 						else
 						{


### PR DESCRIPTION
Introduced in #1995

Reproducible by allowing Seargeant to leave. The last door is the sliding door on which he freezes if it's closed.