### PR TITLE
Fix running out of disk space for Android github runner

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -32,6 +32,17 @@ jobs:
     name: ${{ matrix.cfg.name }} ${{ github.ref }}
     runs-on: ${{ matrix.cfg.os }}
     steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      if: ${{ startsWith(matrix.cfg.os, 'ubuntu') }}
+      with:
+        tool-cache: false
+        android: false
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: true
+        swap-storage: true
 
     - name: Context in env
       env:


### PR DESCRIPTION
Tries to fix the disk space issues for the Android build on GitHub actions by clearing some space at the beginning of the pipeline.