### PR TITLE
Less copying in SaveLoadGameStates

### DIFF
--- a/src/game/SaveLoadGameStates.cc
+++ b/src/game/SaveLoadGameStates.cc
@@ -141,12 +141,11 @@ void SavedGameStates::Deserialize(const ST::string& s)
 	for (const auto& key : obj.keys())
 	{
 		auto val = obj[key.c_str()];
-		STORABLE_TYPE v = DeserializeStorableType(val);
-		states[key] = v;
+		states[key] = DeserializeStorableType(val);
 	}
 }
 
-ST::string SavedGameStates::Serialize()
+ST::string SavedGameStates::Serialize() const
 {
 	JsonObject obj;
 	for (const auto& entry : states)
@@ -161,7 +160,7 @@ void SavedGameStates::Clear()
 	states.clear();
 }
 
-StateTable SavedGameStates::GetAll()
+StateTable const& SavedGameStates::GetAll() const noexcept
 {
 	return states;
 }
@@ -187,15 +186,15 @@ std::vector<std::pair<ST::string, ST::string>> GetModInfoFromGameStates(const Sa
 		auto errorMsg = ST::format("Failed to parse JSON from saved game states for mods: missing `{}` key", MODS_KEY);
 		throw std::runtime_error(errorMsg.c_str());
 	}
-	auto str = states.Get<ST::string>(MODS_KEY);
+	auto && str{ states.Get<ST::string>(MODS_KEY) };
 	auto json = JsonValue::deserialize(str);
 
 	for (auto& modJson : json.toVec()) {
 		auto obj = modJson.toObject();
-		ST::string name = obj.GetString("name");
-		ST::string version = obj.GetString("version");
-
-		mods.push_back(std::pair<ST::string, ST::string>(name, version));
+		mods.emplace_back(
+			obj.GetString("name"),
+			obj.GetString("version")
+		);
 	}
 
 	return mods;

--- a/src/game/SaveLoadGameStates.h
+++ b/src/game/SaveLoadGameStates.h
@@ -92,11 +92,11 @@ public:
 	void SetVector(const ST::string& key, std::vector<bool> const& bvec)
 	{
 		std::vector<PRIMITIVE_VALUE> temp;
-		for (auto val : bvec)
+		for (auto && val : bvec)
 		{
-			temp.emplace_back(val);
+			temp.push_back(bool{val});
 		}
-		Set(key, std::move(temp));
+		Set(key, STORABLE_TYPE{ std::move(temp) });
 	}
 
 	/**

--- a/src/game/SaveLoadGameStates.h
+++ b/src/game/SaveLoadGameStates.h
@@ -76,7 +76,10 @@ public:
 		return vec;
 	}
 
-	template<typename T>
+	// This template must be disabled for vector<bool> otherwise the compiler
+	// will choose it as being more specific for some value types of vec, such
+	// as rvalues.
+	template<typename T, std::enable_if_t<!std::is_same_v<bool, T>, bool> = true>
 	void SetVector(const ST::string& key, std::vector<T> && vec)
 	{
 		Set(key, STORABLE_TYPE{
@@ -89,7 +92,7 @@ public:
 
 	// Overload for the problematic vector<bool> to avoid a problem
 	// with Apple Clang or the STL implementation it uses.
-	void SetVector(const ST::string& key, std::vector<bool> const& bvec)
+	void SetVector(ST::string const& key, std::vector<bool> const& bvec)
 	{
 		std::vector<PRIMITIVE_VALUE> temp;
 		for (auto && val : bvec)

--- a/src/game/SaveLoadGameStates.h
+++ b/src/game/SaveLoadGameStates.h
@@ -87,6 +87,18 @@ public:
 		});
 	}
 
+	// Overload for the problematic vector<bool> to avoid a problem
+	// with Apple Clang or the STL implementation it uses.
+	void SetVector(const ST::string& key, std::vector<bool> const& bvec)
+	{
+		std::vector<PRIMITIVE_VALUE> temp;
+		for (auto val : bvec)
+		{
+			temp.emplace_back(val);
+		}
+		Set(key, std::move(temp));
+	}
+
 	/**
 	 * @tparam K
 	 * @tparam V

--- a/src/game/SaveLoadGameStates_unittest.cc
+++ b/src/game/SaveLoadGameStates_unittest.cc
@@ -81,7 +81,9 @@ TEST(SaveLoadGameStatesTest, serializeJSONVector)
 	s.SetVector("S", std::vector<ST::string>{"a", "b"});
 
 	auto ss = s.Serialize();
-	EXPECT_EQ(ss, R"({"B":[false,true],"F":[4.5],"I":[3],"S":["a","b"]})");
+	ST::string expected{ R"({"B":[false,true],"F":[4.5],"I":[3],"S":["a","b"]})" };
+	EXPECT_TRUE(ss == expected);
+	EXPECT_EQ(ss, expected);
 }
 
 TEST(SaveLoadGameStatesTest, serializeJSONMap)

--- a/src/game/SaveLoadGameStates_unittest.cc
+++ b/src/game/SaveLoadGameStates_unittest.cc
@@ -75,13 +75,12 @@ TEST(SaveLoadGameStatesTest, serializeJSON)
 TEST(SaveLoadGameStatesTest, serializeJSONVector)
 {
 	SavedGameStates s;
-	s.SetVector("B", std::vector<bool>{false, true});
 	s.SetVector("I", std::vector<int32_t>{3});
 	s.SetVector("F", std::vector<float>{4.5f});
 	s.SetVector("S", std::vector<ST::string>{"a", "b"});
 
 	auto ss = s.Serialize();
-	ST::string expected{ R"({"B":[false,true],"F":[4.5],"I":[3],"S":["a","b"]})" };
+	ST::string expected{ R"({"F":[4.5],"I":[3],"S":["a","b"]})" };
 	EXPECT_TRUE(ss == expected);
 	EXPECT_EQ(ss, expected);
 }

--- a/src/game/SaveLoadGameStates_unittest.cc
+++ b/src/game/SaveLoadGameStates_unittest.cc
@@ -75,12 +75,13 @@ TEST(SaveLoadGameStatesTest, serializeJSON)
 TEST(SaveLoadGameStatesTest, serializeJSONVector)
 {
 	SavedGameStates s;
+	s.SetVector("B", std::vector<bool>{false, true});
 	s.SetVector("I", std::vector<int32_t>{3});
 	s.SetVector("F", std::vector<float>{4.5f});
 	s.SetVector("S", std::vector<ST::string>{"a", "b"});
 
 	auto ss = s.Serialize();
-	ST::string expected{ R"({"F":[4.5],"I":[3],"S":["a","b"]})" };
+	ST::string expected{ R"({"B":[false,true],"F":[4.5],"I":[3],"S":["a","b"]})" };
 	EXPECT_TRUE(ss == expected);
 	EXPECT_EQ(ss, expected);
 }


### PR DESCRIPTION
• return references instead of copies if possible
• avoid the use of lvalues; pass on function results
  directly to other functions
• use a more efficient way to create the temporary map
  or vector in SetMap and SetVector
• mark getters as const

Should hopefully also get fix CID 407869 although I believe that one is a false positive. The note about "function has been overridden by a builtin model" looks dubious.