### PR TITLE
Fix sign-compare warning in NPCQuoteInfo

### DIFF
--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -1140,7 +1140,7 @@ void DefaultContentManager::loadAllScriptRecords()
 		auto reader = element.toObject();
 		ST::string jsonProfileName = reader.GetString("profile");
 		uint8_t jsonProfileId = (this->getMercProfileInfoByName(jsonProfileName))->profileID;
-		m_scriptRecords[jsonProfileId] = NPCQuoteInfo::deserialize(element, this, this);
+		m_scriptRecords[jsonProfileId] = NPCQuoteInfo::deserialize(element, this);
 	}
 
 	auto json2 = readJsonDataFileWithSchema("script-records-meanwhiles.json");
@@ -1150,11 +1150,11 @@ void DefaultContentManager::loadAllScriptRecords()
 		ST::string jsonProfileName = reader.GetString("profile");
 		uint8_t jsonProfileId = (this->getMercProfileInfoByName(jsonProfileName))->profileID;
 		uint8_t jsonMeanwhileId = reader.GetUInt("meanwhileIndex");
-		m_scriptRecordsMeanwhiles.insert_or_assign({ jsonMeanwhileId, jsonProfileId }, NPCQuoteInfo::deserialize(element, this, this));
+		m_scriptRecordsMeanwhiles.insert_or_assign({ jsonMeanwhileId, jsonProfileId }, NPCQuoteInfo::deserialize(element, this));
 	}
 
 	auto json3 = readJsonDataFileWithSchema("script-records-recruited.json");
-	m_scriptRecordsRecruited = NPCQuoteInfo::deserialize(json3.toVec()[0], this, this);
+	m_scriptRecordsRecruited = NPCQuoteInfo::deserialize(json3.toVec()[0], this);
 }
 
 const std::vector<const BloodCatPlacementsModel*>& DefaultContentManager::getBloodCatPlacements() const

--- a/src/externalized/content/NPCQuoteInfo.h
+++ b/src/externalized/content/NPCQuoteInfo.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include "Interface_Dialogue.h"
-#include "ItemSystem.h"
-#include "MercSystem.h"
-#include "Quests.h"
-
+#include "ContentManager.h"
+#include "Json.h"
+#include "Types.h"
 #include <memory>
 
 constexpr UINT8 NO_QUEST = 255;
@@ -64,5 +62,5 @@ struct NPCQuoteInfo
 	UINT16  usGoToGridno;
 	INT16   sActionData;        // special action value
 
-	static std::unique_ptr<NPCQuoteInfo const []> deserialize(const JsonValue& json, const MercSystem* mercSystem, const ItemSystem* itemSystem);
+	static std::unique_ptr<NPCQuoteInfo const []> deserialize(const JsonValue& json, const ContentManager * contentManager);
 };

--- a/src/game/TacticalAI/NPC.cc
+++ b/src/game/TacticalAI/NPC.cc
@@ -23,6 +23,7 @@
 #include "OppList.h"
 #include "Overhead.h"
 #include "QuestText.h"
+#include "Quests.h"
 #include "Render_Fun.h"
 #include "Scheduling.h"
 #include "SkillCheck.h"


### PR DESCRIPTION
Also, it is not necessary to pass a MercSystem and a ItemSystem pointer to deserialize() because
ContentManager inherits both interfaces.

The code is working as is but this is currently the only warning on the Linux runner; it's nice to keep that one free of warning because it makes it easy to notice any new ones.