### PR TITLE
Clean up ItemModel's deserializer methods

### DIFF
--- a/src/externalized/ItemModel.h
+++ b/src/externalized/ItemModel.h
@@ -92,13 +92,20 @@ struct ItemModel
 	/** Check if the given attachment can be attached to the item. */
 	virtual bool canBeAttached(uint16_t attachment) const;
 
-	virtual JsonValue serialize() const;
+	struct InitData
+	{
+		JsonObject const& json;
+		VanillaItemStrings const& strings;
+	};
 
-	static ST::string deserializeShortName(const JsonObject &obj, const VanillaItemStrings& vanillaItemStrings);
-	static ST::string deserializeName(const JsonObject &obj, const VanillaItemStrings& vanillaItemStrings);
-	static ST::string deserializeDescription(const JsonObject &obj, const VanillaItemStrings& vanillaItemStrings);
+	virtual JsonValue serialize() const;
 	static const ItemModel* deserialize(const JsonValue &json, const VanillaItemStrings& vanillaItemStrings);
+
 protected:
+	static ST::string deserializeShortName(InitData const&);
+	static ST::string deserializeName(InitData const&);
+	static ST::string deserializeDescription(InitData const&);
+
 	uint16_t   itemIndex;
 	ST::string internalName;
 	ST::string shortName;

--- a/src/externalized/MagazineModel.cc
+++ b/src/externalized/MagazineModel.cc
@@ -2,6 +2,7 @@
 
 #include "AmmoTypeModel.h"
 #include "CalibreModel.h"
+#include "ItemModel.h"
 #include <utility>
 
 MagazineModel::MagazineModel(uint16_t itemIndex_,
@@ -63,6 +64,7 @@ MagazineModel* MagazineModel::deserialize(
 	const VanillaItemStrings& vanillaItemStrings)
 {
 	auto obj = json.toObject();
+	ItemModel::InitData const initData{ obj, vanillaItemStrings };
 	int itemIndex                 = obj.GetInt("itemIndex");
 	ST::string internalName       = obj.GetString("internalName");
 	const CalibreModel *calibre   = getCalibre(obj.GetString("calibre"), calibreMap);
@@ -70,9 +72,9 @@ MagazineModel* MagazineModel::deserialize(
 	uint16_t capacity             = obj.GetInt("capacity");
 	const AmmoTypeModel *ammoType = getAmmoType(obj.GetString("ammoType"), ammoTypeMap);
 	bool dontUseAsDefaultMagazine = obj.getOptionalBool("dontUseAsDefaultMagazine");
-	auto shortName = ItemModel::deserializeShortName(obj, vanillaItemStrings);
-	auto name = ItemModel::deserializeName(obj, vanillaItemStrings);
-	auto description = ItemModel::deserializeDescription(obj, vanillaItemStrings);
+	auto shortName = ItemModel::deserializeShortName(initData);
+	auto name = ItemModel::deserializeName(initData);
+	auto description = ItemModel::deserializeDescription(initData);
 	MagazineModel *mag = new MagazineModel(
 		itemIndex,
 		internalName,

--- a/src/externalized/WeaponModels.cc
+++ b/src/externalized/WeaponModels.cc
@@ -1,5 +1,6 @@
 #include "WeaponModels.h"
 #include "CalibreModel.h"
+#include "ItemModel.h"
 #include "Logger.h"
 #include "MagazineModel.h"
 #include "Points.h"
@@ -118,12 +119,13 @@ WeaponModel* WeaponModel::deserialize(const JsonValue &json,
 					const VanillaItemStrings& vanillaItemStrings)
 {
 	auto obj = json.toObject();
+	ItemModel::InitData const initData{ obj, vanillaItemStrings };
 	WeaponModel *wep = NULL;
 	int itemIndex = obj.GetInt("itemIndex");
 	ST::string internalName = obj.GetString("internalName");
-	auto shortName = ItemModel::deserializeShortName(obj, vanillaItemStrings);
-	auto name = ItemModel::deserializeName(obj, vanillaItemStrings);
-	auto description = ItemModel::deserializeDescription(obj, vanillaItemStrings);
+	auto shortName = ItemModel::deserializeShortName(initData);
+	auto name = ItemModel::deserializeName(initData);
+	auto description = ItemModel::deserializeDescription(initData);
 	ST::string internalType = obj.GetString("internalType");
 
 	if (internalType == WEAPON_TYPE_NOWEAPON)


### PR DESCRIPTION
deserializeName, deserializeShortName and deserializeDescription were copy & paste versions of the same code. That code was a bit backwards: it always got the fallback strings before checking if that was even necessary. If the string was overridden in JSON that string was retrieved twice.