### PR TITLE
Clean up CalibreModel

### DIFF
--- a/src/externalized/CalibreModel.cc
+++ b/src/externalized/CalibreModel.cc
@@ -1,30 +1,12 @@
 #include "CalibreModel.h"
 #include "ContentManager.h"
 #include "GameInstance.h"
+#include "Json.h"
 #include <string_theory/format>
 #include <string_theory/string>
 #include <stdexcept>
 #include <utility>
 
-CalibreModel::CalibreModel(uint16_t index_,
-				ST::string internalName_,
-				ST::string sound_,
-				ST::string burstSound_,
-				ST::string silencedSound_,
-				ST::string silencedBurstSound_,
-				bool showInHelpText_,
-				bool monsterWeapon_)
-	:index(index_), internalName(std::move(internalName_)),
-	sound(std::move(sound_)),
-	burstSound(std::move(burstSound_)),
-	silencedSound(std::move(silencedSound_)),
-	silencedBurstSound(std::move(silencedBurstSound_)),
-	showInHelpText(showInHelpText_),
-	monsterWeapon(monsterWeapon_)
-{
-}
-
-CalibreModel::~CalibreModel() = default;
 
 JsonValue CalibreModel::serialize() const
 {
@@ -42,17 +24,19 @@ JsonValue CalibreModel::serialize() const
 
 CalibreModel* CalibreModel::deserialize(const JsonValue &json)
 {
-	auto obj = json.toObject();
-	int index = obj.GetInt("index");
-	ST::string internalName = obj.GetString("internalName");
-	ST::string sound = obj.getOptionalString("sound");
-	ST::string burstSound = obj.getOptionalString("burstSound");
-	ST::string silencedSound = obj.getOptionalString("silencedSound");
-	ST::string silencedBurstSound = obj.getOptionalString("silencedBurstSound");
-	return new CalibreModel(index, internalName, sound, burstSound, silencedSound, silencedBurstSound,
-				obj.GetBool("showInHelpText"),
-				obj.GetBool("monsterWeapon")
-);
+	return new CalibreModel{ json.toObject() };
+}
+
+CalibreModel::CalibreModel(JsonObject const jsonObj) :
+	index{ static_cast<uint16_t>(jsonObj.GetInt("index")) },
+	internalName{ jsonObj.GetString("internalName") },
+	sound{ jsonObj.getOptionalString("sound") },
+	burstSound{ jsonObj.getOptionalString("burstSound") },
+	silencedSound{ jsonObj.getOptionalString("silencedSound") },
+	silencedBurstSound{ jsonObj.getOptionalString("silencedBurstSound") },
+	showInHelpText{ jsonObj.GetBool("showInHelpText") },
+	monsterWeapon{ jsonObj.GetBool("monsterWeapon") }
+{
 }
 
 const ST::string* CalibreModel::getName() const
@@ -62,7 +46,7 @@ const ST::string* CalibreModel::getName() const
 
 const CalibreModel* CalibreModel::getNoCalibreObject()
 {
-	static CalibreModel noCalibre(NOAMMO, "NO CALIBRE", "", "", "", "", false, false);
+	static CalibreModel noCalibre;
 	return &noCalibre;
 }
 

--- a/src/externalized/CalibreModel.h
+++ b/src/externalized/CalibreModel.h
@@ -3,42 +3,32 @@
 #include "Json.h"
 
 #include <map>
-#include <stdexcept>
 #include <stdint.h>
 #include <string_theory/string>
 
-#define NOAMMO (0)
-
 struct CalibreModel
 {
-	CalibreModel(uint16_t index,
-			ST::string internalName,
-			ST::string sound,
-			ST::string burstSound,
-			ST::string silencedSound,
-			ST::string silencedBurstSound,
-			bool showInHelpText,
-			bool monsterWeapon
-	);
+	static constexpr uint16_t NOAMMO = 0;
 
-	// This could be default in C++11
-	virtual ~CalibreModel();
+	[[nodiscard]] const ST::string* getName() const;
 
-	const ST::string* getName() const;
+	[[nodiscard]] JsonValue serialize() const;
+	[[nodiscard]] static CalibreModel* deserialize(const JsonValue &json);
 
-	virtual JsonValue serialize() const;
-	static CalibreModel* deserialize(const JsonValue &json);
+	[[nodiscard]] static const CalibreModel* getNoCalibreObject();
 
-	static const CalibreModel* getNoCalibreObject();
-
-	uint16_t index;
-	ST::string internalName;
+	uint16_t index{ NOAMMO };
+	ST::string internalName{ "NO_CALIBRE" };
 	ST::string sound;
 	ST::string burstSound;
 	ST::string silencedSound;
 	ST::string silencedBurstSound;
-	bool showInHelpText;
-	bool monsterWeapon;
+	bool showInHelpText{ false };
+	bool monsterWeapon{ false };
+
+private:
+	CalibreModel() = default;
+	CalibreModel(JsonObject jsonObj);
 };
 
 const CalibreModel* getCalibre(const ST::string& calibreName,

--- a/src/externalized/MagazineModel.cc
+++ b/src/externalized/MagazineModel.cc
@@ -68,7 +68,7 @@ MagazineModel* MagazineModel::deserialize(
 	int itemIndex                 = obj.GetInt("itemIndex");
 	ST::string internalName       = obj.GetString("internalName");
 	const CalibreModel *calibre   = getCalibre(obj.GetString("calibre"), calibreMap);
-	uint32_t itemClass            = (calibre->index != NOAMMO) ? IC_AMMO : IC_NONE;
+	uint32_t itemClass            = (calibre->index != CalibreModel::NOAMMO) ? IC_AMMO : IC_NONE;
 	uint16_t capacity             = obj.GetInt("capacity");
 	const AmmoTypeModel *ammoType = getAmmoType(obj.GetString("ammoType"), ammoTypeMap);
 	bool dontUseAsDefaultMagazine = obj.getOptionalBool("dontUseAsDefaultMagazine");

--- a/src/game/Tactical/Interface_Items.cc
+++ b/src/game/Tactical/Interface_Items.cc
@@ -2355,7 +2355,7 @@ void RenderItemDescriptionBox(void)
 	{
 		{
 			const WeaponModel * w = GCM->getWeapon(obj.usItem);
-			if (w->calibre->index != NOAMMO)
+			if (w->calibre->index != CalibreModel::NOAMMO)
 			{
 				ST::string name = *w->calibre->getName();
 				pStr += ST::format("{} ", name);

--- a/src/game/Tactical/Items.cc
+++ b/src/game/Tactical/Items.cc
@@ -2463,7 +2463,7 @@ UINT16 DefaultMagazine(UINT16 const gun)
 	const std::vector<const MagazineModel*>& magazines = GCM->getMagazines();
 	for (const MagazineModel* mag : magazines)
 	{
-		if (mag->calibre->index == NOAMMO)      break;
+		if (mag->calibre->index == CalibreModel::NOAMMO) break;
 		if (mag->dontUseAsDefaultMagazine) continue;
 		if (mag->calibre->index != w->calibre->index) continue;
 		if (mag->capacity != w->ubMagSize) continue;
@@ -2480,7 +2480,7 @@ UINT16 FindReplacementMagazine(const CalibreModel * calibre, UINT8 const mag_siz
 	const std::vector<const MagazineModel*>& magazines = GCM->getMagazines();
 	for (const MagazineModel* mag : magazines)
 	{
-		if (mag->calibre->index == NOAMMO)   break;
+		if (mag->calibre->index == CalibreModel::NOAMMO) break;
 		if (mag->calibre->index != calibre->index)  continue;
 		if (mag->capacity != mag_size) continue;
 


### PR DESCRIPTION
This struct neither inherits from anything nor is it inherited anywhere so its functions don't need to be virtual.

Let the constructor do all the work of creating a new instance from JSON instead of moving all data from deserialize().