### PR TITLE
Fix mercs refusing to join/renew contract

### DIFF
--- a/src/game/Laptop/AIMMembers.cc
+++ b/src/game/Laptop/AIMMembers.cc
@@ -90,7 +90,6 @@
 #define SIZE_MERC_ADDITIONAL_INFO		160
 
 #define MERC_ANNOYED_WONT_CONTACT_TIME_MINUTES	6 * 60
-#define NUMBER_HATED_MERCS_ONTEAM		3
 
 
 #define STATS_X					IMAGE_OFFSET_X + 121
@@ -1782,11 +1781,11 @@ static BOOLEAN CanMercBeHired(void)
 		return FALSE;
 	}
 
-	INT const buddy = GetFirstBuddyOnTeam(p);
+	BuddySlot const buddy = GetFirstBuddyOnTeam(p);
 
 	// loop through the list of people the merc hates
 	UINT16 join_quote = QUOTE_NONE;
-	for (UINT8 i = 0; i < NUMBER_HATED_MERCS_ONTEAM; ++i)
+	for (UINT8 i = HATED_SLOT1; i < NUM_HATED_SLOTS; ++i)
 	{
 		//see if someone the merc hates is on the team
 		INT8 const bMercID = p.bHated[i];
@@ -1799,9 +1798,9 @@ static BOOLEAN CanMercBeHired(void)
 		switch (buddy)
 		{
 			UINT16 quote;
-			case 0: quote = QUOTE_JOINING_CAUSE_BUDDY_1_ON_TEAM;               goto join_buddy;
-			case 1: quote = QUOTE_JOINING_CAUSE_BUDDY_2_ON_TEAM;               goto join_buddy;
-			case 2: quote = QUOTE_JOINING_CAUSE_LEARNED_TO_LIKE_BUDDY_ON_TEAM; goto join_buddy;
+			case BUDDY_SLOT1:          quote = QUOTE_JOINING_CAUSE_BUDDY_1_ON_TEAM;               goto join_buddy;
+			case BUDDY_SLOT2:          quote = QUOTE_JOINING_CAUSE_BUDDY_2_ON_TEAM;               goto join_buddy;
+			case LEARNED_TO_LIKE_SLOT: quote = QUOTE_JOINING_CAUSE_LEARNED_TO_LIKE_BUDDY_ON_TEAM; goto join_buddy;
 join_buddy:
 				InitVideoFaceTalking(pid, quote);
 				return TRUE;
@@ -1811,7 +1810,7 @@ join_buddy:
 		UINT16 quote;
 		switch (i)
 		{
-			case 0:
+			case HATED_SLOT1:
 				if (p.bHatedTime[i] >= 24)
 				{
 					join_quote = QUOTE_PERSONALITY_BIAS_WITH_MERC_1;
@@ -1820,7 +1819,7 @@ join_buddy:
 				quote = QUOTE_HATE_MERC_1_ON_TEAM;
 				break;
 
-			case 1:
+			case HATED_SLOT2:
 				if (p.bHatedTime[i] >= 24)
 				{
 					join_quote = QUOTE_PERSONALITY_BIAS_WITH_MERC_2;
@@ -1838,7 +1837,7 @@ join_buddy:
 		return FALSE;
 	}
 
-	if (buddy >= 0) return TRUE;
+	if (buddy != BUDDY_NOT_FOUND) return TRUE;
 
 	// Check the players Death rate
 	if (MercThinksDeathRateTooHigh(p))

--- a/src/game/Strategic/Merc_Contract.cc
+++ b/src/game/Strategic/Merc_Contract.cc
@@ -416,9 +416,9 @@ BOOLEAN WillMercRenew(SOLDIERTYPE* const s, BOOLEAN const say_quote)
 	UINT16 buddy_quote;
 	switch (GetFirstBuddyOnTeam(p))
 	{
-		case 0:  buddy_quote = QUOTE_RENEWING_CAUSE_BUDDY_1_ON_TEAM;               break;
-		case 1:  buddy_quote = QUOTE_RENEWING_CAUSE_BUDDY_2_ON_TEAM;               break;
-		case 2:  buddy_quote = QUOTE_RENEWING_CAUSE_LEARNED_TO_LIKE_BUDDY_ON_TEAM; break;
+		case BUDDY_SLOT1:           buddy_quote = QUOTE_RENEWING_CAUSE_BUDDY_1_ON_TEAM;               break;
+		case BUDDY_SLOT2:           buddy_quote = QUOTE_RENEWING_CAUSE_BUDDY_2_ON_TEAM;               break;
+		case LEARNED_TO_LIKE_SLOT:  buddy_quote = QUOTE_RENEWING_CAUSE_LEARNED_TO_LIKE_BUDDY_ON_TEAM; break;
 		default: buddy_quote = QUOTE_NONE;                                         break;
 	}
 

--- a/src/game/Strategic/Strategic.cc
+++ b/src/game/Strategic/Strategic.cc
@@ -50,12 +50,12 @@ static void HandleSoldierDeadComments(SOLDIERTYPE const* const dead)
 		if (s->bLife < OKLIFE) continue;
 
 		UINT16     quote_num;
-		INT8 const buddy_idx = WhichBuddy(s->ubProfile, dead->ubProfile);
+		BuddySlot const buddy_idx = WhichBuddy(s->ubProfile, dead->ubProfile);
 		switch (buddy_idx)
 		{
-			case 0: quote_num = QUOTE_BUDDY_ONE_KILLED;            break;
-			case 1: quote_num = QUOTE_BUDDY_TWO_KILLED;            break;
-			case 2: quote_num = QUOTE_LEARNED_TO_LIKE_MERC_KILLED; break;
+			case BUDDY_SLOT1:          quote_num = QUOTE_BUDDY_ONE_KILLED;            break;
+			case BUDDY_SLOT2:          quote_num = QUOTE_BUDDY_TWO_KILLED;            break;
+			case LEARNED_TO_LIKE_SLOT: quote_num = QUOTE_LEARNED_TO_LIKE_MERC_KILLED; break;
 
 			default: continue;
 		}

--- a/src/game/Strategic/Strategic_Merc_Handler.cc
+++ b/src/game/Strategic/Strategic_Merc_Handler.cc
@@ -558,12 +558,12 @@ void UpdateBuddyAndHatedCounters(void)
 
 				ProfileID const ubOtherProfileID = other->ubProfile;
 
-				for (INT32 i = 0; i < 4; ++i)
+				for (INT32 i = HATED_SLOT1; i < NUM_HATED_SLOTS + 1; ++i)
 				{
 					switch (i)
 					{
-						case 0:
-						case 1:
+						case HATED_SLOT1:
+						case HATED_SLOT2:
 							if (p.bHated[i] == ubOtherProfileID)
 							{
 								// arrgs, we're on assignment with the person we loathe!
@@ -634,7 +634,7 @@ void UpdateBuddyAndHatedCounters(void)
 							}
 							break;
 
-						case 2:
+						case LEARNED_TO_HATE_SLOT:
 							if (p.bLearnToHate == ubOtherProfileID)
 							{
 								if (p.bLearnToHateCount > 0)
@@ -656,7 +656,7 @@ void UpdateBuddyAndHatedCounters(void)
 									}
 									else if (p.bLearnToHateCount == 0)
 									{ // Set as bHated[2];
-										p.bHated[2] = p.bLearnToHate;
+										p.bHated[LEARNED_TO_HATE_SLOT] = p.bLearnToHate;
 										p.bMercOpinion[ubOtherProfileID] = HATED_OPINION;
 
 										if (s->ubWhatKindOfMercAmI == MERC_TYPE__MERC || (
@@ -704,13 +704,13 @@ void UpdateBuddyAndHatedCounters(void)
 							}
 							break;
 
-						case 3:
+						case LEARNED_TO_LIKE_SLOT + 1:
 							if (p.bLearnToLikeCount > 0	&& p.bLearnToLike == ubOtherProfileID)
 							{
 								p.bLearnToLikeCount--;
 								if (p.bLearnToLikeCount == 0)
 								{ // Add to liked!
-									p.bBuddy[2] = p.bLearnToLike;
+									p.bBuddy[LEARNED_TO_LIKE_SLOT] = p.bLearnToLike;
 									p.bMercOpinion[ubOtherProfileID] = BUDDY_OPINION;
 								}
 								else if (p.bLearnToLikeCount < p.bLearnToLikeTime / 2)

--- a/src/game/Tactical/Handle_Items.cc
+++ b/src/game/Tactical/Handle_Items.cc
@@ -242,7 +242,7 @@ ItemHandleResult HandleItem(SOLDIERTYPE* const s, INT16 usGridNo, const INT8 bLe
 		}
 		// buddies won't shoot each other
 		if (tgt->ubProfile != NO_PROFILE &&
-			WhichBuddy(s->ubProfile, tgt->ubProfile) != -1)
+			WhichBuddy(s->ubProfile, tgt->ubProfile) != BUDDY_NOT_FOUND)
 		{
 			TacticalCharacterDialogue(s, QUOTE_REFUSING_ORDER);
 			return ITEM_HANDLE_REFUSAL;

--- a/src/game/Tactical/Merc_Hiring.cc
+++ b/src/game/Tactical/Merc_Hiring.cc
@@ -390,8 +390,8 @@ void HandleMercArrivesQuotes(SOLDIERTYPE& s)
 		// hates the merc who has arrived and is going to gripe about it!
 		switch (WhichHated(other->ubProfile, s.ubProfile))
 		{
-			case 0:  TacticalCharacterDialogue(other, QUOTE_HATED_1_ARRIVES); break;
-			case 1:  TacticalCharacterDialogue(other, QUOTE_HATED_2_ARRIVES); break;
+			case HATED_SLOT1:  TacticalCharacterDialogue(other, QUOTE_HATED_1_ARRIVES); break;
+			case HATED_SLOT2:  TacticalCharacterDialogue(other, QUOTE_HATED_2_ARRIVES); break;
 			default: break;
 		}
 	}

--- a/src/game/Tactical/Morale.cc
+++ b/src/game/Tactical/Morale.cc
@@ -719,7 +719,7 @@ void HourlyMoraleUpdate()
 			{
 				INT8 const hated = WhichHated(s->ubProfile, other->ubProfile);
 				INT8 hated_time = 0;
-				if (hated > 2)
+				if (hated > 1)
 				{
 					// Learn to hate which has become full-blown hatred, full strength
 					found_hated = true;

--- a/src/game/Tactical/Morale.cc
+++ b/src/game/Tactical/Morale.cc
@@ -574,7 +574,7 @@ void HandleMoraleEvent(SOLDIERTYPE *pSoldier, INT8 bMoraleEvent, const SGPSector
 				if (other.ubProfile == NO_PROFILE) continue;
 
 				// We hate 'em anyways
-				if (WhichHated(other.ubProfile, pSoldier->ubProfile) != -1) continue;
+				if (WhichHated(other.ubProfile, pSoldier->ubProfile) != HATED_NOT_FOUND) continue;
 
 				MERCPROFILESTRUCT const& p = GetProfile(other.ubProfile);
 				if (p.bSex == FEMALE)
@@ -717,15 +717,15 @@ void HourlyMoraleUpdate()
 			INT8 opinion = p.bMercOpinion[other->ubProfile];
 			if (opinion == HATED_OPINION)
 			{
-				INT8 const hated = WhichHated(s->ubProfile, other->ubProfile);
+				HatedSlot const hated = WhichHated(s->ubProfile, other->ubProfile);
 				INT8 hated_time = 0;
-				if (hated > 1)
+				if (hated >= LEARNED_TO_HATE_SLOT)
 				{
 					// Learn to hate which has become full-blown hatred, full strength
 					found_hated = true;
 					break;
 				}
-				else if (hated >= 0)
+				else if (hated >= HATED_SLOT1)
 				{
 					hated_time = p.bHatedTime[hated];
 					if (p.bHatedCount[hated] <= hated_time)

--- a/src/game/Tactical/Overhead.cc
+++ b/src/game/Tactical/Overhead.cc
@@ -2295,12 +2295,12 @@ void HandlePlayerTeamMemberDeath(SOLDIERTYPE* pSoldier)
 		{
 			if (s->bInSector && s->bLife >= OKLIFE)
 			{
-				const INT8 bBuddyIndex = WhichBuddy(s->ubProfile, pSoldier->ubProfile);
+				const BuddySlot bBuddyIndex = WhichBuddy(s->ubProfile, pSoldier->ubProfile);
 				switch (bBuddyIndex)
 				{
-					case 0:  TacticalCharacterDialogue(s, QUOTE_BUDDY_ONE_KILLED);            break;
-					case 1:  TacticalCharacterDialogue(s, QUOTE_BUDDY_TWO_KILLED);            break;
-					case 2:  TacticalCharacterDialogue(s, QUOTE_LEARNED_TO_LIKE_MERC_KILLED); break;
+					case BUDDY_SLOT1:           TacticalCharacterDialogue(s, QUOTE_BUDDY_ONE_KILLED);            break;
+					case BUDDY_SLOT2:           TacticalCharacterDialogue(s, QUOTE_BUDDY_TWO_KILLED);            break;
+					case LEARNED_TO_LIKE_SLOT:  TacticalCharacterDialogue(s, QUOTE_LEARNED_TO_LIKE_MERC_KILLED); break;
 					default: break;
 				}
 			}

--- a/src/game/Tactical/SkillCheck.cc
+++ b/src/game/Tactical/SkillCheck.cc
@@ -425,20 +425,20 @@ INT32 SkillCheck( SOLDIERTYPE * pSoldier, INT8 bReason, INT8 bChanceMod )
 			{
 				if (!OkControllableMerc(s)) continue;
 
-				const INT8 bBuddyIndex = WhichBuddy(s->ubProfile, pSoldier->ubProfile);
-				if (bBuddyIndex >= 0 && SpacesAway(pSoldier->sGridNo, s->sGridNo) < 15)
+				const BuddySlot bBuddyIndex = WhichBuddy(s->ubProfile, pSoldier->ubProfile);
+				if (bBuddyIndex != BUDDY_NOT_FOUND && SpacesAway(pSoldier->sGridNo, s->sGridNo) < 15)
 				{
 					switch (bBuddyIndex)
 					{
-						case 0:
+						case BUDDY_SLOT1:
 							// buddy #1 did something good!
 							TacticalCharacterDialogue(s, QUOTE_BUDDY_1_GOOD);
 							break;
-						case 1:
+						case BUDDY_SLOT2:
 							// buddy #2 did something good!
 							TacticalCharacterDialogue(s, QUOTE_BUDDY_2_GOOD);
 							break;
-						case 2:
+						case LEARNED_TO_LIKE_SLOT:
 							// learn to like buddy did something good!
 							TacticalCharacterDialogue(s, QUOTE_LEARNED_TO_LIKE_WITNESSED);
 							break;

--- a/src/game/Tactical/Soldier_Ani.cc
+++ b/src/game/Tactical/Soldier_Ani.cc
@@ -2558,8 +2558,8 @@ static BOOLEAN ShouldMercSayHappyWithGunQuote(SOLDIERTYPE* pSoldier)
 
 static void SayBuddyWitnessedQuoteFromKill(SOLDIERTYPE* pKillerSoldier, INT16 sGridNo, INT8 bLevel)
 {
-	INT8  bBuddyIndex[ 20 ] = { -1 };
-	INT8  bTempBuddyIndex;
+	BuddySlot  bBuddyIndex[ 20 ] = { BUDDY_NOT_FOUND };
+	BuddySlot  bTempBuddyIndex;
 	UINT8 ubNumMercs = 0;
 	UINT8 ubChosenMerc;
 	INT16 sDistVisible = FALSE;
@@ -2579,25 +2579,25 @@ static void SayBuddyWitnessedQuoteFromKill(SOLDIERTYPE* pKillerSoldier, INT16 sG
 			// Are we a buddy of killer?
 			bTempBuddyIndex = WhichBuddy(s->ubProfile, pKillerSoldier->ubProfile);
 
-			if ( bTempBuddyIndex != -1 )
+			if ( bTempBuddyIndex != BUDDY_NOT_FOUND )
 			{
 				switch( bTempBuddyIndex )
 				{
-					case 0:
+					case BUDDY_SLOT1:
 						if (s->usQuoteSaidExtFlags & SOLDIER_QUOTE_SAID_BUDDY_1_WITNESSED)
 						{
 							continue;
 						}
 						break;
 
-					case 1:
+					case BUDDY_SLOT2:
 						if (s->usQuoteSaidExtFlags & SOLDIER_QUOTE_SAID_BUDDY_2_WITNESSED)
 						{
 							continue;
 						}
 						break;
 
-					case 2:
+					case LEARNED_TO_LIKE_SLOT:
 						if (s->usQuoteSaidExtFlags & SOLDIER_QUOTE_SAID_BUDDY_3_WITNESSED)
 						{
 							continue;
@@ -2640,17 +2640,17 @@ static void SayBuddyWitnessedQuoteFromKill(SOLDIERTYPE* pKillerSoldier, INT16 sG
 			UINT16 usQuoteNum; // XXX HACK000E
 			switch( bBuddyIndex[ ubChosenMerc ] )
 			{
-				case 0:
+				case BUDDY_SLOT1:
 					usQuoteNum = QUOTE_BUDDY_1_GOOD;
 					chosen->usQuoteSaidExtFlags |= SOLDIER_QUOTE_SAID_BUDDY_1_WITNESSED;
 					break;
 
-				case 1:
+				case BUDDY_SLOT2:
 					usQuoteNum = QUOTE_BUDDY_2_GOOD;
 					chosen->usQuoteSaidExtFlags |= SOLDIER_QUOTE_SAID_BUDDY_2_WITNESSED;
 					break;
 
-				case 2:
+				case LEARNED_TO_LIKE_SLOT:
 					usQuoteNum = QUOTE_LEARNED_TO_LIKE_WITNESSED;
 					chosen->usQuoteSaidExtFlags |= SOLDIER_QUOTE_SAID_BUDDY_3_WITNESSED;
 					break;

--- a/src/game/Tactical/Soldier_Profile.cc
+++ b/src/game/Tactical/Soldier_Profile.cc
@@ -858,7 +858,7 @@ INT8 GetFirstBuddyOnTeam(MERCPROFILESTRUCT const& p)
 		if (buddy < 0)                     continue;
 		if (!IsMercOnTeam(buddy))          continue;
 		if (IsMercDead(GetProfile(buddy))) continue;
-		return buddy;
+		return i;
 	}
 	return -1;
 }

--- a/src/game/Tactical/Soldier_Profile.cc
+++ b/src/game/Tactical/Soldier_Profile.cc
@@ -815,52 +815,52 @@ BOOLEAN UnRecruitEPC(ProfileID const pid)
 }
 
 
-INT8 WhichBuddy( UINT8 ubCharNum, UINT8 ubBuddy )
+BuddySlot WhichBuddy( UINT8 ubCharNum, UINT8 ubBuddy )
 {
 	if (ubCharNum == NO_PROFILE)
 	{
-		return -1;
+		return BUDDY_NOT_FOUND;
 	}
 
 	MERCPROFILESTRUCT const& p = GetProfile(ubCharNum);
-	for (INT8 bLoop = 0; bLoop < 3; bLoop++)
+	for (INT8 bLoop = BUDDY_SLOT1; bLoop < NUM_BUDDY_SLOTS; bLoop++)
 	{
 		if (p.bBuddy[bLoop] == ubBuddy)
 		{
-			return( bLoop );
+			return static_cast<BuddySlot>(bLoop);
 		}
 	}
-	return( -1 );
+	return BUDDY_NOT_FOUND;
 }
 
-INT8 WhichHated( UINT8 ubCharNum, UINT8 ubHated )
+HatedSlot WhichHated( UINT8 ubCharNum, UINT8 ubHated )
 {
 	INT8								bLoop;
 
 	MERCPROFILESTRUCT const& p = GetProfile(ubCharNum);
 
-	for (bLoop = 0; bLoop < 3; bLoop++)
+	for (bLoop = HATED_SLOT1; bLoop < NUM_HATED_SLOTS; bLoop++)
 	{
 		if (p.bHated[bLoop] == ubHated)
 		{
-			return( bLoop );
+			return static_cast<HatedSlot>(bLoop);
 		}
 	}
-	return( -1 );
+	return HATED_NOT_FOUND;
 }
 
 
-INT8 GetFirstBuddyOnTeam(MERCPROFILESTRUCT const& p)
+BuddySlot GetFirstBuddyOnTeam(MERCPROFILESTRUCT const& p)
 {
-	for (INT i = 0; i != 3; ++i)
+	for (INT i = BUDDY_SLOT1; i < NUM_BUDDY_SLOTS; ++i)
 	{
 		INT8 const buddy = p.bBuddy[i];
 		if (buddy < 0)                     continue;
 		if (!IsMercOnTeam(buddy))          continue;
 		if (IsMercDead(GetProfile(buddy))) continue;
-		return i;
+		return static_cast<BuddySlot>(i);
 	}
-	return -1;
+	return BUDDY_NOT_FOUND;
 }
 
 

--- a/src/game/Tactical/Soldier_Profile.h
+++ b/src/game/Tactical/Soldier_Profile.h
@@ -205,10 +205,10 @@ BOOLEAN RecruitRPC( UINT8 ubCharNum );
 BOOLEAN RecruitEPC( UINT8 ubCharNum );
 BOOLEAN UnRecruitEPC(ProfileID);
 
-INT8 WhichBuddy( UINT8 ubCharNum, UINT8 ubBuddy );
-INT8 WhichHated( UINT8 ubCharNum, UINT8 ubHated );
+BuddySlot WhichBuddy( UINT8 ubCharNum, UINT8 ubBuddy );
+HatedSlot WhichHated( UINT8 ubCharNum, UINT8 ubHated );
 
-INT8 GetFirstBuddyOnTeam(MERCPROFILESTRUCT const&);
+BuddySlot GetFirstBuddyOnTeam(MERCPROFILESTRUCT const&);
 
 SOLDIERTYPE* ChangeSoldierTeam(SOLDIERTYPE*, UINT8 team);
 

--- a/src/game/Tactical/Soldier_Profile_Type.h
+++ b/src/game/Tactical/Soldier_Profile_Type.h
@@ -158,6 +158,24 @@ enum CharacterEvolution
 #define BUDDY_OPINION						+25
 #define HATED_OPINION						-25
 
+enum BuddySlot
+{
+	BUDDY_NOT_FOUND = -1,
+	BUDDY_SLOT1,
+	BUDDY_SLOT2,
+	LEARNED_TO_LIKE_SLOT,
+	NUM_BUDDY_SLOTS
+};
+
+enum HatedSlot
+{
+	HATED_NOT_FOUND = -1,
+	HATED_SLOT1,
+	HATED_SLOT2,
+	LEARNED_TO_HATE_SLOT,
+	NUM_HATED_SLOTS
+};
+
 struct MERCPROFILESTRUCT
 {
 	ST::string zName;


### PR DESCRIPTION
`GetFirstBuddyOnTeam()` returns merc ID instead of expected index for the array of friends. As a result, mercs who are joining or renewing the contract ignore friends on the team if there are also enemies. The bug is not present in vanilla.

Steps to reproduce (using Grizzly who is friends with Bull and enemies with Dr. Q): 
1. Hire Dr. Q and make sure he's in Omerta
2. Attempt to hire Grizzly. He will decline and mention Dr. Q as the reason.
3. Hire Bull and make sure he's in Omerta
4. Attempt to hire Grizzly. He will decline and mention Dr. Q as the reason. The correct behavior: he must agree and mention Bull as the reason

Additionally: code that's unreachable because `hated` by design cannot be more then 2. Doesn't actually affect anything except 
code readability.