### PR TITLE
Extract smoke effects

### DIFF
--- a/assets/externalized/smoke-effects.json
+++ b/assets/externalized/smoke-effects.json
@@ -1,0 +1,40 @@
+[
+    {
+        "name": "SMOKE",
+        "graphics": "tilecache/smoke.sti",
+        "dissipatingGraphics": "tilecache/smalsmke.sti",
+        "staticGraphics": "tilecache/smkechze.sti",
+        "maxVisibility": 3
+    },
+    {
+        "name": "TEARGAS",
+        "graphics": "tilecache/teargas.sti",
+        "dissipatingGraphics": "tilecache/smaltear.sti",
+        "staticGraphics": "tilecache/tearchze.sti",
+        "damage": 0,
+        "breathDamage": 20,
+        "lostVisibilityPerTile": 2,
+        "maxVisibilityWhenAffected": 2
+    },
+    {
+        "name": "MUSTARDGAS",
+        "graphics": "tilecache/mustard2.sti",
+        "dissipatingGraphics": "tilecache/smalmust.sti",
+        "staticGraphics": "tilecache/mustchze.sti",
+        "damage": 15,
+        "breathDamage": 40,
+        "lostVisibilityPerTile": 2,
+        "maxVisibilityWhenAffected": 2
+    },
+    {
+        "name": "CREATUREGAS",
+        "graphics": "tilecache/spit_gas.sti",
+        "dissipatingGraphics": "tilecache/spit_gas.sti",
+        "staticGraphics": "tilecache/spit_gas.sti",
+        "damage": 5,
+        "breathDamage": 0,
+        "ignoresGasMask": true,
+        "affectsRobot": true,
+        "affectsMonsters": false
+    }
+]

--- a/rust/stracciatella/src/schemas/yaml/smoke-effects.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/smoke-effects.schema.yaml
@@ -1,0 +1,69 @@
+$schema: http://json-schema.org/schema#
+type: array
+title: Smoke Effects
+description: |
+  **Limitations**: No smoke effects can be added or removed currently as they are referenced in source code.
+minItems: 4
+maxItems: 4
+items:
+  allOf:
+    - title: Smoke effect
+      description: |
+        A smoke effect that can affect tiles.
+      type: object
+      properties:
+        name:
+          title: Name
+          description: The internal name used for this smoke effect
+          $ref: types/id.schema.yaml
+        graphics:
+          title: Graphics
+          description: The animation used for the smoke effect
+          $ref: types/resource-path.schema.yaml
+        dissipatingGraphics:
+          title: Dissipating graphics
+          description: The animation used for the smoke effect when dissipating
+          $ref: types/resource-path.schema.yaml
+        staticGraphics:
+          title: Static graphics
+          description: The animation used for the smoke effect when user disabled smoke animation
+          $ref: types/resource-path.schema.yaml
+        breathDamage:
+          title: Breath Damage
+          description: The breath damage caused by this smoke effect per round
+          $ref: types/uint8.schema.yaml
+        damage:
+          title: Damage
+          description: The damage caused by this smoke effect per round
+          $ref: types/uint8.schema.yaml
+        lostVisibilityPerTile:
+          title: Lose visibility per tile
+          description: Lose this amount of tiles of visibility when LOS passes this smoke effect
+          $ref: types/uint8.schema.yaml
+        maxVisibility:
+          title: Max Visibility
+          description: The maximum number of tiles of this smoke effect the LOS can pass without losing visibility
+          $ref: types/uint8.schema.yaml
+        maxVisibilityWhenAffected:
+          title: Max Visibility When Affected
+          description: The maximum number of tiles the merc can see when they are affected by the smoke effect
+        ignoresGasMask:
+          title: Ignores Gas Mask
+          description: Does this smoke effect ignore the mercs gas mask and affect them anyways.
+          type: boolean
+          default: false
+        affectsRobot:
+          title: Affects Robot
+          description: Does this smoke effect affect the robot?
+          type: boolean
+          default: false
+        affectsMonsters:
+          title: Affects Monsters
+          description: Does this smoke effect affect monsters?
+          type: boolean
+          default: true
+      required:
+        - name
+        - graphics
+        - dissipatingGraphics
+        - staticGraphics

--- a/src/externalized/ContentManager.h
+++ b/src/externalized/ContentManager.h
@@ -24,6 +24,7 @@ class DealerModel;
 class ExplosionAnimationModel;
 class FactParamsModel;
 class GamePolicy;
+class SmokeEffectModel;
 class GarrisonGroupModel;
 class IMPPolicy;
 class ExplosiveCalibreModel;
@@ -56,6 +57,7 @@ struct ARMY_COMPOSITION;
 struct PATROL_GROUP;
 struct GARRISON_GROUP;
 struct NPCQuoteInfo;
+enum class SmokeEffectID;
 
 class ContentManager : public ItemSystem, public MercSystem
 {
@@ -117,6 +119,8 @@ public:
 	virtual const ST::string* getCalibreNameForBobbyRay(uint8_t index) const = 0;
 
 	virtual const AmmoTypeModel* getAmmoType(uint8_t index) = 0;
+
+	virtual const SmokeEffectModel* getSmokeEffect(SmokeEffectID id) const = 0;
 
 	virtual const ExplosionAnimationModel* getExplosionAnimation(uint8_t id) = 0;
 	virtual const ExplosiveModel* getExplosive(uint16_t index) = 0;

--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -89,6 +89,8 @@ public:
 
 	virtual const AmmoTypeModel* getAmmoType(uint8_t index) override;
 
+	virtual const SmokeEffectModel* getSmokeEffect(SmokeEffectID id) const override;
+
 	virtual const ExplosionAnimationModel* getExplosionAnimation(uint8_t id) override;
 	virtual const ExplosiveModel* getExplosive(uint16_t index) override;
 	virtual const ExplosiveModel* getExplosiveByName(const ST::string &name) override;
@@ -217,6 +219,7 @@ protected:
 	std::map<uint16_t, uint16_t> m_mapItemReplacements;
 	std::multimap<MusicMode, const ST::string> m_musicMap;
 
+	std::vector<const SmokeEffectModel*> m_smokeEffects;
 	std::vector<const ExplosionAnimationModel*> m_explosionAnimations;
 	std::vector<const ExplosiveCalibreModel*> m_explosiveCalibres;
 
@@ -273,6 +276,7 @@ protected:
 
 	bool loadGameData(const VanillaItemStrings& vanillaItemStrings);
 	bool loadWeapons(const VanillaItemStrings& vanillaItemStrings);
+	bool loadSmokeEffects();
 	bool loadExplosionAnimations();
 	bool loadExplosives(const VanillaItemStrings& vanillaItemStrings, const std::vector<const ExplosionAnimationModel*>& animations);
 	bool loadItems(const VanillaItemStrings& vanillaItemStrings);

--- a/src/externalized/ExplosionAnimationModel.cc
+++ b/src/externalized/ExplosionAnimationModel.cc
@@ -1,3 +1,4 @@
+#include "Debug.h"
 #include "ExplosionAnimationModel.h"
 #include "Exceptions.h"
 
@@ -38,6 +39,7 @@ std::vector<const ExplosionAnimationModel*> ExplosionAnimationModel::deserialize
 
 	for (auto& element : jsonVec) {
 		auto model = ExplosionAnimationModel::deserialize(element);
+		SLOGD("Loaded explosion animation {} {}", static_cast<uint16_t>(model->getID()), model->getName());
 
 		explosionAnimations.push_back(model);
 	}

--- a/src/externalized/tactical/CMakeLists.txt
+++ b/src/externalized/tactical/CMakeLists.txt
@@ -2,6 +2,7 @@ file(GLOB LOCAL_JA2_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
 set(JA2_SOURCES
     ${JA2_SOURCES}
     ${LOCAL_JA2_HEADERS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/SmokeEffectModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/MapItemReplacementModel.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/NpcActionParamsModel.cc
     PARENT_SCOPE

--- a/src/externalized/tactical/SmokeEffectModel.cc
+++ b/src/externalized/tactical/SmokeEffectModel.cc
@@ -1,0 +1,107 @@
+#include "SmokeEffectModel.h"
+
+SmokeEffectModel::SmokeEffectModel(
+	SmokeEffectID id,
+	ST::string name,
+	ST::string graphics,
+	ST::string dissipatingGraphics,
+	ST::string staticGraphics,
+	uint8_t damage,
+	uint8_t breathDamage,
+	uint8_t lostVisibilityPerTile,
+	uint8_t maxVisibility,
+	uint8_t maxVisibilityWhenAffected,
+	bool ignoresGasMask,
+	bool affectsRobot,
+	bool affectsMonsters
+) {
+	this->id = id;
+	this->name = name;
+	this->graphics = graphics;
+	this->dissipatingGraphics = dissipatingGraphics;
+	this->staticGraphics = staticGraphics;
+	this->damage = damage;
+	this->breathDamage = breathDamage;
+	this->lostVisibilityPerTile = lostVisibilityPerTile;
+	this->maxVisibility = maxVisibility;
+	this->maxVisibilityWhenAffected = maxVisibilityWhenAffected;
+	this->ignoresGasMask = ignoresGasMask;
+	this->affectsRobot = affectsRobot;
+	this->affectsMonsters = affectsMonsters;
+}
+
+SmokeEffectModel* SmokeEffectModel::deserialize(uint16_t index, const JsonValue& value) {
+	auto obj = value.toObject();
+	auto id = static_cast<SmokeEffectID>(index);
+	auto name = obj.GetString("name");
+	auto graphics = obj.GetString("graphics");
+	auto dissipatingGraphics = obj.GetString("dissipatingGraphics");
+	auto staticGraphics = obj.GetString("staticGraphics");
+	uint8_t damage = obj.getOptionalUInt("damage");
+	uint8_t breathDamage = obj.getOptionalUInt("breathDamage");
+	uint8_t lostVisibilityPerTile = obj.getOptionalUInt("lostVisibilityPerTile");
+	uint8_t maxVisibility = obj.getOptionalUInt("maxVisibility");
+	uint8_t maxVisibilityWhenAffected = obj.getOptionalUInt("maxVisibilityWhenAffected");
+	bool ignoresGasMask = obj.getOptionalBool("ignoresGasMask");
+	bool affectsRobot = obj.getOptionalBool("affectsRobot");
+	bool affectsMonsters = obj.getOptionalBool("affectsMonsters", true);
+
+	return new SmokeEffectModel(id, name, graphics, dissipatingGraphics, staticGraphics, damage, breathDamage, lostVisibilityPerTile, maxVisibility, maxVisibilityWhenAffected, ignoresGasMask, affectsRobot, affectsMonsters);
+}
+
+SmokeEffectID SmokeEffectModel::getID() const {
+	return id;
+}
+
+const ST::string& SmokeEffectModel::getName() const {
+	return name;
+}
+
+const ST::string& SmokeEffectModel::getGraphics() const {
+	return graphics;
+}
+
+const ST::string& SmokeEffectModel::getDissipatingGraphics() const {
+	return dissipatingGraphics;
+}
+
+const ST::string& SmokeEffectModel::getStaticGraphics() const {
+	return staticGraphics;
+}
+
+
+uint8_t SmokeEffectModel::getDamage() const {
+	return damage;
+}
+
+uint8_t SmokeEffectModel::getBreathDamage() const {
+	return breathDamage;
+}
+
+uint8_t SmokeEffectModel::getLostVisibilityPerTile() const {
+	return lostVisibilityPerTile;
+}
+
+uint8_t SmokeEffectModel::getMaxVisibility() const {
+	return maxVisibility;
+}
+
+uint8_t SmokeEffectModel::getMaxVisibilityWhenAffected() const {
+	return maxVisibilityWhenAffected;
+}
+
+bool SmokeEffectModel::dealsAnyDamage() const {
+	return damage > 0 || breathDamage > 0;
+}
+
+bool SmokeEffectModel::getIgnoresGasMask() const {
+	return ignoresGasMask;
+}
+
+bool SmokeEffectModel::getAffectsRobot() const {
+	return affectsRobot;
+}
+
+bool SmokeEffectModel::getAffectsMonsters() const {
+	return affectsMonsters;
+}

--- a/src/externalized/tactical/SmokeEffectModel.h
+++ b/src/externalized/tactical/SmokeEffectModel.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "Json.h"
+
+enum class SmokeEffectID {
+	NOTHING,
+	SMOKE,
+	TEARGAS,
+	MUSTARDGAS,
+	CREATUREGAS
+};
+
+class SmokeEffectModel {
+	public:
+		SmokeEffectModel(
+			SmokeEffectID index,
+			ST::string name,
+			ST::string graphics,
+			ST::string dissipatingGraphics,
+			ST::string staticGraphics,
+			uint8_t damage,
+			uint8_t breathDamage,
+			uint8_t lostVisibilityPerTile,
+			uint8_t maxVisibility,
+			uint8_t maxVisibilityWhenAffected,
+			bool ignoresGasMask,
+			bool affectsRobot,
+			bool affectsMonsters
+		);
+		static SmokeEffectModel* deserialize(uint16_t index, const JsonValue& value);
+
+		SmokeEffectID getID() const;
+		const ST::string& getName() const;
+		const ST::string& getGraphics() const;
+		const ST::string& getDissipatingGraphics() const;
+		const ST::string& getStaticGraphics() const;
+		uint8_t getDamage() const;
+		uint8_t getBreathDamage() const;
+		uint8_t getLostVisibilityPerTile() const;
+		uint8_t getMaxVisibility() const;
+		uint8_t getMaxVisibilityWhenAffected() const;
+		bool dealsAnyDamage() const;
+		bool getIgnoresGasMask() const;
+		bool getAffectsRobot() const;
+		bool getAffectsMonsters() const;
+	private:
+		SmokeEffectID id;
+		ST::string name;
+		ST::string graphics;
+		ST::string dissipatingGraphics;
+		ST::string staticGraphics;
+		uint8_t damage;
+		uint8_t breathDamage;
+		uint8_t lostVisibilityPerTile;
+		uint8_t maxVisibility;
+		uint8_t maxVisibilityWhenAffected;
+		bool ignoresGasMask;
+		bool affectsRobot;
+		bool affectsMonsters;
+};

--- a/src/game/Tactical/OppList.cc
+++ b/src/game/Tactical/OppList.cc
@@ -38,6 +38,7 @@
 #include "Meanwhile.h"
 #include "WorldMan.h"
 #include "SkillCheck.h"
+#include "SmokeEffects.h"
 #include "Smell.h"
 #include "GameSettings.h"
 #include "Game_Clock.h"
@@ -1014,9 +1015,12 @@ INT16 DistanceVisible(const SOLDIERTYPE* pSoldier, INT8 bFacingDir, INT8 bSubjec
 		sDistVisible = std::max(sDistVisible + 5, int(MaxDistanceVisible()));
 	}
 
-	if ( gpWorldLevelData[ pSoldier->sGridNo ].ubExtFlags[ bLevel ] & (MAPELEMENT_EXT_TEARGAS | MAPELEMENT_EXT_MUSTARDGAS) )
+	auto smokeEffectID = GetSmokeEffectOnTile(pSoldier->sGridNo, bLevel);
+	if ( smokeEffectID != SmokeEffectID::NOTHING )
 	{
-		if (!IsWearingHeadGear(*pSoldier, GASMASK))
+		auto smokeEffect = GCM->getSmokeEffect(smokeEffectID);
+		auto maxVisibilityWhenAffected = smokeEffect->getMaxVisibilityWhenAffected();
+		if (maxVisibilityWhenAffected != 0 && (!IsWearingHeadGear(*pSoldier, GASMASK) || smokeEffect->getIgnoresGasMask()))
 		{
 			// in gas without a gas mask; reduce max distance visible to 2 tiles at most
 			sDistVisible = std::min(2, sDistVisible);

--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -2067,7 +2067,7 @@ static void SetSoldierGridNo(SOLDIERTYPE& s, GridNo new_grid_no, BOOLEAN const f
 	}
 
 	// Are we now standing in tear gas without a decently working gas mask?
-	if (GetSmokeEffectOnTile(new_grid_no, s.bLevel) != NO_SMOKE_EFFECT &&
+	if (GetSmokeEffectOnTile(new_grid_no, s.bLevel) != SmokeEffectID::NOTHING &&
 		(s.inv[HEAD1POS].usItem != GASMASK || s.inv[HEAD1POS].bStatus[0] < GASMASK_MIN_STATUS) &&
 		(s.inv[HEAD2POS].usItem != GASMASK || s.inv[HEAD2POS].bStatus[0] < GASMASK_MIN_STATUS))
 	{
@@ -4047,7 +4047,7 @@ void EVENT_BeginMercTurn(SOLDIERTYPE& s)
 	{
 		// Must get a gas mask or leave the gassed area to get over it
 		if (IsWearingHeadGear(s, GASMASK) ||
-			GetSmokeEffectOnTile(s.sGridNo, s.bLevel) == NO_SMOKE_EFFECT)
+			GetSmokeEffectOnTile(s.sGridNo, s.bLevel) == SmokeEffectID::NOTHING)
 		{
 			// Turn off gassed flag
 			s.uiStatusFlags &= ~SOLDIER_GASSED;

--- a/src/game/TacticalAI/AIUtils.cc
+++ b/src/game/TacticalAI/AIUtils.cc
@@ -15,6 +15,7 @@
 #include "Buildings.h"
 #include "Soldier_Macros.h"
 #include "Render_Fun.h"
+#include "SmokeEffects.h"
 #include "StrategicMap.h"
 #include "Environment.h"
 #include "Lighting.h"

--- a/src/game/TileEngine/Explosion_Control.h
+++ b/src/game/TileEngine/Explosion_Control.h
@@ -3,6 +3,7 @@
 
 #include "JA2Types.h"
 #include "ExplosiveModel.h"
+#include "SmokeEffectModel.h"
 #include "Weapons.h"
 #include "Observable.h"
 
@@ -72,7 +73,7 @@ void RemoveAllActiveTimedBombs( void );
 
 #define GASMASK_MIN_STATUS 70
 
-BOOLEAN DishOutGasDamage(SOLDIERTYPE* pSoldier, const ExplosiveModel* pExplosive, INT16 sSubsequent, BOOLEAN fRecompileMovementCosts, INT16 sWoundAmt, INT16 sBreathAmt, SOLDIERTYPE* owner);
+BOOLEAN DishOutGasDamage(SOLDIERTYPE* pSoldier, const SmokeEffectModel* smokeEffect, INT16 sSubsequent, BOOLEAN fRecompileMovementCosts, INT16 sWoundAmt, INT16 sBreathAmt, SOLDIERTYPE* owner);
 
 void HandleExplosionQueue();
 

--- a/src/game/TileEngine/SmokeEffects.h
+++ b/src/game/TileEngine/SmokeEffects.h
@@ -2,16 +2,7 @@
 #define __SMOKE_EFFECTS
 
 #include "JA2Types.h"
-
-// Smoke effect types
-enum SmokeEffectKind
-{
-	NO_SMOKE_EFFECT,
-	NORMAL_SMOKE_EFFECT,
-	TEARGAS_SMOKE_EFFECT,
-	MUSTARDGAS_SMOKE_EFFECT,
-	CREATURE_SMOKE_EFFECT,
-};
+#include "SmokeEffectModel.h"
 
 #define SMOKE_EFFECT_INDOORS          0x01
 #define SMOKE_EFFECT_ON_ROOF          0x02
@@ -34,15 +25,20 @@ struct SMOKEEFFECT
 };
 
 
-// Returns NO_SMOKE_EFFECT if none there...
-SmokeEffectKind GetSmokeEffectOnTile(INT16 sGridNo, INT8 bLevel);
+// Returns the smoke effect id for a specific tile on the current map or SmokeEffectID::NOTHING if no smoke effect is present.
+SmokeEffectID GetSmokeEffectOnTile(INT16 sGridNo, INT8 bLevel);
+// Returns the smoke effect id for the world flags of a tile or SmokeEffectID::NOTHING if no smoke effect is present.
+SmokeEffectID FromWorldFlagsToSmokeType(UINT8 ubWorldFlags);
+
+// Returns whether a soldier was already affected by a specific smoke effect in this round
+bool IsSoldierAlreadyAffectedBySmokeEffect(const SOLDIERTYPE*, const SmokeEffectModel*);
 
 // Decays all smoke effects...
 void DecaySmokeEffects(UINT32 uiTime, bool updateSightings);
 
 // Add smoke to gridno
 // ( Replacement algorithm uses distance away )
-void AddSmokeEffectToTile(SMOKEEFFECT const*, SmokeEffectKind, INT16 sGridNo, INT8 bLevel);
+void AddSmokeEffectToTile(SMOKEEFFECT const*, const SmokeEffectModel*, INT16 sGridNo, INT8 bLevel);
 
 void RemoveSmokeEffectFromTile( INT16 sGridNo, INT8 bLevel );
 


### PR DESCRIPTION
Still needs some testing, but should be about done. This externalizes `SmokeEffectModel` from code, which represents the effects of smoke (e.g. Smoke, Teargas).