### PR TITLE
Fix logic error introduced in the previous commit

### DIFF
--- a/src/game/TacticalAI/Attacks.cc
+++ b/src/game/TacticalAI/Attacks.cc
@@ -675,7 +675,7 @@ static void CalcBestThrow(SOLDIERTYPE* pSoldier, ATTACKTYPE* pBestThrow)
 
 				// Check to see if we have considered this tile before:
 				if (std::find(sExcludeTile, sExcludeTile + ubNumExcludedTiles, sGridNo)
-					== sExcludeTile + ubNumExcludedTiles)
+					!= sExcludeTile + ubNumExcludedTiles)
 				{
 					// already checked!
 					continue;


### PR DESCRIPTION
This code did the opposite of what the comment says and what is intended: the search for gridnos should continue if the current one is not in the excluded list yet.