### PR TITLE
Merge three arrays that control Render()

### DIFF
--- a/src/game/TileEngine/WorldDef.h
+++ b/src/game/TileEngine/WorldDef.h
@@ -165,16 +165,6 @@ struct LEVELNODE
 };
 
 
-#define LAND_START_INDEX			1
-#define OBJECT_START_INDEX			2
-#define STRUCT_START_INDEX			3
-#define SHADOW_START_INDEX			4
-#define MERC_START_INDEX			5
-#define ROOF_START_INDEX			6
-#define ONROOF_START_INDEX			7
-#define TOPMOST_START_INDEX			8
-
-
 struct MAP_ELEMENT
 {
 	union
@@ -214,6 +204,18 @@ struct MAP_ELEMENT
 	UINT8 ubReservedSoldierID;
 	UINT8 ubBloodInfo;
 	UINT8 ubSmellInfo;
+
+	enum NodeIndex : UINT8
+	{
+		LAND_START_INDEX    = 1,
+		OBJECT_START_INDEX  = 2,
+		STRUCT_START_INDEX  = 3,
+		SHADOW_START_INDEX  = 4,
+		MERC_START_INDEX    = 5,
+		ROOF_START_INDEX    = 6,
+		ONROOF_START_INDEX  = 7,
+		TOPMOST_START_INDEX = 8
+	};
 };
 
 /**


### PR DESCRIPTION
Merging the three arrays RenderFX, RenderFXStartIndex and g_render_fx_layer_flags has two advantages:

1. It indicates the close relationship of these arrays and how they control the program flow in Render().
2. This makes it more obvious that copying values from RenderFX and RenderFXStartIndex to temporary arrays at the start of Render() was not necessary. We can just look up these values in the constant table when needed.

Seeing that this data is constant also made it easier to see that we do not need to initialize various variables for every levelnode because they will stay constant while Render() processes an entire render layer.