### PR TITLE
Fix Realtime mode spread burst.

### DIFF
--- a/src/game/Tactical/Real_Time_Input.cc
+++ b/src/game/Tactical/Real_Time_Input.cc
@@ -390,7 +390,7 @@ static void QueryRTLeftButton(UIEventKind* const puiNewEvent)
 						}
 
 						// CHECK IF WE CLICKED-HELD
-						if (COUNTERDONE(LMOUSECLICK_DELAY_COUNTER, false) && gpItemPointer)
+						if (COUNTERDONE(LMOUSECLICK_DELAY_COUNTER, false))
 						{
 							// LEFT CLICK-HOLD EVENT
 							// Switch on UI mode

--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -444,7 +444,7 @@ FireWeaponResult FireWeapon(SOLDIERTYPE * const pSoldier, GridNo const sTargetGr
 				pSoldier->fDoSpread = FALSE;
 			}
 
-			if ( pSoldier->fDoSpread >= 6 )
+			if ( pSoldier->fDoSpread > 6 )
 			{
 				pSoldier->fDoSpread = FALSE;
 			}


### PR DESCRIPTION
Removed a gpItemPointer check that I suspect used to not be correctly set to null as well as a check in Weapons.cc that caused pSoldier->sSpreadLocations[5] to never be used, leading to the last shot of a minimi burst to go to the start of the aimed/spread burst rather than the end.