### PR TITLE
Clean up STRUCTURE_FILE_REF and TILE_IMAGERY

### DIFF
--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -174,14 +174,9 @@ STRUCTURE_FILE_REF::~STRUCTURE_FILE_REF()
 {
 	/* Free all of the memory associated with a file reference, including the file
 	 * reference structure itself */
-	if (DB_STRUCTURE_REF* const sr{ pDBStructureRef })
+	for (auto const& dbs : pDBStructureRef)
 	{
-		DB_STRUCTURE_REF const* const end = &sr[usNumberOfStructures];
-		for (DB_STRUCTURE_REF* i = sr; i != end; ++i)
-		{
-			if (i->ppTile) delete[] i->ppTile;
-		}
-		delete[] sr;
+		delete[] dbs.ppTile;
 	}
 }
 
@@ -321,8 +316,9 @@ static void CreateFileStructureArrays(STRUCTURE_FILE_REF* const pFileRef, UINT32
 { /* Based on a file chunk, creates all the dynamic arrays for the structure
 	 * definitions contained within */
 	auto * pCurrent{ pFileRef->pubStructureData.data() };
-	DB_STRUCTURE_REF* const pDBStructureRef = new DB_STRUCTURE_REF[pFileRef->usNumberOfStructures]{};
-	pFileRef->pDBStructureRef = pDBStructureRef;
+	auto & pDBStructureRef{ pFileRef->pDBStructureRef };
+	pDBStructureRef.resize(pFileRef->usNumberOfStructures);
+
 	for (UINT16 usLoop = 0; usLoop < pFileRef->usNumberOfStructuresStored; ++usLoop)
 	{
 		if (uiDataSize < sizeof(DB_STRUCTURE))

--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -57,8 +57,6 @@
  *    starting with the deletion of a MULTI SPECIAL structure
  */
 
-UINT8 AtHeight[PROFILE_Z_SIZE] = { 0x01, 0x02, 0x04, 0x08 };
-
 constexpr UINT16 FIRST_AVAILABLE_STRUCTURE_ID = INVALID_STRUCTURE_ID + 2;
 
 static UINT16 gusNextAvailableStructureID = FIRST_AVAILABLE_STRUCTURE_ID;
@@ -222,6 +220,9 @@ void FreeAllStructureFiles()
 // Loads a structure file's data as a honking chunk o' memory
 STRUCTURE_FILE_REF::STRUCTURE_FILE_REF(SGPFile & jsdFile)
 {
+	constexpr UINT8 STRUCTURE_FILE_CONTAINS_AUXIMAGEDATA  = 0x01;
+	constexpr UINT8 STRUCTURE_FILE_CONTAINS_STRUCTUREDATA = 0x02;
+
 	BYTE data[16];
 	jsdFile.read(data, sizeof(data));
 

--- a/src/game/TileEngine/Structure.h
+++ b/src/game/TileEngine/Structure.h
@@ -40,7 +40,6 @@ enum StructureDamageReason
 // functions at the structure database level
 STRUCTURE_FILE_REF* LoadStructureFile(ST::string const& fileName);
 void FreeAllStructureFiles( void );
-void FreeStructureFile(STRUCTURE_FILE_REF*);
 
 //
 // functions at the structure instance level

--- a/src/game/TileEngine/Structure.h
+++ b/src/game/TileEngine/Structure.h
@@ -1,7 +1,6 @@
 #ifndef STRUCTURE_H
 #define STRUCTURE_H
 
-#include "AutoObj.h"
 #include "JA2Types.h"
 #include "Structure_Internals.h"
 #include "Overhead_Types.h"
@@ -138,7 +137,5 @@ UINT8				StructureFlagToType( UINT32 uiFlag );
 SoundID GetStructureOpenSound(STRUCTURE const*, bool closing);
 
 extern const UINT8 gubMaterialArmour[];
-
-typedef SGP::AutoObj<STRUCTURE_FILE_REF, FreeStructureFile> AutoStructureFileRef;
 
 #endif

--- a/src/game/TileEngine/Structure_Internals.h
+++ b/src/game/TileEngine/Structure_Internals.h
@@ -198,8 +198,13 @@ struct STRUCTURE_FILE_REF
 	std::vector<RelTileLoc>    pTileLocData;
 	std::vector<std::byte>     pubStructureData;
 	DB_STRUCTURE_REF*   pDBStructureRef; // dynamic array
+
+	 // number of elements in the pAuxData vector, should always be == pAuxData.size()
 	UINT16              usNumberOfStructures;
+	// number of elements pDBStructureRef points to.
 	UINT16              usNumberOfStructuresStored;
+
+	~STRUCTURE_FILE_REF();
 };
 
 #define STRUCTURE_FILE_CONTAINS_AUXIMAGEDATA		0x01

--- a/src/game/TileEngine/Structure_Internals.h
+++ b/src/game/TileEngine/Structure_Internals.h
@@ -160,7 +160,7 @@ struct DB_STRUCTURE_REF
 {
 	DB_STRUCTURE * 												pDBStructure;
 	DB_STRUCTURE_TILE **									ppTile; // dynamic array
-}; // 8 bytes
+};
 
 struct STRUCTURE
 {
@@ -188,20 +188,17 @@ struct STRUCTURE
 	UINT8													ubVehicleHitLocation;
 	UINT8													ubStructureHeight; // if 0, then unset; otherwise stores height of structure when last calculated
 	UINT8													ubUnused[1]; // XXX HACK000B
-}; // 32 bytes
+};
 
 struct STRUCTURE_FILE_REF
 {
 	STRUCTURE_FILE_REF* pPrev;
 	STRUCTURE_FILE_REF* pNext;
-	std::vector<AuxObjectData> pAuxData;
-	std::vector<RelTileLoc>    pTileLocData;
-	std::vector<std::byte>     pubStructureData;
-	DB_STRUCTURE_REF*   pDBStructureRef; // dynamic array
-
-	 // number of elements in the pAuxData vector, should always be == pAuxData.size()
+	std::vector<AuxObjectData>    pAuxData;
+	std::vector<RelTileLoc>       pTileLocData;
+	std::vector<std::byte>        pubStructureData;
+	std::vector<DB_STRUCTURE_REF> pDBStructureRef;
 	UINT16              usNumberOfStructures;
-	// number of elements pDBStructureRef points to.
 	UINT16              usNumberOfStructuresStored;
 
 	~STRUCTURE_FILE_REF();

--- a/src/game/TileEngine/Structure_Internals.h
+++ b/src/game/TileEngine/Structure_Internals.h
@@ -192,8 +192,6 @@ struct STRUCTURE
 
 struct STRUCTURE_FILE_REF
 {
-	STRUCTURE_FILE_REF* pPrev;
-	STRUCTURE_FILE_REF* pNext;
 	std::vector<AuxObjectData>    pAuxData;
 	std::vector<RelTileLoc>       pTileLocData;
 	std::vector<std::byte>        pubStructureData;

--- a/src/game/TileEngine/Structure_Internals.h
+++ b/src/game/TileEngine/Structure_Internals.h
@@ -6,6 +6,7 @@
 // structure_extern.h, not structure.h!
 //
 
+#include "SGPFile.h"
 #include "Types.h"
 #include <cstddef>
 #include <vector>
@@ -199,6 +200,7 @@ struct STRUCTURE_FILE_REF
 	UINT16              usNumberOfStructures;
 	UINT16              usNumberOfStructuresStored;
 
+	STRUCTURE_FILE_REF(SGPFile & jsdFile);
 	~STRUCTURE_FILE_REF();
 };
 

--- a/src/game/TileEngine/Structure_Internals.h
+++ b/src/game/TileEngine/Structure_Internals.h
@@ -7,6 +7,8 @@
 //
 
 #include "Types.h"
+#include <cstddef>
+#include <vector>
 
 // A few words about the overall structure scheme:
 //
@@ -192,13 +194,13 @@ struct STRUCTURE_FILE_REF
 {
 	STRUCTURE_FILE_REF* pPrev;
 	STRUCTURE_FILE_REF* pNext;
-	AuxObjectData*      pAuxData;
-	RelTileLoc*         pTileLocData;
-	UINT8*              pubStructureData;
+	std::vector<AuxObjectData> pAuxData;
+	std::vector<RelTileLoc>    pTileLocData;
+	std::vector<std::byte>     pubStructureData;
 	DB_STRUCTURE_REF*   pDBStructureRef; // dynamic array
 	UINT16              usNumberOfStructures;
 	UINT16              usNumberOfStructuresStored;
-}; // 24 bytes
+};
 
 #define STRUCTURE_FILE_CONTAINS_AUXIMAGEDATA		0x01
 #define STRUCTURE_FILE_CONTAINS_STRUCTUREDATA		0x02

--- a/src/game/TileEngine/Structure_Internals.h
+++ b/src/game/TileEngine/Structure_Internals.h
@@ -44,9 +44,9 @@
 #define STRUCTURE_ON_GROUND_MAX PROFILE_Z_SIZE
 #define STRUCTURE_ON_ROOF_MAX PROFILE_Z_SIZE * 2
 
-typedef UINT8 PROFILE[PROFILE_X_SIZE][PROFILE_Y_SIZE];
+using PROFILE = const UINT8[PROFILE_X_SIZE][PROFILE_Y_SIZE];
 
-extern UINT8 AtHeight[PROFILE_Z_SIZE];
+constexpr UINT8 AtHeight[PROFILE_Z_SIZE] { 0x01, 0x02, 0x04, 0x08 };
 
 // MAP_ELEMENT may get later:
 // PROFILE *		CombinedLOSProfile;
@@ -188,7 +188,6 @@ struct STRUCTURE
 	UINT8													ubWallOrientation;
 	UINT8													ubVehicleHitLocation;
 	UINT8													ubStructureHeight; // if 0, then unset; otherwise stores height of structure when last calculated
-	UINT8													ubUnused[1]; // XXX HACK000B
 };
 
 struct STRUCTURE_FILE_REF
@@ -197,14 +196,11 @@ struct STRUCTURE_FILE_REF
 	std::vector<RelTileLoc>       pTileLocData;
 	std::vector<std::byte>        pubStructureData;
 	std::vector<DB_STRUCTURE_REF> pDBStructureRef;
-	UINT16              usNumberOfStructures;
-	UINT16              usNumberOfStructuresStored;
+	UINT16                        usNumberOfStructures{ 0 };
+	UINT16                        usNumberOfStructuresStored{ 0 };
 
 	STRUCTURE_FILE_REF(SGPFile & jsdFile);
 	~STRUCTURE_FILE_REF();
 };
-
-#define STRUCTURE_FILE_CONTAINS_AUXIMAGEDATA		0x01
-#define STRUCTURE_FILE_CONTAINS_STRUCTUREDATA		0x02
 
 #endif

--- a/src/game/TileEngine/TileDef.cc
+++ b/src/game/TileEngine/TileDef.cc
@@ -64,8 +64,7 @@ void CreateTileDatabase()
 		UINT32 cnt2;
 		for (cnt2 = 0; cnt2 < NumRegions; ++cnt2)
 		{
-			TILE_ELEMENT TileElement;
-			TileElement = TILE_ELEMENT{};
+			TILE_ELEMENT TileElement{};
 			TileElement.usRegionIndex = (UINT16)cnt2;
 			TileElement.hTileSurface	= TileSurf->vo;
 			TileElement.sBuddyNum			= -1;
@@ -75,7 +74,7 @@ void CreateTileDatabase()
 			if (zsi && zsi[cnt2]) TileElement.uiFlags |= MULTI_Z_TILE;
 
 			// Structure database stuff!
-			STRUCTURE_FILE_REF * const sfr = TileSurf->pStructureFileRef;
+			auto const& sfr{ TileSurf->pStructureFileRef };
 			if (sfr && !sfr->pubStructureData.empty())
 			{
 				auto & sr = sfr->pDBStructureRef[cnt2];

--- a/src/game/TileEngine/TileDef.cc
+++ b/src/game/TileEngine/TileDef.cc
@@ -75,11 +75,11 @@ void CreateTileDatabase()
 			if (zsi && zsi[cnt2]) TileElement.uiFlags |= MULTI_Z_TILE;
 
 			// Structure database stuff!
-			STRUCTURE_FILE_REF const* const sfr = TileSurf->pStructureFileRef;
+			STRUCTURE_FILE_REF * const sfr = TileSurf->pStructureFileRef;
 			if (sfr && !sfr->pubStructureData.empty())
 			{
-				DB_STRUCTURE_REF* const sr = &sfr->pDBStructureRef[cnt2];
-				if (sr->pDBStructure) TileElement.pDBStructureRef	= sr;
+				auto & sr = sfr->pDBStructureRef[cnt2];
+				if (sr.pDBStructure) TileElement.pDBStructureRef = &sr;
 			}
 
 			TileElement.fType             = (UINT16)TileSurf->fType;

--- a/src/game/TileEngine/TileDef.cc
+++ b/src/game/TileEngine/TileDef.cc
@@ -76,7 +76,7 @@ void CreateTileDatabase()
 
 			// Structure database stuff!
 			STRUCTURE_FILE_REF const* const sfr = TileSurf->pStructureFileRef;
-			if (sfr && sfr->pubStructureData /* XXX testing wrong attribute? */)
+			if (sfr && !sfr->pubStructureData.empty())
 			{
 				DB_STRUCTURE_REF* const sr = &sfr->pDBStructureRef[cnt2];
 				if (sr->pDBStructure) TileElement.pDBStructureRef	= sr;

--- a/src/game/TileEngine/TileDef.h
+++ b/src/game/TileEngine/TileDef.h
@@ -3,6 +3,7 @@
 
 #include "JA2Types.h"
 #include "TileDat.h"
+#include <memory>
 #include <optional>
 
 // CATEGORY TYPES
@@ -39,7 +40,7 @@ enum WallOrientationDefines
 };
 
 // TERRAIN ID VALUES.
-enum TerrainTypeDefines
+enum TerrainTypeDefines : UINT8
 {
 	NO_TERRAIN,
 	FLAT_GROUND,
@@ -60,15 +61,12 @@ enum TerrainTypeDefines
 struct TILE_IMAGERY
 {
 	HVOBJECT           vo;
-	UINT32             fType;
 	AuxObjectData      *pAuxData;
 	RelTileLoc         *pTileLocData;
-	STRUCTURE_FILE_REF *pStructureFileRef;
-	UINT8              ubTerrainID;
-	BYTE               bRaisedObjectType;
-
-	// Reserved for added room and 32-byte boundaries
-	BYTE               bReserved[2];
+	std::unique_ptr<STRUCTURE_FILE_REF> pStructureFileRef;
+	TileTypeDefines    fType;
+	TerrainTypeDefines ubTerrainID;
+	bool               bRaisedObjectType;
 };
 
 struct TILE_ANIMATION_DATA

--- a/src/game/TileEngine/Tile_Surface.cc
+++ b/src/game/TileEngine/Tile_Surface.cc
@@ -48,10 +48,10 @@ try
 
 	SGP::PODObj<TILE_IMAGERY> pTileSurf;
 
-	if (pStructureFileRef && pStructureFileRef->pAuxData != NULL)
+	if (pStructureFileRef && !pStructureFileRef->pAuxData.empty())
 	{
-		pTileSurf->pAuxData = pStructureFileRef->pAuxData;
-		pTileSurf->pTileLocData = pStructureFileRef->pTileLocData;
+		pTileSurf->pAuxData = pStructureFileRef->pAuxData.data();
+		pTileSurf->pTileLocData = pStructureFileRef->pTileLocData.data();
 	}
 	else if (hImage->uiAppDataSize == hVObject->SubregionCount() * sizeof(AuxObjectData))
 	{

--- a/src/game/TileEngine/Tile_Surface.cc
+++ b/src/game/TileEngine/Tile_Surface.cc
@@ -64,7 +64,7 @@ try
 	}
 
 	pTileSurf->vo                = hVObject.release();
-	pTileSurf->pStructureFileRef = pStructureFileRef.release();
+	pTileSurf->pStructureFileRef.swap(pStructureFileRef);
 	return pTileSurf.Release();
 }
 catch (...)
@@ -76,19 +76,12 @@ catch (...)
 
 void DeleteTileSurface(TILE_IMAGERY* const pTileSurf)
 {
-	if ( pTileSurf->pStructureFileRef != NULL )
-	{
-		delete pTileSurf->pStructureFileRef;
-	}
-	else
+	if (!pTileSurf->pStructureFileRef)
 	{
 		// If a structure file exists, it will free the auxdata.
 		// Since there is no structure file in this instance, we
 		// free it ourselves.
-		if (pTileSurf->pAuxData != NULL)
-		{
-			delete[] pTileSurf->pAuxData;
-		}
+		delete[] pTileSurf->pAuxData;
 	}
 
 	DeleteVideoObject(pTileSurf->vo);

--- a/src/game/TileEngine/Tile_Surface.cc
+++ b/src/game/TileEngine/Tile_Surface.cc
@@ -31,19 +31,19 @@ try
 	// Start by hacking the image filename into that for the structure data
 	ST::string cStructureFilename(FileMan::replaceExtension(cFilename, "jsd"));
 
-	AutoStructureFileRef pStructureFileRef;
+	std::unique_ptr<STRUCTURE_FILE_REF> pStructureFileRef;
 	if (GCM->doesGameResExists( cStructureFilename ))
 	{
 		SLOGD("loading tile {}", cStructureFilename);
 
-		pStructureFileRef = LoadStructureFile(cStructureFilename);
+		pStructureFileRef.reset(LoadStructureFile(cStructureFilename));
 
 		if (hVObject->SubregionCount() != pStructureFileRef->usNumberOfStructures)
 		{
 			throw std::runtime_error("Structure file error");
 		}
 
-		AddZStripInfoToVObject(hVObject.get(), pStructureFileRef, FALSE, 0);
+		AddZStripInfoToVObject(hVObject.get(), pStructureFileRef.get(), FALSE, 0);
 	}
 
 	SGP::PODObj<TILE_IMAGERY> pTileSurf;
@@ -64,7 +64,7 @@ try
 	}
 
 	pTileSurf->vo                = hVObject.release();
-	pTileSurf->pStructureFileRef = pStructureFileRef.Release();
+	pTileSurf->pStructureFileRef = pStructureFileRef.release();
 	return pTileSurf.Release();
 }
 catch (...)
@@ -78,7 +78,7 @@ void DeleteTileSurface(TILE_IMAGERY* const pTileSurf)
 {
 	if ( pTileSurf->pStructureFileRef != NULL )
 	{
-		FreeStructureFile( pTileSurf->pStructureFileRef );
+		delete pTileSurf->pStructureFileRef;
 	}
 	else
 	{

--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -250,7 +250,7 @@ static void AddTileSurface(ST::string const& filename, UINT32 const type)
 	}
 
 	TILE_IMAGERY* const t = LoadTileSurface(filename);
-	t->fType = type;
+	t->fType = static_cast<TileTypeDefines>(type);
 	SetRaisedObjectFlag(filename, t);
 
 	slot = t;


### PR DESCRIPTION
The motivation behind this PR is not a mere puritanical "raw ownings pointers are bad, modern C++ should use RAII" but rather to improve the debug experience with these structs. It is just more productive when your debugger can tell you that `pAuxObjectData` is a vector of 12 elements and not just a pointer to an unknown number of elements, etc.

For example, `gpStructureFileRefs ` in the current code simply points to the first elements of a linked list that usually has more than 300 elements. `gpStructureFileRefs->pNext->pNext->pNext->pNext...` is not fun at all and just a waste of time. The map that replaces this pointer is easy to browse and additionally tells you the filename of the JSD.
