### PR TITLE
Move the FPS limit out of RefreshScreen to a separate function

### DIFF
--- a/src/game/GameLoop.cc
+++ b/src/game/GameLoop.cc
@@ -21,7 +21,6 @@
 #include "HelpScreen.h"
 #include "SaveLoadGame.h"
 #include "Options_Screen.h"
-#include "Video.h"
 #include "Button_System.h"
 #include "Font_Control.h"
 #include "UILayout.h"
@@ -212,7 +211,10 @@ try
 		guiCurrentScreen = uiOldScreen;
 	}
 
-	RefreshScreen();
+	// Call the special version of RefreshScreen that respects the
+	// user defined FPS limit in game.json.
+	extern void RefreshScreenCapped();
+	RefreshScreenCapped();
 
 	guiGameCycleCounter++;
 

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -60,7 +60,6 @@ static SDL_Texture* ScaledScreenTexture;
 static Uint32       g_window_flags = 0;
 static VideoScaleQuality ScaleQuality = VideoScaleQuality::LINEAR;
 static std::chrono::steady_clock::duration TimeBetweenRefreshScreens;
-static std::chrono::steady_clock::time_point LastRefresh;
 
 static void DeletePrimaryVideoSurfaces(void);
 
@@ -484,13 +483,6 @@ void RefreshScreen(void)
 
 	const BOOLEAN scrolling = (gsScrollXIncrement != 0 || gsScrollYIncrement != 0);
 
-	auto const now = std::chrono::steady_clock::now();
-	if (!scrolling && now - LastRefresh < TimeBetweenRefreshScreens)
-	{
-		return;
-	}
-	LastRefresh = now;
-
 	SDL_BlitSurface(FrameBuffer, &MouseBackground, ScreenBuffer, &MouseBackground);
 
 	// This variable will hold the union of all modified regions.
@@ -583,6 +575,23 @@ void RefreshScreen(void)
 	gfForceFullScreenRefresh = FALSE;
 	guiDirtyRegionCount = 0;
 	guiDirtyRegionExCount = 0;
+}
+
+
+// This is a semi-private function that is supposed to be called only
+// by GameLoop(). This is why is has external linkage but is not
+// declared in Video.h.
+void RefreshScreenCapped()
+{
+	static std::chrono::steady_clock::time_point LastRefresh;
+
+	auto const now{ std::chrono::steady_clock::now() };
+	if (gsScrollXIncrement != 0 || gsScrollYIncrement != 0 ||
+	    now - LastRefresh >= TimeBetweenRefreshScreens)
+	{
+		LastRefresh = now;
+		RefreshScreen();
+	}
 }
 
 


### PR DESCRIPTION
RefreshScreen was originally intended to force a refresh of all regions that were marked as invalid at the time. On systems more modern that the original minimum system requirements that resulted in hundreds of FPS and high CPU usage so it got a limiter. However, this meant that in some situations the screen was not updated often enough, resulting in somewhat choppy animations or content that might not show up at all.

Two examples of where you should notice a difference, especially if you have a rather low FPS limit in game.json:
1. The transition from the map screen to the Laptop is now a bit more fluid.
2. The message box that simply says "Saving..." whenever we save the game should now always appear; before it was often not visible at all.