### PR TITLE
Remove workaround for an old SDL bug in ScrollJA2Background

### DIFF
--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -445,12 +445,7 @@ static void ScrollJA2Background(INT16 sScrollXIncrement, INT16 sScrollYIncrement
 	SDL_FillRect(Dest, NULL, 0);
 #endif
 
-	{
-		SurfaceUniquePtr Source(SDL_CreateRGBSurfaceWithFormat(0,
-			ScreenBuffer->w, ScreenBuffer->h, 0, ScreenBuffer->format->format));
-		SDL_BlitSurface(ScreenBuffer, nullptr, Source.get(), nullptr);
-		SDL_BlitSurface(Source.get(), &SrcRect, Dest, &DstRect);
-	}
+	SDL_BlitSurface(Dest, &SrcRect, Dest, &DstRect);
 
 	for (UINT i = 0; i < NumStrips; i++)
 	{


### PR DESCRIPTION
Older versions of SDL_BlitSurface did not always handle the case where the source and destination surface are the same correctly. This bug has been fixed quite a while ago and is included in SDL 2.0.5, which is coincidentally also our current minimum requirement so we can remove the workaround where we use a temporary surface and blit twice.

This makes scrolling a bit faster and we no longer have to allocate at least 600 KB every time we scroll.