### PR TITLE
Bug fix: size of SaveStates in the save game header

### DIFF
--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -80,6 +80,7 @@
 #include "Quests.h"
 #include "Random.h"
 #include "RenderWorld.h"
+#include "SGPFile.h"
 #include "SaveLoadGame.h"
 #include "SaveLoadGameStates.h"
 #include "SaveLoadScreen.h"
@@ -210,6 +211,41 @@ static void InjectGameOptions(DataWriter& d, GAME_OPTIONS const& g)
 	Assert(d.getConsumed() == start + 12);
 }
 
+namespace {
+// This function must be called after setting the file seek position back
+// to the start of the file! It expects to be allowed to overwrite the first
+// 432 bytes.
+void SaveHeader(SGPFile & file, SAVED_GAME_HEADER const& header)
+{
+	// Save the savegame header
+	BYTE data[SAVED_GAME_HEADER::ON_DISK_SIZE];
+	DataWriter d{data};
+	INJ_U32(   d, header.uiSavedGameVersion)
+	INJ_STR(   d, header.zGameVersionNumber, lengthof(header.zGameVersionNumber))
+	d.writeUTF16(header.sSavedGameDesc, SAVED_GAME_HEADER::SIZE_OF_SAVE_GAME_DESC);
+	INJ_SKIP(  d, 4)
+	INJ_U32(   d, header.uiDay)
+	INJ_U8(    d, header.ubHour)
+	INJ_U8(    d, header.ubMin)
+	INJ_I16(   d, header.sSector.x)
+	INJ_I16(   d, header.sSector.y)
+	INJ_I8(    d, header.sSector.z)
+	INJ_U8(    d, header.ubNumOfMercsOnPlayersTeam)
+	INJ_I32(   d, header.iCurrentBalance)
+	INJ_U32(   d, header.uiCurrentScreen)
+	INJ_BOOL(  d, header.fAlternateSector)
+	INJ_BOOL(  d, header.fWorldLoaded)
+	INJ_U8(    d, header.ubLoadScreenID)
+	InjectGameOptions(d, header.sInitialGameOptions);
+	INJ_SKIP(  d, 1)
+	INJ_U32(   d, header.uiRandom)
+	INJ_U32(   d, header.uiSaveStateSize)
+	INJ_SKIP(  d, 108)
+	Assert(d.getConsumed() == SAVED_GAME_HEADER::ON_DISK_SIZE);
+
+	file.write(data, SAVED_GAME_HEADER::ON_DISK_SIZE);
+}
+}
 
 static void CalcJA2EncryptionSet(SAVED_GAME_HEADER const&);
 static void PauseBeforeSaveGame(void);
@@ -286,8 +322,7 @@ BOOLEAN SaveGame(const ST::string& saveName, const ST::string& gameDesc)
 		//Save the current sectors open temp files to the disk
 		SaveCurrentSectorsInformationToTempItemFile();
 
-		SAVED_GAME_HEADER header;
-		header = SAVED_GAME_HEADER{};
+		SAVED_GAME_HEADER header{};
 
 		if (gameDesc.empty())
 		{
@@ -341,35 +376,10 @@ BOOLEAN SaveGame(const ST::string& saveName, const ST::string& gameDesc)
 		}
 
 		header.uiRandom = Random(RAND_MAX);
-		header.uiSaveStateSize = SaveStatesSize();
 
-		// Save the savegame header
-		BYTE  data[432];
-		DataWriter d{data};
-		INJ_U32(   d, header.uiSavedGameVersion)
-		INJ_STR(   d, header.zGameVersionNumber, lengthof(header.zGameVersionNumber))
-		d.writeUTF16(header.sSavedGameDesc, SIZE_OF_SAVE_GAME_DESC);
-		INJ_SKIP(  d, 4)
-		INJ_U32(   d, header.uiDay)
-		INJ_U8(    d, header.ubHour)
-		INJ_U8(    d, header.ubMin)
-		INJ_I16(   d, header.sSector.x)
-		INJ_I16(   d, header.sSector.y)
-		INJ_I8(    d, header.sSector.z)
-		INJ_U8(    d, header.ubNumOfMercsOnPlayersTeam)
-		INJ_I32(   d, header.iCurrentBalance)
-		INJ_U32(   d, header.uiCurrentScreen)
-		INJ_BOOL(  d, header.fAlternateSector)
-		INJ_BOOL(  d, header.fWorldLoaded)
-		INJ_U8(    d, header.ubLoadScreenID)
-		InjectGameOptions(d, header.sInitialGameOptions);
-		INJ_SKIP(  d, 1)
-		INJ_U32(   d, header.uiRandom)
-		INJ_U32(   d, header.uiSaveStateSize)
-		INJ_SKIP(  d, 108)
-		Assert(d.getConsumed() == lengthof(data));
-
-		f->write(data, sizeof(data));
+		// Just reserve space for the header at the start for now, the
+		// actual header data will be written last.
+		f->seek(SAVED_GAME_HEADER::ON_DISK_SIZE, FILE_SEEK_FROM_START);
 
 		CalcJA2EncryptionSet(header);
 
@@ -465,7 +475,15 @@ BOOLEAN SaveGame(const ST::string& saveName, const ST::string& gameDesc)
 
 		NewWayOfSavingBobbyRMailOrdersToSaveGameFile(f);
 
-		SaveStatesToSaveGameFile(f);
+		// Compute this last, after all save functions had the opportunity to
+		// add more data to the SaveStates.
+		header.uiSaveStateSize = SaveStatesToSaveGameFile(*f);
+		f->seek(0, FileSeekMode::FILE_SEEK_FROM_START);
+
+		SaveHeader(*f, header);
+
+		// Close the file.
+		f.Deallocate();
 
 		FileMan::moveFile(GCM->tempFiles()->absolutePath(savegameTempPath), GCM->saveGameFiles()->absolutePath(savegamePath));
 
@@ -528,7 +546,7 @@ void ParseSavedGameHeader(const BYTE *data, SAVED_GAME_HEADER& h, bool stracLinu
 	DataReader d{data};
 	EXTR_U32(   d, h.uiSavedGameVersion);
 	EXTR_STR(   d, h.zGameVersionNumber, lengthof(h.zGameVersionNumber));
-	h.sSavedGameDesc = d.readString(SIZE_OF_SAVE_GAME_DESC, stracLinuxFormat);
+	h.sSavedGameDesc = d.readString(SAVED_GAME_HEADER::SIZE_OF_SAVE_GAME_DESC, stracLinuxFormat);
 	EXTR_SKIP(  d, 4)
 	EXTR_U32(   d, h.uiDay)
 	EXTR_U8(    d, h.ubHour)
@@ -586,7 +604,7 @@ void ExtractSavedGameHeaderFromFile(HWFILE const f, SAVED_GAME_HEADER& h, bool *
 	// first try Strac Linux format
 	try
 	{
-		BYTE data[SAVED_GAME_HEADER_ON_DISK_SIZE_STRAC_LIN];
+		BYTE data[SAVED_GAME_HEADER::ON_DISK_SIZE_STRAC_LIN];
 		f->read(data, sizeof(data));
 		ParseSavedGameHeader(data, h, true);
 		if(isValidSavedGameHeader(h))
@@ -599,7 +617,7 @@ void ExtractSavedGameHeaderFromFile(HWFILE const f, SAVED_GAME_HEADER& h, bool *
 
 	{
 		// trying vanilla format
-		BYTE data[SAVED_GAME_HEADER_ON_DISK_SIZE];
+		BYTE data[SAVED_GAME_HEADER::ON_DISK_SIZE];
 		f->seek(0, FILE_SEEK_FROM_START);
 		f->read(data, sizeof(data));
 		ParseSavedGameHeader(data, h, false);
@@ -607,12 +625,6 @@ void ExtractSavedGameHeaderFromFile(HWFILE const f, SAVED_GAME_HEADER& h, bool *
 	}
 }
 
-void ExtractSavedGameHeaderFromSave(const ST::string &saveName, SAVED_GAME_HEADER& h, bool *stracLinuxFormat)
-{
-	auto savegamePath = GetSaveGamePath(saveName);
-	AutoSGPFile f(GCM->saveGameFiles()->openForReading(savegamePath));
-	ExtractSavedGameHeaderFromFile(f, h, stracLinuxFormat);
-}
 
 static void HandleOldBobbyRMailOrders(void);
 static void LoadGeneralInfo(HWFILE, UINT32 savegame_version);

--- a/src/game/SaveLoadGame.h
+++ b/src/game/SaveLoadGame.h
@@ -11,20 +11,16 @@
 #define BYTESINMEGABYTE				1048576 //1024*1024
 #define REQUIRED_FREE_SPACE				(20 * BYTESINMEGABYTE)
 
-#define SIZE_OF_SAVE_GAME_DESC				128
-
 #define NUM_SAVE_GAME_BACKUPS				2
 
-#define GAME_VERSION_LENGTH				16
-
-#define SAVE__ERROR_NUM				99
-#define SAVE__END_TURN_NUM				98
-
-#define SAVED_GAME_HEADER_ON_DISK_SIZE			(432) // Size of SAVED_GAME_HEADER on disk in Vanilla and Stracciatella Windows
-#define SAVED_GAME_HEADER_ON_DISK_SIZE_STRAC_LIN	(688) // Size of SAVED_GAME_HEADER on disk in Stracciatella Linux
 
 struct SAVED_GAME_HEADER
 {
+	static constexpr size_t GAME_VERSION_LENGTH{ 16 };
+	static constexpr size_t ON_DISK_SIZE{ 432 }; // Size of SAVED_GAME_HEADER on disk in Vanilla and Stracciatella Windows
+	static constexpr size_t ON_DISK_SIZE_STRAC_LIN{ 688 }; // Size of SAVED_GAME_HEADER on disk in Stracciatella Linux
+	static constexpr size_t SIZE_OF_SAVE_GAME_DESC{ 128 }; // Number of UTF-16 characters reserved for the description string
+
 	UINT32	uiSavedGameVersion;
 	char zGameVersionNumber[GAME_VERSION_LENGTH];
 
@@ -70,10 +66,6 @@ extern bool isValidSavedGameHeader(SAVED_GAME_HEADER& h);
 /** @brief Extract saved game header from a file.
  * Return \a stracLinuxFormat = true, when the file is in "Stracciatella Linux" format. */
 void ExtractSavedGameHeaderFromFile(HWFILE, SAVED_GAME_HEADER&, bool *stracLinuxFormat);
-
-/** @brief Extract saved game header from a save name. Uses GCM to determine save location
- * Return \a stracLinuxFormat = true, when the file is in "Stracciatella Linux" format. */
-void ExtractSavedGameHeaderFromSave(const ST::string &saveName, SAVED_GAME_HEADER&, bool *stracLinuxFormat);
 
 
 extern ScreenID guiScreenToGotoAfterLoadingSavedGame;

--- a/src/game/SaveLoadGameStates.cc
+++ b/src/game/SaveLoadGameStates.cc
@@ -11,18 +11,13 @@
 
 SavedGameStates g_gameStates;
 
-uint32_t SaveStatesSize()
-{
-	auto str = g_gameStates.Serialize().to_std_string();
-	return str.size();
-}
-
-void SaveStatesToSaveGameFile(HWFILE const hFile)
+uint32_t SaveStatesToSaveGameFile(SGPFile & hFile)
 {
 	std::string data = g_gameStates.Serialize().to_std_string();
-	UINT32      len  = data.length();
-	hFile->write(&len, sizeof(UINT32));
-	hFile->write(data.c_str(), len);
+	uint32_t const len{ static_cast<uint32_t>(data.length()) };
+	hFile.write(&len, sizeof(len));
+	hFile.write(data.data(), len);
+	return len;
 }
 
 void LoadStatesFromSaveFile(HWFILE const hFile, SavedGameStates &states)

--- a/src/game/SaveLoadGameStates.h
+++ b/src/game/SaveLoadGameStates.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "SGPFile.h"
 #include "Types.h"
 #include <iterator>
 #include <map>
@@ -34,8 +35,7 @@ typedef std::map<ST::string, STORABLE_TYPE> StateTable;
  */
 extern SavedGameStates g_gameStates;
 
-uint32_t SaveStatesSize();
-void SaveStatesToSaveGameFile(HWFILE);
+uint32_t SaveStatesToSaveGameFile(SGPFile &);
 void LoadStatesFromSaveFile(HWFILE, SavedGameStates &states);
 void ResetGameStates();
 

--- a/src/game/SaveLoadGame_unittest.cc
+++ b/src/game/SaveLoadGame_unittest.cc
@@ -83,8 +83,8 @@ const uint8_t s_savedGameHeaderStracLinux[] = {
 
 TEST(SaveLoadGameTest, structSizes)
 {
-	EXPECT_EQ(sizeof(s_savedGameHeaderVanilla),    static_cast<size_t>(SAVED_GAME_HEADER_ON_DISK_SIZE));
-	EXPECT_EQ(sizeof(s_savedGameHeaderStracLinux), static_cast<size_t>(SAVED_GAME_HEADER_ON_DISK_SIZE_STRAC_LIN));
+	EXPECT_EQ(sizeof(s_savedGameHeaderVanilla),    SAVED_GAME_HEADER::ON_DISK_SIZE);
+	EXPECT_EQ(sizeof(s_savedGameHeaderStracLinux), SAVED_GAME_HEADER::ON_DISK_SIZE_STRAC_LIN);
 }
 
 
@@ -164,8 +164,8 @@ TEST(SaveLoadGameTest, savedGameHeaderValidityCheck)
 
 	// parse vanilla header with "strac linux" parser; should be invalid
 	// this needs some padding bytes at the end to avoid a buffer overrun
-	uint8_t paddedVanillaHeader[SAVED_GAME_HEADER_ON_DISK_SIZE_STRAC_LIN]{};
-	std::copy_n(s_savedGameHeaderVanilla, SAVED_GAME_HEADER_ON_DISK_SIZE, paddedVanillaHeader);
+	uint8_t paddedVanillaHeader[SAVED_GAME_HEADER::ON_DISK_SIZE_STRAC_LIN]{};
+	std::copy_n(s_savedGameHeaderVanilla, SAVED_GAME_HEADER::ON_DISK_SIZE, paddedVanillaHeader);
 	ParseSavedGameHeader(paddedVanillaHeader, header, true);
 	EXPECT_EQ(isValidSavedGameHeader(header), false);
 


### PR DESCRIPTION
The size of ste SaveStates was written to the file header at the start of SaveGame but since #2051 was checked in, saving the strategic status added more data to those SaveStates. The result of this bug was that SaveGameInfo could no longer determine the mods activated for a save, resulting in wrong tool tips on the load screen and wrong warnings about a mismatch in the activated mods.