### PR TITLE
Mark include directories of dependencies as SYSTEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,8 @@ endif()
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
     ${JA2_INCLUDES}
+)
+target_include_directories(${JA2_BINARY} SYSTEM PRIVATE
     ${SDL2_INCLUDE_DIR}
     ${SOL_INCLUDE_DIR}
     ${LUA_INCLUDE_DIRS}

--- a/dependencies/lib-string_theory/CMakeLists.txt
+++ b/dependencies/lib-string_theory/CMakeLists.txt
@@ -15,7 +15,7 @@ if (NOT LOCAL_STRING_THEORY_LIB)
 
     # interface library
     add_library(string_theory-internal INTERFACE)
-    target_include_directories(string_theory-internal INTERFACE ${STRING_THEORY_INCLUDE_DIRS})
+    target_include_directories(string_theory-internal SYSTEM INTERFACE ${STRING_THEORY_INCLUDE_DIRS})
     return()
 endif()
 
@@ -45,6 +45,6 @@ execute_process(COMMAND ${CMAKE_COMMAND} --build "${CMAKE_CURRENT_BINARY_DIR}/bu
 # interface library
 include("${INSTALL_PREFIX}/lib/cmake/string_theory/string_theory-config.cmake")
 add_library(string_theory-internal INTERFACE)
-target_include_directories(string_theory-internal INTERFACE "${STRING_THEORY_INCLUDE_DIRS}")
+target_include_directories(string_theory-internal SYSTEM INTERFACE "${STRING_THEORY_INCLUDE_DIRS}")
 
 message(STATUS "</string_theory>")


### PR DESCRIPTION
This informs the compiler not to generate warnings for code in this header. This change was brought about by clang's complaints about miniaudio.h.