### PR TITLE
Fix ReduceStringLength()

### DIFF
--- a/src/game/Utils/WordWrap.cc
+++ b/src/game/Utils/WordWrap.cc
@@ -540,11 +540,13 @@ ST::string ReduceStringLength(const ST::utf32_buffer& codepoints, UINT32 widthTo
 		UINT32 charWidth = GetCharWidth(font, c);
 		if (width + charWidth + dotsWidth > widthToFitIn) break;
 		buf += c;
+		width += charWidth;
 	}
 	for (size_t i = 0; i < numDots; ++i)
 	{
 		if (width + dotWidth > widthToFitIn) break;
 		buf += dot;
+		width += dotWidth;
 	}
 	return buf;
 }


### PR DESCRIPTION
Because the width variable was never updated this function didn't really do anything. Fixes #1491.
![Screenshot_20241006_114634](https://github.com/user-attachments/assets/20dd85e4-0d2e-464e-9c62-8066e459e8fe)
