### PR TITLE
Fix warning C4146 in SaveGameInfo

### DIFF
--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -2488,7 +2488,9 @@ SaveGameInfo::SaveGameInfo(ST::string name_, HWFILE file) : saveName(std::move(n
 			if (savedGameHeader.uiSaveStateSize == 0) {
 				throw std::runtime_error("save state size was 0");
 			}
-			file->seek(-savedGameHeader.uiSaveStateSize - sizeof(UINT32), FileSeekMode::FILE_SEEK_FROM_END);
+			file->seek(-static_cast<INT32>(
+				savedGameHeader.uiSaveStateSize + sizeof(UINT32)),
+				FileSeekMode::FILE_SEEK_FROM_END);
 			SavedGameStates states;
 			LoadStatesFromSaveFile(file, states);
 			this->enabledMods = GetModInfoFromGameStates(states);


### PR DESCRIPTION
MSVC correctly points out that the combination of unary minus and an unsigned integer does not do what one might expect; the result is still positive. In our case we are passing a huge number close to 2^32 to seek() and the only reason we are getting the expected result is that seek() interprets this number as a small negative number. If we would ever modernize seek's first argument to int64 this would break.