### PR TITLE
Remove InitializeFontManager

### DIFF
--- a/src/sgp/Font.cc
+++ b/src/sgp/Font.cc
@@ -99,7 +99,7 @@ void UnloadFont(SGPFont const font)
 
 
 /* Returns the width of a given character in the font. */
-static UINT32 GetWidth(HVOBJECT const hSrcVObject, GlyphIdx const ssIndex)
+static UINT32 GetWidth(SGPFont const hSrcVObject, GlyphIdx const ssIndex)
 {
 	// Get Offsets from Index into structure
 	ETRLEObject const& pTrav = hSrcVObject->SubregionProperties(ssIndex);
@@ -144,7 +144,7 @@ void RestoreFontSettings(void)
 
 
 /* Returns the height of a given character in the font. */
-static UINT32 GetHeight(HVOBJECT hSrcVObject, INT16 ssIndex)
+static UINT32 GetHeight(SGPFont hSrcVObject, INT16 ssIndex)
 {
 	// Get Offsets from Index into structure
 	ETRLEObject const& pTrav = hSrcVObject->SubregionProperties(ssIndex);
@@ -182,7 +182,7 @@ static GlyphIdx GetGlyphIndex(char32_t c)
 }
 
 
-UINT32 GetCharWidth(HVOBJECT SGPFont, char32_t c)
+UINT32 GetCharWidth(SGPFont SGPFont, char32_t c)
 {
 	return GetWidth(SGPFont, GetGlyphIndex(c));
 }
@@ -288,11 +288,4 @@ void MPrint(INT32 x, INT32 y, const ST::utf32_buffer& codepoints)
 {
 	SGPVSurface::Lock l(FontDestBuffer);
 	MPrintBuffer(l.Buffer<UINT16>(), l.Pitch(), x, y, codepoints);
-}
-
-
-void InitializeFontManager(void)
-{
-	FontDefault    = 0;
-	SetFontDestBuffer(BACKBUFFER);
 }

--- a/src/sgp/Font.h
+++ b/src/sgp/Font.h
@@ -2,8 +2,6 @@
 #define FONT_H
 
 #include "Types.h"
-
-#include <map>
 #include <string_theory/string>
 
 
@@ -70,7 +68,7 @@ UINT16  GetFontHeight(SGPFont);
 void    InitializeFontManager(void);
 void    UnloadFont(SGPFont);
 
-UINT32 GetCharWidth(HVOBJECT SGPFont, char32_t c);
+UINT32 GetCharWidth(SGPFont SGPFont, char32_t c);
 
 INT16 StringPixLength(const ST::utf32_buffer& codepoints, SGPFont font);
 inline INT16 StringPixLength(const ST::string& str, SGPFont font)

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -1,6 +1,5 @@
 #include "Button_System.h"
 #include "FPS.h"
-#include "Font.h"
 #include "GameLoop.h"
 #include "GameSettings.h"
 #include "Input.h"
@@ -403,11 +402,6 @@ int main(int argc, char* argv[])
 		InitializeVideoSurfaceManager();
 
 		InitJA2SplashScreen();
-
-		// Initialize Font Manager
-		SLOGD("Initializing the Font Manager");
-		// Init the manager and copy the TransTable stuff into it.
-		InitializeFontManager();
 
 		SLOGD("Initializing Sound Manager");
 		InitializeSoundManager();


### PR DESCRIPTION
Both lines of this function are useless:
A NULL default font would just cause failed assertions and there is nothing in the code base that wants to print to the back buffer.

Also use the SGPFont typedef where appropriate.