### PR TITLE
github-ci: macos-12 is getting sunset, switch to latest

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -22,7 +22,7 @@ jobs:
           target: linux-mingw64
 
         - name: Mac
-          os: macos-12
+          os: macos-latest
           target: mac
 
         - name: Android


### PR DESCRIPTION
Trivial stuff, one other cases is already using this runner.