### PR TITLE
Avoid some conversions from and to ST::string in DealerInventory

### DIFF
--- a/src/externalized/DealerInventory.cc
+++ b/src/externalized/DealerInventory.cc
@@ -1,18 +1,14 @@
 #include "DealerInventory.h"
-
 #include "ItemModel.h"
 #include "ItemSystem.h"
 
-#include <string_theory/format>
-
-#include <stdexcept>
 
 DealerInventory::DealerInventory(const JsonValue& json, const ItemSystem *itemSystem)
 {
 	auto obj = json.toObject();
 	for (auto& it : obj.keys())
 	{
-		const ItemModel *item = itemSystem->getItemByName(it.c_str());
+		const ItemModel *item = itemSystem->getItemByName(it);
 		int count = obj.GetInt(it.c_str());
 		m_inventory.insert(std::make_pair(item, count));
 	}


### PR DESCRIPTION
getItemByName takes a reference to ST::string, which is already the type of the variable 'it'. The old code did a round trip ST::string -> C string -> ST::string.