### PR TITLE
Enable CMake policy CMP0156

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@
 cmake_minimum_required (VERSION 3.18.1)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+if(POLICY CMP0156)
+    # de-deduplicate libraries when calling the linker
+    cmake_policy(SET CMP0156 NEW)
+endif()
+
 ## Some macros
 
 macro(add_custom_templated_target NAME)


### PR DESCRIPTION
This policy de-duplicates libraries when the linker is called and was added in CMake 3.29.

https://cmake.org/cmake/help/latest/policy/CMP0156.html

The point of this PR is to find out if the long link times of the Mingw runner are caused by the huge number of link libraries added by the Rust build step.