### PR TITLE
Fix prone positioning

### DIFF
--- a/src/game/Tactical/Animation_Data.cc
+++ b/src/game/Tactical/Animation_Data.cc
@@ -550,6 +550,27 @@ void InitAnimationSystem()
 			if (GCM->doesGameResExists(Filename))
 			{
 				STRUCTURE_FILE_REF* pStructureFileRef = LoadStructureFile(Filename);
+
+				// fix non-base prone tiles by making them all passable (#2115)
+				if ((cnt1 >= REGMALE && cnt1 <= REGFEMALE) && cnt2 == P_STRUCT)
+				{
+					for (UINT8 dirIdx = 0; dirIdx < 8; dirIdx++)
+					{
+						DB_STRUCTURE_REF const* const pDBStructureRef = &pStructureFileRef->pDBStructureRef[dirIdx];
+						DB_STRUCTURE_TILE** ppTile = pDBStructureRef->ppTile;
+						UINT8 const n_tiles = pDBStructureRef->pDBStructure->ubNumberOfTiles;
+
+						for (UINT8 tileIdx = 0; tileIdx < n_tiles; tileIdx++)
+						{
+							// if not a base tile
+							if (ppTile[tileIdx]->sPosRelToBase != 0)
+							{
+								ppTile[tileIdx]->fFlags |= TILE_PASSABLE;
+							}
+						}
+					}
+				}
+
 				gAnimStructureDatabase[ cnt1 ][ cnt2 ].pStructureFileRef = pStructureFileRef;
 			}
 		}

--- a/src/game/Tactical/Animation_Data.cc
+++ b/src/game/Tactical/Animation_Data.cc
@@ -551,7 +551,7 @@ void InitAnimationSystem()
 			{
 				STRUCTURE_FILE_REF* pStructureFileRef = LoadStructureFile(Filename);
 
-				// fix non-base prone tiles by making them all passable (#2115)
+				// fix non-base prone tiles by making them all passable (#2116)
 				if ((cnt1 >= REGMALE && cnt1 <= REGFEMALE) && cnt2 == P_STRUCT)
 				{
 					for (UINT8 dirIdx = 0; dirIdx < 8; dirIdx++)


### PR DESCRIPTION
Some of the problems with the prone stance:

1. You can go prone when closely facing a structure that is **whole-tile** blocking, but not when facing north. And, if facing away, not when facing south or east:
![from-into-tree](https://github.com/user-attachments/assets/81d249d4-8433-4e92-88c9-721e2946469f)
 (reminder: the game world north is the direction Dynamo is looking in on the first pic)
2. Crawling along the south (and only south) side of such structures looks like this:
![crawling](https://github.com/user-attachments/assets/29372492-c141-4627-aedf-b10f3a77fb6d)
![crawling2](https://github.com/user-attachments/assets/4808a318-2648-49a0-95f2-99357f89361d)
Crawling along all other sides moves the char instantaneously - no stance change needed.
3. None of the above happens with walls and doors. Instead, they have a clipping problem that results in soldiers affecting or being affected by things illogically, like obstructing paths or taking damage with one part of their structure phased through a wall:
![wallClips](https://github.com/user-attachments/assets/46e63a2d-4aac-444d-840a-7fd82718a69f)
The only reason it's not very game-breaking is because that part is invisible (no matter if it's clipped or not), so enemies can't choose to attack it.

All of that comes from structure DB descriptions that don't make sense:
![structures](https://github.com/user-attachments/assets/09c174df-b196-44b3-90c4-d2e9b0214adc)

The fix for all 3 problems is trivial: flag all "extended" tiles as passable, and you can drop prone anywhere independent of what's in the neighboring tiles.
Another gameplay effect so far: chars lying in the first 3 (out of 8) directions have one less tile to take shockwave and gas damage with.

Probably solves #1822 (the save file is unavailable but if I remember correctly the prone soldier was facing south while phased into a box with his non-passable tile)