### PR TITLE
Remove three header files

### DIFF
--- a/src/game/Credits.cc
+++ b/src/game/Credits.cc
@@ -1,4 +1,3 @@
-#include "Credits.h"
 #include "Cursors.h"
 #include "Debug.h"
 #include "Directories.h"
@@ -9,6 +8,7 @@
 #include "MouseSystem.h"
 #include "Random.h"
 #include "Render_Dirty.h"
+#include "ScreenIDs.h"
 #include "SysUtil.h"
 #include "Text.h"
 #include "Timer_Control.h"
@@ -170,7 +170,7 @@ static void GetCreditScreenUserInput(void);
 static void HandleCreditScreen(void);
 
 
-ScreenID CreditScreenHandle(void)
+template<> ScreenID HandleScreen<CREDIT_SCREEN>()
 {
 	if (!g_credits_active)
 	{

--- a/src/game/Credits.h
+++ b/src/game/Credits.h
@@ -1,9 +1,0 @@
-#ifndef CREDITS_H
-#define CREDITS_H
-
-#include "ScreenIDs.h"
-
-
-ScreenID CreditScreenHandle(void);
-
-#endif

--- a/src/game/GameInitOptionsScreen.cc
+++ b/src/game/GameInitOptionsScreen.cc
@@ -7,7 +7,6 @@
 #include "Font.h"
 #include "Font_Control.h"
 #include "Options_Screen.h"
-#include "GameInitOptionsScreen.h"
 #include "GameSettings.h"
 #include "Input.h"
 #include "Intro.h"
@@ -17,6 +16,7 @@
 #include "ContentMusic.h"
 #include "Options_Screen.h"
 #include "Render_Dirty.h"
+#include "ScreenIDs.h"
 #include "SysUtil.h"
 #include "Text.h"
 #include "Types.h"
@@ -186,7 +186,7 @@ static void ConfirmGioDeadIsDeadMessageBoxCallBack(MessageBoxReturnValue);
 static void ConfirmGioDeadIsDeadGoToSaveMessageBoxCallBack(MessageBoxReturnValue);
 
 
-ScreenID GameInitOptionsScreenHandle(void)
+template<> ScreenID HandleScreen<GAME_INIT_OPTIONS_SCREEN>()
 {
 	if (gfGIOScreenEntry)
 	{

--- a/src/game/GameInitOptionsScreen.h
+++ b/src/game/GameInitOptionsScreen.h
@@ -1,9 +1,0 @@
-#ifndef GAME_INIT_OPTIONS_SCREEN_H
-#define GAME_INIT_OPTIONS_SCREEN_H
-
-#include "ScreenIDs.h"
-
-
-ScreenID GameInitOptionsScreenHandle(void);
-
-#endif

--- a/src/game/ScreenIDs.h
+++ b/src/game/ScreenIDs.h
@@ -32,4 +32,6 @@ enum ScreenID
 	NO_PENDING_SCREEN = 0xFFFF
 };
 
+template<ScreenID> ScreenID HandleScreen();
+
 #endif

--- a/src/game/Screens.cc
+++ b/src/game/Screens.cc
@@ -1,8 +1,6 @@
 #include "Auto_Resolve.h"
-#include "Credits.h"
 #include "EditScreen.h"
 #include "Fade_Screen.h"
-#include "GameInitOptionsScreen.h"
 #include "GameScreen.h"
 #include "Intro.h"
 #include "JAScreens.h"
@@ -10,12 +8,12 @@
 #include "LoadScreen.h"
 #include "MainMenuScreen.h"
 #include "MapScreen.h"
-#include "MapUtility.h"
 #include "MessageBoxScreen.h"
 #include "Options_Screen.h"
 #include "Quest_Debug_System.h"
 #include "SaveLoadScreen.h"
 #include "Screens.h"
+#include "ScreenIDs.h"
 #include "ShopKeeper_Interface.h"
 
 
@@ -33,7 +31,7 @@ Screens const GameScreens[] =
 	{ MapScreenInit,        MapScreenHandle,             MapScreenShutdown        },
 	{ LaptopScreenInit,     LaptopScreenHandle,          LaptopScreenShutdown     },
 	{ NULL,                 LoadSaveScreenHandle,        NULL                     },
-	{ NULL,                 MapUtilScreenHandle,         NULL                     },
+	{ nullptr,              HandleScreen<MAPUTILITY_SCREEN>, nullptr              },
 	{ NULL,                 FadeScreenHandle,            NULL                     },
 	{ NULL,                 MessageBoxScreenHandle,      MessageBoxScreenShutdown },
 	{ NULL,                 MainMenuScreenHandle,        NULL                     },
@@ -42,10 +40,10 @@ Screens const GameScreens[] =
 	{ NULL,                 OptionsScreenHandle,         NULL                     },
 	{ ShopKeeperScreenInit, ShopKeeperScreenHandle,      ShopKeeperScreenShutdown },
 	{ NULL,                 SexScreenHandle,             NULL                     },
-	{ NULL,                 GameInitOptionsScreenHandle, NULL                     },
+	{ nullptr,              HandleScreen<GAME_INIT_OPTIONS_SCREEN>, nullptr       },
 	{ NULL,                 NULL,                        NULL                     },
 	{ NULL,                 IntroScreenHandle,           NULL                     },
-	{ NULL,                 CreditScreenHandle,          NULL                     },
+	{ nullptr,              HandleScreen<CREDIT_SCREEN>, nullptr                  },
 	{ QuestDebugScreenInit, QuestDebugScreenHandle,      NULL                     }
 };
 

--- a/src/game/Utils/MapUtility.cc
+++ b/src/game/Utils/MapUtility.cc
@@ -1,5 +1,4 @@
 #include "Input.h"
-#include "MapUtility.h"
 #include "Overhead_Types.h"
 #include "SDL_keycode.h"
 #include "SDL_timer.h"
@@ -18,6 +17,7 @@
 #include "WorldDat.h"
 #include "Map_Information.h"
 #include "Line.h"
+#include "ScreenIDs.h"
 #include "Video.h"
 #include "Quantize.h"
 #include "UILayout.h"
@@ -39,7 +39,7 @@ static float     gdYStep;
 // quantizes it into an 8-bit image ans writes it to an sti file in radarmaps.
 
 
-ScreenID MapUtilScreenHandle()
+template<> ScreenID HandleScreen<MAPUTILITY_SCREEN>()
 {
 	static auto p24BitValues{ std::make_unique<SGPPaletteEntry[]>(MINIMAP_X_SIZE * MINIMAP_Y_SIZE) };
 

--- a/src/game/Utils/MapUtility.h
+++ b/src/game/Utils/MapUtility.h
@@ -1,8 +1,0 @@
-#ifndef MAPUTILITY_H
-#define MAPUTILITY_H
-
-#include "ScreenIDs.h"
-
-ScreenID MapUtilScreenHandle();
-
-#endif


### PR DESCRIPTION
These headers only contained a single definition for a ScreenHandle function. In their place we are now using a function template in ScreenIDs.h.