### PR TITLE
Fix missing buttons in MapScreen

### DIFF
--- a/src/game/MessageBoxScreen.cc
+++ b/src/game/MessageBoxScreen.cc
@@ -134,7 +134,6 @@ void DoMessageBox(MessageBoxStyleID ubStyle, const ST::string& str, ScreenID uiE
 
 	if (fInMapMode)
 	{
-		gfStartedFromMapScreen = TRUE;
 		fMapPanelDirty         = TRUE;
 	}
 
@@ -400,23 +399,13 @@ ScreenID MessageBoxScreenHandle()
 	if (gfNewMessageBox)
 	{
 		// If in game screen....
-		if (gfStartedFromGameScreen || gfStartedFromMapScreen)
+		if (gfStartedFromGameScreen)
 		{
-			if (gfStartedFromGameScreen)
-			{
-				HandleTacticalUILoseCursorFromOtherScreen();
-			}
-			else
-			{
-				HandleMAPUILoseCursorFromOtherScreen();
-			}
-
+			HandleTacticalUILoseCursorFromOtherScreen();
 			gfStartedFromGameScreen = FALSE;
-			gfStartedFromMapScreen  = FALSE;
 		}
 
 		gfNewMessageBox = FALSE;
-
 		return MSG_BOX_SCREEN;
 	}
 

--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -59,6 +59,7 @@
 #include "RenderWorld.h"
 #include "SAM_Sites.h"
 #include "SaveLoadScreen.h"
+#include "ScreenIDs.h"
 #include "Soldier_Control.h"
 #include "Soldier_Macros.h"
 #include "Squads.h"
@@ -371,7 +372,6 @@ static bool fLockOutMapScreenInterface = false;
 
 
 extern BOOLEAN fDeletedNode;
-extern BOOLEAN gfStartedFromMapScreen;
 
 
 extern PathSt* pTempCharacterPath;
@@ -7860,9 +7860,9 @@ BOOLEAN CanDrawSectorCursor(void)
 		GetNumberOfMercsInUpdateList() == 0 &&
 		sSelectedMilitiaTown == 0           &&
 		!gfMilitiaPopupCreated              &&
-		!gfStartedFromMapScreen             &&
 		!fShowMapScreenMovementList         &&
 		ghMoveBox == NO_POPUP_BOX           &&
+		guiPendingScreen != MSG_BOX_SCREEN  &&
 		!fMapInventoryItem;
 }
 

--- a/src/game/Strategic/Map_Screen_Interface.cc
+++ b/src/game/Strategic/Map_Screen_Interface.cc
@@ -6,6 +6,7 @@
 #include "Finances.h"
 #include "Font.h"
 #include "Font_Control.h"
+#include "GameLoop.h"
 #include "Game_Clock.h"
 #include "Game_Event_Hook.h"
 #include "Game_Init.h"
@@ -38,6 +39,7 @@
 #include "RenderWorld.h"
 #include "SAM_Sites.h"
 #include "SamSiteModel.h"
+#include "ScreenIDs.h"
 #include "ShippingDestinationModel.h"
 #include "Soldier_Macros.h"
 #include "SoundMan.h"
@@ -799,18 +801,23 @@ void EnableTeamInfoPanels( void )
 void DoMapMessageBoxWithRect(MessageBoxStyleID ubStyle, const ST::string& str, ScreenID uiExitScreen, MessageBoxFlags usFlags, MSGBOX_CALLBACK ReturnCallback, const SGPBox* centering_rect)
 {	// reset the highlighted line
 	giHighLine = -1;
+
+	// Suppresses the cursor interaction over the map ofArulco, checked
+	// by CanDrawSectorCursor().
+	guiPendingScreen = MSG_BOX_SCREEN;
+
+	// Force redraw.
+	MapScreenHandle();
+
 	DoMessageBox(ubStyle, str, uiExitScreen, usFlags, ReturnCallback, centering_rect);
 }
 
 
 void DoMapMessageBox(MessageBoxStyleID ubStyle, const ST::string& str, ScreenID uiExitScreen, MessageBoxFlags usFlags, MSGBOX_CALLBACK ReturnCallback)
 {
-	// reset the highlighted line
-	giHighLine = -1;
-
 	// do message box and return
 	SGPBox const centering_rect = { 0, 0, SCREEN_WIDTH, INV_INTERFACE_START_Y };
-	DoMessageBox(ubStyle, str, uiExitScreen, usFlags, ReturnCallback, &centering_rect);
+	DoMapMessageBoxWithRect(ubStyle, str, uiExitScreen, usFlags, ReturnCallback, &centering_rect);
 }
 
 
@@ -1313,18 +1320,6 @@ void FindAndSetThisContractSoldier( SOLDIERTYPE *pSoldier )
 			fTeamPanelDirty = TRUE;
 			fCharacterInfoPanelDirty = TRUE;
 		}
-	}
-}
-
-
-void HandleMAPUILoseCursorFromOtherScreen( void )
-{
-	// rerender map without cursors
-	fMapPanelDirty = TRUE;
-
-	if ( fInMapMode )
-	{
-		RenderMapRegionBackground( );
 	}
 }
 

--- a/src/game/Strategic/Map_Screen_Interface.h
+++ b/src/game/Strategic/Map_Screen_Interface.h
@@ -335,9 +335,6 @@ void UpdateCharRegionHelpText( void );
 // find this soldier in mapscreen character list and set as contract
 void FindAndSetThisContractSoldier( SOLDIERTYPE *pSoldier );
 
-// lose the cursor, re-render
-void HandleMAPUILoseCursorFromOtherScreen( void );
-
 void RenderMapRegionBackground( void );
 
 // update mapscreen assignment positions


### PR DESCRIPTION
This removes the secret handshake between the message box screen and the map screen where the former asked the latter to redraw itself without the cursor interaction over the Arulco map before rendering itself. Some code change in the past (I did not investigate which) broke this brittle concept and made some buttons and the map coordinates disappear.

Now the map screen redraws itself without the mentioned interaction one last time before handing control over to the message box screen.

The function `HandleTacticalUILoseCursorFromOtherScreen` which does something similar for the game screen is also a bit suspect but unless someone can point to an actual problem with it I'd rather not touch it.

Fixes #2119.