### PR TITLE
Remove the last two fprintf calls from our code

### DIFF
--- a/src/game/Editor/LoadScreen.cc
+++ b/src/game/Editor/LoadScreen.cc
@@ -902,14 +902,11 @@ static ScreenID ProcessFileIO(void)
 
 			try
 			{
-				UINT32 const start = SDL_GetTicks();
 				if (!FileMan::isAbsolute(gFileForIO)) {
 					LoadWorld(gFileForIO);
 				} else {
 					LoadWorldAbsolute(gFileForIO);
 				}
-
-				fprintf(stderr, "---> %u\n", SDL_GetTicks() - start);
 			}
 			catch (...)
 			{ //Want to override crash, so user can do something else.

--- a/src/game/Tactical/TeamTurns.cc
+++ b/src/game/Tactical/TeamTurns.cc
@@ -1110,12 +1110,6 @@ BOOLEAN StandardInterruptConditionsMet(const SOLDIERTYPE* const pSoldier, const 
 		return(FALSE);
 	}
 
-
-#ifdef RECORDINTERRUPT
-	// this usually starts a new series of logs, so that's why the blank line
-	fprintf(InterruptFile, "\nStandardInterruptConditionsMet by %d vs. %d\n", pSoldier->guynum, pOpponent->ubID);
-#endif
-
 	return(TRUE);
 }
 

--- a/src/sgp/SGPStrings.h
+++ b/src/sgp/SGPStrings.h
@@ -3,7 +3,6 @@
 
 #include <stdexcept>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 #include <utility>
 #include <string_theory/string>


### PR DESCRIPTION
One was inside an inactive #ifdef block that would not even compile if it had been activated, the other simply printed the number of ticks in took to load a map into the editor.