### PR TITLE
Avoid unnecessary copies in Explosion_Control

### DIFF
--- a/src/game/TileEngine/Explosion_Control.cc
+++ b/src/game/TileEngine/Explosion_Control.cc
@@ -238,14 +238,10 @@ static void GenerateExplosionFromExplosionPointer(EXPLOSIONTYPE* pExplosion)
 		}
 	}
 
-	auto soundCandidates = explosionAnimation->getSounds();
-	auto sound = soundCandidates.at(0);
-	if ( soundCandidates.size() > 1 )
-	{
-		sound = soundCandidates.at(Random(soundCandidates.size()));
-	}
-
-	PlayLocationJA2Sample(sGridNo, sound, HIGHVOLUME, 1);
+	auto && soundCandidates{ explosionAnimation->getSounds() };
+	PlayLocationJA2Sample(sGridNo, soundCandidates.at(
+			Random(static_cast<UINT32>(soundCandidates.size()))),
+		HIGHVOLUME, 1);
 }
 
 


### PR DESCRIPTION
GenerateExplosionFromExplosionPointer() made copies of the vector returned by getSounds() and the first string contained in that vector. We can just use these values directly.