### PR TITLE
Fix crash in StartInterrupt()

### DIFF
--- a/src/game/Tactical/TeamTurns.cc
+++ b/src/game/Tactical/TeamTurns.cc
@@ -642,10 +642,16 @@ static void StartInterrupt(void)
 
 
 		// here we have to rebuilt the AI list!
-		BuildAIListForTeam( bTeam );
+		if (!BuildAIListForTeam(bTeam))
+		{
+			// Nobody on that team matched the conditions to get added to the
+			// AI list which means we don't have anyone left for this interrupt.
+			return EndInterrupt(false);
+		}
 
 		// set to the new first interrupter
 		SOLDIERTYPE* const pSoldier = RemoveFirstAIListEntry();
+		AssertMsg(pSoldier, "BuildAIListForTeam returned true but list is empty");
 
 		//if ( gTacticalStatus.ubCurrentTeam == OUR_TEAM)
 		if ( pSoldier->bTeam != OUR_TEAM )


### PR DESCRIPTION
In some rare situations, this function can get called when none of the members of one of involved teams can really act (either dying or out of breath) which means that its AI list would be empty. StartInterrupt() didn't handle this and just tried to use the first entry of the AI list and then crashed when it tried to deref a NULL pSoldier.