### PR TITLE
Fix out of bounds read in SameBuilding

### DIFF
--- a/src/game/TacticalAI/AIUtils.cc
+++ b/src/game/TacticalAI/AIUtils.cc
@@ -963,7 +963,7 @@ INT16 ClosestReachableDisturbance(SOLDIERTYPE *pSoldier, UINT8 ubUnconsciousOK, 
 
 INT16 ClosestKnownOpponent(SOLDIERTYPE *pSoldier, INT16 * psGridNo, INT8 * pbLevel)
 {
-	INT16 sGridNo, sClosestOpponent = NOWHERE;
+	GridNo sGridNo, sClosestOpponent = NOWHERE;
 	INT32 iRange, iClosestRange = 1500;
 	INT8  *pbPersOL, *pbPublOL;
 	INT8  bLevel, bClosestLevel;
@@ -1016,6 +1016,12 @@ INT16 ClosestKnownOpponent(SOLDIERTYPE *pSoldier, INT16 * psGridNo, INT8 * pbLev
 			// using public knowledge, obtain opponent's "best guess" gridno
 			sGridNo = gsPublicLastKnownOppLoc[pSoldier->bTeam][pOpp->ubID];
 			bLevel = gbPublicLastKnownOppLevel[pSoldier->bTeam][pOpp->ubID];
+		}
+
+		if (sGridNo == NOWHERE)
+		{
+			// This team has not seen this opponent at all yet.
+			continue;
 		}
 
 		// if we are standing at that gridno(!, obviously our info is old...)


### PR DESCRIPTION
Found by valgrind. If a merc and his team have no idea about an opponent's location yet, `ClosestKnownOpponent` calls `SameBuilding` with sGridNo == NOWHERE, which uses it unchecked an as an index to the `gubBuildingInfo` array.

The closely related function `ClosestReachableDisturbance` already checks for this so it is not affected.