### PR TITLE
Fix surprising conversion of string literals to JsonValue

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,16 +7,15 @@ option(WITH_FIXMES "Build with fixme messages" OFF)
 option(WITH_MAEMO "Build with right click mapped to F4 (menu button)" OFF)
 
 function(add_warnings target)
-    if(NOT MSVC)
-        target_compile_options(${target} PRIVATE -Wall -Wtype-limits -Wignored-qualifiers)
-    else()
-        target_compile_options(${target} PRIVATE /W3 /wd4018 /wd4101 /wd4244 /wd4996)
-        # 4018 : example: signed/unsigned mismatch
-        # 4101 : example: unreferenced local variable
-        # 4200 : example: nonstandard extension used : zero-sized array in struct/union
-        # 4244 : example: conversion from 'int' to 'real', possible loss of data
-        # 4996 : example: This function or variable may be unsafe (sscanf)
-    endif()
+    target_compile_options(${target} PRIVATE
+        $<$<CXX_COMPILER_ID:Clang>:-Wall -Wtype-limits -Wignored-qualifiers -Wstring-conversion>
+        $<$<CXX_COMPILER_ID:GNU>:-Wall -Wtype-limits -Wignored-qualifiers>
+        $<$<CXX_COMPILER_ID:MSVC>:/W3 /wd4018 /wd4101 /wd4244 /wd4996>
+            # 4018 : example: signed/unsigned mismatch
+            # 4101 : example: unreferenced local variable
+            # 4244 : example: conversion from 'int' to 'real', possible loss of data
+            # 4996 : example: This function or variable may be unsafe (sscanf)
+    )
 endfunction()
 
 target_include_directories(${JA2_BINARY} SYSTEM PRIVATE

--- a/src/externalized/json/Json.h
+++ b/src/externalized/json/Json.h
@@ -16,6 +16,7 @@ class JsonValue {
 		JsonValue(double value) : m_value(RustPointer<RJsonValue>(RJsonValue_fromDouble(value))) {}
 		JsonValue(bool value) : m_value(RustPointer<RJsonValue>(RJsonValue_fromBool(value))) {}
 		JsonValue(const ST::string& value) : m_value(RustPointer<RJsonValue>(RJsonValue_fromString(value.c_str()))) {}
+		JsonValue(char const * const value) : m_value{ RJsonValue_fromString(value) } {}
 
 		static JsonValue deserialize(const ST::string& str);
 		static JsonValue deserialize(const ST::string& vanillaStr, const ST::string& patchStr);


### PR DESCRIPTION
MercProfile::serializeStruct contains several lines like this:

obj.set("074sexismMode", "GENTLEMAN");

where obj is a JsonObject and set's second parameter is a JsonValue. One would expect this line to set the property "074sexismMode" to the string "GENTLEMAN" but with the old set of JsonValue constructors this would actually choose the constructor taking a bool value, so in effect this line set the property to a bool with the value true.

Found by Clang and Coverity (with a quite confusing diagnostic message), CID 419742.