### PR TITLE
Remove SetProgressBarTextDisplayFlag

### DIFF
--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -163,7 +163,7 @@ BOOLEAN HasSaveGameExtension(const ST::string &fileName) {
 
 ST::string GetAutoSaveName(uint32_t index) {
 	return ST::format("{}{02}", g_autosave_prefix, index);
-};
+}
 
 BOOLEAN IsAutoSaveName(const ST::string &saveName) {
 	return std::regex_match(saveName.c_str(), g_autosave_regex);
@@ -171,19 +171,19 @@ BOOLEAN IsAutoSaveName(const ST::string &saveName) {
 
 ST::string GetQuickSaveName() {
 	return g_quicksave_name;
-};
+}
 
 BOOLEAN IsQuickSaveName(const ST::string &saveName) {
 	return saveName.compare(g_quicksave_name, ST::case_insensitive) == 0;
-};
+}
 
 BOOLEAN IsErrorSaveName(const ST::string &saveName) {
 	return saveName.compare(g_error_save_name, ST::case_insensitive) == 0;
-};
+}
 
 ST::string GetErrorSaveName() {
 	return g_error_save_name;
-};
+}
 
 
 static void ExtractGameOptions(DataReader& d, GAME_OPTIONS& g)

--- a/src/game/Utils/Animated_ProgressBar.h
+++ b/src/game/Utils/Animated_ProgressBar.h
@@ -3,9 +3,6 @@
 
 #include "Types.h"
 
-#include <string_theory/string>
-
-
 void CreateLoadingScreenProgressBar(void);
 void RemoveLoadingScreenProgressBar(void);
 
@@ -39,7 +36,7 @@ void RemoveProgressBar( UINT8 ubID );
 //As the process animates using UpdateProgressBar( 0 to 100 ), the total progress bar will only reach 30%
 //at the 100% mark within UpdateProgressBar.  At that time, you would go onto the next step, resetting the
 //relative start and end percentage from 30 to whatever, until your done.
-void SetRelativeStartAndEndPercentage(UINT8 id, UINT32 uiRelStartPerc, UINT32 uiRelEndPerc, const ST::string& str);
+void SetRelativeStartAndEndPercentage(UINT8 id, UINT32 uiRelStartPerc, UINT32 uiRelEndPerc, ST::string const& unused);
 
 //This part renders the progress bar at the percentage level that you specify.  If you have set relative
 //percentage values in the above function, then the uiPercentage will be reflected based off of the relative
@@ -49,8 +46,5 @@ void RenderProgressBar( UINT8 ubID, UINT32 uiPercentage );
 
 //Sets the color of the progress bars main color.
 void SetProgressBarColor( UINT8 ubID, UINT8 ubColorFillRed, UINT8 ubColorFillGreen, UINT8 ubColorFillBlue );
-
-//Pass in TRUE to display the strings.
-void SetProgressBarTextDisplayFlag( UINT8 ubID, BOOLEAN fDisplayText, BOOLEAN fUseSaveBuffer, BOOLEAN fSaveScreenToFrameBuffer );
 
 #endif


### PR DESCRIPTION
This function was only used in code inside JA2BETAVERSION blocks, apparently to give the developers a way to observe the loading progress. Not only is that code gone now, on modern computers those messages would disappear far too fast to be usable.

This also makes two flags and their related code redundant.