### PR TITLE
Properly center the history table header columns

### DIFF
--- a/src/game/Laptop/History.cc
+++ b/src/game/Laptop/History.cc
@@ -387,7 +387,9 @@ static void DisplayHistoryListHeaders(void)
 
 	// event header
 	x += RECORD_LOCATION_WIDTH;
-	MPrint(x, RECORD_HEADER_Y, pHistoryHeaders[4], CenterAlign(292));
+	// 471 is the width in pixels of one row (the width of guiSHADELINE index 0).
+	constexpr int RECORD_EVENT_WIDTH{ 471 - RECORD_DATE_WIDTH - RECORD_LOCATION_WIDTH };
+	MPrint(x, RECORD_HEADER_Y, pHistoryHeaders[4], CenterAlign(RECORD_EVENT_WIDTH));
 
 	// reset shadow
 	SetFontShadow(DEFAULT_SHADOW);

--- a/src/game/Laptop/History.cc
+++ b/src/game/Laptop/History.cc
@@ -377,20 +377,18 @@ static void DisplayHistoryListHeaders(void)
 	// this procedure will display the headers to each column in History
 	SetFontAttributes(HISTORY_TEXT_FONT, FONT_BLACK, NO_SHADOW);
 
-	INT16 usX;
-	INT16 usY;
-
 	// the date header
-	FindFontCenterCoordinates(RECORD_DATE_X + 5,0,RECORD_DATE_WIDTH,0, pHistoryHeaders[0], HISTORY_TEXT_FONT,&usX, &usY);
-	MPrint(usX, RECORD_HEADER_Y, pHistoryHeaders[0]);
+	int x{ RECORD_DATE_X + 5 };
+	MPrint(x, RECORD_HEADER_Y, pHistoryHeaders[0], CenterAlign(RECORD_DATE_WIDTH));
 
-	// the date header
-	FindFontCenterCoordinates(RECORD_DATE_X + RECORD_DATE_WIDTH + 5,0,RECORD_LOCATION_WIDTH,0, pHistoryHeaders[ 3 ], HISTORY_TEXT_FONT,&usX, &usY);
-	MPrint(usX, RECORD_HEADER_Y, pHistoryHeaders[3]);
+	// Location header
+	x += RECORD_DATE_WIDTH;
+	MPrint(x, RECORD_HEADER_Y, pHistoryHeaders[3], CenterAlign(RECORD_LOCATION_WIDTH));
 
 	// event header
-	FindFontCenterCoordinates(RECORD_DATE_X + RECORD_DATE_WIDTH + RECORD_LOCATION_WIDTH + 5,0,RECORD_LOCATION_WIDTH,0, pHistoryHeaders[ 3 ], HISTORY_TEXT_FONT,&usX, &usY);
-	MPrint(usX, RECORD_HEADER_Y, pHistoryHeaders[4]);
+	x += RECORD_LOCATION_WIDTH;
+	MPrint(x, RECORD_HEADER_Y, pHistoryHeaders[4], CenterAlign(292));
+
 	// reset shadow
 	SetFontShadow(DEFAULT_SHADOW);
 }

--- a/src/sgp/Font.cc
+++ b/src/sgp/Font.cc
@@ -226,23 +226,19 @@ void SetFontDestBuffer(SGPVSurface* const dst)
 
 void FindFontRightCoordinates(INT16 sLeft, INT16 sTop, INT16 sWidth, INT16 sHeight, const ST::utf32_buffer& codepoints, SGPFont font, INT16* psNewX, INT16* psNewY)
 {
-	// Compute the coordinates to right justify the text
-	INT16 xp = sWidth - StringPixLength(codepoints, font) + sLeft;
-	INT16 yp = (sHeight - GetFontHeight(font)) / 2 + sTop;
-
-	*psNewX = xp;
-	*psNewY = yp;
+	// Compute the coordinates to center the text
+	auto const pt{ HRightVCenterAlign{ sWidth, sHeight }(sLeft, sTop, codepoints, font) };
+	*psNewX = static_cast<INT16>(pt.x);
+	*psNewY = static_cast<INT16>(pt.y);
 }
 
 
 void FindFontCenterCoordinates(INT16 sLeft, INT16 sTop, INT16 sWidth, INT16 sHeight, const ST::utf32_buffer& codepoints, SGPFont font, INT16* psNewX, INT16* psNewY)
 {
 	// Compute the coordinates to center the text
-	INT16 xp = (sWidth - StringPixLength(codepoints, font) + 1) / 2 + sLeft;
-	INT16 yp = (sHeight - GetFontHeight(font)) / 2 + sTop;
-
-	*psNewX = xp;
-	*psNewY = yp;
+	auto const pt{ HCenterVCenterAlign{ sWidth, sHeight }(sLeft, sTop, codepoints, font) };
+	*psNewX = static_cast<INT16>(pt.x);
+	*psNewY = static_cast<INT16>(pt.y);
 }
 
 
@@ -288,4 +284,42 @@ void MPrint(INT32 x, INT32 y, const ST::utf32_buffer& codepoints)
 {
 	SGPVSurface::Lock l(FontDestBuffer);
 	MPrintBuffer(l.Buffer<UINT16>(), l.Pitch(), x, y, codepoints);
+}
+
+
+void MPrint(int const x, int const y, ST::string const& text, IAlignment const& alignment)
+{
+	auto const codepoints{ text.to_utf32() };
+	auto const alignedPosition{ alignment(x, y, codepoints, FontDefault) };
+	MPrint(alignedPosition.x, alignedPosition.y, codepoints);
+}
+
+
+SDL_Point CenterAlign::operator()(int x, int y,
+	ST::utf32_buffer const& codepoints, SGPFont const font) const noexcept
+{
+	return { (width - StringPixLength(codepoints, font) + 1) / 2 + x, y };
+}
+
+
+SDL_Point RightAlign::operator()(int x, int y,
+	ST::utf32_buffer const& codepoints, SGPFont const font) const noexcept
+{
+	return { width - StringPixLength(codepoints, font) + x, y };
+}
+
+
+SDL_Point HCenterVCenterAlign::operator()(int x, int y,
+	ST::utf32_buffer const& codepoints, SGPFont const font) const noexcept
+{
+	return { (width - StringPixLength(codepoints, font) + 1) / 2 + x,
+		(height - GetFontHeight(font)) / 2 + y };
+}
+
+
+SDL_Point HRightVCenterAlign::operator()(int x, int y,
+	ST::utf32_buffer const& codepoints, SGPFont const font) const noexcept
+{
+	return { width - StringPixLength(codepoints, font) + x,
+		(height - GetFontHeight(font)) / 2 + y };
 }

--- a/src/sgp/Font.h
+++ b/src/sgp/Font.h
@@ -21,6 +21,48 @@
 #define FONT_FCOLOR_ORANGE	76
 #define FONT_FCOLOR_PURPLE	160
 
+struct IAlignment
+{
+	virtual SDL_Point operator()(int x, int y, ST::utf32_buffer const&, SGPFont) const noexcept = 0;
+	virtual ~IAlignment() = default;
+};
+
+// Horizontally align the given text right. Vertically the coordinate is
+// returned without change (top aligned).
+struct RightAlign : public IAlignment
+{
+	int width;
+	constexpr RightAlign(int w) : width{ w } {}
+	SDL_Point operator()(int x, int y, ST::utf32_buffer const&, SGPFont) const noexcept override;
+};
+
+// Center align the given text right horizontally. Vertically the coordinate is
+// returned without change (top aligned).
+struct CenterAlign : public IAlignment
+{
+	int width;
+	constexpr CenterAlign(int w) : width{ w } {}
+	SDL_Point operator()(int x, int y, ST::utf32_buffer const&, SGPFont) const noexcept override;
+};
+
+// Horizontally align the given text right. Vertically the coordinate is
+// centered as well.
+struct HRightVCenterAlign : public IAlignment
+{
+	int width, height;
+	constexpr HRightVCenterAlign(int w, int h) : width{ w }, height{ h } {}
+	SDL_Point operator()(int x, int y, ST::utf32_buffer const&, SGPFont) const noexcept override;
+};
+
+// Center align the given text right horizontally. Vertically the coordinate is
+// centered as well.
+struct HCenterVCenterAlign : public IAlignment
+{
+	int width, height;
+	constexpr HCenterVCenterAlign(int w, int h) : width{ w }, height{ h } {}
+	SDL_Point operator()(int x, int y, ST::utf32_buffer const&, SGPFont) const noexcept override;
+};
+
 
 extern SGPFont FontDefault;
 
@@ -52,6 +94,8 @@ inline void MPrint(INT32 x, INT32 y, const ST::string& str)
 {
 	MPrint(x, y, str.to_utf32());
 }
+
+void MPrint(int x, int y, ST::string const& text, IAlignment const& alignment);
 
 /* Sets the destination buffer for printing to and the clipping rectangle. */
 void SetFontDestBuffer(SGPVSurface* dst, INT32 x1, INT32 y1, INT32 x2, INT32 y2);


### PR DESCRIPTION
The three column headers were all supposed to be centered but the 'Event' header was not since the the vanilla days.

The imminent cause of this bug is almost certainly a case of copy & paste and then forgetting to adjust the arguments but I believe the real underlying problem is the text API which makes this often needed task far more cumbersome to use than necessary:

The first method is to use FindFontCenterCoordinates or FindFontRightCoordinates followed by MPrint. This method requires passing several arguments twice.

The second method is the DrawToScreen function. This is just one call but it doesn't respect the currenly active font and colors and instead requires the caller to always pass in this information.

For this reason this commit adds a new MPrint overload that takes an additional argument to specify the alignment.

This is how it looks currently:
![screenshot_20241220_174831](https://github.com/user-attachments/assets/4e16e77e-62f8-40e7-8e8c-dd661b291b4a)

With this commit:
![screenshot_20241220_181159](https://github.com/user-attachments/assets/9996f3b0-d7e1-436f-9da4-50cfc8169116)

