### PR TITLE
Address new coverity issues caused by the IAlignment code

### DIFF
--- a/src/sgp/Font.cc
+++ b/src/sgp/Font.cc
@@ -296,21 +296,21 @@ void MPrint(int const x, int const y, ST::string const& text, IAlignment const& 
 
 
 SDL_Point CenterAlign::operator()(int x, int y,
-	ST::utf32_buffer const& codepoints, SGPFont const font) const noexcept
+	ST::utf32_buffer const& codepoints, SGPFont const font) const
 {
 	return { (width - StringPixLength(codepoints, font) + 1) / 2 + x, y };
 }
 
 
 SDL_Point RightAlign::operator()(int x, int y,
-	ST::utf32_buffer const& codepoints, SGPFont const font) const noexcept
+	ST::utf32_buffer const& codepoints, SGPFont const font) const
 {
 	return { width - StringPixLength(codepoints, font) + x, y };
 }
 
 
 SDL_Point HCenterVCenterAlign::operator()(int x, int y,
-	ST::utf32_buffer const& codepoints, SGPFont const font) const noexcept
+	ST::utf32_buffer const& codepoints, SGPFont const font) const
 {
 	return { (width - StringPixLength(codepoints, font) + 1) / 2 + x,
 		(height - GetFontHeight(font)) / 2 + y };
@@ -318,7 +318,7 @@ SDL_Point HCenterVCenterAlign::operator()(int x, int y,
 
 
 SDL_Point HRightVCenterAlign::operator()(int x, int y,
-	ST::utf32_buffer const& codepoints, SGPFont const font) const noexcept
+	ST::utf32_buffer const& codepoints, SGPFont const font) const
 {
 	return { width - StringPixLength(codepoints, font) + x,
 		(height - GetFontHeight(font)) / 2 + y };

--- a/src/sgp/Font.h
+++ b/src/sgp/Font.h
@@ -23,7 +23,7 @@
 
 struct IAlignment
 {
-	virtual SDL_Point operator()(int x, int y, ST::utf32_buffer const&, SGPFont) const noexcept = 0;
+	virtual SDL_Point operator()(int x, int y, ST::utf32_buffer const&, SGPFont) const = 0;
 	virtual ~IAlignment() = default;
 };
 
@@ -33,7 +33,7 @@ struct RightAlign : public IAlignment
 {
 	int width;
 	constexpr RightAlign(int w) : width{ w } {}
-	SDL_Point operator()(int x, int y, ST::utf32_buffer const&, SGPFont) const noexcept override;
+	SDL_Point operator()(int x, int y, ST::utf32_buffer const&, SGPFont) const override;
 };
 
 // Center align the given text right horizontally. Vertically the coordinate is
@@ -42,7 +42,7 @@ struct CenterAlign : public IAlignment
 {
 	int width;
 	constexpr CenterAlign(int w) : width{ w } {}
-	SDL_Point operator()(int x, int y, ST::utf32_buffer const&, SGPFont) const noexcept override;
+	SDL_Point operator()(int x, int y, ST::utf32_buffer const&, SGPFont) const override;
 };
 
 // Horizontally align the given text right. Vertically the coordinate is
@@ -51,7 +51,7 @@ struct HRightVCenterAlign : public IAlignment
 {
 	int width, height;
 	constexpr HRightVCenterAlign(int w, int h) : width{ w }, height{ h } {}
-	SDL_Point operator()(int x, int y, ST::utf32_buffer const&, SGPFont) const noexcept override;
+	SDL_Point operator()(int x, int y, ST::utf32_buffer const&, SGPFont) const override;
 };
 
 // Center align the given text right horizontally. Vertically the coordinate is
@@ -60,7 +60,7 @@ struct HCenterVCenterAlign : public IAlignment
 {
 	int width, height;
 	constexpr HCenterVCenterAlign(int w, int h) : width{ w }, height{ h } {}
-	SDL_Point operator()(int x, int y, ST::utf32_buffer const&, SGPFont) const noexcept override;
+	SDL_Point operator()(int x, int y, ST::utf32_buffer const&, SGPFont) const override;
 };
 
 


### PR DESCRIPTION
The new functions cannot be marked noexcept because another function it calls indirectly (SubRegionProperties) can potentially throw.