### PR TITLE
Use SDL to simplify AddVideoSurfaceFromFile

### DIFF
--- a/src/sgp/HImage.h
+++ b/src/sgp/HImage.h
@@ -99,10 +99,6 @@ struct SGPImage
 
 SGPImage* CreateImage(const ST::string& ImageFile, UINT16 fContents);
 
-// This function will run the appropriate copy function based on the type of SGPImage object
-BOOLEAN CopyImageToBuffer(SGPImage const*, UINT32 fBufferType, BYTE* pDestBuf, UINT16 usDestWidth, UINT16 usDestHeight, UINT16 usX, UINT16 usY, SGPBox const* src_rect);
-
-
 // UTILITY FUNCTIONS
 
 // Used to create a 16BPP Palette from an 8 bit palette, found in himage.c


### PR DESCRIPTION
In its original form `CopyImageToBuffer` supported copying compressed data to a surface. It lost that ability long ago apparently because it was not used and now this function is just an elaborate way to copy raw data from a `SGPImage` to a `SGPVSurface`.

`SDL_ConvertPixels` can do this copy just as well which allows us to remove `CopyImageToBuffer` and its helper functions.

The loading screens and the map of Arulco on the map screen are among the users of this function if you want to verify that this approach works.