### PR TITLE
Remove IGameDataLoader.h

### DIFF
--- a/src/externalized/DefaultContentManager.h
+++ b/src/externalized/DefaultContentManager.h
@@ -9,9 +9,8 @@
 #include "ContentManager.h"
 #include "ContentMusic.h"
 #include "IEDT.h"
-#include "IGameDataLoader.h"
 #include "ItemStrings.h"
-#include "RustInterface.h"
+#include "Json.h"
 #include "StringEncodingTypes.h"
 
 #include <string_theory/string>
@@ -21,7 +20,7 @@
 #include <string_view>
 #include <vector>
 
-class DefaultContentManager : public ContentManager, public IGameDataLoader
+class DefaultContentManager : public ContentManager
 {
 public:
 	DefaultContentManager(RustPointer<EngineOptions> engineOptions);

--- a/src/externalized/IGameDataLoader.h
+++ b/src/externalized/IGameDataLoader.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#include "Json.h"
-
-class IGameDataLoader
-{
-public:
-	JsonValue readJsonDataFile(const char *fileName) const;
-};


### PR DESCRIPTION
Apparently class IGameDataLoader was supposed to be an interface definition but because its only function is not declared virtual this is really a class without any data members and a declaration for a function that does not exist anywhere.

The actually existing and used readJsonDataFile is a non virtual member function of DefaultContentManager.