### PR TITLE
Fix possible OOB crash in SetRecalculateWireFrameFlagRadius

### DIFF
--- a/src/game/TileEngine/Render_Fun.cc
+++ b/src/game/TileEngine/Render_Fun.cc
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <optional>
 
 
 // Room Information
@@ -49,7 +50,6 @@ BOOLEAN InAHiddenRoom( UINT16 sGridNo, UINT8 *pubRoomNo )
 }
 
 
-// @@ATECLIP TO WORLD!
 void SetRecalculateWireFrameFlagRadius(const GridNo pos, const INT16 sRadius)
 {
 	INT16 pos_x_;
@@ -61,8 +61,10 @@ void SetRecalculateWireFrameFlagRadius(const GridNo pos, const INT16 sRadius)
 	{
 		for (INT16 x = pos_x - sRadius; x < pos_x + sRadius + 2; ++x)
 		{
-			const UINT32 uiTile = MAPROWCOLTOPOS(y, x);
-			gpWorldLevelData[uiTile].uiFlags |= MAPELEMENT_RECALCULATE_WIREFRAMES;
+			if (auto gridno{ GridNoFromRowColumn(y, x) }; gridno)
+			{
+				gpWorldLevelData[*gridno].uiFlags |= MAPELEMENT_RECALCULATE_WIREFRAMES;
+			}
 		}
 	}
 }
@@ -221,4 +223,16 @@ void RemoveRoomRoof( UINT16 sGridNo, UINT8 bRoomNum, SOLDIERTYPE *pSoldier )
 	SetRenderFlags(RENDER_FLAG_FULL );
 
 	CalculateWorldWireFrameTiles( FALSE );
+}
+
+
+std::optional<GridNo> GridNoFromRowColumn(int row, int column)
+{
+	if (row >= 0 && row < WORLD_ROWS &&
+	    column >= 0 && column < WORLD_COLS)
+	{
+		return row * WORLD_COLS + column;
+	}
+
+	return std::nullopt;
 }

--- a/src/game/TileEngine/Render_Fun.h
+++ b/src/game/TileEngine/Render_Fun.h
@@ -3,6 +3,7 @@
 
 #include "JA2Types.h"
 #include "WorldDef.h"
+#include <optional>
 
 #define NO_ROOM		0
 #define MAX_ROOMS	250
@@ -11,6 +12,7 @@
 extern UINT8 gubWorldRoomHidden[MAX_ROOMS];
 extern UINT8 gubWorldRoomInfo[WORLD_MAX];
 
+std::optional<GridNo> GridNoFromRowColumn(int row, int column);
 
 void InitRoomDatabase(void);
 


### PR DESCRIPTION
This can be triggered by the Night Ops map for H14, which has buggy room information data.

It's a bit more code than strictly necessary but I really dislike the MAPROWCOLTOPOS macro with its use of  0xFFFF to indicate a problem with its input arguments.