### PR TITLE
Load the Laptop title bar graphic just once

### DIFF
--- a/src/game/Laptop/EMail.cc
+++ b/src/game/Laptop/EMail.cc
@@ -219,7 +219,6 @@ static MOUSE_REGION g_mail_scroll_region;
 static Record* pMessageRecordList = NULL;
 
 // video handles
-static SGPVObject* guiEmailTitle;
 static SGPVObject* guiEmailBackground;
 static SGPVObject* guiEmailIndicator;
 static SGPVObject* guiEmailMessage;
@@ -300,9 +299,6 @@ void EnterEmail()
 
 	iCurrentPage = LaptopSaveInfo.iCurrentEmailPage;
 
-	// title bar
-	guiEmailTitle = AddVideoObjectFromFile(LAPTOPDIR "/programtitlebar.sti");
-
 	// the list background
 	guiEmailBackground = AddVideoObjectFromFile(LAPTOPDIR "/mailwindow.sti");
 
@@ -368,7 +364,6 @@ void ExitEmail()
 	DeleteEmailMouseRegions();
 
 	// remove video objects being used by email screen
-	DeleteVideoObject(guiEmailTitle);
 	DeleteVideoObject(guiEmailBackground);
 	DeleteVideoObject(guiMAILDIVIDER);
 	DeleteVideoObject(guiEmailIndicator);
@@ -471,7 +466,7 @@ static void ReDisplayBoxes(void);
 void RenderEmail( void )
 {
 	BltVideoObject(FRAME_BUFFER, guiEmailBackground, 0, LAPTOP_SCREEN_UL_X, EMAIL_LIST_WINDOW_Y + LAPTOP_SCREEN_UL_Y);
-	BltVideoObject(FRAME_BUFFER, guiEmailTitle,      0, LAPTOP_SCREEN_UL_X, LAPTOP_SCREEN_UL_Y - 2);
+	BltVideoObject(FRAME_BUFFER, guiTITLEBARLAPTOP,  0, LAPTOP_SCREEN_UL_X, LAPTOP_SCREEN_UL_Y - 2);
 
 	// show text on titlebar
 	DisplayTextOnTitleBar( );

--- a/src/game/Laptop/Files.cc
+++ b/src/game/Laptop/Files.cc
@@ -113,7 +113,6 @@ BOOLEAN fNewFilesInFileViewer = FALSE;
 
 namespace {
 // graphics handles
-cache_key_t const guiTITLE{ LAPTOPDIR "/programtitlebar.sti" };
 cache_key_t const guiTOP{ LAPTOPDIR "/fileviewer.sti" };
 }
 
@@ -288,7 +287,7 @@ void RenderFiles(void)
 static void RenderFilesBackGround(void)
 {
 	// render generic background for file system
-	BltVideoObject(FRAME_BUFFER, guiTITLE, 0, TOP_X, TOP_Y -  2);
+	BltVideoObject(FRAME_BUFFER, guiTITLEBARLAPTOP, 0, TOP_X, TOP_Y - 2);
 	BltVideoObject(FRAME_BUFFER, guiTOP,   0, TOP_X, TOP_Y + 22);
 }
 
@@ -305,7 +304,6 @@ static void RemoveFiles(void)
 {
 	// delete files video objects from memory
 	RemoveVObject(guiTOP);
-	RemoveVObject(guiTITLE);
 }
 
 

--- a/src/game/Laptop/Finances.cc
+++ b/src/game/Laptop/Finances.cc
@@ -120,7 +120,6 @@ static FinanceUnit* pFinanceListHead = NULL;
 static INT32 iCurrentPage = 0;
 
 // video object id's
-static SGPVObject* guiTITLE;
 static SGPVObject* guiTOP;
 static SGPVObject* guiLINE;
 static SGPVObject* guiLONGLINE;
@@ -327,9 +326,6 @@ static void LoadFinances(void)
 {
 	// load Finance video objects into memory
 
-	// title bar
-	guiTITLE = AddVideoObjectFromFile(LAPTOPDIR "/programtitlebar.sti");
-
 	// top portion of the screen background
 	guiTOP = AddVideoObjectFromFile(LAPTOPDIR "/financeswindow.sti");
 
@@ -351,14 +347,13 @@ static void RemoveFinances(void)
 	DeleteVideoObject(guiLINE);
 	DeleteVideoObject(guiLISTCOLUMNS);
 	DeleteVideoObject(guiTOP);
-	DeleteVideoObject(guiTITLE);
 }
 
 
 static void RenderBackGround(void)
 {
 	// render generic background for Finance system
-	BltVideoObject(FRAME_BUFFER, guiTITLE, 0, TOP_X, TOP_Y -  2);
+	BltVideoObject(FRAME_BUFFER, guiTITLEBARLAPTOP, 0, TOP_X, TOP_Y - 2);
 	BltVideoObject(FRAME_BUFFER, guiTOP,   0, TOP_X, TOP_Y + 22);
 }
 

--- a/src/game/Laptop/History.cc
+++ b/src/game/Laptop/History.cc
@@ -68,8 +68,6 @@ struct HistoryUnit
 
 // graphics handles
 namespace {
-cache_key_t const guiTITLE{ LAPTOPDIR "/programtitlebar.sti" };
-
 // top portion of the screen background
 cache_key_t const guiTOP{ LAPTOPDIR "/historywindow.sti" };
 
@@ -205,7 +203,6 @@ static void RemoveHistory(void)
 	// delete history video objects from memory
 	RemoveVObject(guiLONGLINE);
 	RemoveVObject(guiTOP);
-	RemoveVObject(guiTITLE);
 	RemoveVObject(guiSHADELINE);
 }
 
@@ -213,7 +210,7 @@ static void RemoveHistory(void)
 static void RenderHistoryBackGround(void)
 {
 	// render generic background for history system
-	BltVideoObject(FRAME_BUFFER, guiTITLE, 0, TOP_X, TOP_Y -  2);
+	BltVideoObject(FRAME_BUFFER, guiTITLEBARLAPTOP, 0, TOP_X, TOP_Y - 2);
 	BltVideoObject(FRAME_BUFFER, guiTOP,   0, TOP_X, TOP_Y + 22);
 }
 

--- a/src/game/Laptop/Laptop.cc
+++ b/src/game/Laptop/Laptop.cc
@@ -245,7 +245,6 @@ cache_key_t const guiGRAPHBAR{ LAPTOPDIR "/graphsegment.sti" };
 cache_key_t const guiLIGHTS{ LAPTOPDIR "/lights.sti" };
 }
 SGPVObject* guiLaptopBACKGROUND;
-static SGPVObject* guiTITLEBARLAPTOP;
 SGPVObject* guiTITLEBARICONS;
 static SGPVSurface* guiDESKTOP;
 
@@ -474,9 +473,6 @@ static void EnterLaptop(void)
 	// background for panel
 	guiLaptopBACKGROUND = AddVideoObjectFromFile(LAPTOPDIR "/taskbar.sti");
 
-	// background for panel
-	guiTITLEBARLAPTOP = AddVideoObjectFromFile(LAPTOPDIR "/programtitlebar.sti");
-
 	// icons for title bars
 	guiTITLEBARICONS = AddVideoObjectFromFile(LAPTOPDIR "/icons.sti");
 
@@ -590,7 +586,7 @@ void ExitLaptop(void)
 
 	RemoveVObject(guiLAPTOP);
 	DeleteVideoObject(guiLaptopBACKGROUND);
-	DeleteVideoObject(guiTITLEBARLAPTOP);
+	RemoveVObject(guiTITLEBARLAPTOP);
 	RemoveVObject(guiLIGHTS);
 	DeleteVideoObject(guiTITLEBARICONS);
 	DeleteVideoObject(guiEmailWarning);
@@ -731,7 +727,7 @@ static void RenderLaptop(void)
 }
 
 
-static void InitTitleBarMaximizeGraphics(const SGPVObject* uiBackgroundGraphic, const ST::string& str, const SGPVObject* uiIconGraphic, UINT16 usIconGraphicIndex);
+static void InitTitleBarMaximizeGraphics(cache_key_t const uiBackgroundGraphic, const ST::string& str, const SGPVObject* uiIconGraphic, UINT16 usIconGraphicIndex);
 static void SetSubSiteAsVisted(void);
 
 
@@ -2165,10 +2161,8 @@ void WebPageTileBackground(const UINT8 ubNumX, const UINT8 ubNumY, const UINT16 
 }
 
 
-static void InitTitleBarMaximizeGraphics(const SGPVObject* uiBackgroundGraphic, const ST::string& str, const SGPVObject* uiIconGraphic, UINT16 usIconGraphicIndex)
+static void InitTitleBarMaximizeGraphics(cache_key_t const uiBackgroundGraphic, const ST::string& str, const SGPVObject* uiIconGraphic, UINT16 usIconGraphicIndex)
 {
-	Assert(uiBackgroundGraphic);
-
 	// Create a background video surface to blt the title bar onto
 	guiTitleBarSurface = AddVideoSurface(LAPTOP_TITLE_BAR_WIDTH + LAPTOP_TITLE_BAR_ICON_OFFSET_X,
 						LAPTOP_TITLE_BAR_HEIGHT + LAPTOP_TITLE_BAR_ICON_OFFSET_Y, PIXEL_DEPTH);
@@ -2818,7 +2812,7 @@ void HandleKeyBoardShortCutsForLapTop(UINT16 usEvent, UINT32 usParam, UINT16 usK
 void RenderWWWProgramTitleBar(void)
 {
 	// will render the title bar for the www program
-	BltVideoObjectOnce(FRAME_BUFFER, LAPTOPDIR "/programtitlebar.sti", 0, LAPTOP_SCREEN_UL_X, LAPTOP_SCREEN_UL_Y - 2);
+	BltVideoObject(FRAME_BUFFER, guiTITLEBARLAPTOP, 0, LAPTOP_SCREEN_UL_X, LAPTOP_SCREEN_UL_Y - 2);
 
 	// now slapdown text
 	SetFontAttributes(FONT14ARIAL, FONT_WHITE);

--- a/src/game/Laptop/Laptop.h
+++ b/src/game/Laptop/Laptop.h
@@ -1,8 +1,10 @@
 #ifndef LAPTOP_H
 #define LAPTOP_H
 
+#include "Directories.h"
 #include "MessageBoxScreen.h"
 #include "MouseSystem.h"
+#include "Object_Cache.h"
 #include "ScreenIDs.h"
 #include "Types.h"
 #include "UILayout.h"
@@ -146,5 +148,7 @@ void DoLapTopSystemMessageBoxWithRect(MessageBoxStyleID ubStyle, const ST::strin
 void     LaptopScreenInit(void);
 ScreenID LaptopScreenHandle(void);
 void     LaptopScreenShutdown(void);
+
+inline cache_key_t const guiTITLEBARLAPTOP{ LAPTOPDIR "/programtitlebar.sti" };
 
 #endif

--- a/src/game/Laptop/Personnel.cc
+++ b/src/game/Laptop/Personnel.cc
@@ -239,7 +239,6 @@ static const INT16 pers_stat_y[] =
 };
 
 namespace {
-cache_key_t const guiTITLE{ LAPTOPDIR "/programtitlebar.sti" };
 cache_key_t const guiSCREEN { LAPTOPDIR "/personnelwindow.sti" };
 cache_key_t const guiDEPARTEDTEAM{ LAPTOPDIR "/departed.sti" };
 cache_key_t const guiCURRENTTEAM{ LAPTOPDIR "/currentteam.sti" };
@@ -378,7 +377,6 @@ static void RemovePersonnelGraphics(void)
 {
 	// delete graphics needed for personnel screen
 	RemoveVObject(guiSCREEN);
-	RemoveVObject(guiTITLE);
 	RemoveVObject(guiPersonnelInventory);
 }
 
@@ -399,7 +397,7 @@ void RenderPersonnel(void)
 	// re-renders personnel screen
 	// render main background
 
-	BltVideoObject(FRAME_BUFFER, guiTITLE,  0, LAPTOP_SCREEN_UL_X, LAPTOP_SCREEN_UL_Y -  2);
+	BltVideoObject(FRAME_BUFFER, guiTITLEBARLAPTOP, 0, LAPTOP_SCREEN_UL_X, LAPTOP_SCREEN_UL_Y - 2);
 	BltVideoObject(FRAME_BUFFER, guiSCREEN, 0, LAPTOP_SCREEN_UL_X, LAPTOP_SCREEN_UL_Y + 22);
 
 	// render personnel screen background


### PR DESCRIPTION
This video object is needed by the main Laptop code and gets loaded when the Laptop screen is entered. Nevertheless several sub screens had their own copy of this file without any good reason; now these screens also use the already existing instance.