### PR TITLE
Fix four blitters

### DIFF
--- a/src/sgp/VObject_Blitters.cc
+++ b/src/sgp/VObject_Blitters.cc
@@ -779,14 +779,14 @@ void Blt8BPPDataTo16BPPBufferTransShadow(UINT16* pBuffer, UINT32 uiDestPitchBYTE
 				do
 				{
 					UINT8 px = *SrcPtr++;
-
+					auto DestPtr16{ reinterpret_cast<UINT16 *>(DestPtr) };
 					if (px == 254)
 					{
-						*(UINT16*)DestPtr = ShadeTable[2 * (*(UINT16*)DestPtr)];
+						*DestPtr16 = ShadeTable[*DestPtr16];
 					}
 					else
 					{
-						*(UINT16*)DestPtr = p16BPPPalette[2 * px];
+						*DestPtr16 = p16BPPPalette[px];
 					}
 					DestPtr += 2;
 				}
@@ -854,19 +854,19 @@ void Blt8BPPDataTo16BPPBufferTransShadowZ(UINT16* pBuffer, UINT32 uiDestPitchBYT
 				do
 				{
 					UINT8 px = *SrcPtr++;
-
+					auto DestPtr16{ reinterpret_cast<UINT16 *>(DestPtr) };
 					if (px == 254)
 					{
 						if (*(UINT16*)ZPtr < usZValue)
 						{
-							*(UINT16*)DestPtr = ShadeTable[2 * (*(UINT16*)DestPtr)];
+							*DestPtr16 = ShadeTable[*DestPtr16];
 						}
 					}
 					else
 					{
 						if (*(UINT16*)ZPtr <= usZValue)
 						{
-							*(UINT16*)DestPtr = p16BPPPalette[2 * px];
+							*DestPtr16 = p16BPPPalette[px];
 						}
 					}
 					DestPtr += 2;

--- a/src/sgp/VObject_Blitters.cc
+++ b/src/sgp/VObject_Blitters.cc
@@ -22,6 +22,17 @@ static uint16_t DoZ(int32_t const a, int32_t const b)
 	return a > b ? static_cast<uint16_t>(a - b) : 0;
 }
 
+namespace {
+// Helper function objects for blitters implemented using function templates.
+
+// This version is used by the blitters that do not have 'NB' in their name.
+// 'NB' probably means "no bleed through".
+struct UpdateZ { void operator()(UINT16 * zdst, UINT16 zval) { *zdst = zval; } };
+
+// This version does not update the ZBuffer and needs the following line
+// as a somewhat elaborate way to say NOP. Is is used by 'NB' blitters.
+struct DontUpdateZ { void operator()(UINT16 *, UINT16) {} };
+}
 
 /* Blit an image into the destination buffer, using an ETRLE brush as a source,
  * and a 16-bit buffer as a destination. As it is blitting, it checks the Z
@@ -1052,6 +1063,7 @@ Blt8BPPDataTo16BPPBufferTransShadowZClip
 	254 are shaded instead of blitted.
 
 **********************************************************************************************/
+template<typename UpdateZOrDont>
 void Blt8BPPDataTo16BPPBufferTransShadowZClip(UINT16* pBuffer, UINT32 uiDestPitchBYTES, UINT16* pZBuffer, UINT16 usZValue, HVOBJECT hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex, SGPRect* clipregion, const UINT16* p16BPPPalette)
 {
 	UINT8  *DestPtr, *ZPtr;
@@ -1186,9 +1198,11 @@ BlitNonTransLoop: // blit non-transparent pixels
 
 				do
 				{
-					if (*ZPtr < usZValue )
+					auto zptr16{ reinterpret_cast<UINT16 *>(ZPtr) };
+					if (*zptr16 < usZValue )
 					{
-						*ZPtr = usZValue;
+						// This will either become *zptr16 = usZValue or a NOP.
+						UpdateZOrDont{}(zptr16, usZValue);
 						px = *SrcPtr++;
 						if (px != 254)
 							*(UINT16*)DestPtr = p16BPPPalette[px];
@@ -1209,6 +1223,30 @@ BlitNonTransLoop: // blit non-transparent pixels
 	}
 	while ( --BlitHeight > 0 );
 }
+
+
+void Blt8BPPDataTo16BPPBufferTransShadowZClip(UINT16* pBuffer, UINT32 uiDestPitchBYTES, UINT16* pZBuffer, UINT16 usZValue, HVOBJECT hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex, SGPRect* clipregion, const UINT16* p16BPPPalette)
+{
+	Blt8BPPDataTo16BPPBufferTransShadowZClip<UpdateZ>(pBuffer, uiDestPitchBYTES, pZBuffer, usZValue, hSrcVObject, iX, iY, usIndex, clipregion, p16BPPPalette);
+}
+
+/**********************************************************************************************
+Blt8BPPDataTo16BPPBufferTransShadowZNBClip
+
+	Blits an image into the destination buffer, using an ETRLE brush as a source, and a 16-bit
+	buffer as a destination. As it is blitting, it checks the Z value of the ZBuffer, and if the
+	pixel's Z level is below that of the current pixel, it is written on.
+	The Z-buffer is 16 bit, and	must be the same dimensions (including Pitch) as the
+	destination. Pixels with a value of	254 are shaded instead of blitted. The Z buffer is
+	NOT updated.
+
+**********************************************************************************************/
+
+void Blt8BPPDataTo16BPPBufferTransShadowZNBClip(UINT16* pBuffer, UINT32 uiDestPitchBYTES, UINT16* pZBuffer, UINT16 usZValue, HVOBJECT hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex, SGPRect* clipregion, const UINT16* p16BPPPalette)
+{
+	Blt8BPPDataTo16BPPBufferTransShadowZClip<DontUpdateZ>(pBuffer, uiDestPitchBYTES, pZBuffer, usZValue, hSrcVObject, iX, iY, usIndex, clipregion, p16BPPPalette);
+}
+
 
 /**********************************************************************************************
 Blt8BPPDataTo16BPPBufferTransShadowClip
@@ -1368,178 +1406,6 @@ BlitNonTransLoop: // blit non-transparent pixels
 		DestPtr += LineSkip;
 	}
 	while ( --BlitHeight > 0 );
-}
-
-/**********************************************************************************************
-Blt8BPPDataTo16BPPBufferTransShadowZNBClip
-
-	Blits an image into the destination buffer, using an ETRLE brush as a source, and a 16-bit
-	buffer as a destination. As it is blitting, it checks the Z value of the ZBuffer, and if the
-	pixel's Z level is below that of the current pixel, it is written on.
-	The Z-buffer is 16 bit, and	must be the same dimensions (including Pitch) as the
-	destination. Pixels with a value of	254 are shaded instead of blitted. The Z buffer is
-	NOT updated.
-
-**********************************************************************************************/
-void Blt8BPPDataTo16BPPBufferTransShadowZNBClip(UINT16* pBuffer, UINT32 uiDestPitchBYTES, UINT16* pZBuffer, UINT16 usZValue, HVOBJECT hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex, SGPRect* clipregion, const UINT16* p16BPPPalette)
-{
-	UINT32 Unblitted;
-	UINT8  *DestPtr, *ZPtr;
-	UINT32 LineSkip;
-	INT32  LeftSkip, RightSkip, TopSkip, BottomSkip, BlitLength, BlitHeight, LSCount;
-	INT32  ClipX1, ClipY1, ClipX2, ClipY2;
-
-	// Assertions
-	Assert( hSrcVObject != NULL );
-	Assert( pBuffer != NULL );
-
-	// Get Offsets from Index into structure
-	ETRLEObject const& pTrav = hSrcVObject->SubregionProperties(usIndex);
-	UINT32      const  usHeight = pTrav.usHeight;
-	UINT32      const  usWidth  = pTrav.usWidth;
-
-	// Add to start position of dest buffer
-	INT32 const iTempX = iX + pTrav.sOffsetX;
-	INT32 const iTempY = iY + pTrav.sOffsetY;
-
-	if(clipregion==NULL)
-	{
-		ClipX1=ClippingRect.iLeft;
-		ClipY1=ClippingRect.iTop;
-		ClipX2=ClippingRect.iRight;
-		ClipY2=ClippingRect.iBottom;
-	}
-	else
-	{
-		ClipX1=clipregion->iLeft;
-		ClipY1=clipregion->iTop;
-		ClipX2=clipregion->iRight;
-		ClipY2=clipregion->iBottom;
-	}
-
-	// Calculate rows hanging off each side of the screen
-	LeftSkip = std::min(ClipX1 - std::min(ClipX1, iTempX), (INT32)usWidth);
-	RightSkip = std::clamp(iTempX + (INT32)usWidth - ClipX2, 0, (INT32)usWidth);
-	TopSkip = std::min(ClipY1 - std::min(ClipY1, iTempY), (INT32)usHeight);
-	BottomSkip = std::clamp(iTempY + (INT32)usHeight - ClipY2, 0, (INT32)usHeight);
-
-	// calculate the remaining rows and columns to blit
-	BlitLength=((INT32)usWidth-LeftSkip-RightSkip);
-	BlitHeight=((INT32)usHeight-TopSkip-BottomSkip);
-
-	// check if whole thing is clipped
-	if((LeftSkip >=(INT32)usWidth) || (RightSkip >=(INT32)usWidth))
-		return;
-
-	// check if whole thing is clipped
-	if((TopSkip >=(INT32)usHeight) || (BottomSkip >=(INT32)usHeight))
-		return;
-
-	UINT8 const* SrcPtr = hSrcVObject->PixData(pTrav);
-	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
-	ZPtr = (UINT8 *)pZBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
-	LineSkip=(uiDestPitchBYTES-(BlitLength*2));
-
-	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
-
-	do
-	{
-		for (LSCount = LeftSkip; LSCount > 0; LSCount -= PxCount)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80)
-			{
-				PxCount &= 0x7F;
-				if (PxCount > static_cast<UINT32>(LSCount))
-				{
-					PxCount -= LSCount;
-					LSCount = BlitLength;
-					goto BlitTransparent;
-				}
-			}
-			else
-			{
-				if (PxCount > static_cast<UINT32>(LSCount))
-				{
-					SrcPtr += LSCount;
-					PxCount -= LSCount;
-					LSCount = BlitLength;
-					goto BlitNonTransLoop;
-				}
-				SrcPtr += PxCount;
-			}
-		}
-
-		LSCount = BlitLength;
-		while (LSCount > 0)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80)
-			{
-BlitTransparent: // skip transparent pixels
-				PxCount &= 0x7F;
-				if (PxCount > static_cast<UINT32>(LSCount)) PxCount = LSCount;
-				LSCount -= PxCount;
-				DestPtr += 2 * PxCount;
-				ZPtr    += 2 * PxCount;
-			}
-			else
-			{
-BlitNonTransLoop: // blit non-transparent pixels
-				if (PxCount > static_cast<UINT32>(LSCount))
-				{
-					Unblitted = PxCount - LSCount;
-					PxCount = LSCount;
-				}
-				else
-				{
-					Unblitted = 0;
-				}
-				LSCount -= PxCount;
-
-				do
-				{
-					UINT8 px = *SrcPtr++;
-
-					if (px == 254)
-					{
-						if (*(UINT16*)ZPtr < usZValue)
-						{
-							*(UINT16*)DestPtr = ShadeTable[*(UINT16*)DestPtr];
-						}
-					}
-					else
-					{
-						if (*(UINT16*)ZPtr <= usZValue)
-						{
-							*(UINT16*)DestPtr = p16BPPPalette[px];
-						}
-					}
-					DestPtr += 2;
-					ZPtr += 2;
-				}
-				while (--PxCount > 0);
-				SrcPtr += Unblitted;
-			}
-		}
-
-		while (*SrcPtr++ != 0) {} // skip along until we hit and end-of-line marker
-		DestPtr += LineSkip;
-		ZPtr += LineSkip;
-	}
-	while (--BlitHeight > 0);
 }
 
 


### PR DESCRIPTION
• Blt8BPPDataTo16BPPBufferTransShadowZNBClip was using the wrong comparison operator (<= instead of <)
• Blt8BPPDataTo16BPPBufferTransShadowZClip was accessing the 16-bit Z Buffer as if it was and array of 8-bit values.
    
Both are not implemented as instantiations of a shared function template to ensure they don't diverge again.

• Blt8BPPDataTo16BPPBufferTransShadow and Blt8BPPDataTo16BPPBufferTransShadowZ multiplied their indices into arrays by 2 as the result of a mistranslation of the original x86 code.

I am not sure how I feel about this PR. Code inspection suggests these changes should be correct, but as I wrote in #2146, I can't to trigger these blitters except Blt8BPPDataTo16BPPBufferTransShadowZNBClip, which is the least problematic of the four. Here, all that can happen that one pixel might have the wrong color occasionally.

So this PR is probably not that important but OTOH it will definitely get in the way of #738 again.