### PR TITLE
Fix mixed up variables in Blt8BPPDataTo16BPPBufferTransShadowZClip

### DIFF
--- a/src/sgp/VObject_Blitters.cc
+++ b/src/sgp/VObject_Blitters.cc
@@ -1313,13 +1313,12 @@ void Blt8BPPDataTo16BPPBufferTransShadowClip(UINT16* pBuffer, UINT32 uiDestPitch
 	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	LineSkip=(uiDestPitchBYTES-(BlitLength*2));
 
-	UINT8 PxCount, px = 0;
 	UINT32 Unblitted;
 	INT32 LSCount;
 
 	while (TopSkip)
 	{
-		px = *SrcPtr++;
+		UINT8 const px = *SrcPtr++;
 		if (px & 0x80)  continue;
 		if (px)
 		{
@@ -1332,6 +1331,7 @@ void Blt8BPPDataTo16BPPBufferTransShadowClip(UINT16* pBuffer, UINT32 uiDestPitch
 	do
 	{
 		Unblitted = 0;
+		UINT8 PxCount{};
 		for (LSCount = LeftSkip; LSCount > 0; LSCount -= PxCount)
 		{
 			PxCount = *SrcPtr++;
@@ -1348,7 +1348,7 @@ void Blt8BPPDataTo16BPPBufferTransShadowClip(UINT16* pBuffer, UINT32 uiDestPitch
 			}
 			else
 			{
-				if (px > LSCount)
+				if (PxCount > LSCount)
 				{
 					SrcPtr += LSCount;
 					PxCount -= LSCount;
@@ -1388,14 +1388,12 @@ BlitNonTransLoop: // blit non-transparent pixels
 
 				do
 				{
-					px = *SrcPtr++;
-					if (px != 254)
-						*(UINT16*)DestPtr = p16BPPPalette[px];
-					else
-						*(UINT16*)DestPtr = ShadeTable[*(UINT16*)DestPtr];
+					UINT8 const px{ *SrcPtr++ };
+					auto dstPtr16{ reinterpret_cast<UINT16 *>(DestPtr) };
+					*dstPtr16 = (px != 254)	? p16BPPPalette[px] : ShadeTable[*dstPtr16];
 					DestPtr += 2;
 				}
-				while ( --px > 0 );
+				while (--PxCount > 0);
 				SrcPtr += Unblitted;
 			}
 		}
@@ -3617,9 +3615,6 @@ void Blt8BPPDataTo16BPPBufferOutlineZPixelateObscuredClip(UINT16* const pBuffer,
 
 	LineSkip=(uiDestPitchBYTES-(BlitLength*2));
 	UINT16 const* const p16BPPPalette = hSrcVObject->CurrentShade();
-	uiLineFlag=(iTempY&1);
-
-
 	uiLineFlag = (iTempY + TopSkip) & 1;
 
 	UINT32 PxCount;
@@ -5421,8 +5416,6 @@ void Blt8BPPDataTo16BPPBufferTransZClipPixelateObscured( UINT16 *pBuffer, UINT32
 	ZPtr = (UINT8 *)pZBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	UINT16 const* const p16BPPPalette = hSrcVObject->CurrentShade();
 	LineSkip=(uiDestPitchBYTES-(BlitLength*2));
-	uiLineFlag=(iTempY&1);
-
 	uiLineFlag = (iTempY + TopSkip) & 1;
 
 	UINT32 PxCount;


### PR DESCRIPTION
This blitter used the variable px in places where it should have used PxCount. Another bug was that the src pointer must always be incremented, no matter if we write to the Z buffer or not.