### PR TITLE
github: ubuntu-20.04 was removed, bump used runner

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   coverity_scan:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -24,6 +24,7 @@ jobs:
         run: ${{ github.workspace }}/.ci/ci-setup.sh 2>&1
         env:
           CI_TARGET: linux
+          TARGET_GCC_MAJOR_VERSION: 13
 
       - name: Download and install Coverity Build Tool
         run: |

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         cfg:
         - name: Linux
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           target: linux
 
         - name: Linux mingw64
@@ -26,7 +26,7 @@ jobs:
           target: mac
 
         - name: Android
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           target: android
 
     name: ${{ matrix.cfg.name }} ${{ github.ref }}
@@ -102,6 +102,7 @@ jobs:
       env:
         CI_TARGET: ${{ matrix.cfg.target }}
         ANDROID_KEYSTORE_FILE: ${{ secrets.ANDROID_KEYSTORE_FILE }}
+        TARGET_GCC_MAJOR_VERSION: 9
 
     - name: Build and run tests
       shell: bash


### PR DESCRIPTION
Let's see if it all still builds. The image got removed last week, triggering a scheduled coverity runner failure.