### PR TITLE
Upgrade dependencies for CMake 4

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -18,7 +18,7 @@ jobs:
           target: linux
 
         - name: Linux mingw64
-          os: ubuntu-22.04
+          os: ubuntu-24.04
           target: linux-mingw64
 
         - name: Mac

--- a/dependencies/lib-gtest/getter/CMakeLists.txt.in
+++ b/dependencies/lib-gtest/getter/CMakeLists.txt.in
@@ -12,8 +12,8 @@ project(getter NONE)
 
 include(ExternalProject)
 externalproject_add(get-gtest
-    URL "https://github.com/google/googletest/archive/release-1.11.0.tar.gz"
-    URL_MD5 "e8a8df240b6938bb6384155d4c37d937"
+    URL "https://github.com/google/googletest/releases/download/v1.16.0/googletest-1.16.0.tar.gz"
+    URL_MD5 "9a75eb2ac97300cdb8b65b1a5833f411"
     CMAKE_ARGS
         "-G@CMAKE_GENERATOR@"
         SOURCE_DIR          "@SRC_DIR@"

--- a/dependencies/lib-string_theory/builder/CMakeLists.txt.in
+++ b/dependencies/lib-string_theory/builder/CMakeLists.txt.in
@@ -12,8 +12,8 @@ project(builder NONE)
 
 include(ExternalProject)
 externalproject_add(string_theory
-    URL "https://github.com/zrax/string_theory/archive/3.8.tar.gz"
-    URL_MD5 "910af6773498c6064e9d14d935d2603d"
+    URL "https://github.com/zrax/string_theory/archive/3.9.tar.gz"
+    URL_MD5 "52f855d28460ac377c7c1df00e0438f1"
     CMAKE_ARGS
         "-G@CMAKE_GENERATOR@"
         "-C@CACHE_FILE@"


### PR DESCRIPTION
I currently cannot build the project with my version of CMake (4.0.0) anymore. It results in the following error:

```
CMake Error at _bin/lib-gtest/src/CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

The same happens for `string_theory`.

This PR upgrades `gtest` and `string_theory` to their most recent versions, which fixes the issue.