### PR TITLE
Make some Github runners do less work

### DIFF
--- a/.ci/ci-functions.sh
+++ b/.ci/ci-functions.sh
@@ -33,17 +33,6 @@ linux-install-appimage-build-tools () {
     sudo chmod +x /usr/bin/linuxdeploy
     sudo curl -sSfL -o /usr/bin/appimagelint https://github.com/TheAssassin/appimagelint/releases/download/continuous/appimagelint-x86_64.AppImage
     sudo chmod +x /usr/bin/appimagelint
-
-    ###
-    ### See #1431. This whole block can be removed when CI runners use Ubuntu 21.04 or newer
-    linux-install-via-apt-get zstd
-    curl -sL -o "tar-1.34.tar.gz" https://ftp.gnu.org/gnu/tar/tar-1.34.tar.gz
-    tar zxf "tar-1.34.tar.gz"
-    cd tar-1.34 && ./configure && make && sudo make install
-    sudo cp /usr/local/bin/tar /usr/bin/tar
-    which tar
-    tar --version
-    ###
 }
 
 linux-install-via-android-sdkmanager () {

--- a/.ci/ci-setup.sh
+++ b/.ci/ci-setup.sh
@@ -45,6 +45,11 @@ elif [[ "$CI_TARGET" == "mac" ]]; then
     # sccache for compilation caching
     macOS-install-via-brew sccache
 
+    # fltk for the launcher
+    macOS-install-via-brew fltk
+    # gtest
+    macOS-install-via-brew googletest
+
     # Google Cloud SDK for Artifact Upload
     macOS-install-via-brew-cask google-cloud-sdk
     source "$(brew --prefix)/share/google-cloud-sdk/path.bash.inc"

--- a/.ci/ci-setup.sh
+++ b/.ci/ci-setup.sh
@@ -46,7 +46,10 @@ elif [[ "$CI_TARGET" == "mac" ]]; then
     macOS-install-via-brew sccache
 
     # fltk for the launcher
-    macOS-install-via-brew fltk
+    macOS-install-via-brew fltk@1.3
+    echo 'export PATH="/opt/homebrew/opt/fltk@1.3/bin:$PATH"' >> ~/.bash_profile
+    source ~/.bash_profile
+
     # gtest
     macOS-install-via-brew googletest
 

--- a/.ci/upload-artifact.sh
+++ b/.ci/upload-artifact.sh
@@ -5,6 +5,7 @@
 #
 # Required env variables (nightly and releases):
 #   CI_REF - full reference of the current branch, tag, or pull request
+#   CI_TARGET - target platform we are building for
 #   GCLOUD_CREDENTIALS_KEY, GCLOUD_CREDENTIALS_IV, GCLOUD_CREDENTIALS_SALT - values to decrypt gcloud credentials
 
 set -e
@@ -24,11 +25,13 @@ if [[ "$PUBLISH_DIR" == "" ]]; then
   exit 1
 fi
 
+# Fix used python version for google cloud sdk
 if [[ "$CI_TARGET" == windows-msvc-* ]]; then
-  # Fix used python version for google cloud sdk
   export CLOUDSDK_PYTHON="C:\\Python39\\python.exe"
+elif [[ "$CI_TARGET" == "mac" ]]; then
+  # keep in sync with brew pkg dependency (pinned to 3.12 as of 2025)
+  export CLOUDSDK_PYTHON=python3.12
 fi
-
 
 # Bucket Name to upload to
 BUCKET_NAME=ja2-builds

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -121,6 +121,7 @@ jobs:
       run: ${{ github.workspace }}/.ci/ci-publish.sh 2>&1
       env:
         CI_REF: ${{ github.ref }}
+        CI_TARGET: ${{ matrix.cfg.target }}
         GCLOUD_CREDENTIALS_SALT: ${{ secrets.GCLOUD_CREDENTIALS_SALT }}
         GCLOUD_CREDENTIALS_KEY: ${{ secrets.GCLOUD_CREDENTIALS_KEY }}
         GCLOUD_CREDENTIALS_IV: ${{ secrets.GCLOUD_CREDENTIALS_IV }}

--- a/cmake/toolchain-macos.cmake
+++ b/cmake/toolchain-macos.cmake
@@ -3,8 +3,7 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 
 set(LOCAL_SDL_LIB "dependencies/lib-SDL2-2.0.20-macos" CACHE STRING "" FORCE)
-set(LOCAL_FLTK_LIB ON CACHE BOOL "" FORCE)
-set(LOCAL_GTEST_LIB ON CACHE BOOL "" FORCE)
+set(LOCAL_GTEST_LIB OFF CACHE BOOL "" FORCE)
 set(CMAKE_MACOSX_RPATH ON CACHE BOOL "" FORCE)
 
 set(CMAKE_EXE_LINKER_FLAGS "-framework IOKit -framework Carbon -framework AudioUnit -framework AudioToolbox -framework OpenGL -framework CoreFoundation -framework AppKit" CACHE STRING "" FORCE)

--- a/src/launcher/CMakeLists.txt
+++ b/src/launcher/CMakeLists.txt
@@ -39,8 +39,20 @@ set_target_properties(${LAUNCHER_BINARY}
 
 add_dependencies(${LAUNCHER_BINARY} stracciatella)
 
+if (NOT LOCAL_FLTK_LIB AND APPLE)
+    find_package(PNG REQUIRED)
+    # force static linking
+    target_link_libraries(${LAUNCHER_BINARY} PRIVATE
+        /opt/homebrew/opt/fltk@1.3/lib/libfltk_forms.a /opt/homebrew/opt/fltk@1.3/lib/libfltk_images.a /opt/homebrew/opt/fltk@1.3/lib/libfltk.a ${PNG_LIBRARIES}
+    )
+else ()
+    target_link_libraries(${LAUNCHER_BINARY} PRIVATE
+        ${FLTK_LIBRARIES}
+    )
+endif ()
+
+
 target_link_libraries(${LAUNCHER_BINARY} PRIVATE
-    ${FLTK_LIBRARIES}
     ${STRACCIATELLA_LIBRARIES}
     ${SDL2_LIBRARY}
     string_theory-internal


### PR DESCRIPTION
 #2099
saves:
- ~15s by not building tar any more on linux
- ~60s by not building fltk on mac
- ~1s by not building gtest on mac

Also fixes too new python on the mac runner and CI_TARGET being ignored.