### PR TITLE
Add backward compatibility for the old strategic-map-towns.json

### DIFF
--- a/assets/externalized/strategic-mines.json
+++ b/assets/externalized/strategic-mines.json
@@ -7,6 +7,7 @@
  *
  * Field definitions:
  *  - entranceSector:    Sector of the mine entrance on the surface level.
+ *  - associatedTownId:    DEPRECATED in favour of associatedTown. Present here only for backward compatibility with pre-22 version mods that don't have internalName property in strategic-map-towns.json.
  *  - associatedTown:    Name of the associated town, refer to strategic-map-towns.json.
  *  - mineType:    Either "GOLD_MINE" or "SILVER_MINE".
  *  - headMinerAssigned:    True if there is a specific head miner assigned (in merc profile) to the entrance sector. If not, a head miner will be randomly assigned. Either way, the mine entrance sector must have the head miner slot(s) placed, unless it is abandoned.
@@ -19,6 +20,7 @@
 [
     {
         "entranceSector": "D4",
+        "associatedTownId": 7, // deprecated
         "associatedTown": "SAN_MONA",
         "mineType": "GOLD_MINE",
         "minimumMineProduction": 0, // abandoned
@@ -28,6 +30,7 @@
     },
     {
         "entranceSector": "D13",
+        "associatedTownId": 2, // deprecated
         "associatedTown": "DRASSEN",
         "mineType": "SILVER_MINE",
         "delayDepletion": true,
@@ -39,6 +42,7 @@
     },
     {
         "entranceSector": "I14",
+        "associatedTownId": 3, // deprecated
         "associatedTown": "ALMA",
         "mineType": "SILVER_MINE",
         "headMinerAssigned": true, // Matt is always the head miner here
@@ -50,6 +54,7 @@
     },
     {
         "entranceSector": "H8",
+        "associatedTownId": 6, // deprecated
         "associatedTown": "CAMBRIA",
         "mineType": "SILVER_MINE",
         "minimumMineProduction": 1500,
@@ -59,6 +64,7 @@
     },
     {
         "entranceSector": "B2",
+        "associatedTownId": 12, // deprecated
         "associatedTown": "CHITZENA",
         "mineType": "SILVER_MINE",
         "minimumMineProduction": 500,
@@ -69,6 +75,7 @@
     },
     {
         "entranceSector": "H3",
+        "associatedTownId": 4, // deprecated
         "associatedTown": "GRUMM",
         "mineType": "GOLD_MINE",
         "minimumMineProduction": 2000,

--- a/rust/stracciatella/src/schemas/yaml/strategic-map-towns.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/strategic-map-towns.schema.yaml
@@ -42,7 +42,7 @@ items:
       type: boolean
   required:
   - townId
-  - internalName
+  #- internalName #commented out for backward compatibility with pre-22 version mods
   - sectors
   - townPoint
   - isMilitiaTrainingAllowed

--- a/src/externalized/DefaultContentManager.cc
+++ b/src/externalized/DefaultContentManager.cc
@@ -1106,13 +1106,14 @@ bool DefaultContentManager::loadStrategicLayerData()
 		m_factParams[params->fact] = params;
 	}
 
+	bool jsonIsOnModLayer = (openGameResForReadingOnAllLayers("script-records-NPCs.json").size() > 1);
 	json = readJsonDataFileWithSchema("strategic-mines.json");
 
 	uint8_t i = 0;
 	for (auto& element : json.toVec())
 	{
 		m_mines.push_back(
-			MineModel::deserialize(i, element, this)
+			MineModel::deserialize(i, element, this, jsonIsOnModLayer)
 		);
 		i++;
 	}

--- a/src/externalized/json/Json.cc
+++ b/src/externalized/json/Json.cc
@@ -209,7 +209,7 @@ unsigned int JsonObject::getOptionalUInt(const char* name, unsigned int defaultV
     }
 }
 
-const ST::string JsonObject::getOptionalString(const char* name, const ST::string defaultValue) const
+ST::string JsonObject::getOptionalString(const char* name, const ST::string defaultValue) const
 {
     if(has(name))
     {

--- a/src/externalized/json/Json.h
+++ b/src/externalized/json/Json.h
@@ -85,7 +85,7 @@ class JsonObject
 		double getOptionalDouble(const char* name, double defaultValue = 0) const;
 		int getOptionalInt(const char* name, int defaultValue = 0) const;
 		unsigned int getOptionalUInt(const char* name, unsigned int defaultValue = 0) const;
-		const ST::string getOptionalString(const char* name, const ST::string defaultValue = {}) const;
+		ST::string getOptionalString(const char* name, const ST::string defaultValue = {}) const;
 		bool has(const char* name) const;
 		std::vector<ST::string> keys() const;
 		void set(const char* name, JsonValue value);

--- a/src/externalized/strategic/MineModel.cc
+++ b/src/externalized/strategic/MineModel.cc
@@ -46,14 +46,14 @@ std::vector<std::array<uint8_t, 2>> readMineSectors(const JsonValue& sectorsJson
 	return sectors;
 }
 
-MineModel* MineModel::deserialize(uint8_t index, const JsonValue& json, const ContentManager* contentManager)
+MineModel* MineModel::deserialize(uint8_t index, const JsonValue& json, const ContentManager* contentManager, const bool jsonIsOnModLayer)
 {
 	auto obj = json.toObject();
 	auto entrance = JsonUtility::parseSectorID(obj["entranceSector"]);
 	auto mineSectors = readMineSectors(obj["mineSectors"]);
 
 	uint8_t townId = obj.getOptionalUInt("associatedTownId");
-	if (townId) SLOGW("Property `associatedTownId` in strategic-mines.json has been deprecated. Use `associatedTown` instead.");
+	if (townId && jsonIsOnModLayer) SLOGW("Property `associatedTownId` in strategic-mines.json has been deprecated. Use `associatedTown` instead.");
 
 	return new MineModel(
 		index,

--- a/src/externalized/strategic/MineModel.h
+++ b/src/externalized/strategic/MineModel.h
@@ -29,6 +29,6 @@ public:
 
 	const int16_t faceDisplayYOffset;
 
-	static MineModel* deserialize(uint8_t index, const JsonValue& json, const ContentManager* contentManager);
+	static MineModel* deserialize(uint8_t index, const JsonValue& json, const ContentManager* contentManager, const bool jsonIsOnModLayer);
 	static void validateData(std::vector<const MineModel*>& models);
 };

--- a/src/externalized/strategic/TownModel.cc
+++ b/src/externalized/strategic/TownModel.cc
@@ -27,7 +27,7 @@ TownModel* TownModel::deserialize(const JsonValue& json)
 
 	return new TownModel(
 		obj.GetInt("townId"),
-		obj.GetString("internalName"),
+		obj.getOptionalString("internalName"),
 		std::move(sectorIDs),
 		townPoint,
 		obj.getOptionalBool("isMilitiaTrainingAllowed")


### PR DESCRIPTION
Fixes the problem introduced by #2081.
I think this solves the last known release-blocking issue.
@selaux, thank you for the tip-off.