### PR TITLE
string theory: don't print up-to-date lines on rebuilds

### DIFF
--- a/dependencies/lib-string_theory/builder/CMakeLists.txt.in
+++ b/dependencies/lib-string_theory/builder/CMakeLists.txt.in
@@ -28,6 +28,7 @@ externalproject_add(string_theory
         -DCMAKE_BUILD_TYPE=RelWithDebInfo
         -DST_ENABLE_STL_FILESYSTEM:BOOL=OFF
         -DST_BUILD_TESTS:BOOL=OFF
+        -DCMAKE_INSTALL_MESSAGE=LAZY
     BUILD_COMMAND "${CMAKE_COMMAND}" --build . --config RelWithDebInfo
     INSTALL_COMMAND "${CMAKE_COMMAND}" --build . --config RelWithDebInfo --target install
     BUILD_ALWAYS 1


### PR DESCRIPTION
just QoL spam reduction