### PR TITLE
Fix crashing on destruction of a corner wall

### DIFF
--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -543,7 +543,7 @@ static BOOLEAN OkayToAddStructureToTile(INT16 const sBaseGridNo, INT16 const sCu
 					for (ubTileIndex = 0; ubTileIndex < pDBStructure->ubNumberOfTiles; ++ubTileIndex)
 					{
 						STRUCTURE const* const pOtherExistingStructure = FindStructureByID(sOtherGridNo, pExistingStructure->usStructureID);
-						if (pOtherExistingStructure) return FALSE;
+						if (pOtherExistingStructure && !(pOtherExistingStructure->fFlags & STRUCTURE_WALL)) return FALSE;
 					}
 				}
 			}


### PR DESCRIPTION
Steps to reproduce:
Detonate a bomb on this tile right at the beginning of the game in Omerta:
![Image](https://github.com/user-attachments/assets/9a082ee3-b2fe-4fd8-abba-6d369961f48b)
Crash will happen with the message:
`[ERROR] sgp\SGP.cc: Game has been terminated due to an unrecoverable error: Failed to add node to world`
It will occur with almost any corner consisting of walls placed in this way:
![Image](https://github.com/user-attachments/assets/fe9f3502-1adb-42ed-9c98-b50da940e56f)

The reason is slightly wider walls used to place adjacent walls like this:
![Untitled6](https://github.com/user-attachments/assets/522b7700-b6ff-4707-ae61-d2bcf6c0d246)
They take up two tiles thus being able to "overlap" with other walls. Since they are purely for visual effect we can easily make a special exception for them.

The bug was introduced by [this](https://github.com/ja2-stracciatella/ja2-stracciatella/commit/119a1d172852ca503e1dda10435e4430af73a134) ancient commit.