### PR TITLE
Fix broken interaction with boxes

### DIFF
--- a/src/game/Tactical/Handle_Doors.cc
+++ b/src/game/Tactical/Handle_Doors.cc
@@ -252,6 +252,7 @@ void InteractWithOpenableStruct(SOLDIERTYPE& s, STRUCTURE& structure, UINT8 cons
 				}
 				return;
 			}
+			if (!is_door) s.ubDoorHandleCode = HANDLE_DOOR_OPEN;
 		}
 		else
 		{


### PR DESCRIPTION
Introduced by #2166
`ubDoorHandleCode` not reset properly for structures other than doors.
Closes #2187