### PR TITLE
Fix exception handling in main menu

### DIFF
--- a/src/game/GameLoop.cc
+++ b/src/game/GameLoop.cc
@@ -224,27 +224,30 @@ try
 catch (std::exception const& e)
 {
 	guiPreviousOptionScreen = guiCurrentScreen;
-	char const* what;
+	char const* what = "file";
 	ST::string success = "failed";
 	char const* attach = "";
 
-	if (gfEditMode && GameMode::getInstance()->isEditorMode())
+	if (guiCurrentScreen != MAINMENU_SCREEN)
 	{
-		what = "map";
-		if (SaveWorldAbsolute("error.dat"))
+		if (gfEditMode && GameMode::getInstance()->isEditorMode())
 		{
-			success = "succeeded (error.dat)";
-			attach  = " Do not forget to attach the map.";
+			what = "map";
+			if (SaveWorldAbsolute("error.dat"))
+			{
+				success = "succeeded (error.dat)";
+				attach = " Do not forget to attach the map.";
+			}
 		}
-	}
-	else
-	{
-		what = "savegame";
-		auto saveName = GetErrorSaveName();
-		if (SaveGame(saveName, "error savegame"))
+		else
 		{
-			success = ST::format("succeeded ({}.sav)", saveName);
-			attach  = " Do not forget to attach the savegame.";
+			what = "savegame";
+			auto saveName = GetErrorSaveName();
+			if (SaveGame(saveName, "error savegame"))
+			{
+				success = ST::format("succeeded ({}.sav)", saveName);
+				attach = " Do not forget to attach the savegame.";
+			}
 		}
 	}
 	ST::string msg = ST::format(


### PR DESCRIPTION
Steps to reproduce:
1. In `ja2.json` substitute `game_dir` value with UB dir:
```javascript
"game_dir": "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Jagged Alliance 2 Gold Unfinished Business",
``` 
2. The game will crash without giving a useful error text because it tries to create an error save file and fails since there cannot be game world loaded while in main menu.

This fix makes it bypass the error save file creation (if in main menu) and correctly output:
`[ERROR] sgp\SGP.cc: Game has been terminated due to an unrecoverable error: openGameResForReading: Vfs_open "loadscreens/ja2logo.sti": entity not found`
before the crash.