### PR TITLE
Fix lockpicking being overridden with opening on cursor hover over door

### DIFF
--- a/src/game/Tactical/Handle_Doors.cc
+++ b/src/game/Tactical/Handle_Doors.cc
@@ -193,6 +193,7 @@ void InteractWithOpenableStruct(SOLDIERTYPE& s, STRUCTURE& structure, UINT8 cons
 {
 	STRUCTURE& base    = *FindBaseStructure(&structure);
 	bool const is_door = structure.fFlags & STRUCTURE_ANYDOOR;
+	bool const is_switch = structure.fFlags & STRUCTURE_SWITCH;
 
 	if (is_door)
 	{
@@ -252,7 +253,7 @@ void InteractWithOpenableStruct(SOLDIERTYPE& s, STRUCTURE& structure, UINT8 cons
 				}
 				return;
 			}
-			if (!is_door) s.ubDoorHandleCode = HANDLE_DOOR_OPEN;
+			if (!is_door && !is_switch) s.ubDoorHandleCode = HANDLE_DOOR_OPEN;
 		}
 		else
 		{

--- a/src/game/Tactical/Handle_UI.cc
+++ b/src/game/Tactical/Handle_UI.cc
@@ -3127,6 +3127,7 @@ static INT8 DrawUIMovementPath(SOLDIERTYPE* const pSoldier, UINT16 usMapPos, Mov
 	LEVELNODE *pIntTile;
 	INT8 bReturnCode = 0;
 	BOOLEAN fPlot;
+	int8_t preservedDoorHandleCode;
 
 	if ((gTacticalStatus.uiFlags & INCOMBAT) || _KeyDown( SHIFT ))
 	{
@@ -3153,8 +3154,10 @@ static INT8 DrawUIMovementPath(SOLDIERTYPE* const pSoldier, UINT16 usMapPos, Mov
 		{
 			if (pStructure->fFlags & (STRUCTURE_ANYDOOR | STRUCTURE_SWITCH))
 			{
+				preservedDoorHandleCode = pSoldier->ubDoorHandleCode;
 				sActionGridNo = FindAdjacentGridExAdvanced(pSoldier, *pStructure, sIntTileGridNo, nullptr);
 				sAPCost = doorAPs[pSoldier->ubDoorHandleCode];
+				pSoldier->ubDoorHandleCode = preservedDoorHandleCode;
 			}
 			else
 			{


### PR DESCRIPTION
Introduced by #2166 
Steps to reproduce:
1. In real-time press the lockpick button in the door menu
2. Right away before the lockpicking action has been completed hover the cursor over the door
3. The lockpicking will be replaced with the ordinary door opening action

Closes #2192 