### PR TITLE
Fix infinite UI lock on item-giving action

### DIFF
--- a/src/game/Tactical/Handle_Items.cc
+++ b/src/game/Tactical/Handle_Items.cc
@@ -2297,6 +2297,7 @@ SOLDIERTYPE* VerifyGiveItem(SOLDIERTYPE* const pSoldier)
 			pSoldier->pTempObject = NULL;
 
 		}
+		TriggerNPCWithGivenApproach(pSoldier->ubProfile, APPROACH_DONE_GIVING_ITEM);
 	}
 
 	return NULL;


### PR DESCRIPTION
Conditions for reproduction:
1. Trigger an item-giving quote. E.g. Mary's ("This is all the vacation money we have[...]").
2. WHILE the item-receiving char is BOTH visible to the giver (Mary) and moving....
3. ... end the quote (by clicking on it or waiting for it to finish).

Closes #2194