### PR TITLE
Remove non-explosive items when encountered in the explosion queue (duds)

### DIFF
--- a/src/game/TileEngine/Explosion_Control.cc
+++ b/src/game/TileEngine/Explosion_Control.cc
@@ -1986,7 +1986,8 @@ void HandleExplosionQueue()
 			auto item = GCM->getItem(o.usBombItem);
 			auto explosive = item->asExplosive();
 			if (!explosive) {
-				SLOGE("Non explosive item {} as bomb item in explosion queue", item->getInternalName());
+				// This can happen for duds, where an explosion is queued, but usBombItem is not set
+				RemoveItemFromPool(wi);
 				e.fExists = false;
 				continue;
 			}


### PR DESCRIPTION
This should restore the behavior as it was before the explosives externalization: The dud disappears after a random number of rounds.

Closing #2212.

Maybe in the future we can introduce a policy that restores the probable intended behavior: Duds exploding after a random number of rounds.