### PR TITLE
Update included FLTK version

### DIFF
--- a/dependencies/lib-fltk/builder/CMakeLists.txt.in
+++ b/dependencies/lib-fltk/builder/CMakeLists.txt.in
@@ -12,8 +12,8 @@ project(builder NONE)
 
 include(ExternalProject)
 externalproject_add(fltk
-    URL "https://www.fltk.org/pub/fltk/1.3.8/fltk-1.3.8-source.tar.gz"
-    URL_MD5 "84907602c2e50fadec3bc40fb61935cd"
+    URL "https://github.com/fltk/fltk/releases/download/release-1.3.11/fltk-1.3.11-source.tar.gz"
+    URL_MD5 "75b2fd1aa2433e13abcbb311043eaee0"
     CMAKE_ARGS
         "-G@CMAKE_GENERATOR@"
         "-C@CACHE_FILE@"


### PR DESCRIPTION
This should fix the windows build hopefully. Unfortunately on my machine (Manjaro) building with `-DLOCAL_FLTK_LIB=ON` still fails, because it complains about undefined references to XLib functions. I have the same behavior for FLTK `1.3.8` though, so that is not a new regression.