### PR TITLE
Fix some cmake_minimum_required calls for CMake 4

### DIFF
--- a/cmake/JSONParser.cmake
+++ b/cmake/JSONParser.cmake
@@ -1,7 +1,7 @@
 # Copied from https://github.com/sbellus/json-cmake
 # Licence: MIT
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.18)
 
 if (DEFINED JSonParserGuard)
     return()

--- a/dependencies/lib-SDL2-2.0.20-mingw/test/CMakeLists.txt
+++ b/dependencies/lib-SDL2-2.0.20-mingw/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.18)
 project(SDL2 C)
 
 # Global settings for all of the test targets


### PR DESCRIPTION
Seems like the nightly build is still broken for MSVC and macOS. I guess this will also be true for release builds. E.g.:

- https://github.com/ja2-stracciatella/ja2-stracciatella/actions/runs/17720881873/job/50352833800#step:10:330
- https://ci.appveyor.com/project/ja2-stracciatella/ja2-stracciatella/builds/52742733/job/cpua9b4387dms5ga#L1126

Hopefully this is the last fix for CMake 4.