### PR TITLE
Call RenderClear on every frame again

### DIFF
--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -160,8 +160,6 @@ static void MainLoop()
 				case SDL_FINGERUP:     FingerUp(&event.tfinger); break;
 				case SDL_FINGERDOWN:   FingerDown(&event.tfinger); break;
 
-				case SDL_WINDOWEVENT: HandleWindowEvent(event); break;
-
 				case SDL_QUIT: deinitGameAndExit(); break;
 			}
 		}

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -651,11 +651,3 @@ void ShutdownVideoSurfaceManager(void)
 		delete gpVSurfaceHead;
 	}
 }
-
-
-void HandleWindowEvent(SDL_Event const& evt)
-{
-	if (evt.window.event == SDL_WINDOWEVENT_RESIZED) {
-		SDL_RenderClear(GameRenderer);
-	}
-}

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -99,7 +99,6 @@ void VideoToggleFullScreen(void)
 	{
 		SDL_SetWindowFullscreen(g_game_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
 	}
-	SDL_RenderClear(GameRenderer);
 }
 
 void VideoSetBrightness(float brightness)
@@ -537,6 +536,8 @@ void RefreshScreen(void)
 		+ ScreenTextureUpdateRect.x * ScreenBuffer->format->BytesPerPixel;
 	SDL_UpdateTexture(ScreenTexture, &ScreenTextureUpdateRect,
 	                  SrcPixels, ScreenBuffer->pitch);
+
+	SDL_RenderClear(GameRenderer);
 
 	if (ScaleQuality == VideoScaleQuality::NEAR_PERFECT) {
 		SDL_SetRenderTarget(GameRenderer, ScaledScreenTexture);

--- a/src/sgp/Video.h
+++ b/src/sgp/Video.h
@@ -1,10 +1,9 @@
 #ifndef VIDEO_H
 #define VIDEO_H
 
-#include <SDL_events.h>
-#include <SDL_video.h>
 #include "Types.h"
 #include "RustInterface.h"
+#include "SDL.h"
 
 
 #define VIDEO_DEFAULT_TO_NO_CURSOR 0xFFFE // VIDEO_DEFAULT_TO_NO_CURSOR is equal to VIDEO_NO_CURSOR unless always_show_cursor_in_tactical is true
@@ -27,8 +26,6 @@ void VideoSetBrightness(float brightness);
 /* Toggle between fullscreen and window mode after initialising the video
  * manager */
 void VideoToggleFullScreen(void);
-
-void HandleWindowEvent(SDL_Event const&);
 
 void SetMouseCursorProperties(INT16 sOffsetX, INT16 sOffsetY, UINT16 usCursorHeight, UINT16 usCursorWidth);
 


### PR DESCRIPTION
Required by some video drivers to avoid ugly artifacts in the border area.