### PR TITLE
MinGW/MSYS2: deprecate mingwstd_threads package. Fix ja2-launcher.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,9 +167,9 @@ add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/dependencies/lib-smacker")
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/dependencies/lib-stracciatella")
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/dependencies/lib-string_theory")
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/dependencies/lib-miniaudio")
-if (MINGW)
-    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/dependencies/lib-mingw-std-threads")
-endif()
+#if (MINGW)
+#    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/dependencies/lib-mingw-std-threads")
+#endif()
 
 # Prepare compilation of our own C++ source files.
 add_subdirectory(src)
@@ -198,7 +198,7 @@ target_link_libraries(${JA2_BINARY} PRIVATE
     lua
 )
 if (MINGW)
-    target_link_libraries(${JA2_BINARY} PRIVATE mingw_stdthreads ntdll)
+    target_link_libraries(${JA2_BINARY} PRIVATE ntdll)
 endif()
 if (ANDROID)
     target_link_libraries(${JA2_BINARY} PRIVATE android log)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,9 +167,7 @@ add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/dependencies/lib-smacker")
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/dependencies/lib-stracciatella")
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/dependencies/lib-string_theory")
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/dependencies/lib-miniaudio")
-#if (MINGW)
-#    add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/dependencies/lib-mingw-std-threads")
-#endif()
+
 
 # Prepare compilation of our own C++ source files.
 add_subdirectory(src)

--- a/dependencies/lib-gtest/CMakeLists.txt
+++ b/dependencies/lib-gtest/CMakeLists.txt
@@ -19,7 +19,7 @@ execute_process(COMMAND ${CMAKE_COMMAND} --build "${CMAKE_CURRENT_BINARY_DIR}/ge
 set(BUILD_GMOCK OFF CACHE INTERNAL "no gmock" FORCE)
 set(INSTALL_GTEST OFF CACHE INTERNAL "no install, gtest is integrated" FORCE)
 set(gtest_force_shared_crt ON CACHE INTERNAL "always use shared run-time lib (DLL)" FORCE)
-set(gtest_disable_pthreads ON CACHE INTERNAL "no pthreads in gtest" FORCE)
+set(gtest_disable_pthreads OFF CACHE INTERNAL "use pthreads in gtest" FORCE)
 set(gtest_build_samples OFF CACHE INTERNAL "default value" FORCE)
 set(gtest_build_tests OFF CACHE INTERNAL "default value" FORCE)
 set(gtest_hide_internal_symbols OFF CACHE INTERNAL "default value" FORCE)

--- a/src/launcher/main.cc
+++ b/src/launcher/main.cc
@@ -3,6 +3,10 @@
 #include <FL/Fl.H>
 #include <string_theory/string>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 int main(int argc, char* argv[])
 try
 {


### PR DESCRIPTION
MinGW/MSYS2: deprecate mingw-std-threads is no longer needed and prints annoying compiler messages.
ja2-launcher could not resolve the HANDLE symbol and that need the windows.h inclusion.
