### PR TITLE
Fix mercs' opinions and relations not extracting from prof.dat

### DIFF
--- a/src/externalized/mercs/MercProfile.cc
+++ b/src/externalized/mercs/MercProfile.cc
@@ -352,6 +352,14 @@ std::unique_ptr<MERCPROFILESTRUCT> MercProfile::deserializeStruct(const MERCPROF
 		prof->ubApproachMod[APPROACH_THREATEN - 1][apprIdx] = jApproaches[apprIdx].getOptionalUInt("threatenMod", binaryProf->ubApproachMod[APPROACH_THREATEN - 1][apprIdx]);
 	}
 
+	std::copy(std::begin(binaryProf->bMercOpinion), std::end(binaryProf->bMercOpinion), std::begin(prof->bMercOpinion));
+	std::copy(std::begin(binaryProf->bBuddy), std::end(binaryProf->bBuddy), std::begin(prof->bBuddy));
+	std::copy(std::begin(binaryProf->bHated), std::end(binaryProf->bHated), std::begin(prof->bHated));
+	prof->bLearnToLike = binaryProf->bLearnToLike;
+	prof->bLearnToLikeTime = binaryProf->bLearnToLikeTime;
+	prof->bLearnToHate = binaryProf->bLearnToHate;
+	prof->bLearnToHateTime = binaryProf->bLearnToHateTime;
+
 	return prof;
 }
 


### PR DESCRIPTION
From Discord:

https://discord.com/channels/348449397308391426/883987395484200970/1423893658863665153

> Merc relations are not working. Ex: Grizzly does not bark negatively when dropped into Omerta with Dr. Q, Fox does not when dropped in with Steroid, Steroid with Igor and so on. Mercs also neither gain nor lose morale when spending time with liked or disliked mercs...

Given the severity this calls for a release update.