### PR TITLE
Use "git apply" instead of "patch" command to apply custom sol2 patch

### DIFF
--- a/dependencies/lib-sol2/getter/CMakeLists.txt.in
+++ b/dependencies/lib-sol2/getter/CMakeLists.txt.in
@@ -22,5 +22,5 @@ externalproject_add(get-sol2
         BUILD_COMMAND       ""
         INSTALL_COMMAND     ""
         TEST_COMMAND        ""
-    PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/gcc-15.patch
+    PATCH_COMMAND git apply -p1 --ignore-space-change --ignore-whitespace < ${CMAKE_CURRENT_SOURCE_DIR}/gcc-15.patch
 )


### PR DESCRIPTION
The sol2 patch was not applied on MSVC using the "patch" command.

Using "git apply" instead makes it work as intended.