### PR TITLE
Properly reset gfPendingButtonDeletion

### DIFF
--- a/src/sgp/Button_System.cc
+++ b/src/sgp/Button_System.cc
@@ -89,7 +89,7 @@ static UINT16   GenericButtonFillColors;
 static HVOBJECT GenericButtonIcons[MAX_BUTTON_ICONS];
 
 static BOOLEAN gfDelayButtonDeletion   = FALSE;
-static BOOLEAN gfPendingButtonDeletion = FALSE;
+static bool gfPendingButtonDeletion = false;
 
 
 // Finds an available slot for loading button pictures
@@ -408,6 +408,7 @@ static void RemoveButtonsMarkedForDeletion(void)
 	{
 		if ((*i)->uiFlags & BUTTON_DELETION_PENDING) delete *i;
 	}
+	gfPendingButtonDeletion = false;
 }
 
 
@@ -429,7 +430,7 @@ void RemoveButton(GUIButtonRef& btn)
 	if (gfDelayButtonDeletion)
 	{
 		b->uiFlags |= BUTTON_DELETION_PENDING;
-		gfPendingButtonDeletion = TRUE;
+		gfPendingButtonDeletion = true;
 		return;
 	}
 


### PR DESCRIPTION
There is a mechanism to ensure that button callback handlers can safely can RemoveButton. If this happens, the button is not deleted immediately but only marked for deletion and the flag gfPendingButtonDeletion is set.

At the end of button system's mouse region callback handler, this flag is checked and if it is set, the function RemoveButtonsMarkedForDeletion is called which finally deletes all marked buttons.

However the flag was never reset which means the function was called every time even when it is no longer necessary.