### PR TITLE
Subtract usage points from the actual medkit

### DIFF
--- a/src/game/Strategic/Assignments.cc
+++ b/src/game/Strategic/Assignments.cc
@@ -1400,7 +1400,7 @@ static UINT16 HealPatient(SOLDIERTYPE* pPatient, SOLDIERTYPE* pDoctor, UINT16 us
 		// go through doctor's pockets and heal, starting at with his in-hand item
 		for (bPocket = HANDPOS; bPocket <= SMALLPOCK8POS; bPocket++)
 		{
-			OBJECTTYPE o = pDoctor->inv[bPocket];
+			auto & o = pDoctor->inv[bPocket];
 			if (IsMedicalKitItem(&o))
 			{
 				// ok, we have med kit in this pocket, use it


### PR DESCRIPTION
In HealPatient() we were passing a copy of the doctor's medkit to UseKitPoints(), so the points were not deducted from the actual medkit.

This was introduced in commit https://github.com/ja2-stracciatella/ja2-stracciatella/commit/3e42a03e57d1eb3bb85e8acd1d3ca79227eeea25, so apparently nobody noticed that our doctors were very frugal with their medical supplies compared to vanilla.