### PR TITLE
CLI start mode options should always override ja2.json

### DIFF
--- a/rust/stracciatella/src/config/cli.rs
+++ b/rust/stracciatella/src/config/cli.rs
@@ -198,6 +198,7 @@ impl Cli {
 
                 if m.opt_present("fullscreen") {
                     engine_options.start_in_fullscreen = true;
+                    engine_options.start_in_window = false;
                 }
 
                 if m.opt_present("nosound") {
@@ -205,6 +206,7 @@ impl Cli {
                 }
 
                 if m.opt_present("window") {
+                    engine_options.start_in_fullscreen = false;
                     engine_options.start_in_window = true;
                 }
 


### PR DESCRIPTION
Minor problem - if JA2-Launcher / `ja2.json` is set to start in fullscreen, `ja2 -window` is not respected.

This is because we have 2 conflicting options - run in fullscreen and run in windows. CLI should be overriding in any cases.