### PR TITLE
Fix attached launcher mode on non-burstable weapons

### DIFF
--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -3731,15 +3731,34 @@ void ChangeWeaponMode(SOLDIERTYPE* const s)
 	if (gAnimControl[s->usAnimState].uiFlags & ANIM_FIRE) return;
 
 	WeaponModes& mode = s->bWeaponMode;
-	WeaponModes previousMode = mode;
-	mode = mode == WM_ATTACHED ? WM_NORMAL : static_cast<WeaponModes>(mode + 1);
+	switch (mode)
+	{
+		case WM_NORMAL:
+			if (IsGunBurstCapable(s, HANDPOS))
+			{
+				mode = WM_BURST;
+			}
+			else if (HasLauncher(s))
+			{
+				mode = WM_ATTACHED;
+			}
+			else
+			{
+				ScreenMsg(FONT_MCOLOR_LTYELLOW, MSG_UI_FEEDBACK, st_format_printf(g_langRes->Message[STR_NOT_BURST_CAPABLE], s->name));
+			}
+			break;
+
+		case WM_BURST:
+			mode = (HasLauncher(s) ? WM_ATTACHED : WM_NORMAL);
+			break;
+
+		case WM_ATTACHED:
+		default:
+			mode = WM_NORMAL;
+			break;
+	}
 
 	EnsureConsistentWeaponMode(s);
-
-	if (previousMode == mode)
-	{
-		ScreenMsg(FONT_MCOLOR_LTYELLOW, MSG_UI_FEEDBACK, st_format_printf(g_langRes->Message[STR_NOT_BURST_CAPABLE], s->name));
-	}
 
 	DirtyMercPanelInterface(s, DIRTYLEVEL2);
 	gfUIForceReExamineCursorData = TRUE;


### PR DESCRIPTION
Fixes an [issue](https://github.com/ja2-stracciatella/ja2-stracciatella/pull/1577#discussion_r2444782388), that in the master and nightlies, it is impossible to switch to launcher mode on a non-burstable weapon.

In `ChangeWeaponMode`, you start with `WM_NORMAL` mode, then add 1 you get `WM_BURST`, but gets reverted because the weapon is not burstable.

This pull request partially reverts bc588c04115eb76d4bb8ad928179014977fd6311. I like the clever one-liner we had, but it does not address non-burstable weapons. The original case-switch, even though verbose, is easier to follow through different cases. Feel free to propose something better than this.