### PR TITLE
Soldiers pathing to avoid blue flag tiles

### DIFF
--- a/src/game/Tactical/PathAI.cc
+++ b/src/game/Tactical/PathAI.cc
@@ -1013,7 +1013,6 @@ INT32 FindBestPath(SOLDIERTYPE* s, INT16 sDestination, INT8 ubLevel, INT16 usMov
 				goto NEXTDIR;
 			}
 
-			/*
 			if ( gpWorldLevelData[newLoc].uiFlags & (MAPELEMENT_ENEMY_MINE_PRESENT | MAPELEMENT_PLAYER_MINE_PRESENT) )
 			{
 				if (s->bSide == Side::FRIENDLY)
@@ -1036,7 +1035,7 @@ INT32 FindBestPath(SOLDIERTYPE* s, INT16 sDestination, INT8 ubLevel, INT16 usMov
 						goto NEXTDIR;
 					}
 				}
-			}*/
+			}
 
 			//how much is admission to the next tile
 			if ( gfPathAroundObstacles )


### PR DESCRIPTION
I realized the tactical path finding logic does not avoid tiles with blue flag. I keep having my mercs walking into mines they had just recently flagged. The logic is already there in the PathAI code but has been commented out since the first import. 

I reinstated that logic and the PathAI now works as I would expect - avoiding tiles already flagged.