### PR TITLE
Fix obscured item highlights

### DIFF
--- a/src/game/TileEngine/RenderWorld.cc
+++ b/src/game/TileEngine/RenderWorld.cc
@@ -1906,6 +1906,7 @@ static void RenderDynamicWorld(void)
 
 	SaveBackgroundRects();
 
+	// Fixes obscured item highlight issues. Omitting RENDER_STATIC_ONROOF for now as it seems redundant ?
 	RenderTiles( TILES_OBSCURED, RENDER_STATIC_STRUCTS );
 
 	RenderTiles(TILES_NONE,


### PR DESCRIPTION
# Fixes

- Obscured items render properly now when "make items glow" is enabled
- Merc light no longer "wipes away" obscured items, an issue that also exists in vanilla JA2 ( see image )

![ja2_obscured_item_glitchx](https://github.com/user-attachments/assets/d37bddf7-3d34-44e4-9f02-fb2cf5cbb2fd)