### PR TITLE
Fix the robot remote control being compatible with eyewear on hotkey item swap

### DIFF
--- a/src/externalized/Soldier.cc
+++ b/src/externalized/Soldier.cc
@@ -277,9 +277,9 @@ void Soldier::putDayHeadGear()
 
 void Soldier::switchHeadGear(int switchDirection)
 {
-	if (IsWearingHeadGear(*mSoldier, GASMASK))
+	if (IsWearingHeadGear(*mSoldier, GASMASK) || IsWearingHeadGear(*mSoldier, ROBOT_REMOTE_CONTROL))
 	{
-		// Gas mask is not compatible with eye gears
+		// Equipped items incompatible with eye gears
 		return;
 	}
 


### PR DESCRIPTION
The robot remote control can be worn with eyewear using the ctrl+n hotkey swap. Meant to be impossible.