### PR TITLE
Remove gfReportHitChances

### DIFF
--- a/src/game/Tactical/Turn_Based_Input.cc
+++ b/src/game/Tactical/Turn_Based_Input.cc
@@ -2031,7 +2031,6 @@ static void HandleModAltCheats(UINT32 const key, UIEventKind * const new_event)
 			break;
 
 		case 'g': *new_event = I_NEW_MERC;                  break;
-		case 'h': gfReportHitChances = !gfReportHitChances; break;
 		case 'i': CreateRandomItem();                       break;
 		case 'j': gfNextFireJam = TRUE;                     break;
 		case 'k': GrenadeTest(MUSTARD_GRENADE, -20, 20);    break;

--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -41,7 +41,6 @@
 #include "Soldier_Macros.h"
 #include "SmokeEffects.h"
 #include "Auto_Resolve.h"
-#include "Debug.h"
 
 #include "ContentManager.h"
 #include "GameInstance.h"
@@ -73,7 +72,6 @@
 
 BOOLEAN gfNextFireJam      = FALSE;
 BOOLEAN gfNextShotKills    = FALSE;
-BOOLEAN gfReportHitChances = FALSE;
 
 //GLOBALS
 

--- a/src/game/Tactical/Weapons.h
+++ b/src/game/Tactical/Weapons.h
@@ -3,7 +3,6 @@
 
 #include "Item_Types.h"
 #include "JA2Types.h"
-#include "Sound_Control.h"
 
 struct CalibreModel;
 
@@ -178,6 +177,5 @@ UINT16 GunRange(OBJECTTYPE const&);
 
 extern BOOLEAN gfNextFireJam;
 extern BOOLEAN gfNextShotKills;
-extern BOOLEAN gfReportHitChances;
 
 #endif


### PR DESCRIPTION
Apparently it was ever only active in beta builds, which were removed a long time ago. We have a show_hit_chance game policy now.