### PR TITLE
Replace FOR_EACHX with ranged for loops

### DIFF
--- a/src/game/Credits.cc
+++ b/src/game/Credits.cc
@@ -536,9 +536,9 @@ static void SelectCreditFaceMovementRegionCallBack(MOUSE_REGION* pRegion, UINT32
 static void InitCreditEyeBlinking(void)
 {
 	const UINT32 now = GetJA2Clock();
-	FOR_EACH(CreditFace, f, gCreditFaces)
+	for (auto & f : gCreditFaces)
 	{
-		f->uiLastBlinkTime = now + Random(f->sBlinkFreq * 2);
+		f.uiLastBlinkTime = now + Random(f.sBlinkFreq * 2);
 	}
 }
 
@@ -546,9 +546,8 @@ static void InitCreditEyeBlinking(void)
 static void HandleCreditEyeBlinking()
 {
 	UINT16 gfx = 0;
-	FOR_EACHX(CreditFace, i, gCreditFaces, gfx += 3)
+	for (auto & f : gCreditFaces)
 	{
-		CreditFace&  f   = *i;
 		UINT32 const now = GetJA2Clock();
 		if (now - f.uiLastBlinkTime > f.sBlinkFreq)
 		{
@@ -566,6 +565,8 @@ static void HandleCreditEyeBlinking()
 
 			f.uiEyesClosedTime = 0;
 		}
+
+		gfx += 3;
 	}
 }
 

--- a/src/game/Editor/Editor_Taskbar_Utils.cc
+++ b/src/game/Editor/Editor_Taskbar_Utils.cc
@@ -126,12 +126,12 @@ static void InitEditorRegions()
 	UINT16       x   = 261;
 	UINT16 const y   = EDITOR_TASKBAR_POS_Y + 9;
 	INT32        idx =   0;
-	FOR_EACHX(MOUSE_REGION, i, TerrainTileButtonRegion, x += 42)
+	for (auto & r : TerrainTileButtonRegion)
 	{
-		MOUSE_REGION& r = *i;
 		MSYS_DefineRegion(&r, x, y, x + 42, y + 22, MSYS_PRIORITY_NORMAL, 0, MSYS_NO_CALLBACK, TerrainTileButtonRegionCallback);
 		MSYS_SetRegionUserData(&r, 0, idx++);
 		r.Disable();
+		x += 42;
 	}
 	gfShowTerrainTileButtons = FALSE;
 

--- a/src/game/Laptop/AIM.cc
+++ b/src/game/Laptop/AIM.cc
@@ -488,12 +488,12 @@ void InitAimMenuBar()
 	UINT16     const   y    = BOTTOM_BUTTON_START_Y;
 	const ST::string*  text = AimBottomMenuText.data();
 	LaptopMode const*  page = gCurrentAimPage;
-	FOR_EACHX(GUIButtonRef, i, guiBottomButtons, x += BOTTOM_BUTTON_START_WIDTH)
+	for (auto & b : guiBottomButtons)
 	{
-		GUIButtonRef const b = CreateIconAndTextButton(gfx, *text++, FONT10ARIAL, AIM_BUTTON_ON_COLOR, DEFAULT_SHADOW, AIM_BUTTON_OFF_COLOR, DEFAULT_SHADOW, x, y, MSYS_PRIORITY_HIGH, BtnAimBottomButtonsCallback);
+		b = CreateIconAndTextButton(gfx, *text++, FONT10ARIAL, AIM_BUTTON_ON_COLOR, DEFAULT_SHADOW, AIM_BUTTON_OFF_COLOR, DEFAULT_SHADOW, x, y, MSYS_PRIORITY_HIGH, BtnAimBottomButtonsCallback);
 		b->SetCursor(CURSOR_LAPTOP_SCREEN);
 		b->SetUserData(*page++);
-		*i = b;
+		x += BOTTOM_BUTTON_START_WIDTH;
 	}
 }
 

--- a/src/game/Laptop/AIMLinks.cc
+++ b/src/game/Laptop/AIMLinks.cc
@@ -53,11 +53,11 @@ void EnterAimLinks()
 	UINT16 const  x    = STD_SCREEN_X + AIM_LINK_LINK_OFFSET_X;
 	UINT16        y    = AIM_LINK_BOBBY_LINK_Y;
 	UINT8  const* page = gubLinkPages;
-	FOR_EACHX(MOUSE_REGION, i, gSelectedLinkRegion, y += AIM_LINK_LINK_OFFSET_Y)
+	for (auto & r : gSelectedLinkRegion)
 	{
-		MOUSE_REGION& r = *i;
 		MSYS_DefineRegion(&r, x, y, x + AIM_LINK_LINK_WIDTH, y + AIM_LINK_LINK_HEIGHT, MSYS_PRIORITY_HIGH, CURSOR_WWW, MSYS_NO_CALLBACK, SelectLinkRegionCallBack);
 		MSYS_SetRegionUserData(&r, 0, *page++);
+		y += AIM_LINK_LINK_OFFSET_Y;
 	}
 
 	RenderAimLinks();

--- a/src/game/Laptop/AIMPolicies.cc
+++ b/src/game/Laptop/AIMPolicies.cc
@@ -372,12 +372,12 @@ static void InitAimPolicyMenuBar()
 	UINT16  const   y    = AIM_POLICY_MENU_Y;
 	const ST::string* text = AimPolicyText.data();
 	INT32           idx  = 0;
-	FOR_EACHX(GUIButtonRef, i, guiPoliciesMenuButton, x += AIM_POLICY_GAP_X)
+	for (auto & b : guiPoliciesMenuButton)
 	{
-		GUIButtonRef const b = CreateIconAndTextButton(gfx, *text++, FONT10ARIAL, AIM_BUTTON_ON_COLOR, DEFAULT_SHADOW, AIM_BUTTON_OFF_COLOR, DEFAULT_SHADOW, x, y, MSYS_PRIORITY_HIGH, BtnPoliciesMenuButtonCallback);
+		b = CreateIconAndTextButton(gfx, *text++, FONT10ARIAL, AIM_BUTTON_ON_COLOR, DEFAULT_SHADOW, AIM_BUTTON_OFF_COLOR, DEFAULT_SHADOW, x, y, MSYS_PRIORITY_HIGH, BtnPoliciesMenuButtonCallback);
 		b->SetCursor(CURSOR_WWW);
 		b->SetUserData(idx++);
-		*i = b;
+		x += AIM_POLICY_GAP_X;
 	}
 }
 
@@ -436,12 +436,12 @@ static void InitAimPolicyTocMenu()
 	UINT16 const x    = AIM_POLICY_TOC_X;
 	UINT16       y    = AIM_POLICY_TOC_Y;
 	INT32        page = 2;
-	FOR_EACHX(MOUSE_REGION, i, gSelectedPolicyTocMenuRegion, y += AIM_POLICY_TOC_GAP_Y)
+	for (auto & r : gSelectedPolicyTocMenuRegion)
 	{
 		// Mouse region for the toc buttons
-		MOUSE_REGION& r = *i;
 		MSYS_DefineRegion(&r, x, y, x + AIM_CONTENTBUTTON_WIDTH, y + AIM_CONTENTBUTTON_HEIGHT, MSYS_PRIORITY_HIGH, CURSOR_WWW, MSYS_NO_CALLBACK, SelectPolicyTocMenuRegionCallBack);
 		MSYS_SetRegionUserData(&r, 0, page++);
+		y += AIM_POLICY_TOC_GAP_Y;
 	}
 }
 
@@ -509,12 +509,12 @@ static void InitAgreementRegion()
 	UINT16  const   y    = AIM_POLICY_AGREEMENT_Y;
 	const ST::string* text = &AimPolicyText[AIM_POLICIES_DISAGREE];
 	INT32           idx  = 0;
-	FOR_EACHX(GUIButtonRef, i, guiPoliciesAgreeButton, x += 125)
+	for (auto & b : guiPoliciesAgreeButton)
 	{
-		GUIButtonRef const b = CreateIconAndTextButton(gfx, *text++, AIM_POLICY_TOC_FONT, AIM_POLICY_AGREE_TOC_COLOR_ON, DEFAULT_SHADOW, AIM_POLICY_AGREE_TOC_COLOR_OFF, DEFAULT_SHADOW, x, y, MSYS_PRIORITY_HIGH, BtnPoliciesAgreeButtonCallback);
+		b = CreateIconAndTextButton(gfx, *text++, AIM_POLICY_TOC_FONT, AIM_POLICY_AGREE_TOC_COLOR_ON, DEFAULT_SHADOW, AIM_POLICY_AGREE_TOC_COLOR_OFF, DEFAULT_SHADOW, x, y, MSYS_PRIORITY_HIGH, BtnPoliciesAgreeButtonCallback);
 		b->SetCursor(CURSOR_WWW);
 		b->SetUserData(idx++);
-		*i = b;
+		x += 125;
 	}
 	gfInAgreementPage = TRUE;
 }

--- a/src/game/Laptop/BobbyRGuns.cc
+++ b/src/game/Laptop/BobbyRGuns.cc
@@ -349,12 +349,12 @@ void InitBobbyMenuBar()
 	UINT16     const   y    = BOBBYR_CATALOGUE_BUTTON_Y;
 	const ST::string* text = &BobbyRText[BOBBYR_GUNS_GUNS];
 	LaptopMode const*  mode = ubCatalogueButtonValues;
-	FOR_EACHX(GUIButtonRef, i, guiBobbyRPageMenu, x += BOBBYR_CATALOGUE_BUTTON_GAP)
+	for (auto & b : guiBobbyRPageMenu)
 	{
 		// Catalogue buttons
-		GUIButtonRef const b = MakeButton(gfx, *text++, x, y, BtnBobbyRPageMenuCallback);
+		b = MakeButton(gfx, *text++, x, y, BtnBobbyRPageMenuCallback);
 		b->SetUserData(*mode++);
-		*i = b;
+		x += BOBBYR_CATALOGUE_BUTTON_GAP;
 	}
 
 	// Order Form button

--- a/src/game/Laptop/IMP_MainPage.cc
+++ b/src/game/Laptop/IMP_MainPage.cc
@@ -443,9 +443,10 @@ static void CreateMouseRegionsForIMPMainPageBasedOnCharGenStatus(void)
 	UINT16 const y = LAPTOP_SCREEN_WEB_UL_Y + 245;
 	UINT16 const w = 115;
 	UINT16 const h =  93;
-	FOR_EACHX(MOUSE_REGION, r, pIMPMainPageMouseRegions, x += 120)
+	for (auto & r : pIMPMainPageMouseRegions)
 	{
-		MSYS_DefineRegion(r, x, y, x + w, y + h, MSYS_PRIORITY_HIGH + 5, CURSOR_WWW, MSYS_NO_CALLBACK, IMPMainPageNotSelectableBtnCallback);
+		MSYS_DefineRegion(&r, x, y, x + w, y + h, MSYS_PRIORITY_HIGH + 5, CURSOR_WWW, MSYS_NO_CALLBACK, IMPMainPageNotSelectableBtnCallback);
+		x += 120;
 	}
 }
 

--- a/src/sgp/Types.h
+++ b/src/sgp/Types.h
@@ -23,8 +23,7 @@
 #define lengthof(a) (sizeof(a) / sizeof(a[0]))
 #define endof(a) ((a) + lengthof(a))
 
-#define FOR_EACHX(type, iter, array, x) for (type* iter = (array); iter != endof((array)); (x), ++iter)
-#define FOR_EACH(type, iter, array)     FOR_EACHX(type, iter, (array), (void)0)
+#define FOR_EACH(type, iter, array) for (type* iter = (array); iter != endof((array)); ++iter)
 
 typedef int32_t     INT;
 typedef int32_t     INT32;


### PR DESCRIPTION
The FOR_EACH and FOR_EACHX macros predate C+11 and were intended to iterate over C style arrays. FOR_EACHX tries to mimic the normal for statement by allowing an additional expression to execute at the end of the loop. This looks a bit strange because all parts of the for loop are seperated by commas.

Using an ordinary ranged for loop and moving the extra expression inside the loop body improves readability.