### PR TITLE
Fix possible infinite recursion after Auto Resolve

### DIFF
--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -7568,8 +7568,9 @@ static void HandlePostAutoresolveMessages(void)
 	if( gsCiviliansEatenByMonsters >= 1 )
 	{
 		SGPSector sSector(gsEnemyGainedControlOfSectorID);
-		AdjustLoyaltyForCivsEatenByMonsters(sSector, gsCiviliansEatenByMonsters);
-		gsCiviliansEatenByMonsters = -2;
+		// We must set gsCiviliansEatenByMonsters to its new value before
+		// calling this function to avoid infinite recursion.
+		AdjustLoyaltyForCivsEatenByMonsters(sSector, std::exchange(gsCiviliansEatenByMonsters, -2));
 	}
 	else if( gsCiviliansEatenByMonsters == -2 )
 	{

--- a/src/game/Strategic/Strategic_Town_Loyalty.cc
+++ b/src/game/Strategic/Strategic_Town_Loyalty.cc
@@ -32,7 +32,6 @@
 #include <string_theory/string>
 
 #include <algorithm>
-#include <iterator>
 #include <vector>
 
 // the max loyalty rating for any given town
@@ -808,10 +807,6 @@ static INT32 IsTownUnderCompleteControlByEnemy(INT8 bTownId)
 
 void AdjustLoyaltyForCivsEatenByMonsters(const SGPSector& sSector, UINT8 ubHowMany)
 {
-	UINT32 uiLoyaltyChange = 0;
-	ST::string str;
-	ST::string pSectorString;
-
 	UINT8 const bTownId = GetTownIdForSector(sSector);
 
 	// if NOT in a town
@@ -821,12 +816,12 @@ void AdjustLoyaltyForCivsEatenByMonsters(const SGPSector& sSector, UINT8 ubHowMa
 	}
 
 	//Report this to player
-	pSectorString = GetSectorIDString(sSector, TRUE);
-	str = st_format_printf(gpStrategicString[ STR_DIALOG_CREATURES_KILL_CIVILIANS ], ubHowMany, pSectorString);
+	auto const pSectorString = GetSectorIDString(sSector, TRUE);
+	auto const str = st_format_printf(gpStrategicString[STR_DIALOG_CREATURES_KILL_CIVILIANS], ubHowMany, pSectorString);
 	DoScreenIndependantMessageBox( str, MSG_BOX_FLAG_OK, MapScreenDefaultOkBoxCallback );
 
 	// use same formula as if it were a civilian "murder" in tactical!!!
-	uiLoyaltyChange = ubHowMany * BASIC_COST_FOR_CIV_MURDER * MULTIPLIER_FOR_MURDER_BY_MONSTER;
+	UINT32 const uiLoyaltyChange = ubHowMany * BASIC_COST_FOR_CIV_MURDER * MULTIPLIER_FOR_MURDER_BY_MONSTER;
 	DecrementTownLoyalty( bTownId, uiLoyaltyChange );
 }
 


### PR DESCRIPTION
When the monsters won an auto resolved battle, an infinite recursion crash occured because the function
HandlePostAutoresolveMessages did not reset a global variable it is using to determine its flow before calling another function that moves through HandlePostAutoresolveMessages again.

Closes #2271.