### PR TITLE
Fixed a bug that clears map screen messages in the new game at laptop exit

### DIFF
--- a/src/game/Laptop/Laptop.cc
+++ b/src/game/Laptop/Laptop.cc
@@ -1353,7 +1353,6 @@ static void LeaveLapTopScreen(void)
 			{
 				LaptopSaveInfo.gfNewGameLaptop = FALSE;
 				fExitingLaptopFlag = TRUE;
-				InitNewGame();
 				gfDontStartTransitionFromLaptop = TRUE;
 				return;
 			}

--- a/src/game/Strategic/Game_Init.cc
+++ b/src/game/Strategic/Game_Init.cc
@@ -64,8 +64,6 @@
 #include <stdexcept>
 #include <string_theory/format>
 
-extern BOOLEAN fExitingLaptopFlag;
-
 void InitScriptingEngine();
 
 UINT8			gubScreenCount=0;
@@ -213,7 +211,7 @@ void InitNewGame()
 	}
 
 	ClearTacticalMessageQueue();
-	if (!fExitingLaptopFlag) FreeGlobalMessageList(); // Clear mapscreen messages
+	FreeGlobalMessageList(); // Clear mapscreen messages
 
 	ResetGameStates();
 	InitScriptingEngine();


### PR DESCRIPTION
Before the fix, the bug can be reproduced by doing the following steps:

1. Start the new game.
2. Leave the laptop to the map screen - observe the map screen messages in the bottom (there should be history log notifications at least).
3. Go back to the laptop and hire a merc.
4. Close the laptop and notice that all the messages are now missing - including the one about hiring the new merc.

The messages are cleared by FreeGlobalMessageList(), which is called by InitNewGame(), which in turn is triggered inside LeaveLapTopScreen() by gfAtLeastOneMercWasHired (set on hiring).

This fix is pretty straightforward - it utilizes a variable set in LeaveLapTopScreen().