### PR TITLE
Change the return type of LoadGenericButtonIcon

### DIFF
--- a/src/game/Editor/Editor_Taskbar_Utils.cc
+++ b/src/game/Editor/Editor_Taskbar_Utils.cc
@@ -54,7 +54,6 @@
 
 
 //editor icon storage vars
-INT32	giEditMercDirectionIcons[2];
 SGPVObject* guiMercInventoryPanel;
 SGPVObject* guiOmertaMap;
 SGPVSurface* guiMercInvPanelBuffers[9];
@@ -169,8 +168,8 @@ static void DeleteEditorImages(void)
 	DeleteVideoObject(guiMercInventoryPanel);
 	DeleteVideoObject(guiOmertaMap);
 	//The merc directional buttons
-	UnloadGenericButtonIcon( (INT16)giEditMercDirectionIcons[0] );
-	UnloadGenericButtonIcon( (INT16)giEditMercDirectionIcons[1] );
+	UnloadGenericButtonIcon(giEditMercDirectionIcons[0]);
+	UnloadGenericButtonIcon(giEditMercDirectionIcons[1]);
 }
 
 

--- a/src/game/Editor/Editor_Taskbar_Utils.h
+++ b/src/game/Editor/Editor_Taskbar_Utils.h
@@ -2,6 +2,7 @@
 #define __EDITOR_TASKBAR_UTILS_H
 
 #include <string_theory/string>
+#include "Button_System.h"
 #include "Types.h"
 
 //These are utilities that are used within the editor.  This function absorbs the expensive
@@ -60,7 +61,7 @@ void MPrintEditor(INT16 x, INT16 y, const ST::string& str);
 void ClearTaskbarRegion( INT16 sLeft, INT16 sTop, INT16 sRight, INT16 sBottom );
 void DrawEditorInfoBox(const ST::string& str, SGPFont, UINT16 x, UINT16 y, UINT16 w, UINT16 h);
 
-extern INT32	giEditMercDirectionIcons[2];
+inline GenericIcon giEditMercDirectionIcons[2];
 extern SGPVObject* guiMercInventoryPanel;
 extern SGPVObject* guiOmertaMap;
 extern SGPVSurface* guiMercInvPanelBuffers[9];

--- a/src/game/Editor/SelectWin.cc
+++ b/src/game/Editor/SelectWin.cc
@@ -83,7 +83,7 @@ static INT16 iEndClickY;
 #define DOWN_ICON		2
 #define OK_ICON		3
 
-static INT16 iButtonIcons[4];
+static GenericIcon iButtonIcons[4];
 static GUIButtonRef iSelectWin;
 static GUIButtonRef iCancelWin;
 static GUIButtonRef iScrollUp;
@@ -228,7 +228,7 @@ static void UpClkCallback(GUI_BUTTON* button, UINT32 reason);
 
 static GUIButtonRef MakeButton(UINT idx, const char* gfx, INT16 y, INT16 h, GUI_CALLBACK click, const ST::string& help)
 {
-	INT16 const img = LoadGenericButtonIcon(gfx);
+	auto const img = LoadGenericButtonIcon(gfx);
 	iButtonIcons[idx] = img;
 	GUIButtonRef const btn = CreateIconButton(img, 0, SCREEN_WIDTH - 40, y,
 	 40, h, MSYS_PRIORITY_HIGH, std::move(click));
@@ -604,7 +604,7 @@ static DisplayList* TrashList(DisplayList* pNode);
 //
 void ShutdownJA2SelectionWindow( void )
 {
-	for (INT16 const icon : iButtonIcons)
+	for (GenericIcon icon : iButtonIcons)
 		UnloadGenericButtonIcon(icon);
 
 	if (pDispList != NULL)

--- a/src/sgp/Button_System.h
+++ b/src/sgp/Button_System.h
@@ -202,11 +202,13 @@ void InitButtonSystem(void);
  */
 void ShutdownButtonSystem(void);
 
+using GenericIcon = SGPVObject const *;
+
 // Loads an image file for use as a button icon.
-INT16 LoadGenericButtonIcon(const char* filename);
+GenericIcon LoadGenericButtonIcon(const char* filename);
 
 // Removes a button icon graphic from the system
-void UnloadGenericButtonIcon(INT16 GenImg);
+void UnloadGenericButtonIcon(GenericIcon);
 
 // Load images for use with QuickButtons.
 BUTTON_PICS* LoadButtonImage(const char* filename, INT32 Grayed, INT32 OffNormal, INT32 OffHilite, INT32 OnNormal, INT32 OnHilite);
@@ -258,7 +260,7 @@ GUIButtonRef QuickCreateButtonImg(const char* gfx, INT32 off_normal, INT32 on_no
 GUIButtonRef CreateCheckBoxButton(INT16 x, INT16 y, const char* filename, INT16 Priority, GUI_CALLBACK ClickCallback);
 
 // Creates an Iconic type button.
-GUIButtonRef CreateIconButton(INT16 Icon, INT16 IconIndex, INT16 xloc, INT16 yloc, INT16 w, INT16 h, INT16 Priority, GUI_CALLBACK ClickCallback);
+GUIButtonRef CreateIconButton(GenericIcon, INT16 IconIndex, INT16 xloc, INT16 yloc, INT16 w, INT16 h, INT16 Priority, GUI_CALLBACK ClickCallback);
 
 /* Creates a button like HotSpot. HotSpots have no graphics associated with
  * them.


### PR DESCRIPTION
This function now returns a pointer to a video object directly instead of an index into an array of pointers. This simplifies the code and removes the restriction of max. 40 icons.