### PR TITLE
Fix raised gun animation disabling sidestepping and backward walking

### DIFF
--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -1381,7 +1381,8 @@ void EVENT_InitNewSoldierAnim(SOLDIERTYPE* const pSoldier, UINT16 usNewState, UI
 	}
 
 	// ATE: If not a moving animation - turn off reverse....
-	if ( !( gAnimControl[ usNewState ].uiFlags & ANIM_MOVING ) && usNewState != END_RIFLE_STAND )
+	if ( !( gAnimControl[ usNewState ].uiFlags & ANIM_MOVING ) &&
+		    usNewState != END_RIFLE_STAND && usNewState != END_DUAL_STAND )
 	{
 		pSoldier->bReverse = FALSE;
 	}


### PR DESCRIPTION
It's currently impossible to make a char walk backwards or sidestep unless their gun is lowered.