### PR TITLE
Remove the closing menu for all structures

### DIFF
--- a/src/game/Tactical/Handle_Doors.cc
+++ b/src/game/Tactical/Handle_Doors.cc
@@ -218,19 +218,13 @@ void InteractWithOpenableStruct(SOLDIERTYPE& s, STRUCTURE& structure, UINT8 cons
 	{
 		if (IsOnOurTeam(s) && !(structure.fFlags & STRUCTURE_SWITCH))
 		{
-			// Bring up menu to decide what to do
 			if (!s.bCollapsed)
 			{
 				SoldierGotoStationaryStance(&s);
 			}
-			DOOR* const d = FindDoorInfoAtGridNo(base.sGridNo);
-			if (!d || !DoTrapCheckOnStartingMenu(s, *d))
-				InitDoorOpenMenu(&s, d, true);
 		}
-		else
-		{ // Easily close door
-			ChangeSoldierState(&s, GetAnimStateForInteraction(s, is_door, CLOSE_DOOR), 0, FALSE);
-		}
+		// Easily close door
+		ChangeSoldierState(&s, GetAnimStateForInteraction(s, is_door, CLOSE_DOOR), 0, FALSE);
 	}
 	else
 	{

--- a/src/game/Tactical/Interface.cc
+++ b/src/game/Tactical/Interface.cc
@@ -1315,7 +1315,6 @@ struct OPENDOOR_MENU
 	INT16   sX;
 	INT16   sY;
 	BOOLEAN fMenuHandled;
-	BOOLEAN fClosingDoor;
 };
 
 static OPENDOOR_MENU gOpenDoorMenu;
@@ -1341,7 +1340,6 @@ void InitDoorOpenMenu(SOLDIERTYPE* const pSoldier, DOOR* const d, BOOLEAN const 
 
 	gOpenDoorMenu.pSoldier     = pSoldier;
 	gOpenDoorMenu.pDoor        = d;
-	gOpenDoorMenu.fClosingDoor = fClosingDoor;
 
 	// OK, Determine position...
 	// Center on guy
@@ -1394,7 +1392,7 @@ static void MakeButtonDoor(UINT idx, UINT gfx, INT16 x, INT16 y, INT16 ap, INT16
 	SOLDIERTYPE* const soldier = gOpenDoorMenu.pSoldier;
 	DOOR* const          pDoor = gOpenDoorMenu.pDoor;
 
-	if (!gOpenDoorMenu.fClosingDoor && gamepolicy(informative_tooltips)) {
+	if (gamepolicy(informative_tooltips)) {
 		switch (idx) {
 			case LOCKPICK_DOOR_ICON:
 				revealedMods = GetModifiersForLockPicking(soldier, pDoor);
@@ -1607,14 +1605,7 @@ static void BtnDoorMenuCallback(GUI_BUTTON* btn, UINT32 reason)
 				// Set UI
 				SetUIBusy(gOpenDoorMenu.pSoldier);
 
-				if (gOpenDoorMenu.fClosingDoor)
-				{
-					ChangeSoldierState(gOpenDoorMenu.pSoldier, GetAnimStateForInteraction(*gOpenDoorMenu.pSoldier, TRUE, CLOSE_DOOR), 0, FALSE);
-				}
-				else
-				{
-					InteractWithClosedDoor(gOpenDoorMenu.pSoldier, HANDLE_DOOR_OPEN);
-				}
+				InteractWithClosedDoor(gOpenDoorMenu.pSoldier, HANDLE_DOOR_OPEN);
 			}
 			else
 			{


### PR DESCRIPTION
Null pointer exception occurs on bringing up the closing menu for anything that is not a door.
Introduced by #2262
Edit: The closing menu is removed completely since it serves no purpose whether it's for a door or not. One can technically set a trap on an open structure in the map editor, but vanilla maps don't have such setups because the logic gets broken: the traps can't be triggered unless the structure is closed, you can't actively detect it because the detect button is inactive unless closed and so on.