### PR TITLE
Fix crash when training militia in SAM site

### DIFF
--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -784,7 +784,12 @@ static void DrawCharacterInfo(SOLDIERTYPE const& s)
 			break;
 
 		case TRAIN_TOWN:
-			assignment2 = GCM->getTown(GetTownIdForSector(s.sSector.AsByte()))->name;
+			{
+				auto townId = GetTownIdForSector(s.sSector.AsByte());
+				if (townId != BLANK_SECTOR) {
+					assignment2 = GCM->getTown(townId)->name;
+				}
+			}
 			break;
 
 		case REPAIR:

--- a/src/game/Strategic/Map_Screen_Interface.cc
+++ b/src/game/Strategic/Map_Screen_Interface.cc
@@ -1048,7 +1048,11 @@ static void HandleEquipmentLeft(UINT32 const slot_idx, INT const sector, GridNo 
 	if (MERC_LEAVE_ITEM* i = gpLeaveListHead[slot_idx])
 	{
 		ST::string sString;
-		ST::string town = GCM->getTown(GetTownIdForSector(sector))->nameLocative;
+		ST::string town;
+		auto townId = GetTownIdForSector(sector);
+		if (townId != BLANK_SECTOR) {
+			town = GCM->getTown(townId)->nameLocative;
+		}
 		SGPSector sMap(sector);
 		ProfileID      const id   = guiLeaveListOwnerProfileId[slot_idx];
 		if (id != NO_PROFILE)

--- a/src/game/Strategic/Town_Militia.cc
+++ b/src/game/Strategic/Town_Militia.cc
@@ -481,8 +481,14 @@ static void HandleInterfaceMessageForContinuingTrainingMilitia(SOLDIERTYPE* cons
 	// is there enough loyalty to continue training
 	if (!DoesSectorMercIsInHaveSufficientLoyaltyToTrainMilitia(pSoldier))
 	{
+		ST::string town;
+		auto townId = GetTownIdForSector(sector);
+		if (townId != BLANK_SECTOR) {
+			town = GCM->getTown(townId)->name;
+		}
+
 		// loyalty too low to continue training
-		sString = st_format_printf(pMilitiaConfirmStrings[8], GCM->getTown(GetTownIdForSector(sector))->name, MIN_RATING_TO_TRAIN_TOWN);
+		sString = st_format_printf(pMilitiaConfirmStrings[8], town, MIN_RATING_TO_TRAIN_TOWN);
 		DoScreenIndependantMessageBox( sString, MSG_BOX_FLAG_OK, CantTrainMilitiaOkBoxCallback );
 		return;
 	}


### PR DESCRIPTION
Not really well tested as I haven't got a proper savegame ready, but this should fix the crashes when training militia on SAM sites. It also adds the check for `BLANK_SECTOR` in some other cases where it was not previously checked.

Closes #2295

@ShishkinP Please let me know if the fix works for you.