### PR TITLE
Fix crashing for monster body type on inventory display

### DIFF
--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -6674,6 +6674,7 @@ bool MapCharacterHasAccessibleInventory(SOLDIERTYPE const& s)
 		s.bAssignment         != ASSIGNMENT_POW &&
 		!IsMechanical(s)                        &&
 		s.ubWhatKindOfMercAmI != MERC_TYPE__EPC &&
+		!CREATURE_OR_BLOODCAT(&s)               &&
 		s.bLife               >= OKLIFE;
 }
 

--- a/src/game/Tactical/Overhead.cc
+++ b/src/game/Tactical/Overhead.cc
@@ -2927,11 +2927,11 @@ static SOLDIERTYPE* FindActiveAndAliveMerc(const SOLDIERTYPE* const curr, const 
 		s = &GetMan(i);
 		if (!s->bActive) continue;
 
-		if (fOnlyRegularMercs && (AM_AN_EPC(s) || AM_A_ROBOT(s))) continue;
-		if (s->bAssignment != curr->bAssignment)                  continue;
-		if (!OK_INTERRUPT_MERC(s))                                continue;
-		if (!s->bInSector)                                        continue;
-		if (s->bLife < (fGoodForLessOKLife ? 1 : OKLIFE))         continue;
+		if (fOnlyRegularMercs && (AM_AN_EPC(s) || !IS_MERC_BODY_TYPE(s))) continue;
+		if (s->bAssignment != curr->bAssignment)                          continue;
+		if (!OK_INTERRUPT_MERC(s))                                        continue;
+		if (!s->bInSector)                                                continue;
+		if (s->bLife < (fGoodForLessOKLife ? 1 : OKLIFE))                 continue;
 		break;
 	}
 	while (s != curr);

--- a/src/game/Tactical/Turn_Based_Input.cc
+++ b/src/game/Tactical/Turn_Based_Input.cc
@@ -2744,6 +2744,7 @@ static void ChangeSoldiersBodyType(SoldierBodyType const ubBodyType, BOOLEAN con
 				std::fill_n(sel->inv, static_cast<size_t>(NUM_INV_SLOTS), OBJECTTYPE{});
 				AssignCreatureInventory(sel);
 				CreateItem(CREATURE_YOUNG_MALE_SPIT, 100, &sel->inv[HANDPOS]);
+				SetCurrentTacticalPanelCurrentMerc(sel);
 				break;
 
 			case TANK_NW:


### PR DESCRIPTION
While having a monster body type (ALT+5 in cheat mode) any attempt to open inventory panel crashes the game. Happens accidentally too often so it's worth the bother to fix it.
Only relevant to making crepitus-related debugging smoother.