### PR TITLE
Fix monster spit landing on the wrong side of wall-oriented structures

### DIFF
--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -1640,7 +1640,6 @@ void StructureHit(BULLET* const pBullet, const UINT16 usStructureID, const INT32
 
 		case MONSTERCLASS:
 			// If the structure is wall-oriented determine which side of it monster spit arrives at
-			pStructure = FindStructureByID(sGridNo, usStructureID);
 			if (pStructure && pStructure->ubWallOrientation)
 			{
 				if (pStructure->ubWallOrientation == OUTSIDE_TOP_RIGHT || pStructure->ubWallOrientation == INSIDE_TOP_RIGHT)


### PR DESCRIPTION
<img width="215" height="170" alt="image" src="https://github.com/user-attachments/assets/1ea4d61a-2084-4ece-8e96-4d32fd287134" />

It always arrives at the grid number that the wall is "attached" to. This update makes it dependent on the side that the monster is actually shooting from.