### PR TITLE
Fix crashing when noise-interrupting a former team member

### DIFF
--- a/src/game/Tactical/TeamTurns.cc
+++ b/src/game/Tactical/TeamTurns.cc
@@ -1041,7 +1041,7 @@ BOOLEAN StandardInterruptConditionsMet(const SOLDIERTYPE* const pSoldier, const 
 		if ( pOpponent->bTeam == OUR_TEAM )
 		{
 			const SOLDIERTYPE* const sel = GetSelectedMan();
-			if (pOpponent != sel && pSoldier->bSide != sel->bSide)
+			if (sel == nullptr || (pOpponent != sel && pSoldier->bSide != sel->bSide) )
 			{
 				return( FALSE );
 			}


### PR DESCRIPTION
Steps to reproduce:
1. Have a team member who belongs to a civilian group, e.g. Dimitri's rebel group
2. Place him and another team member on opposite sides of a wall that can be penetrated with bullets
3. Dimitri must be always SELECTED in the UI and out of sight of all friendlies
4. Have Dimitri shoot the other member through the wall
5. He will be fired back at, become hostile and invisible and start walking making noise
6. The noise interrupt check will produce an unhandled null pointer crash