### PR TITLE
Fixed lib-sol2 patching

### DIFF
--- a/dependencies/lib-sol2/getter/gcc-15.patch
+++ b/dependencies/lib-sol2/getter/gcc-15.patch
@@ -1,14 +1,3 @@
-From 8f80cd79f60613b96c877cec2bba3efee2a78225 Mon Sep 17 00:00:00 2001
-From: martin nylin <martin.nylin@gmail.com>
-Date: Tue, 11 Mar 2025 20:58:43 +0100
-Subject: [PATCH 1/2] Change end() to sen() in usertype_container.hpp
-
----
- include/sol/usertype_container.hpp | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/include/sol/usertype_container.hpp b/include/sol/usertype_container.hpp
-index 6d25d2a8..3ff81724 100644
 --- a/include/sol/usertype_container.hpp
 +++ b/include/sol/usertype_container.hpp
 @@ -1189,7 +1189,7 @@ namespace sol {
@@ -21,17 +10,6 @@ index 6d25d2a8..3ff81724 100644
  					return stack::push(L_, lua_nil);
  				}
 
-From a6872ef46b08704b9069ebf83161f4637459ce63 Mon Sep 17 00:00:00 2001
-From: martin nylin <martin.nylin@gmail.com>
-Date: Tue, 11 Mar 2025 21:28:44 +0100
-Subject: [PATCH 2/2] Fix array index out of bounds in stack_field.hpp
-
----
- include/sol/stack_field.hpp | 12 +++++++++++-
- 1 file changed, 11 insertions(+), 1 deletion(-)
-
-diff --git a/include/sol/stack_field.hpp b/include/sol/stack_field.hpp
-index 9dd66e2e..3b815225 100644
 --- a/include/sol/stack_field.hpp
 +++ b/include/sol/stack_field.hpp
 @@ -113,7 +113,17 @@ namespace sol { namespace stack {


### PR DESCRIPTION
This is a minor correction on top of [this patch](https://github.com/ja2-stracciatella/ja2-stracciatella/pull/2200). It fixes JA2S compilation for Visual Studio.

Right now if one follows the steps in COMPILATION.md for generating VS solution using Developer Command Prompt, it would silently fail applying the patch in the process of configuring lib-sol2, which would then cause JA2S compilation failure in Visual Studio (the issue in usertype_container.hpp handled by the diff in the original patch mentioned above).

The root-cause is a little bit weird and took me some time to figure out - it seems that there is something wrong with the way 'git apply' handles Git metadata in the diff (contents of gcc-15.patch). At some point I tried to manually use this command to apply the diff and, to my surprize, it didn't change the target source until I removed Git metadata to make the diff look generic (like the output of 'diff' tool).

I also noticed that the original diff, which was replaced by the patch mentioned above, didn't have Git metadata as well (maybe for a reason).

I suspect that this issue is only reproduced when the environment doesn't have 'patch' command in place (e.g. when one uses the default VS Developer Command Prompt according to the compilation guide) so `dependencies/lib-sol2/getter/CMakeLists.txt.in` selects 'git apply' for doing the work instead.