### PR TITLE
Fix explosion propagation through walls

### DIFF
--- a/src/game/TileEngine/Explosion_Control.cc
+++ b/src/game/TileEngine/Explosion_Control.cc
@@ -1323,15 +1323,7 @@ void SpreadEffect(const INT16 sGridNo, const UINT8 ubRadius, const UINT16 usItem
 
 		uiTempRange = sRange;
 
-		INT32 cnt;
-		if (ubDir & 1)
-		{
-			cnt = 3;
-		}
-		else
-		{
-			cnt = 2;
-		}
+		INT32 cnt = isDirectionDiagonal(ubDir) ? 3 : 2;
 		while( cnt <= uiTempRange) // end of range loop
 		{
 			// move one tile in direction
@@ -1369,17 +1361,9 @@ void SpreadEffect(const INT16 sGridNo, const UINT8 ubRadius, const UINT16 usItem
 					uiBranchSpot = uiNewSpot;
 
 					// figure the branch direction - which is one dir clockwise
-					ubBranchDir = (ubDir + 1) % 8;
+					ubBranchDir = OneCDirection(ubDir);
 
-					if (ubBranchDir & 1)
-					{
-						branchCnt = 3;
-					}
-					else
-					{
-						branchCnt = 2;
-					}
-
+					branchCnt = isDirectionDiagonal(ubBranchDir) ? 3 : 2;
 					while( branchCnt <= ubBranchRange) // end of range loop
 					{
 						ubKeepGoing = TRUE;
@@ -1412,15 +1396,7 @@ void SpreadEffect(const INT16 sGridNo, const UINT8 ubRadius, const UINT16 usItem
 							}
 						}
 
-						if (ubBranchDir & 1)
-						{
-							branchCnt += 3;
-						}
-						else
-						{
-							branchCnt += 2;
-						}
-
+						branchCnt += isDirectionDiagonal(ubBranchDir) ? 3 : 2;
 					}
 				} // end of if a branch to do
 
@@ -1430,14 +1406,7 @@ void SpreadEffect(const INT16 sGridNo, const UINT8 ubRadius, const UINT16 usItem
 				break;
 			}
 
-			if (ubDir & 1)
-			{
-				cnt += 3;
-			}
-			else
-			{
-				cnt += 2;
-			}
+			cnt += isDirectionDiagonal(ubDir) ? 3 : 2;
 		}
 
 	} // end of dir loop

--- a/src/game/TileEngine/Isometric_Utils.h
+++ b/src/game/TileEngine/Isometric_Utils.h
@@ -24,6 +24,8 @@ static inline UINT8 TwoCDirection(UINT dir)     { return (dir + 2) % NUM_WORLD_D
 static inline UINT8 OneCCDirection(UINT dir)    { return (dir + 7) % NUM_WORLD_DIRECTIONS; }
 static inline UINT8 OneCDirection(UINT dir)     { return (dir + 1) % NUM_WORLD_DIRECTIONS; }
 
+static inline bool isDirectionDiagonal(uint32_t dir) { return dir & 1; }
+
 extern const UINT8 gPurpendicularDirection[NUM_WORLD_DIRECTIONS][NUM_WORLD_DIRECTIONS];
 
 constexpr INT16 DirIncrementer[8]


### PR DESCRIPTION
Missile and bomb explosions don't do damage through walls in certain directions.
In this example the TNT detonation will only affect Igor: 
<img width="189" height="181" alt="image" src="https://github.com/user-attachments/assets/456aaf50-3ad4-4784-a147-1ca9806d672a" />
In this - nobody will be damaged:
<img width="206" height="167" alt="image" src="https://github.com/user-attachments/assets/677fb688-a7fd-4fcc-bdb6-4ae224bcf1a9" />
In both situations everybody will be wounded if the bomb and mercs swap sides.