### PR TITLE
Cleanup SGPImage and related code

### DIFF
--- a/src/game/Tactical/Interface_Panels.cc
+++ b/src/game/Tactical/Interface_Panels.cc
@@ -1207,7 +1207,7 @@ void ProgressBarBackgroundRect(const INT16 sLeft, const INT16 sTop, const INT16 
 	const int g = s(0xff & rgb >> 8);
 	const int b = s(0xff & rgb);
 
-	const UINT16 fill_color = Get16BPPColor((b << 16) + (g << 8) + r);
+	const UINT16 fill_color = Get16BPPColor(r, g, b);
 
 	UINT16* const dst = l.Buffer<UINT16>();
 

--- a/src/sgp/HImage.h
+++ b/src/sgp/HImage.h
@@ -15,10 +15,6 @@
 //   image header.
 
 
-// Defines for buffer bit depth
-#define BUFFER_8BPP							0x1
-#define BUFFER_16BPP						0x2
-
 // Defines for image charactoristics
 #define IMAGE_TRLECOMPRESSED		0x0002
 #define IMAGE_PALETTE						0x0004
@@ -82,7 +78,6 @@ struct SGPImage
 	UINT8                        ubBitDepth;
 	UINT16                       fFlags;
 	SGP::Buffer<SGPPaletteEntry> pPalette;
-	SGP::Buffer<UINT16>          pui16BPPPalette;
 	SGP::Buffer<UINT8>           pAppData;
 	UINT32                       uiAppDataSize;
 	SGP::Buffer<UINT8>           pImageData;
@@ -105,6 +100,7 @@ SGPImage* CreateImage(const ST::string& ImageFile, UINT16 fContents);
 UINT16* Create16BPPPaletteShaded(const SGPPaletteEntry* pPalette, UINT32 rscale, UINT32 gscale, UINT32 bscale, BOOLEAN mono);
 UINT16* Create16BPPPalette(const SGPPaletteEntry* pPalette);
 UINT16 Get16BPPColor( UINT32 RGBValue );
+UINT16 Get16BPPColor(UINT8 r, UINT8 g, UINT8 b);
 UINT32 GetRGBColor( UINT16 Value16BPP );
 
 extern UINT16 gusRedMask;
@@ -113,12 +109,6 @@ extern UINT16 gusBlueMask;
 extern INT16  gusRedShift;
 extern INT16  gusBlueShift;
 extern INT16  gusGreenShift;
-
-// used to convert 565 RGB data into different bit-formats
-void ConvertRGBDistribution565To555( UINT16 * p16BPPData, UINT32 uiNumberOfPixels );
-void ConvertRGBDistribution565To655( UINT16 * p16BPPData, UINT32 uiNumberOfPixels );
-void ConvertRGBDistribution565To556( UINT16 * p16BPPData, UINT32 uiNumberOfPixels );
-void ConvertRGBDistribution565ToAny( UINT16 * p16BPPData, UINT32 uiNumberOfPixels );
 
 typedef std::unique_ptr<SGPImage> AutoSGPImage;
 

--- a/src/sgp/PCX.cc
+++ b/src/sgp/PCX.cc
@@ -76,7 +76,6 @@ SGPImage* LoadPCXFileToImage(const ST::string& filename, UINT16 const contents)
 			dst[i].b      = palette[i * 3 + 2];
 			dst[i].a      = 0;
 		}
-		img->pui16BPPPalette = Create16BPPPalette(dst);
 	}
 
 	return img.release();
@@ -103,13 +102,4 @@ static void BlitPcxToBuffer(UINT8 const* src, UINT8* dst, UINT16 const w, UINT16
 	}
 }
 
-
-#ifdef WITH_UNITTESTS
-#include "gtest/gtest.h"
-
-TEST(PCX, asserts)
-{
-	EXPECT_EQ(sizeof(PcxHeader), 128u);
-}
-
-#endif
+static_assert(sizeof(PcxHeader) == 128u);

--- a/src/sgp/SGPFile.h
+++ b/src/sgp/SGPFile.h
@@ -66,6 +66,9 @@ public:
 
 	/** Get an SDL_RWops from the file. */
 	SDL_RWops* getRwOps();
+
+	/** Get the name of the file. */
+	auto const& getName() const noexcept { return name; }
 };
 
 void DeleteSGPFile(SGPFile *file);


### PR DESCRIPTION
• Remove SGPImage::pui16BPPPalette, which was not
  used since commit b6bdcab
• 16-bit color STCI images where always silently
  assumed to be in RGB565 format. This is now
  enforced with an exception
• Removed the conversion functions from RGB565 to
  other 15-/16 bit color formats that were still
  widely used by many gfx chips in the late 1990s.
• Replaced unit tests that only test the sizes of
  structs with static_asserts
• Don't heap allocate the 768 bytes needed for the
  STCI palette
• Use SDL to implement GetRGBColor