### PR TITLE
Fix blast wave spread being blocked by walls regardless of their orientation

### DIFF
--- a/src/game/TileEngine/Explosion_Control.cc
+++ b/src/game/TileEngine/Explosion_Control.cc
@@ -504,7 +504,6 @@ static bool ExplosiveDamageStructureAtGridNo(STRUCTURE* const pCurrent, STRUCTUR
 			}
 		}
 
-		// OK, Check if this is a wall, then search and change other walls based on this
 		if (pCurrent->fFlags & STRUCTURE_WALLSTUFF || pCurrent->fFlags & STRUCTURE_WIREFENCE)
 		{
 			/* ATE
@@ -514,6 +513,7 @@ static bool ExplosiveDamageStructureAtGridNo(STRUCTURE* const pCurrent, STRUCTUR
 			RemoveAllStructsOfTypeRange(base_grid_no, FIFTHWALLDECAL, EIGTHWALLDECAL);
 		}
 
+		// OK, Check if this is a wall, then search and change other walls based on this
 		if (pCurrent->fFlags & STRUCTURE_WALLSTUFF)
 		{
 			/* Based on orientation, go either x or y dir, check for wall in both _ve

--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -1771,12 +1771,31 @@ INT8 GetBlockingStructureInfo( INT16 sGridNo, INT8 bDir, INT8 bNextDir, INT8 bLe
 				fMinimumBlockingFound = TRUE;
 			}
 
-			// Default, if we are a wall, set full blocking
-			if ( ( pCurrent->fFlags & STRUCTURE_WALL ) && !fWallsBlock )
+			if ( pCurrent->fFlags & STRUCTURE_WALL )
 			{
-				// Return full blocking!
-				// OK! This will be handled by movement costs......!
-				fOKStructOnLevel = FALSE;
+				if (!fWallsBlock)
+				{
+					// OK! This will be handled by movement costs......!
+					fOKStructOnLevel = FALSE;
+				}
+				else
+				{
+					// Check how a wall is oriented relative to the direction the test ray is coming from
+					const uint8_t orientation{ pCurrent->ubWallOrientation };
+					if ((bDir >= NORTH && bDir <= SOUTH) && (orientation == INSIDE_TOP_RIGHT || orientation == OUTSIDE_TOP_RIGHT))
+					{
+						fOKStructOnLevel = FALSE;
+					}
+					else if ((bDir >= EAST && bDir <= WEST) && (orientation == INSIDE_TOP_LEFT || orientation == OUTSIDE_TOP_LEFT))
+					{
+						fOKStructOnLevel = FALSE;
+					}
+					else
+					{
+						fOKStructOnLevel = TRUE;
+						break;
+					}
+				}
 			}
 
 			// CHECK FOR WINDOW


### PR DESCRIPTION
Solves only one particular issue with the spread:
<img width="539" height="320" alt="image" src="https://github.com/user-attachments/assets/0a006bba-bbf2-46ef-b629-62e0494481b5" />
