### PR TITLE
Factor out some common code from the clipping blitters

### DIFF
--- a/src/game/TileEngine/RenderWorld.cc
+++ b/src/game/TileEngine/RenderWorld.cc
@@ -2396,7 +2396,7 @@ static void Blt8BPPDataTo16BPPBufferTransZIncClip(UINT16* pBuffer, UINT32 uiDest
 	if (LeftSkip >= usWidth  || RightSkip  >= usWidth)  return;
 	if (TopSkip  >= usHeight || BottomSkip >= usHeight) return;
 
-	UINT8 const* SrcPtr   = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr  = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	UINT8*       DestPtr  = (UINT8*)pBuffer  + uiDestPitchBYTES * (iTempY + TopSkip) + (iTempX + LeftSkip) * 2;
 	UINT8*       ZPtr     = (UINT8*)pZBuffer + uiDestPitchBYTES * (iTempY + TopSkip) + (iTempX + LeftSkip) * 2;
 	const UINT32 LineSkip = uiDestPitchBYTES - BlitLength * 2;
@@ -2466,18 +2466,6 @@ static void Blt8BPPDataTo16BPPBufferTransZIncClip(UINT16* pBuffer, UINT32 uiDest
 	usZIndex = usZStartIndex;
 
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -2659,7 +2647,7 @@ static void Blt8BPPDataTo16BPPBufferTransZIncClipZSameZBurnsThrough(UINT16* pBuf
 	if (LeftSkip >= usWidth  || RightSkip  >= usWidth)  return;
 	if (TopSkip  >= usHeight || BottomSkip >= usHeight) return;
 
-	UINT8 const* SrcPtr   = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr  = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	UINT8*       DestPtr  = (UINT8*)pBuffer  + uiDestPitchBYTES * (iTempY + TopSkip) + (iTempX + LeftSkip) * 2;
 	UINT8*       ZPtr     = (UINT8*)pZBuffer + uiDestPitchBYTES * (iTempY + TopSkip) + (iTempX + LeftSkip) * 2;
 	const UINT32 LineSkip = uiDestPitchBYTES - BlitLength * 2;
@@ -2728,18 +2716,6 @@ static void Blt8BPPDataTo16BPPBufferTransZIncClipZSameZBurnsThrough(UINT16* pBuf
 	usZIndex = usZStartIndex;
 
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -2916,7 +2892,7 @@ static void Blt8BPPDataTo16BPPBufferTransZIncObscureClip(UINT16* pBuffer, UINT32
 	const INT32 RightSkip  = std::clamp(iTempX + usWidth - ClipX2, 0, usWidth);
 	const INT32 BottomSkip = std::clamp(iTempY + usHeight - ClipY2, 0, usHeight);
 
-	UINT32 uiLineFlag = iTempY & 1;
+	UINT32 uiLineFlag = (iTempY + TopSkip) & 1;
 
 	// calculate the remaining rows and columns to blit
 	const INT32 BlitLength = usWidth  - LeftSkip - RightSkip;
@@ -2926,7 +2902,7 @@ static void Blt8BPPDataTo16BPPBufferTransZIncObscureClip(UINT16* pBuffer, UINT32
 	if (LeftSkip >= usWidth  || RightSkip  >= usWidth)  return;
 	if (TopSkip  >= usHeight || BottomSkip >= usHeight) return;
 
-	UINT8 const* SrcPtr   = hSrcVObject->PixData(pTrav);
+	UINT8 const* SrcPtr   = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	UINT8*       DestPtr  = (UINT8*)pBuffer  + uiDestPitchBYTES * (iTempY + TopSkip) + (iTempX + LeftSkip) * 2;
 	UINT8*       ZPtr     = (UINT8*)pZBuffer + uiDestPitchBYTES * (iTempY + TopSkip) + (iTempX + LeftSkip) * 2;
 	const UINT32 LineSkip = uiDestPitchBYTES - BlitLength * 2;
@@ -2996,19 +2972,6 @@ static void Blt8BPPDataTo16BPPBufferTransZIncObscureClip(UINT16* pBuffer, UINT32
 	usZIndex = usZStartIndex;
 
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		uiLineFlag ^= 1; // XXX evaluate before loop
-		TopSkip--;
-	}
 
 	do
 	{
@@ -3189,7 +3152,7 @@ static void Blt8BPPDataTo16BPPBufferTransZTransShadowIncObscureClip(UINT16* pBuf
 	if (LeftSkip >= usWidth  || RightSkip  >= usWidth)  return;
 	if (TopSkip  >= usHeight || BottomSkip >= usHeight) return;
 
-	UINT8 const* SrcPtr   = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	UINT8*       DestPtr = (UINT8*)pBuffer  + uiDestPitchBYTES * (iTempY + TopSkip) + (iTempX + LeftSkip) * 2;
 	UINT8*       ZPtr    = (UINT8*)pZBuffer + uiDestPitchBYTES * (iTempY + TopSkip) + (iTempX + LeftSkip) * 2;
 	const UINT32 LineSkip = uiDestPitchBYTES - BlitLength * 2;
@@ -3258,18 +3221,6 @@ static void Blt8BPPDataTo16BPPBufferTransZTransShadowIncObscureClip(UINT16* pBuf
 	usZIndex = usZStartIndex;
 
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -3455,7 +3406,7 @@ static void Blt8BPPDataTo16BPPBufferTransZTransShadowIncClip(UINT16* pBuffer, UI
 	if (LeftSkip >= usWidth  || RightSkip  >= usWidth)  return;
 	if (TopSkip  >= usHeight || BottomSkip >= usHeight) return;
 
-	UINT8 const* SrcPtr   = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr  = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	UINT8*       DestPtr  = (UINT8*)pBuffer  + uiDestPitchBYTES * (iTempY + TopSkip) + (iTempX + LeftSkip) * 2;
 	UINT8*       ZPtr     = (UINT8*)pZBuffer + uiDestPitchBYTES * (iTempY + TopSkip) + (iTempX + LeftSkip) * 2;
 	const UINT32 LineSkip = uiDestPitchBYTES - BlitLength * 2;
@@ -3524,18 +3475,6 @@ static void Blt8BPPDataTo16BPPBufferTransZTransShadowIncClip(UINT16* pBuffer, UI
 	usZIndex = usZStartIndex;
 
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{

--- a/src/sgp/VObject_Blitters.cc
+++ b/src/sgp/VObject_Blitters.cc
@@ -381,23 +381,11 @@ void Blt8BPPDataTo16BPPBufferMonoShadowClip( UINT16 *pBuffer, UINT32 uiDestPitch
 	if((TopSkip >=(INT32)usHeight) || (BottomSkip >=(INT32)usHeight))
 		return;
 
-	UINT8 const* SrcPtr = hSrcVObject->PixData(pTrav);
+	UINT8 const* SrcPtr = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	LineSkip=(uiDestPitchBYTES-(BlitLength*2));
 
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -990,24 +978,12 @@ void Blt8BPPDataTo16BPPBufferTransShadowZClip(UINT16* pBuffer, UINT32 uiDestPitc
 	if((TopSkip >=(INT32)usHeight) || (BottomSkip >=(INT32)usHeight))
 		return;
 
-	UINT8 const* SrcPtr = hSrcVObject->PixData(pTrav);
+	UINT8 const* SrcPtr = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	ZPtr = (UINT8 *)pZBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	LineSkip=(uiDestPitchBYTES-(BlitLength*2));
 
 	UINT32 Unblitted, LSCount;
-
-	while (TopSkip)
-	{
-		UINT8 const px = *SrcPtr++;
-		if (px & 0x80)  continue;
-		if (px)
-		{
-			SrcPtr += px;
-			continue;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -1182,24 +1158,12 @@ void Blt8BPPDataTo16BPPBufferTransShadowClip(UINT16* pBuffer, UINT32 uiDestPitch
 	if((TopSkip >=(INT32)usHeight) || (BottomSkip >=(INT32)usHeight))
 		return;
 
-	UINT8 const* SrcPtr = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	LineSkip=(uiDestPitchBYTES-(BlitLength*2));
 
 	UINT32 Unblitted;
 	INT32 LSCount;
-
-	while (TopSkip)
-	{
-		UINT8 const px = *SrcPtr++;
-		if (px & 0x80)  continue;
-		if (px)
-		{
-			SrcPtr += px;
-			continue;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -1342,7 +1306,7 @@ void Blt8BPPDataTo16BPPBufferTransShadowZNBObscuredClip(UINT16* pBuffer, UINT32 
 	if((TopSkip >=(INT32)usHeight) || (BottomSkip >=(INT32)usHeight))
 		return;
 
-	UINT8 const* SrcPtr = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	ZPtr = (UINT8 *)pZBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	LineSkip=(uiDestPitchBYTES-(BlitLength*2));
@@ -1350,18 +1314,6 @@ void Blt8BPPDataTo16BPPBufferTransShadowZNBObscuredClip(UINT16* pBuffer, UINT32 
 	uiLineFlag = (iTempY + TopSkip) & 1;
 
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -1588,24 +1540,12 @@ void Blt8BPPDataTo16BPPBufferShadowZClip( UINT16 *pBuffer, UINT32 uiDestPitchBYT
 	if((TopSkip >=(INT32)usHeight) || (BottomSkip >=(INT32)usHeight))
 		return;
 
-	UINT8 const* SrcPtr = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	ZPtr = (UINT8 *)pZBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	LineSkip=(uiDestPitchBYTES-(BlitLength*2));
 
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -1808,24 +1748,12 @@ void Blt8BPPDataTo16BPPBufferShadowZNBClip( UINT16 *pBuffer, UINT32 uiDestPitchB
 	if((TopSkip >=(INT32)usHeight) || (BottomSkip >=(INT32)usHeight))
 		return;
 
-	UINT8 const* SrcPtr = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	ZPtr = (UINT8 *)pZBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	LineSkip=(uiDestPitchBYTES-(BlitLength*2));
 
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -1966,25 +1894,13 @@ void Blt8BPPDataTo16BPPBufferTransZClip( UINT16 *pBuffer, UINT32 uiDestPitchBYTE
 	if((TopSkip >=(INT32)usHeight) || (BottomSkip >=(INT32)usHeight))
 		return;
 
-	UINT8 const* SrcPtr = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	ZPtr = (UINT8 *)pZBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	UINT16 const* const p16BPPPalette = hSrcVObject->CurrentShade();
 	LineSkip=(uiDestPitchBYTES-(BlitLength*2));
 
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -2128,25 +2044,13 @@ void Blt8BPPDataTo16BPPBufferTransZNBClip( UINT16 *pBuffer, UINT32 uiDestPitchBY
 	if((TopSkip >=(INT32)usHeight) || (BottomSkip >=(INT32)usHeight))
 		return;
 
-	UINT8 const* SrcPtr = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	ZPtr = (UINT8 *)pZBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	UINT16 const* const p16BPPPalette = hSrcVObject->CurrentShade();
 	LineSkip=(uiDestPitchBYTES-(BlitLength*2));
 
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -2646,25 +2550,13 @@ void Blt8BPPDataTo16BPPBufferTransparentClip(UINT16* const pBuffer, const UINT32
 	if((TopSkip >=(INT32)usHeight) || (BottomSkip >=(INT32)usHeight))
 		return;
 
-	UINT8 const* SrcPtr = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	UINT16 const* const p16BPPPalette = hSrcVObject->CurrentShade();
 	LineSkip=(uiDestPitchBYTES-(BlitLength*2));
 
 	UINT32 LSCount;
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -2854,24 +2746,12 @@ void Blt8BPPDataTo16BPPBufferShadowClip( UINT16 *pBuffer, UINT32 uiDestPitchBYTE
 	if((TopSkip >=(INT32)usHeight) || (BottomSkip >=(INT32)usHeight))
 		return;
 
-	UINT8 const* SrcPtr = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	LineSkip=(uiDestPitchBYTES-(BlitLength*2));
 
 	UINT32 LSCount;
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -3165,24 +3045,12 @@ void Blt8BPPDataTo16BPPBufferOutlineClip(UINT16* const pBuffer, const UINT32 uiD
 	if((TopSkip >=(INT32)usHeight) || (BottomSkip >=(INT32)usHeight))
 		return;
 
-	UINT8 const* SrcPtr = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	LineSkip=(uiDestPitchBYTES-(BlitLength*2));
 	UINT16 const* const p16BPPPalette = hSrcVObject->CurrentShade();
 
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -3318,7 +3186,7 @@ void Blt8BPPDataTo16BPPBufferOutlineZClip(UINT16* const pBuffer, const UINT32 ui
 	if((TopSkip >=(INT32)usHeight) || (BottomSkip >=(INT32)usHeight))
 		return;
 
-	UINT8 const* SrcPtr = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	ZPtr = (UINT8 *)pZBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 
@@ -3326,18 +3194,6 @@ void Blt8BPPDataTo16BPPBufferOutlineZClip(UINT16* const pBuffer, const UINT32 ui
 	UINT16 const* const p16BPPPalette = hSrcVObject->CurrentShade();
 
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -3482,7 +3338,7 @@ void Blt8BPPDataTo16BPPBufferOutlineZPixelateObscuredClip(UINT16* const pBuffer,
 	if((TopSkip >=(INT32)usHeight) || (BottomSkip >=(INT32)usHeight))
 		return;
 
-	UINT8 const* SrcPtr = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	ZPtr = (UINT8 *)pZBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 
@@ -3491,18 +3347,6 @@ void Blt8BPPDataTo16BPPBufferOutlineZPixelateObscuredClip(UINT16* const pBuffer,
 	uiLineFlag = (iTempY + TopSkip) & 1;
 
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -4412,7 +4256,7 @@ void Blt8BPPDataTo16BPPBufferTransZClipPixelateObscured( UINT16 *pBuffer, UINT32
 	if((TopSkip >=(INT32)usHeight) || (BottomSkip >=(INT32)usHeight))
 		return;
 
-	UINT8 const* SrcPtr = hSrcVObject->PixData(pTrav);
+	UINT8 const * SrcPtr = SkipLines(hSrcVObject->PixData(pTrav), TopSkip);
 	DestPtr = (UINT8 *)pBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	ZPtr = (UINT8 *)pZBuffer + (uiDestPitchBYTES*(iTempY+TopSkip)) + ((iTempX+LeftSkip)*2);
 	UINT16 const* const p16BPPPalette = hSrcVObject->CurrentShade();
@@ -4420,18 +4264,6 @@ void Blt8BPPDataTo16BPPBufferTransZClipPixelateObscured( UINT16 *pBuffer, UINT32
 	uiLineFlag = (iTempY + TopSkip) & 1;
 
 	UINT32 PxCount;
-
-	while (TopSkip > 0)
-	{
-		for (;;)
-		{
-			PxCount = *SrcPtr++;
-			if (PxCount & 0x80) continue;
-			if (PxCount == 0) break;
-			SrcPtr += PxCount;
-		}
-		TopSkip--;
-	}
 
 	do
 	{
@@ -4511,4 +4343,18 @@ BlitNonTransLoop: // blit non-transparent pixels
 		uiLineFlag ^= 1;
 	}
 	while (--BlitHeight > 0);
+}
+
+
+UINT8 const * SkipLines(UINT8 const * SrcPtr, int TopSkip)
+{
+	while (TopSkip > 0)
+	{
+		UINT8 const PxCount = *SrcPtr++;
+		if (PxCount & 0x80) continue;
+		if (PxCount == 0) --TopSkip;
+		SrcPtr += PxCount;
+	}
+
+	return SrcPtr;
 }

--- a/src/sgp/VObject_Blitters.h
+++ b/src/sgp/VObject_Blitters.h
@@ -87,4 +87,8 @@ void Blt8BPPDataTo16BPPBufferTransShadowZNBObscuredClip(UINT16* pBuffer, UINT32 
 void Blt8BPPDataTo16BPPBufferTransZClipPixelateObscured( UINT16 *pBuffer, UINT32 uiDestPitchBYTES, UINT16 *pZBuffer, UINT16 usZValue, HVOBJECT hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex, SGPRect const * clipregion);
 void Blt8BPPDataTo16BPPBufferTransZPixelateObscured( UINT16 *pBuffer, UINT32 uiDestPitchBYTES, UINT16 *pZBuffer, UINT16 usZValue, HVOBJECT hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex );
 
+// SrcPtr must point to the data bytes of a VObject. This function then skips past
+// the next TopSkip lines and returns the pointer to the start of the next line.
+UINT8 const * SkipLines(UINT8 const * SrcPtr, int TopSkip);
+
 #endif


### PR DESCRIPTION
This loop to skip past the clipped top lines of the source object was found in every clipping blitter.

This is just the start; I intend to factor more of the duplicated code in those blitters.