### PR TITLE
Implement templates for clipping and non-clipping blitters

### DIFF
--- a/src/sgp/VObject.cc
+++ b/src/sgp/VObject.cc
@@ -275,9 +275,10 @@ void BltVideoObjectOutlineShadow(SGPVSurface* const dst, const SGPVObject* const
 	UINT16* const pBuffer = l.Buffer<UINT16>();
 	UINT32  const uiPitch = l.Pitch();
 
-	if (BltIsClipped(src, iDestX, iDestY, usIndex, &ClippingRect))
+	ClipInfo const ci{ src, iDestX, iDestY, usIndex, &ClippingRect };
+	if (ci.status != ClipInfo::Status::Not_Clipped)
 	{
-		Blt8BPPDataTo16BPPBufferOutlineShadowClip(pBuffer, uiPitch, src, iDestX, iDestY, usIndex, &ClippingRect);
+		BltOutlineShadow(ci, pBuffer, uiPitch);
 	}
 	else
 	{

--- a/src/sgp/VObject_Blitters.h
+++ b/src/sgp/VObject_Blitters.h
@@ -32,9 +32,6 @@ struct ClipInfo
 	ClipInfo(SGPVObject const * hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex, SGPRect const * clipregion);
 };
 
-bool BltIsClipped(SGPVObject const * hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex, SGPRect const * clipregion);
-
-
 /* Allocate and initialize a Z-buffer for use with the Z-buffer blitters.
  * Doesn't really do much except allocate a chunk of memory, and zero it. */
 UINT16* InitZBuffer(UINT32 width, UINT32 height);
@@ -48,7 +45,6 @@ void Blt8BPPDataTo16BPPBufferTransZNBTranslucent(UINT16* buf, UINT32 uiDestPitch
 void BltTransZNBTranslucent(ClipInfo const& ci, UINT16* buf, UINT32 uiDestPitchBYTES, UINT16* zbuf, UINT16 zval);
 
 void Blt8BPPDataTo16BPPBufferMonoShadowClip( UINT16 *pBuffer, UINT32 uiDestPitchBYTES, HVOBJECT hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex, SGPRect const * clipregion, UINT16 usForeground, UINT16 usBackground, UINT16 usShadow );
-void BltMonoShadow(ClipInfo const& ci, UINT16 *pBuffer, UINT32 uiDestPitchBYTES, UINT16 usForeground, UINT16 usBackground, UINT16 usShadow);
 
 void Blt8BPPDataTo16BPPBufferTransZ(UINT16* buf, UINT32 uiDestPitchBYTES, UINT16* zbuf, UINT16 zval, HVOBJECT hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex);
 void Blt8BPPDataTo16BPPBufferTransZNB( UINT16 *pBuffer, UINT32 uiDestPitchBYTES, UINT16 *pZBuffer, UINT16 usZValue, HVOBJECT hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex );
@@ -95,7 +91,7 @@ void Blt8BPPDataTo16BPPBufferOutline(    UINT16* buf, UINT32 uiDestPitchBYTES, S
 void BltOutline(ClipInfo const& ci, UINT16* pBuffer, UINT32 uiDestPitchBYTES, INT16 s16BPPColor);
 void Blt8BPPDataTo16BPPBufferOutlineZ(                    UINT16* pBuffer, UINT32 uiDestPitchBYTES, UINT16* pZBuffer, UINT16 usZValue, HVOBJECT hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex, INT16 s16BPPColor);
 void Blt8BPPDataTo16BPPBufferOutlineShadow(UINT16* pBuffer, UINT32 uiDestPitchBYTES, const SGPVObject* hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex);
-void Blt8BPPDataTo16BPPBufferOutlineShadowClip( UINT16 *pBuffer, UINT32 uiDestPitchBYTES, const SGPVObject* hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex, const SGPRect* clipregion);
+void BltOutlineShadow(ClipInfo const& ci, UINT16 * pBuffer, UINT32 uiDestPitchBYTES);
 void Blt8BPPDataTo16BPPBufferOutlineZNB(                  UINT16* pBuffer, UINT32 uiDestPitchBYTES, UINT16* pZBuffer, UINT16 usZValue, HVOBJECT hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex);
 void Blt8BPPDataTo16BPPBufferOutlineZPixelateObscured(    UINT16* pBuffer, UINT32 uiDestPitchBYTES, UINT16* pZBuffer, UINT16 usZValue, HVOBJECT hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex, INT16 s16BPPColor);
 void BltOutlineZPixelateObscured(ClipInfo const& ci, UINT16 *pBuffer, UINT32 uiDestPitchBytes, UINT16* pZBuffer, UINT16 usZValue, INT16 s16BPPColor);


### PR DESCRIPTION
This commit adds two new function templates that hold the outer structure of the clipping and non-clipping blitters (the general setup and the loops over rows and columns).

The templates take a "blitter core" as their template argument which is a really small piece of code that actually writes data to the frame buffer.

In theory all blitters that take a SGPVObject as their source could be rewritten to use this framework; this commit only uses it to reimplement the OutlineShadow and MonoShadow blitters. These were chosen because they existed only in one of two variants but with the new templates it was trivial to also implement the missing two versions.