### PR TITLE
Move two editor buttons down a bit

### DIFF
--- a/src/game/Editor/Item_Statistics.cc
+++ b/src/game/Editor/Item_Statistics.cc
@@ -539,7 +539,7 @@ void UpdateItemStatsPanel()
 }
 
 
-static void RealisticOnlyCheckboxCallback(GUI_BUTTON* btn, UINT32 reason)
+static void RealisticOnlyCheckboxCallback(GUI_BUTTON *, UINT32 reason)
 {
 	if( reason & MSYS_CALLBACK_REASON_POINTER_UP )
 	{
@@ -555,7 +555,7 @@ static void RealisticOnlyCheckboxCallback(GUI_BUTTON* btn, UINT32 reason)
 }
 
 
-static void SciFiOnlyCheckboxCallback(GUI_BUTTON* btn, UINT32 reason)
+static void SciFiOnlyCheckboxCallback(GUI_BUTTON *, UINT32 reason)
 {
 	if( reason & MSYS_CALLBACK_REASON_POINTER_UP )
 	{
@@ -571,7 +571,7 @@ static void SciFiOnlyCheckboxCallback(GUI_BUTTON* btn, UINT32 reason)
 }
 
 
-static void BothModesCheckboxCallback(GUI_BUTTON* btn, UINT32 reason)
+static void BothModesCheckboxCallback(GUI_BUTTON *, UINT32 reason)
 {
 	if( reason & MSYS_CALLBACK_REASON_POINTER_UP )
 	{
@@ -623,11 +623,12 @@ static void RemoveGameTypeFlags(void)
 }
 
 
-static bool MakeAttachmentButton(AttachmentInfo& a, INT16 const x, INT16 const y, INT16 const w, GUI_CALLBACK const click)
+static bool MakeAttachmentButton(AttachmentInfo& a, INT16 const x, INT16 const y, INT16 const w, GUI_CALLBACK click)
 {
 	if (!ValidAttachment(a.attachment, gpItem->usItem)) return false;
 
-	GUIButtonRef const btn = CreateTextButton(a.label, SMALLCOMPFONT, FONT_YELLOW, FONT_BLACK, x, y, w, 12, MSYS_PRIORITY_NORMAL, click);
+	GUIButtonRef const btn = CreateTextButton(a.label, SMALLCOMPFONT, FONT_YELLOW,
+		FONT_BLACK, x, y, w, 12, MSYS_PRIORITY_NORMAL, std::move(click));
 	btn->SetUserPtr(&a);
 	a.button   = btn;
 	a.attached = FindAttachment(gpItem, a.attachment) != -1;
@@ -800,7 +801,7 @@ static void SetupArmourGUI(void)
 		AddTextInputField( 485, EDITOR_TASKBAR_POS_Y + 80, 25, 15, MSYS_PRIORITY_NORMAL, str, 3, INPUTTYPE_NUMERICSTRICT );
 	}
 
-	MakeAttachmentButton(g_ceramic_attachment, 558, EDITOR_TASKBAR_POS_Y + 15, 72, ToggleItemAttachment);
+	MakeAttachmentButton(g_ceramic_attachment, 554, EDITOR_TASKBAR_POS_Y + 23, 76, ToggleItemAttachment);
 }
 
 
@@ -900,7 +901,7 @@ static void SetupExplosivesGUI(void)
 		AddTextInputField( 485, EDITOR_TASKBAR_POS_Y + 80, 25, 15, MSYS_PRIORITY_NORMAL, str, 3, INPUTTYPE_NUMERICSTRICT );
 	}
 
-	MakeAttachmentButton(g_detonator_attachment, 570, EDITOR_TASKBAR_POS_Y + 15, 60, ToggleItemAttachment);
+	MakeAttachmentButton(g_detonator_attachment, 570, EDITOR_TASKBAR_POS_Y + 23, 60, ToggleItemAttachment);
 }
 
 
@@ -1189,7 +1190,7 @@ static void ToggleWeaponAttachment(GUI_BUTTON* const btn, UINT32 const reason)
 }
 
 
-static void ActionItemCallback(GUI_BUTTON* btn, UINT32 reason)
+static void ActionItemCallback(GUI_BUTTON *, UINT32 reason)
 {
 	if( reason & MSYS_CALLBACK_REASON_POINTER_UP )
 	{


### PR DESCRIPTION
In the Items tab, the "Detonator" button for explosives and the "Ceramic Plates" button were overlapping the radio buttons for the game mode.

Without this commit:
<img width="153" height="96" alt="Detonator" src="https://github.com/user-attachments/assets/69759c08-4901-4f44-9ca4-565b29a0ee66" /><img width="162" height="96" alt="Plates" src="https://github.com/user-attachments/assets/80b7c90e-cbcc-4f8d-b06f-d09cd53db371" /><img width="153" height="96" alt="Weapon" src="https://github.com/user-attachments/assets/c5ba8200-6c4a-43da-9dd6-9064b08760a1" />

Changed to match the Y position of the first weapon attachment:
<img width="157" height="97" alt="Detonator_new" src="https://github.com/user-attachments/assets/0ccaa11f-0e48-44b4-ade6-052dbda365a6" /><img width="157" height="97" alt="Plates_new" src="https://github.com/user-attachments/assets/45d8c96e-34e2-4a87-aefb-495be34f89a3" />

Includes some code changes to address minor compiler and clang-tidy warnings.

