### PR TITLE
Add a BASIC_SOLDIERCREATE_STRUCT to SOLDERINITNODE

### DIFF
--- a/src/game/Tactical/Soldier_Init_List.cc
+++ b/src/game/Tactical/Soldier_Init_List.cc
@@ -62,7 +62,6 @@ SOLDIERINITNODE* AddBasicPlacementToSoldierInitList(BASIC_SOLDIERCREATE_STRUCT c
 {
 	SOLDIERINITNODE* const si = new SOLDIERINITNODE{};
 
-	si->pBasicPlacement  = new BASIC_SOLDIERCREATE_STRUCT{};
 	*si->pBasicPlacement = bp;
 
 	// It is impossible to set up detailed placement stuff now. If there is any
@@ -100,15 +99,9 @@ void RemoveSoldierNodeFromInitList( SOLDIERINITNODE *pNode )
 		return;
 	if( gfOriginalList )
 		gMapInformation.ubNumIndividuals--;
-	if( pNode->pBasicPlacement )
-	{
-		delete pNode->pBasicPlacement;
-		pNode->pBasicPlacement = NULL;
-	}
 	if( pNode->pDetailedPlacement )
 	{
 		delete pNode->pDetailedPlacement;
-		pNode->pDetailedPlacement = NULL;
 	}
 	if( pNode->pSoldier )
 	{

--- a/src/game/Tactical/Soldier_Init_List.h
+++ b/src/game/Tactical/Soldier_Init_List.h
@@ -7,11 +7,12 @@ struct SOLDIERINITNODE
 {
 	UINT8 ubNodeID;
 	UINT8 ubSoldierID;
-	BASIC_SOLDIERCREATE_STRUCT *pBasicPlacement;
+	BASIC_SOLDIERCREATE_STRUCT * const pBasicPlacement{ &basicPlacement };
 	SOLDIERCREATE_STRUCT *pDetailedPlacement;
 	SOLDIERTYPE *pSoldier;
 	SOLDIERINITNODE* prev;
 	SOLDIERINITNODE* next;
+	BASIC_SOLDIERCREATE_STRUCT basicPlacement;
 };
 
 extern SOLDIERINITNODE *gSoldierInitHead;


### PR DESCRIPTION
This commit removes the extra memory allocations for the BASIC_SOLDIERCREATE_STRUCT by adding one directly to the SOLDERINITNODE. All users of this struct expect its pBasicPlacement to be always valid, it therefore makes no sense to split this in two separate allocations.