### PR TITLE
Fix the return type of GraphicModel::getSubImageIndex

### DIFF
--- a/rust/stracciatella/src/schemas/yaml/types/graphic.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/types/graphic.schema.yaml
@@ -10,6 +10,6 @@ properties:
     title: Subimage index
     description: Index of the subimage inside the graphic file
     default: 0
-    $ref: types/uint8.schema.yaml
+    $ref: types/uint16.schema.yaml
 required:
   - path

--- a/src/externalized/GraphicModel.cc
+++ b/src/externalized/GraphicModel.cc
@@ -1,14 +1,9 @@
 #include "GraphicModel.h"
+#include <utility>
 
-GraphicModel::GraphicModel(const ST::string path_, const uint8_t subImageIndex_) : path(path_), subImageIndex(subImageIndex_) {
-}
-
-const ST::string& GraphicModel::getPath() const {
-	return this->path;
-}
-
-uint8_t GraphicModel::getSubImageIndex() const {
-	return this->subImageIndex;
+GraphicModel::GraphicModel(ST::string path_, uint16_t subImageIndex_)
+	: path(std::move(path_)), subImageIndex(subImageIndex_)
+{
 }
 
 GraphicModel GraphicModel::deserialize(const JsonValue &json) {

--- a/src/externalized/GraphicModel.h
+++ b/src/externalized/GraphicModel.h
@@ -6,14 +6,14 @@
 
 class GraphicModel {
 	public:
-		GraphicModel(const ST::string path_, const uint8_t subImageIndex);
+		GraphicModel(const ST::string path_, const uint16_t subImageIndex);
 
-		const ST::string& getPath() const;
-		uint8_t getSubImageIndex() const;
+		const ST::string& getPath() const noexcept { return path; };
+		uint16_t getSubImageIndex() const noexcept { return subImageIndex; };
 
 		static GraphicModel deserialize(const JsonValue &json);
 		JsonValue serialize() const;
 	private:
 		ST::string path;
-		uint8_t subImageIndex;
+		uint16_t subImageIndex;
 };

--- a/src/game/Laptop/BobbyRGuns.cc
+++ b/src/game/Laptop/BobbyRGuns.cc
@@ -710,7 +710,7 @@ static void DisplayBigItemImage(const ItemModel* item, const UINT16 PosY)
 	INT16 PosX = BOBBYR_GRID_PIC_X;
 
 	auto graphic = GetBigInventoryGraphicForItem(item);
-	AutoSGPVObject uiImage(graphic.first);
+	CAutoSGPVObject uiImage(graphic.first);
 	auto subImageIndex = graphic.second;
 
 	//center picture in frame

--- a/src/game/Tactical/Interface_Items.cc
+++ b/src/game/Tactical/Interface_Items.cc
@@ -214,8 +214,8 @@ cache_key_t const guiBullet{ INTERFACEDIR "/bullet.sti" };
 cache_key_t const guiMoneyGraphicsForDescBox{ INTERFACEDIR "/info_bil.sti" };
 cache_key_t const guiGoldKeyVO{ INTERFACEDIR "/gold_key_button.sti" };
 }
-static SGPVObject *guiItemGraphic;
-static UINT8 guiItemGraphicIndex;
+static SGPVObject const * guiItemGraphic;
+static UINT16 guiItemGraphicIndex;
 BOOLEAN gfInItemDescBox = FALSE;
 static UINT32 guiCurrentItemDescriptionScreen=0;
 OBJECTTYPE *gpItemDescObject = NULL;
@@ -4095,14 +4095,14 @@ void DeleteKeyRingPopup(void)
 	FreeMouseCursor();
 }
 
-std::pair<const SGPVObject*, UINT8> GetFallbackSmallInventoryGraphicForItem(const ItemModel *item) {
+CSubVObject GetFallbackSmallInventoryGraphicForItem(const ItemModel *item) {
 	if (item->getPerPocket() != 0) {
-		return std::make_pair(guiSmallInventoryGraphicMissingSmallPocket, 0);
+		return { guiSmallInventoryGraphicMissingSmallPocket, 0 };
 	}
-	return std::make_pair(guiSmallInventoryGraphicMissingBigPocket, 0);
+	return { guiSmallInventoryGraphicMissingBigPocket, 0 };
 }
 
-std::pair<const SGPVObject*, UINT8> GetSmallInventoryGraphicForItem(const ItemModel *item)
+CSubVObject GetSmallInventoryGraphicForItem(const ItemModel *item)
 {
 	auto path = item->getInventoryGraphicSmall().getPath().to_lower();
 	auto subImageIndex = item->getInventoryGraphicSmall().getSubImageIndex();
@@ -4120,7 +4120,7 @@ std::pair<const SGPVObject*, UINT8> GetSmallInventoryGraphicForItem(const ItemMo
 		);
 		return GetFallbackSmallInventoryGraphicForItem(item);
 	}
-	return std::make_pair(i->second, subImageIndex);
+	return { i->second, subImageIndex };
 }
 
 UINT16 GetTileGraphicForItem(const ItemModel * item)
@@ -4128,11 +4128,11 @@ UINT16 GetTileGraphicForItem(const ItemModel * item)
 	return GetTileIndexFromTypeSubIndex(item->getTileGraphic().tileType, item->getTileGraphic().subIndex);
 }
 
-std::pair<SGPVObject*, UINT8> GetFallbackBigInventoryGraphic() {
-	return std::make_pair(AddVideoObjectFromFile(guiBigInventoryGraphicMissingPath), 0);
+CSubVObject GetFallbackBigInventoryGraphic() {
+	return { AddVideoObjectFromFile(guiBigInventoryGraphicMissingPath), 0 };
 }
 
-std::pair<SGPVObject*, UINT8> GetBigInventoryGraphicForItem(const ItemModel * item)
+CSubVObject GetBigInventoryGraphicForItem(const ItemModel * item)
 {
 	auto path = item->getInventoryGraphicBig().getPath();
 	auto subImageIndex = item->getInventoryGraphicBig().getSubImageIndex();
@@ -4155,7 +4155,7 @@ std::pair<SGPVObject*, UINT8> GetBigInventoryGraphicForItem(const ItemModel * it
 		);
 		return GetFallbackBigInventoryGraphic();
 	}
-	return std::make_pair(vObject, subImageIndex);
+	return { vObject, subImageIndex };
 }
 
 

--- a/src/game/Tactical/Interface_Items.h
+++ b/src/game/Tactical/Interface_Items.h
@@ -7,9 +7,9 @@
 #include "Soldier_Control.h"
 
 #include "UILayout.h"
+#include "VObject.h"
 
 #include <string_theory/string>
-#include <utility>
 
 
 struct ItemModel;
@@ -105,8 +105,8 @@ void DrawItemFreeCursor(void);
 void DrawItemTileCursor(void);
 BOOLEAN HandleItemPointerClick( UINT16 usMapPos );
 UINT8 GetAttachmentHintColor(const OBJECTTYPE* pObj);
-std::pair<const SGPVObject*, UINT8> GetSmallInventoryGraphicForItem(const ItemModel *item);
-std::pair<SGPVObject*, UINT8> GetBigInventoryGraphicForItem(const ItemModel *item);
+CSubVObject GetSmallInventoryGraphicForItem(const ItemModel *item);
+CSubVObject GetBigInventoryGraphicForItem(const ItemModel *item);
 UINT16            GetTileGraphicForItem(const ItemModel *item);
 
 ST::string GetHelpTextForItem(const OBJECTTYPE& obj);

--- a/src/sgp/VObject.cc
+++ b/src/sgp/VObject.cc
@@ -229,6 +229,10 @@ SGPVObject* AddVideoObjectFromFile(const ST::string& ImageFile)
 	return AddVideoObjectFromHImage(hImage.get());
 }
 
+void DeleteVideoObject(SGPVObject const * vo)
+{
+	delete vo;
+}
 
 void BltVideoObject(SGPVSurface* const dst, SGPVObject const* const src, UINT16 const usRegionIndex, INT32 const iDestX, INT32 const iDestY)
 {

--- a/src/sgp/VObject.h
+++ b/src/sgp/VObject.h
@@ -3,7 +3,7 @@
 
 #include "Types.h"
 #include <memory>
-
+#include <utility>
 
 // Defines for HVOBJECT limits
 #define HVOBJECT_SHADE_TABLES										48
@@ -88,6 +88,9 @@ class SGPVObject
 };
 ENUM_BITSET(SGPVObject::Flags)
 
+// A pair of a VObject and one of its SubRegions to specify one particular image.
+using SubVObject  = std::pair<SGPVObject *, UINT16>;
+using CSubVObject = std::pair<SGPVObject const *, UINT16>;
 
 // Creates a list to contain video objects
 void InitializeVideoObjectManager(void);
@@ -100,10 +103,7 @@ SGPVObject* AddVideoObjectFromHImage(SGPImage*);
 SGPVObject* AddVideoObjectFromFile(const ST::string& ImageFile);
 
 // Removes a video object
-static inline void DeleteVideoObject(SGPVObject* const vo)
-{
-	delete vo;
-}
+void DeleteVideoObject(SGPVObject const * vo);
 
 // Blits a video object to another video object
 void BltVideoObject(SGPVSurface* dst, SGPVObject const* src, UINT16 usRegionIndex, INT32 iDestX, INT32 iDestY);
@@ -116,5 +116,6 @@ void BltVideoObjectOutlineShadow(SGPVSurface* dst, SGPVObject const* src, UINT16
 void BltVideoObjectOnce(SGPVSurface* dst, char const* filename, UINT16 region, INT32 x, INT32 y);
 
 typedef std::unique_ptr<SGPVObject> AutoSGPVObject;
+using CAutoSGPVObject = std::unique_ptr<SGPVObject const>;
 
 #endif


### PR DESCRIPTION
STCI files use a 16-bit unsigned integer for the subregion index, but this function used an 8-bit value, which made it impossible to have more than 256 item graphics in one file without a good reason.

Because the combination of a SGPVObject * and an UINT16 in a pair could be useful elsewhere I added two new using directives for them.

Lastly, DeleteVideoObject does not need to be inline, that just increases code size without any benefit. It also needs to be able to delete const objects, just like the delete operator.