### PR TITLE
Improve checks for usable vehicle

### DIFF
--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -6985,7 +6985,7 @@ void EVENT_SoldierBeginFirstAid( SOLDIERTYPE *pSoldier, INT16 sGridNo, UINT8 ubD
 void EVENT_SoldierEnterVehicle(SOLDIERTYPE& s, GridNo const gridno)
 {
 	SOLDIERTYPE const* const tgt = FindSoldier(gridno, FIND_SOLDIER_GRIDNO);
-	if (tgt && tgt->uiStatusFlags & SOLDIER_VEHICLE)
+	if (tgt && OK_ENTERABLE_VEHICLE(tgt))
 	{
 		VEHICLETYPE& v = GetVehicle(tgt->bVehicleID);
 		PutSoldierInVehicle(s, v);

--- a/src/game/Tactical/Soldier_Create.cc
+++ b/src/game/Tactical/Soldier_Create.cc
@@ -1,6 +1,7 @@
 #include "Soldier_Create.h"
 #include "ItemModel.h"
 #include "Overhead.h"
+#include "Soldier_Macros.h"
 #include "Soldier_Profile.h"
 #include "Animation_Control.h"
 #include "Animation_Data.h"
@@ -978,7 +979,7 @@ void InternalTacticalRemoveSoldier(SOLDIERTYPE& s, BOOLEAN const fRemoveVehicle)
 
 	if (s.ubScheduleID) DeleteSchedule(s.ubScheduleID);
 
-	if (s.uiStatusFlags & SOLDIER_VEHICLE && fRemoveVehicle)
+	if (EnterableVehicle(s) && fRemoveVehicle)
 	{
 		RemoveVehicleFromList(GetVehicle(s.bVehicleID));
 	}

--- a/src/game/Tactical/Soldier_Macros.h
+++ b/src/game/Tactical/Soldier_Macros.h
@@ -66,6 +66,14 @@ static inline BOOLEAN OkControllableMerc(const SOLDIERTYPE* const s)
 
 #define TANK(p)			((p)->ubBodyType == TANK_NE || (p)->ubBodyType == TANK_NW)
 
-#define OK_ENTERABLE_VEHICLE(p)	((p)->uiStatusFlags & SOLDIER_VEHICLE && !TANK((p)) && (p)->bLife >= OKLIFE)
+static inline bool EnterableVehicle(SOLDIERTYPE const& s)
+{
+	return (s.uiStatusFlags & SOLDIER_VEHICLE) && !TANK(&s);
+}
+
+static inline bool OK_ENTERABLE_VEHICLE(SOLDIERTYPE const * s)
+{
+	return EnterableVehicle(*s) && s->bLife >= OKLIFE;
+}
 
 #endif

--- a/src/game/Tactical/Vehicles.cc
+++ b/src/game/Tactical/Vehicles.cc
@@ -1,4 +1,3 @@
-#include "ItemModel.h"
 #include "LoadSaveVehicleType.h"
 #include "Map_Screen_Interface_Map.h"
 #include "SaveLoadGame.h"
@@ -787,8 +786,8 @@ void SetVehicleSectorValues(VEHICLETYPE& v, const SGPSector& sMap)
 void UpdateAllVehiclePassengersGridNo(SOLDIERTYPE* const vs)
 {
 	// If not a vehicle, ignore!
-	if (!(vs->uiStatusFlags & SOLDIER_VEHICLE)) return;
-	VEHICLETYPE const& v = pVehicleList[vs->bVehicleID];
+	if (!EnterableVehicle(*vs)) return;
+	VEHICLETYPE const& v = GetVehicle(vs->bVehicleID);
 
 	// Loop through passengers and update each guy's position
 	CFOR_EACH_PASSENGER(v, i)


### PR DESCRIPTION
There is a distinction between vehicles in general and enterable vehicles, so testing only the SOLDIER_VEHICLE flag often is not enough.

Should fix #1933.