### PR TITLE
Add ability to heal stats through doctoring

### DIFF
--- a/assets/externalized/game.json
+++ b/assets/externalized/game.json
@@ -224,6 +224,8 @@
   "unhired_merc_deaths_medium": 2,
   "unhired_merc_deaths_hard": 3,
 
+  "enable_stat_healing": false,
+
   //  Settings for newly started campaigns.
   //  Most probably you do not need to change these unless you are running a full conversion mod.
   "campaign": {

--- a/rust/stracciatella/src/schemas/yaml/game.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/game.schema.yaml
@@ -475,6 +475,15 @@ properties:
       Max number of unhired merc deaths on hard difficulty
 
       Vanilla setting: `3`
+  
+  enable_stat_healing:
+    type: boolean
+    title: Enable stat healing
+    description: |
+      Enable ability to heal stat loss from critical hits with doctoring.
+
+      Vanilla setting: `false`
+
   campaign:
     type: object
     properties:
@@ -534,4 +543,5 @@ required:
   - unhired_merc_deaths_easy
   - unhired_merc_deaths_medium
   - unhired_merc_deaths_hard
+  - enable_stat_healing
   - campaign

--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -91,6 +91,8 @@ DefaultGamePolicy::DefaultGamePolicy(const JsonValue& json)
 	unhired_merc_deaths_medium = gp.getOptionalInt("unhired_merc_deaths_medium", 2);
 	unhired_merc_deaths_hard = gp.getOptionalInt("unhired_merc_deaths_hard", 3);
 
+	enable_stat_healing = gp.getOptionalBool("enable_stat_healing", false);
+
 	auto campaign = gp["campaign"].toObject();
 	ST::string sector_string = campaign.getOptionalString("start_sector");
 	start_sector = SGPSector::FromShortString(!sector_string.empty() ? sector_string : "A9").AsByte();

--- a/src/externalized/policy/GamePolicy.h
+++ b/src/externalized/policy/GamePolicy.h
@@ -115,6 +115,8 @@ public:
 	int8_t unhired_merc_deaths_medium;       // Maximum unhired mercs KIA difficulty Medium
 	int8_t unhired_merc_deaths_hard;       // Maximum unhired mercs KIA difficulty Hard
 
+	bool enable_stat_healing;		// Enable ability to heal stats with doctoring
+
 	uint16_t start_sector;        // Starting sector
 	bool reveal_start_sector;     // Should the start sector radar map be shown at start
 

--- a/src/game/GameVersion.h
+++ b/src/game/GameVersion.h
@@ -17,6 +17,6 @@ extern const char g_version_number[16];
 //	you will invalidate the saved game file
 //
 
-constexpr UINT32 SAVE_GAME_VERSION = 102;
+constexpr UINT32 SAVE_GAME_VERSION = 103;
 
 #endif

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -1318,8 +1318,8 @@ static void SaveSoldierStructure(HWFILE const f)
 		if (!s.bActive) continue;
 
 		// Save the soldier structure
-		BYTE data[2332];
-		std::fill_n(data, 2332, 0);
+		BYTE data[2328];
+		std::fill_n(data, 2328, 0);
 		InjectSoldierType(data, &s);
 		NewJA2EncryptedFileWrite(f, data, sizeof(data));
 

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -1358,13 +1358,13 @@ static void LoadSoldierStructure(HWFILE const f, UINT32 savegame_version, bool s
 		SOLDIERTYPE SavedSoldierInfo;
 		if(stracLinuxFormat)
 		{
-			BYTE Data[2358];
+			BYTE Data[2352];
 			reader(f, Data, sizeof(Data));
 			ExtractSoldierType(Data, &SavedSoldierInfo, stracLinuxFormat, savegame_version);
 		}
 		else
 		{
-			BYTE Data[2332];
+			BYTE Data[2328];
 			reader(f, Data, sizeof(Data));
 			ExtractSoldierType(Data, &SavedSoldierInfo, stracLinuxFormat, savegame_version);
 		}

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -1318,8 +1318,8 @@ static void SaveSoldierStructure(HWFILE const f)
 		if (!s.bActive) continue;
 
 		// Save the soldier structure
-		BYTE data[2328];
-		std::fill_n(data, 2328, 0);
+		BYTE data[2332];
+		std::fill_n(data, 2332, 0);
 		InjectSoldierType(data, &s);
 		NewJA2EncryptedFileWrite(f, data, sizeof(data));
 
@@ -1358,13 +1358,13 @@ static void LoadSoldierStructure(HWFILE const f, UINT32 savegame_version, bool s
 		SOLDIERTYPE SavedSoldierInfo;
 		if(stracLinuxFormat)
 		{
-			BYTE Data[2352];
+			BYTE Data[2358];
 			reader(f, Data, sizeof(Data));
 			ExtractSoldierType(Data, &SavedSoldierInfo, stracLinuxFormat, savegame_version);
 		}
 		else
 		{
-			BYTE Data[2328];
+			BYTE Data[2332];
 			reader(f, Data, sizeof(Data));
 			ExtractSoldierType(Data, &SavedSoldierInfo, stracLinuxFormat, savegame_version);
 		}

--- a/src/game/Strategic/Assignments.cc
+++ b/src/game/Strategic/Assignments.cc
@@ -565,19 +565,24 @@ static BOOLEAN CanCharacterRepair(SOLDIERTYPE const* const pSoldier)
 	return ( TRUE );
 }
 
+static BOOLEAN CanStatsBeHealed(const SOLDIERTYPE* const s)
+{
+	return gamepolicy(enable_stat_healing) &&
+		(
+			s->bAgilityDamage > 0 ||
+			s->bDexterityDamage > 0 ||
+			s->bStrengthDamage > 0 ||
+			s->bWisdomDamage > 0
+		);
+}
+
 
 // can character be set to patient?
 static BOOLEAN CanCharacterPatient(const SOLDIERTYPE* const s)
 {
 	return
 		s->bLife > 0 &&
-		(
-		s->bLife != s->bLifeMax ||
-		s->bAgilityDamage > 0 ||
-		s->bDexterityDamage > 0 ||
-		s->bStrengthDamage > 0 ||
-		s->bWisdomDamage > 0
-		) &&
+		(s->bLife != s->bLifeMax || CanStatsBeHealed(s)) &&
 		AreAssignmentConditionsMet(*s, AC_UNCONSCIOUS | AC_EPC | AC_UNDERGROUND);
 }
 
@@ -1211,7 +1216,7 @@ static void UpdatePatientsWhoAreDoneHealing()
 	{
 		SOLDIERTYPE& s = *i;
 		if (s.bAssignment != PATIENT) continue;
-		if (s.bLife == s.bLifeMax && s.bAgilityDamage == 0 && s.bDexterityDamage == 0 && s.bStrengthDamage == 0 && s.bWisdomDamage == 0)
+		if (s.bLife == s.bLifeMax && !CanStatsBeHealed(i))
 		{
 			// Patient who doesn't need healing
 			AssignmentDone(&s, TRUE, TRUE);
@@ -1360,10 +1365,9 @@ static UINT8 GetMinHealingSkillNeeded(SOLDIERTYPE const* const patient)
 // can this soldier be healed by this doctor?
 static BOOLEAN CanSoldierBeHealedByDoctor(SOLDIERTYPE const* const patient, SOLDIERTYPE const* const doctor, BOOLEAN const fThisHour, BOOLEAN const fSkipKitCheck, BOOLEAN const fSkipSkillCheck)
 {
-	bool fStatsDamaged = patient->bAgilityDamage > 0 || patient->bDexterityDamage > 0 || patient->bStrengthDamage > 0 || patient->bWisdomDamage > 0;
 	if (patient->bAssignment != PATIENT && patient->bAssignment != DOCTOR)        return FALSE;
 	if (patient->bLife == 0)                                                      return FALSE;
-	if (patient->bLife == patient->bLifeMax && !fStatsDamaged)		      return FALSE;
+	if (patient->bLife == patient->bLifeMax && !CanStatsBeHealed(patient))		  return FALSE;
 	if (fThisHour && !EnoughTimeOnAssignment(*patient))                           return FALSE;
 	if (patient->sSector != doctor->sSector)                                      return FALSE;
 	if (patient->fBetweenSectors)                                                 return FALSE;
@@ -1487,12 +1491,8 @@ static UINT16 HealPatient(SOLDIERTYPE* pPatient, SOLDIERTYPE* pDoctor, UINT16 us
 			}
 		}
 	}
-
 	// heal stats that are damaged
-	if (pPatient->bAgilityDamage > 0 ||
-		pPatient->bDexterityDamage > 0 ||
-		pPatient->bStrengthDamage > 0 ||
-		pPatient->bWisdomDamage > 0)
+	if (CanStatsBeHealed(pPatient))
 	{
 		INT8 damagedStats[] =
 		{
@@ -1544,7 +1544,7 @@ static UINT16 HealPatient(SOLDIERTYPE* pPatient, SOLDIERTYPE* pDoctor, UINT16 us
 				}
 
 				// if we're done all we're supposed to, or the guy's fully healed, bail
-				if ( ( bPointsToUse <= 0 ) || (pPatient -> bAgilityDamage == 0 && pPatient -> bDexterityDamage == 0 && pPatient -> bStrengthDamage == 0 && pPatient -> bWisdomDamage == 0 ))
+				if ( ( bPointsToUse <= 0 ) || !CanStatsBeHealed(pPatient))
 				{
 					break;
 				}
@@ -1553,12 +1553,9 @@ static UINT16 HealPatient(SOLDIERTYPE* pPatient, SOLDIERTYPE* pDoctor, UINT16 us
 	}
 
 
+
 	// if this patient is fully healed
-	if( pPatient->bLife == pPatient->bLifeMax &&
-		pPatient -> bAgilityDamage == 0 &&
-		pPatient -> bDexterityDamage == 0 &&
-		pPatient -> bStrengthDamage == 0 &&
-		pPatient -> bWisdomDamage == 0 )
+	if( pPatient->bLife == pPatient->bLifeMax && !CanStatsBeHealed(pPatient) )
 	{
 		// don't count unused full healing points as being used
 		usTotalHundredthsUsed -= (100 * usHealingPtsLeft);

--- a/src/game/Strategic/Assignments.cc
+++ b/src/game/Strategic/Assignments.cc
@@ -81,6 +81,7 @@
 #include <iterator>
 #include <string_theory/format>
 #include <string_theory/string>
+#include <array>
 
 
 // various reason an assignment can be aborted before completion
@@ -193,8 +194,8 @@ BOOLEAN gfReEvaluateEveryonesNothingToDo = FALSE;
 // number of pts needed for each point below OKLIFE
 #define POINT_COST_PER_HEALTH_BELOW_OKLIFE 2
 
-// divisor for rate of damaged stat healing compard to health healing
-#define STAT_HEALING_RATE_DIVISOR 10
+// divisor for rate of damaged stat healing compared to health healing
+#define STAT_HEALING_RATE_DIVISOR 3
 
 // how many points of healing each hospital patients gains per hour in the hospital
 #define HOSPITAL_HEALING_RATE		5				// a top merc doctor can heal about 4 pts/hour maximum, but that's spread among patients!
@@ -570,7 +571,13 @@ static BOOLEAN CanCharacterPatient(const SOLDIERTYPE* const s)
 {
 	return
 		s->bLife > 0 &&
-		s->bLife != s->bLifeMax &&
+		(
+		s->bLife != s->bLifeMax ||
+		s->bAgilityDamage > 0 ||
+		s->bDexterityDamage > 0 ||
+		s->bStrengthDamage > 0 ||
+		s->bWisdomDamage > 0
+		) &&
 		AreAssignmentConditionsMet(*s, AC_UNCONSCIOUS | AC_EPC | AC_UNDERGROUND);
 }
 
@@ -1204,9 +1211,11 @@ static void UpdatePatientsWhoAreDoneHealing()
 	{
 		SOLDIERTYPE& s = *i;
 		if (s.bAssignment != PATIENT) continue;
-		if (s.bLife != s.bLifeMax)    continue;
-		// Patient who doesn't need healing
-		AssignmentDone(&s, TRUE, TRUE);
+		if (s.bLife == s.bLifeMax && s.bAgilityDamage == 0 && s.bDexterityDamage == 0 && s.bStrengthDamage == 0 && s.bWisdomDamage == 0)
+		{
+			// Patient who doesn't need healing
+			AssignmentDone(&s, TRUE, TRUE);
+		}		
 	}
 }
 
@@ -1351,17 +1360,30 @@ static UINT8 GetMinHealingSkillNeeded(SOLDIERTYPE const* const patient)
 // can this soldier be healed by this doctor?
 static BOOLEAN CanSoldierBeHealedByDoctor(SOLDIERTYPE const* const patient, SOLDIERTYPE const* const doctor, BOOLEAN const fThisHour, BOOLEAN const fSkipKitCheck, BOOLEAN const fSkipSkillCheck)
 {
-	bool fStatsDamaged = pPatient->bAgilityDamage == 0 && bPatient->bDexterityDamage == 0 && bPatient->bStrengthDamage == 0 && bPatient->bWisdomDamage == 0;
+	bool fStatsDamaged = patient->bAgilityDamage > 0 || patient->bDexterityDamage > 0 || patient->bStrengthDamage > 0 || patient->bWisdomDamage > 0;
 	if (patient->bAssignment != PATIENT && patient->bAssignment != DOCTOR)        return FALSE;
 	if (patient->bLife == 0)                                                      return FALSE;
-	if (fStatsDamaged)							      return FALSE;
-	if (patient->bLife == patient->bLifeMax)                                      return FALSE;
+	if (patient->bLife == patient->bLifeMax && !fStatsDamaged)		      return FALSE;
 	if (fThisHour && !EnoughTimeOnAssignment(*patient))                           return FALSE;
 	if (patient->sSector != doctor->sSector)                                      return FALSE;
 	if (patient->fBetweenSectors)                                                 return FALSE;
 	if (!fSkipSkillCheck && doctor->bMedical < GetMinHealingSkillNeeded(patient)) return FALSE;
 	if (!fSkipKitCheck && FindObj(doctor, MEDICKIT) == NO_SLOT)                   return FALSE;
 	return TRUE;
+}
+
+// heal a stat (pDamagedStat is the stat's damage e.g. AgilityDamage, pStatToHeal is the corresponding stat to heal e.g. Agility)
+static void HealStat(INT8& pDamagedStat, INT8& pStatToHeal, INT8 bStatAmountHealed)
+{
+	if (bStatAmountHealed > pDamagedStat)
+	{
+		bStatAmountHealed = pDamagedStat;
+	}
+	if (pDamagedStat <= MAX_STAT_VALUE)
+	{
+		pDamagedStat -= bStatAmountHealed;
+		pStatToHeal += bStatAmountHealed;
+	}
 }
 
 
@@ -1467,10 +1489,23 @@ static UINT16 HealPatient(SOLDIERTYPE* pPatient, SOLDIERTYPE* pDoctor, UINT16 us
 	}
 
 	// heal stats that are damaged
-	if (pPatient -> bAgilityDamage > 0 || bPatient -> bDexterityDamage > 0 || bPatient -> bStrengthDamage > 0 || bPatient -> bWisdomDamage > 0)
+	if (pPatient->bAgilityDamage > 0 ||
+		pPatient->bDexterityDamage > 0 ||
+		pPatient->bStrengthDamage > 0 ||
+		pPatient->bWisdomDamage > 0)
 	{
-		bPointsToUse = STAT_HEALING_RATE_DIVISOR * std:max(pPatient -> bAgilityDamage, pPatient -> bDexterityDamage, pPatient -> bStrengthDamage, pPatient -> bWisdomDamage);
+		INT8 damagedStats[] =
+		{
+			pPatient->bAgilityDamage,
+			pPatient->bDexterityDamage,
+			pPatient->bStrengthDamage,
+			pPatient->bWisdomDamage
+		};
+		// find the highest damaged stat and attempt to heal that
+		INT8* pHighestDamagedStat = std::max_element(std::begin(damagedStats), std::end(damagedStats));
+		BYTE damagedStatIndex = std::distance(std::begin(damagedStats), pHighestDamagedStat);
 
+		bPointsToUse = *pHighestDamagedStat;
 		// if guy is hurt more than points we have...heal only what we have
 		if( bPointsToUse > usHealingPtsLeft )
 		{
@@ -1484,59 +1519,32 @@ static UINT16 HealPatient(SOLDIERTYPE* pPatient, SOLDIERTYPE* pDoctor, UINT16 us
 			OBJECTTYPE& o = pDoctor->inv[bPocket];
 			if (IsMedicalKitItem(&o))
 			{
-				// ok, we have med kit in this pocket, use it  (use only half if it's worth double)
-				bPointsUsed   = UseKitPoints(o, bPointsToUse, *pDoctor);
+				// healing stats requires more points
+				bPointsUsed = UseKitPoints(o, bPointsToUse * STAT_HEALING_RATE_DIVISOR, *pDoctor);
 				bPointsHealed = bPointsUsed;
 
 				bPointsToUse -= bPointsHealed;
 				usHealingPtsLeft -= bPointsHealed;
 
-				pPatient -> bLife += bPointsHealed;
-
-				// heal stats that are damaged
 				bStatAmountHealed = (bPointsHealed / STAT_HEALING_RATE_DIVISOR);
-				if (pPatient -> bAgilityDamage > 0)
+				switch (damagedStatIndex)
 				{
-					if (bStatAmountHealed > pPatient -> bAgilityDamage)
-					{
-						bStatAmountHealed = pPatient -> bAgilityDamage;
-					}
-					pPatient -> bAgilityDamage -= bStatAmountHealed;
-					pPatient -> bAgility += bStatAmountHealed;
-				}
-
-				if (pPatient -> bDexterityDamage > 0)
-				{
-					if (bStatAmountHealed > pPatient -> bDexterityDamage)
-					{
-						bStatAmountHealed = pPatient -> bDexterityDamage;
-					}
-					pPatient -> bDexterityDamage -= bStatAmountHealed;
-					pPatient -> bDexterity += bStatAmountHealed;
-				}
-
-				if (pPatient -> bStrengthDamage > 0)
-				{
-					if (bStatAmountHealed > pPatient -> bStrengthDamage)
-					{
-						bStatAmountHealed = pPatient -> bStrengthDamage;
-					}
-					pPatient -> bStrengthDamage -= bStatAmountHealed;
-					pPatient -> bStrength += bStatAmountHealed;
-				}
-
-				if (pPatient -> bWisdomDamage > 0)
-				{
-					if (bStatAmountHealed > pPatient -> bWisdomDamage)
-					{
-						bStatAmountHealed = pPatient -> bWisdomDamage;
-					}
-					pPatient -> bWisdomDamage -= bStatAmountHealed;
-					pPatient -> bWisdom += bStatAmountHealed;
+				case 0:
+					HealStat(pPatient->bAgilityDamage, pPatient->bAgility, bStatAmountHealed);
+					break;
+				case 1:
+					HealStat(pPatient->bDexterityDamage, pPatient->bDexterity, bStatAmountHealed);
+					break;
+				case 2:
+					HealStat(pPatient->bStrengthDamage, pPatient->bStrength, bStatAmountHealed);
+					break;
+				case 3:
+					HealStat(pPatient->bWisdomDamage, pPatient->bWisdom, bStatAmountHealed);
+					break;
 				}
 
 				// if we're done all we're supposed to, or the guy's fully healed, bail
-				if ( ( bPointsToUse <= 0 ) || (pPatient -> bAgilityDamage == 0 && bPatient -> bDexterityDamage == 0 && bPatient -> bStrengthDamage == 0 && bPatient -> bWisdomDamage == 0 ))
+				if ( ( bPointsToUse <= 0 ) || (pPatient -> bAgilityDamage == 0 && pPatient -> bDexterityDamage == 0 && pPatient -> bStrengthDamage == 0 && pPatient -> bWisdomDamage == 0 ))
 				{
 					break;
 				}
@@ -1546,7 +1554,11 @@ static UINT16 HealPatient(SOLDIERTYPE* pPatient, SOLDIERTYPE* pDoctor, UINT16 us
 
 
 	// if this patient is fully healed
-	if( pPatient->bLife == pPatient->bLifeMax && pPatient -> bAgilityDamage == 0 && bPatient -> bDexterityDamage == 0 && bPatient -> bStrengthDamage == 0 && bPatient -> bWisdomDamage == 0 )
+	if( pPatient->bLife == pPatient->bLifeMax &&
+		pPatient -> bAgilityDamage == 0 &&
+		pPatient -> bDexterityDamage == 0 &&
+		pPatient -> bStrengthDamage == 0 &&
+		pPatient -> bWisdomDamage == 0 )
 	{
 		// don't count unused full healing points as being used
 		usTotalHundredthsUsed -= (100 * usHealingPtsLeft);

--- a/src/game/Strategic/Assignments.cc
+++ b/src/game/Strategic/Assignments.cc
@@ -193,6 +193,9 @@ BOOLEAN gfReEvaluateEveryonesNothingToDo = FALSE;
 // number of pts needed for each point below OKLIFE
 #define POINT_COST_PER_HEALTH_BELOW_OKLIFE 2
 
+// divisor for rate of damaged stat healing compard to health healing
+#define STAT_HEALING_RATE_DIVISOR 10
+
 // how many points of healing each hospital patients gains per hour in the hospital
 #define HOSPITAL_HEALING_RATE		5				// a top merc doctor can heal about 4 pts/hour maximum, but that's spread among patients!
 
@@ -1348,8 +1351,10 @@ static UINT8 GetMinHealingSkillNeeded(SOLDIERTYPE const* const patient)
 // can this soldier be healed by this doctor?
 static BOOLEAN CanSoldierBeHealedByDoctor(SOLDIERTYPE const* const patient, SOLDIERTYPE const* const doctor, BOOLEAN const fThisHour, BOOLEAN const fSkipKitCheck, BOOLEAN const fSkipSkillCheck)
 {
+	bool fStatsDamaged = pPatient->bAgilityDamage == 0 && bPatient->bDexterityDamage == 0 && bPatient->bStrengthDamage == 0 && bPatient->bWisdomDamage == 0;
 	if (patient->bAssignment != PATIENT && patient->bAssignment != DOCTOR)        return FALSE;
 	if (patient->bLife == 0)                                                      return FALSE;
+	if (fStatsDamaged)							      return FALSE;
 	if (patient->bLife == patient->bLifeMax)                                      return FALSE;
 	if (fThisHour && !EnoughTimeOnAssignment(*patient))                           return FALSE;
 	if (patient->sSector != doctor->sSector)                                      return FALSE;
@@ -1370,6 +1375,7 @@ static UINT16 HealPatient(SOLDIERTYPE* pPatient, SOLDIERTYPE* pDoctor, UINT16 us
 	INT8 bPointsUsed = 0;
 	INT8 bPointsHealed = 0;
 	INT8 bPocket = 0;
+	INT8 bStatAmountHealed = 0;
 //	INT8 bOldPatientLife = pPatient -> bLife;
 
 
@@ -1460,9 +1466,87 @@ static UINT16 HealPatient(SOLDIERTYPE* pPatient, SOLDIERTYPE* pDoctor, UINT16 us
 		}
 	}
 
+	// heal stats that are damaged
+	if (pPatient -> bAgilityDamage > 0 || bPatient -> bDexterityDamage > 0 || bPatient -> bStrengthDamage > 0 || bPatient -> bWisdomDamage > 0)
+	{
+		bPointsToUse = STAT_HEALING_RATE_DIVISOR * std:max(pPatient -> bAgilityDamage, pPatient -> bDexterityDamage, pPatient -> bStrengthDamage, pPatient -> bWisdomDamage);
+
+		// if guy is hurt more than points we have...heal only what we have
+		if( bPointsToUse > usHealingPtsLeft )
+		{
+			bPointsToUse = ( INT8 )usHealingPtsLeft;
+		}
+
+		// go through doctor's pockets and heal, starting at with his in-hand item
+		// the healing pts are based on what type of medkit is in his hand, so we HAVE to start there first!
+		for (bPocket = HANDPOS; bPocket <= SMALLPOCK8POS; bPocket++)
+		{
+			OBJECTTYPE& o = pDoctor->inv[bPocket];
+			if (IsMedicalKitItem(&o))
+			{
+				// ok, we have med kit in this pocket, use it  (use only half if it's worth double)
+				bPointsUsed   = UseKitPoints(o, bPointsToUse, *pDoctor);
+				bPointsHealed = bPointsUsed;
+
+				bPointsToUse -= bPointsHealed;
+				usHealingPtsLeft -= bPointsHealed;
+
+				pPatient -> bLife += bPointsHealed;
+
+				// heal stats that are damaged
+				bStatAmountHealed = (bPointsHealed / STAT_HEALING_RATE_DIVISOR);
+				if (pPatient -> bAgilityDamage > 0)
+				{
+					if (bStatAmountHealed > pPatient -> bAgilityDamage)
+					{
+						bStatAmountHealed = pPatient -> bAgilityDamage;
+					}
+					pPatient -> bAgilityDamage -= bStatAmountHealed;
+					pPatient -> bAgility += bStatAmountHealed;
+				}
+
+				if (pPatient -> bDexterityDamage > 0)
+				{
+					if (bStatAmountHealed > pPatient -> bDexterityDamage)
+					{
+						bStatAmountHealed = pPatient -> bDexterityDamage;
+					}
+					pPatient -> bDexterityDamage -= bStatAmountHealed;
+					pPatient -> bDexterity += bStatAmountHealed;
+				}
+
+				if (pPatient -> bStrengthDamage > 0)
+				{
+					if (bStatAmountHealed > pPatient -> bStrengthDamage)
+					{
+						bStatAmountHealed = pPatient -> bStrengthDamage;
+					}
+					pPatient -> bStrengthDamage -= bStatAmountHealed;
+					pPatient -> bStrength += bStatAmountHealed;
+				}
+
+				if (pPatient -> bWisdomDamage > 0)
+				{
+					if (bStatAmountHealed > pPatient -> bWisdomDamage)
+					{
+						bStatAmountHealed = pPatient -> bWisdomDamage;
+					}
+					pPatient -> bWisdomDamage -= bStatAmountHealed;
+					pPatient -> bWisdom += bStatAmountHealed;
+				}
+
+				// if we're done all we're supposed to, or the guy's fully healed, bail
+				if ( ( bPointsToUse <= 0 ) || (pPatient -> bAgilityDamage == 0 && bPatient -> bDexterityDamage == 0 && bPatient -> bStrengthDamage == 0 && bPatient -> bWisdomDamage == 0 ))
+				{
+					break;
+				}
+			}
+		}
+	}
+
 
 	// if this patient is fully healed
-	if( pPatient->bLife == pPatient->bLifeMax )
+	if( pPatient->bLife == pPatient->bLifeMax && pPatient -> bAgilityDamage == 0 && bPatient -> bDexterityDamage == 0 && bPatient -> bStrengthDamage == 0 && bPatient -> bWisdomDamage == 0 )
 	{
 		// don't count unused full healing points as being used
 		usTotalHundredthsUsed -= (100 * usHealingPtsLeft);

--- a/src/game/Strategic/Assignments.cc
+++ b/src/game/Strategic/Assignments.cc
@@ -1531,15 +1531,35 @@ static UINT16 HealPatient(SOLDIERTYPE* pPatient, SOLDIERTYPE* pDoctor, UINT16 us
 				{
 				case 0:
 					HealStat(pPatient->bAgilityDamage, pPatient->bAgility, bStatAmountHealed);
+					if (pPatient->ubProfile != NO_PROFILE)
+					{
+						gMercProfiles[ pPatient->ubProfile ].bAgility = pPatient->bAgility;
+						gMercProfiles[ pPatient->ubProfile ].bAgilityDelta += bStatAmountHealed;
+					}
 					break;
 				case 1:
 					HealStat(pPatient->bDexterityDamage, pPatient->bDexterity, bStatAmountHealed);
+					if (pPatient->ubProfile != NO_PROFILE)
+					{
+						gMercProfiles[ pPatient->ubProfile ].bDexterity = pPatient->bDexterity;
+						gMercProfiles[ pPatient->ubProfile ].bDexterityDelta += bStatAmountHealed;
+					}
 					break;
 				case 2:
 					HealStat(pPatient->bStrengthDamage, pPatient->bStrength, bStatAmountHealed);
+					if (pPatient->ubProfile != NO_PROFILE)
+					{
+						gMercProfiles[ pPatient->ubProfile ].bStrength = pPatient->bStrength;
+						gMercProfiles[ pPatient->ubProfile ].bStrengthDelta += bStatAmountHealed;
+					}
 					break;
 				case 3:
 					HealStat(pPatient->bWisdomDamage, pPatient->bWisdom, bStatAmountHealed);
+					if (pPatient->ubProfile != NO_PROFILE)
+					{
+						gMercProfiles[ pPatient->ubProfile ].bWisdom = pPatient->bWisdom;
+						gMercProfiles[ pPatient->ubProfile ].bWisdomDelta += bStatAmountHealed;
+					}
 					break;
 				}
 

--- a/src/game/Tactical/LoadSaveSoldierType.cc
+++ b/src/game/Tactical/LoadSaveSoldierType.cc
@@ -10,6 +10,8 @@
 #include <algorithm>
 #include <stdexcept>
 
+#include "Logger.h"
+
 static UINT32 MercChecksum(SOLDIERTYPE const& s)
 {
 	UINT32 sum = 1;
@@ -136,7 +138,9 @@ void ExtractSoldierType(const BYTE* const data, SOLDIERTYPE* const s, bool strac
 	EXTR_U8(d, s->ubSkillTrait2)
 	EXTR_SKIP(d, 6)
 	EXTR_I8(d, s->bDexterity)
+	EXTR_I8(d, s->bDexterityDamage)
 	EXTR_I8(d, s->bWisdom)
+	EXTR_I8(d, s->bWisdomDamage)
 	EXTR_SKIP_I16(d)
 	EXTR_SOLDIER(d, s->attacker)
 	EXTR_SOLDIER(d, s->previous_attacker)
@@ -156,10 +160,12 @@ void ExtractSoldierType(const BYTE* const data, SOLDIERTYPE* const s, bool strac
 	EXTR_U16(d, s->usAniFrame)
 	EXTR_I16(d, s->sAniDelay)
 	EXTR_I8(d, s->bAgility)
+	EXTR_I8(d, s->bAgilityDamage)
 	EXTR_SKIP(d, 1)
 	EXTR_I16(d, s->sDelayedMovementCauseGridNo)
 	EXTR_I16(d, s->sReservedMovementGridNo)
 	EXTR_I8(d, s->bStrength)
+	EXTR_I8(d, s->bStrengthDamage)
 	EXTR_SKIP(d, 1)
 	EXTR_I16(d, s->sTargetGridNo)
 	EXTR_I8(d, s->bTargetLevel)
@@ -547,11 +553,11 @@ void ExtractSoldierType(const BYTE* const data, SOLDIERTYPE* const s, bool strac
 	EXTR_SKIP(d, 39)
 	if(stracLinuxFormat)
 	{
-		Assert(d.getConsumed() == 2352);
+		Assert(d.getConsumed() == 2358);
 	}
 	else
 	{
-		Assert(d.getConsumed() == 2328);
+		Assert(d.getConsumed() == 2332);
 	}
 
 	if (checksum != MercChecksum(*s))
@@ -566,7 +572,6 @@ void InjectSoldierType(BYTE* const data, const SOLDIERTYPE* const s)
 	UINT16 usPathingData[ MAX_PATH_LIST_SIZE ];
 	UINT16 usPathDataSize;
 	UINT16 usPathIndex;
-
 	DataWriter d{data};
 	INJ_U8(d, s->ubID)
 	INJ_SKIP(d, 1)
@@ -647,7 +652,9 @@ void InjectSoldierType(BYTE* const data, const SOLDIERTYPE* const s)
 	INJ_U8(d, s->ubSkillTrait2)
 	INJ_SKIP(d, 6)
 	INJ_I8(d, s->bDexterity)
+	INJ_I8(d, s->bDexterityDamage)
 	INJ_I8(d, s->bWisdom)
+	INJ_I8(d, s->bWisdomDamage)
 	INJ_SKIP_I16(d)
 	INJ_SOLDIER(d, s->attacker)
 	INJ_SOLDIER(d, s->previous_attacker)
@@ -667,10 +674,12 @@ void InjectSoldierType(BYTE* const data, const SOLDIERTYPE* const s)
 	INJ_U16(d, s->usAniFrame)
 	INJ_I16(d, s->sAniDelay)
 	INJ_I8(d, s->bAgility)
+	INJ_I8(d, s->bAgilityDamage)
 	INJ_SKIP(d, 1)
 	INJ_I16(d, s->sDelayedMovementCauseGridNo)
 	INJ_I16(d, s->sReservedMovementGridNo)
 	INJ_I8(d, s->bStrength)
+	INJ_I8(d, s->bStrengthDamage)
 	INJ_SKIP(d, 1)
 	INJ_I16(d, s->sTargetGridNo)
 	INJ_I8(d, s->bTargetLevel)
@@ -1055,5 +1064,5 @@ void InjectSoldierType(BYTE* const data, const SOLDIERTYPE* const s)
 	INJ_I32(d, s->uiTimeSinceLastBleedGrunt)
 	INJ_SOLDIER(d, s->next_to_previous_attacker)
 	INJ_SKIP(d, 39)
-	Assert(d.getConsumed() == 2328);
+	Assert(d.getConsumed() == 2332);
 }

--- a/src/game/Tactical/LoadSaveSoldierType.cc
+++ b/src/game/Tactical/LoadSaveSoldierType.cc
@@ -47,6 +47,13 @@ void ExtractSoldierType(const BYTE* const data, SOLDIERTYPE* const s, bool strac
 	*s = SOLDIERTYPE{};
 
 	DataReader d{data};
+
+	auto ExtractStatDamage = [&](INT8 & whichDamage)
+	{
+		INT8 val = d.read<INT8>();
+		whichDamage = uiSavedGameVersion >= 103 ? val : 0;
+	};
+
 	EXTR_U8(d, s->ubID)
 	EXTR_SKIP(d, 1)
 	EXTR_U8(d, s->ubBodyType)
@@ -131,10 +138,10 @@ void ExtractSoldierType(const BYTE* const data, SOLDIERTYPE* const s, bool strac
 	s->UpdateCounter = {};
 	s->DamageCounter = {};
 	EXTR_SKIP_I32(d)
-	EXTR_I8(d, s->bAgilityDamage)
-	EXTR_I8(d, s->bDexterityDamage)
-	EXTR_I8(d, s->bStrengthDamage)
-	EXTR_I8(d, s->bWisdomDamage)
+	ExtractStatDamage(s->bAgilityDamage);
+	ExtractStatDamage(s->bDexterityDamage);
+	ExtractStatDamage(s->bStrengthDamage);
+	ExtractStatDamage(s->bWisdomDamage);
 	EXTR_SKIP(d, 8)
 	s->AICounter = {};
 	s->FadeCounter = {};

--- a/src/game/Tactical/LoadSaveSoldierType.cc
+++ b/src/game/Tactical/LoadSaveSoldierType.cc
@@ -131,16 +131,18 @@ void ExtractSoldierType(const BYTE* const data, SOLDIERTYPE* const s, bool strac
 	s->UpdateCounter = {};
 	s->DamageCounter = {};
 	EXTR_SKIP_I32(d)
-	EXTR_SKIP(d, 12)
+	EXTR_I8(d, s->bAgilityDamage)
+	EXTR_I8(d, s->bDexterityDamage)
+	EXTR_I8(d, s->bStrengthDamage)
+	EXTR_I8(d, s->bWisdomDamage)
+	EXTR_SKIP(d, 8)
 	s->AICounter = {};
 	s->FadeCounter = {};
 	EXTR_U8(d, s->ubSkillTrait1)
 	EXTR_U8(d, s->ubSkillTrait2)
 	EXTR_SKIP(d, 6)
 	EXTR_I8(d, s->bDexterity)
-	EXTR_I8(d, s->bDexterityDamage)
 	EXTR_I8(d, s->bWisdom)
-	EXTR_I8(d, s->bWisdomDamage)
 	EXTR_SKIP_I16(d)
 	EXTR_SOLDIER(d, s->attacker)
 	EXTR_SOLDIER(d, s->previous_attacker)
@@ -160,12 +162,10 @@ void ExtractSoldierType(const BYTE* const data, SOLDIERTYPE* const s, bool strac
 	EXTR_U16(d, s->usAniFrame)
 	EXTR_I16(d, s->sAniDelay)
 	EXTR_I8(d, s->bAgility)
-	EXTR_I8(d, s->bAgilityDamage)
 	EXTR_SKIP(d, 1)
 	EXTR_I16(d, s->sDelayedMovementCauseGridNo)
 	EXTR_I16(d, s->sReservedMovementGridNo)
 	EXTR_I8(d, s->bStrength)
-	EXTR_I8(d, s->bStrengthDamage)
 	EXTR_SKIP(d, 1)
 	EXTR_I16(d, s->sTargetGridNo)
 	EXTR_I8(d, s->bTargetLevel)
@@ -553,11 +553,11 @@ void ExtractSoldierType(const BYTE* const data, SOLDIERTYPE* const s, bool strac
 	EXTR_SKIP(d, 39)
 	if(stracLinuxFormat)
 	{
-		Assert(d.getConsumed() == 2358);
+		Assert(d.getConsumed() == 2352);
 	}
 	else
 	{
-		Assert(d.getConsumed() == 2332);
+		Assert(d.getConsumed() == 2328);
 	}
 
 	if (checksum != MercChecksum(*s))
@@ -645,16 +645,17 @@ void InjectSoldierType(BYTE* const data, const SOLDIERTYPE* const s)
 	INJ_I32(d, 0)
 	INJ_I32(d, 0)
 	INJ_SKIP_I32(d)
-	INJ_SKIP(d, 4)
+	INJ_I8(d, s->bAgilityDamage)
+	INJ_I8(d, s->bDexterityDamage)
+	INJ_I8(d, s->bStrengthDamage)
+	INJ_I8(d, s->bWisdomDamage)
 	INJ_I32(d, 0)
 	INJ_I32(d, 0)
 	INJ_U8(d, s->ubSkillTrait1)
 	INJ_U8(d, s->ubSkillTrait2)
 	INJ_SKIP(d, 6)
 	INJ_I8(d, s->bDexterity)
-	INJ_I8(d, s->bDexterityDamage)
 	INJ_I8(d, s->bWisdom)
-	INJ_I8(d, s->bWisdomDamage)
 	INJ_SKIP_I16(d)
 	INJ_SOLDIER(d, s->attacker)
 	INJ_SOLDIER(d, s->previous_attacker)
@@ -674,12 +675,10 @@ void InjectSoldierType(BYTE* const data, const SOLDIERTYPE* const s)
 	INJ_U16(d, s->usAniFrame)
 	INJ_I16(d, s->sAniDelay)
 	INJ_I8(d, s->bAgility)
-	INJ_I8(d, s->bAgilityDamage)
 	INJ_SKIP(d, 1)
 	INJ_I16(d, s->sDelayedMovementCauseGridNo)
 	INJ_I16(d, s->sReservedMovementGridNo)
 	INJ_I8(d, s->bStrength)
-	INJ_I8(d, s->bStrengthDamage)
 	INJ_SKIP(d, 1)
 	INJ_I16(d, s->sTargetGridNo)
 	INJ_I8(d, s->bTargetLevel)
@@ -1064,5 +1063,5 @@ void InjectSoldierType(BYTE* const data, const SOLDIERTYPE* const s)
 	INJ_I32(d, s->uiTimeSinceLastBleedGrunt)
 	INJ_SOLDIER(d, s->next_to_previous_attacker)
 	INJ_SKIP(d, 39)
-	Assert(d.getConsumed() == 2332);
+	Assert(d.getConsumed() == 2328);
 }

--- a/src/game/Tactical/LoadSaveSoldierType_unittest.cc
+++ b/src/game/Tactical/LoadSaveSoldierType_unittest.cc
@@ -11,6 +11,7 @@
 
 #include <cstring>
 #include <memory>
+#include "Logger.h"
 
 #ifndef NO_MAGICENUM_LIB
 #include <magic_enum/magic_enum.hpp>
@@ -42,14 +43,18 @@ protected:
 		testSoldier.bLife = 85;
 		testSoldier.bLifeMax = 85;
 		testSoldier.bAgility = 75;
+		testSoldier.bAgilityDamage = 5;
 		testSoldier.bDexterity = 80;
+		testSoldier.bDexterityDamage = 60;
 		testSoldier.bStrength = 70;
+		testSoldier.bStrengthDamage = 30;
 		testSoldier.bMarksmanship = 90;
 		testSoldier.bMedical = 60;
 		testSoldier.bMechanical = 55;
 		testSoldier.bExplosive = 65;
 		testSoldier.bLeadership = 50;
 		testSoldier.bWisdom = 45;
+		testSoldier.bWisdomDamage = 10;
 		testSoldier.bExpLevel = 3;
 		
 		// Side and team
@@ -189,14 +194,18 @@ TEST_F(LoadSaveSoldierTypeTestImpl, RoundTripSerialization)
 	EXPECT_EQ(extractedSoldier.bLife, testSoldier.bLife);
 	EXPECT_EQ(extractedSoldier.bLifeMax, testSoldier.bLifeMax);
 	EXPECT_EQ(extractedSoldier.bAgility, testSoldier.bAgility);
+	EXPECT_EQ(extractedSoldier.bAgilityDamage, testSoldier.bAgilityDamage);
 	EXPECT_EQ(extractedSoldier.bDexterity, testSoldier.bDexterity);
+	EXPECT_EQ(extractedSoldier.bDexterityDamage, testSoldier.bDexterityDamage);
 	EXPECT_EQ(extractedSoldier.bStrength, testSoldier.bStrength);
+	EXPECT_EQ(extractedSoldier.bStrengthDamage, testSoldier.bStrengthDamage);
 	EXPECT_EQ(extractedSoldier.bMarksmanship, testSoldier.bMarksmanship);
 	EXPECT_EQ(extractedSoldier.bMedical, testSoldier.bMedical);
 	EXPECT_EQ(extractedSoldier.bMechanical, testSoldier.bMechanical);
 	EXPECT_EQ(extractedSoldier.bExplosive, testSoldier.bExplosive);
 	EXPECT_EQ(extractedSoldier.bLeadership, testSoldier.bLeadership);
 	EXPECT_EQ(extractedSoldier.bWisdom, testSoldier.bWisdom);
+	EXPECT_EQ(extractedSoldier.bWisdomDamage, testSoldier.bWisdomDamage);
 	EXPECT_EQ(extractedSoldier.bExpLevel, testSoldier.bExpLevel);
 	
 	// Verify side and team

--- a/src/game/Tactical/LoadSaveSoldierType_unittest.cc
+++ b/src/game/Tactical/LoadSaveSoldierType_unittest.cc
@@ -177,7 +177,7 @@ TEST_F(LoadSaveSoldierTypeTestImpl, RoundTripSerialization)
 	
 	// Extract the soldier data
 	SOLDIERTYPE extractedSoldier;
-	ExtractSoldierType(buffer.get(), &extractedSoldier, false, 0);
+	ExtractSoldierType(buffer.get(), &extractedSoldier, false, 103);
 	
 	// Verify basic identification
 	EXPECT_EQ(extractedSoldier.ubID, testSoldier.ubID);

--- a/src/game/Tactical/Soldier_Control.h
+++ b/src/game/Tactical/Soldier_Control.h
@@ -411,7 +411,9 @@ struct SOLDIERTYPE
 	UINT8 ubSkillTrait2;
 
 	INT8 bDexterity; // dexterity (hand coord) value
+	INT8 bDexterityDamage; // how much dexterity has been damaged by crits
 	INT8 bWisdom;
+	INT8 bWisdomDamage; // how much wisdom has been damaged by crits
 	SOLDIERTYPE* attacker;
 	SOLDIERTYPE* previous_attacker;
 	SOLDIERTYPE* next_to_previous_attacker;
@@ -437,10 +439,12 @@ struct SOLDIERTYPE
 
 	// MOVEMENT TO NEXT TILE HANDLING STUFF
 	INT8 bAgility; // agility (speed) value
+	INT8 bAgilityDamage; // how much agility has been damaged by crits
 	INT16 sDelayedMovementCauseGridNo;
 	INT16 sReservedMovementGridNo;
 
 	INT8 bStrength;
+	INT8 bStrengthDamage; // how much strength has been damaged by crits
 
 	// Weapon Stuff
 	INT16 sTargetGridNo;

--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -2951,7 +2951,7 @@ INT32 BulletImpact( SOLDIERTYPE *pFirer, SOLDIERTYPE * pTarget, UINT8 ubHitLocat
 						if ( bStatLoss > 0 )
 						{
 							pTarget->bWisdom -= bStatLoss;
-							pTarget->bWisdomDamage = bStatLoss;
+							pTarget->bWisdomDamage += bStatLoss;
 
 							if (pTarget->ubProfile != NO_PROFILE)
 							{
@@ -2991,7 +2991,7 @@ INT32 BulletImpact( SOLDIERTYPE *pFirer, SOLDIERTYPE * pTarget, UINT8 ubHitLocat
 							if ( bStatLoss > 0 )
 							{
 								pTarget->bDexterity -= bStatLoss;
-								pTarget->bDexterity = bStatLoss;
+								pTarget->bDexterityDamage += bStatLoss;
 
 								if (pTarget->ubProfile != NO_PROFILE)
 								{
@@ -3025,7 +3025,7 @@ INT32 BulletImpact( SOLDIERTYPE *pFirer, SOLDIERTYPE * pTarget, UINT8 ubHitLocat
 							if ( bStatLoss > 0 )
 							{
 								pTarget->bStrength -= bStatLoss;
-								pTarget->bStrengthDamage = bStatLoss;
+								pTarget->bStrengthDamage += bStatLoss;
 
 								if (pTarget->ubProfile != NO_PROFILE)
 								{
@@ -3059,7 +3059,7 @@ INT32 BulletImpact( SOLDIERTYPE *pFirer, SOLDIERTYPE * pTarget, UINT8 ubHitLocat
 						if ( bStatLoss > 0 )
 						{
 							pTarget->bAgility -= bStatLoss;
-							pTarget->bAgilityDamage = bStatLoss;
+							pTarget->bAgilityDamage += bStatLoss;
 
 							if (pTarget->ubProfile != NO_PROFILE)
 							{

--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -2951,6 +2951,7 @@ INT32 BulletImpact( SOLDIERTYPE *pFirer, SOLDIERTYPE * pTarget, UINT8 ubHitLocat
 						if ( bStatLoss > 0 )
 						{
 							pTarget->bWisdom -= bStatLoss;
+							pTarget->bWisdomDamage = bStatLoss;
 
 							if (pTarget->ubProfile != NO_PROFILE)
 							{
@@ -2990,6 +2991,7 @@ INT32 BulletImpact( SOLDIERTYPE *pFirer, SOLDIERTYPE * pTarget, UINT8 ubHitLocat
 							if ( bStatLoss > 0 )
 							{
 								pTarget->bDexterity -= bStatLoss;
+								pTarget->bDexterity = bStatLoss;
 
 								if (pTarget->ubProfile != NO_PROFILE)
 								{
@@ -3023,6 +3025,7 @@ INT32 BulletImpact( SOLDIERTYPE *pFirer, SOLDIERTYPE * pTarget, UINT8 ubHitLocat
 							if ( bStatLoss > 0 )
 							{
 								pTarget->bStrength -= bStatLoss;
+								pTarget->bStrengthDamage = bStatLoss;
 
 								if (pTarget->ubProfile != NO_PROFILE)
 								{
@@ -3056,6 +3059,7 @@ INT32 BulletImpact( SOLDIERTYPE *pFirer, SOLDIERTYPE * pTarget, UINT8 ubHitLocat
 						if ( bStatLoss > 0 )
 						{
 							pTarget->bAgility -= bStatLoss;
+							pTarget->bAgilityDamage = bStatLoss;
 
 							if (pTarget->ubProfile != NO_PROFILE)
 							{


### PR DESCRIPTION
Adds the ability to heal stats that were damaged by critical hits through doctoring. When `enable_stat_healing` in `game.json` is set to `TRUE` (default `FALSE`), then characters with damaged stats will be able to be healed during doctor assignments. Healing points are first allocated to missing life, and after a character with stat damage has full life they can remain as patients (or doctors when doctoring themselves) to heal their stats. This drains medical supplies at a rate 3x higher than normal as it's currently implemented.

Why add this? Currently when playing with the non-vanilla additional AI options to have the AI go for head and leg shots it results in more critical hits and -- especially in the case with head shots -- more stat damage. Many mercs end up with their stats severely damaged and in vanilla there is no way to heal those stats, and since some stats like WIS can barely be trained at all many mercs end up losing tons of WIS over the course of the game.