### PR TITLE
Fixes cleanup of the keyring popup when leaving the mapscreen.

### DIFF
--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -3065,7 +3065,7 @@ void EndMapScreen( BOOLEAN fDuringFade )
 	if (!fInMapMode) return;
 	
 	// The mapscreen inventory cleanup only removes the keyring button region.
-    // Close the popup itself before tearing down mapscreen regions.
+	// Close the popup itself before tearing down mapscreen regions.
 	DeleteKeyRingPopup();
 	
 	fLeavingMapScreen = FALSE;

--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -3063,7 +3063,11 @@ static void RemoveTeamPanelSortButtonsForMapScreen();
 void EndMapScreen( BOOLEAN fDuringFade )
 {
 	if (!fInMapMode) return;
-
+	
+	// The mapscreen inventory cleanup only removes the keyring button region.
+    // Close the popup itself before tearing down mapscreen regions.
+	DeleteKeyRingPopup();
+	
 	fLeavingMapScreen = FALSE;
 
 	SetRenderFlags( RENDER_FLAG_FULL );


### PR DESCRIPTION
## Summary

Fixes cleanup of the keyring popup when leaving the mapscreen.

<img width="1134" height="549" alt="image" src="https://github.com/user-attachments/assets/b0b8c19b-16e8-4595-92ce-ed5760d91c6e" />


## Reproduction

1. Open the mapscreen.
2. Open a merc’s inventory from the mapscreen und open the keyring popup.
3. Switch back to tactical while the keyring popup is still open.

## Details
The mapscreen inventory teardown removed the keyring button region, but an already open keyring popup was not explicitly closed. This could leave popup state, mouse regions, and cursor restrictions active after switching back to tactical.

The fix closes the keyring popup during mapscreen shutdown via `DeleteKeyRingPopup()`, which is safe to call even when no popup is open.