### PR TITLE
Externalize fire suppression modifier and suppression reaction values

### DIFF
--- a/assets/externalized/game.json
+++ b/assets/externalized/game.json
@@ -236,5 +236,11 @@
     //  Is the start sector revealed at game start?
     //  vanilla settings: true
     "start_sector_revealed": true
-  }
+    },
+
+    // Scales AP loss from suppression (numerator of the AP-loss formula); vanilla 6, recommended setting is 24
+    "suppression_fire_modifier": 6,
+    // Threshold (numerator) above which a suppressed soldier drops to a lower stance.
+    // vanilla settings: 130. Set to 0 to make soldiers always react (1.13 behaviour); raise it to make them even more resistant.
+    "suppression_fire_reaction_threshold": 130
 }

--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -97,6 +97,9 @@ DefaultGamePolicy::DefaultGamePolicy(const JsonValue& json)
 	ST::string sector_string = campaign.getOptionalString("start_sector");
 	start_sector = SGPSector::FromShortString(!sector_string.empty() ? sector_string : "A9").AsByte();
 	reveal_start_sector = campaign.getOptionalBool("start_sector_revealed", false);
+
+	suppression_fire_modifier = gp.getOptionalUInt("suppression_fire_modifier", 6);
+	suppression_fire_reaction_threshold = gp.getOptionalUInt("suppression_fire_reaction_threshold", 130);
 }
 
 /** Check if a hotkey is enabled. */

--- a/src/externalized/policy/GamePolicy.h
+++ b/src/externalized/policy/GamePolicy.h
@@ -120,6 +120,9 @@ public:
 	uint16_t start_sector;        // Starting sector
 	bool reveal_start_sector;     // Should the start sector radar map be shown at start
 
+	uint8_t suppression_fire_modifier; // Scales AP loss from suppression (numerator of the AP-loss formula); vanilla 6, 0 disables AP loss
+	uint16_t suppression_fire_reaction_threshold; // Numerator of the stance-reaction threshold; vanilla 130, 0 = always react (1.13 behaviour), higher = more resistant
+
 	////////////////////////////////////////////////////////////
 	//
 	////////////////////////////////////////////////////////////

--- a/src/game/Tactical/Overhead.cc
+++ b/src/game/Tactical/Overhead.cc
@@ -5168,6 +5168,7 @@ static void HandleSuppressionFire(const SOLDIERTYPE* const targeted_merc, SOLDIE
 	INT16 sClosestOpponent, sClosestOppLoc;
 	UINT8 ubPointsLost, ubTotalPointsLost, ubNewStance;
 	UINT8 ubLoop2;
+	const UINT8 ubSuppressionModifier = gamepolicy(suppression_fire_modifier);
 
 	for (SOLDIERTYPE * const pSoldier : MercSlots)
 	{
@@ -5176,7 +5177,7 @@ static void HandleSuppressionFire(const SOLDIERTYPE* const targeted_merc, SOLDIE
 			bTolerance = CalcSuppressionTolerance( pSoldier );
 
 			// multiply by 2, add 1 and divide by 2 to round off to nearest whole number
-			ubPointsLost = ( ((pSoldier->ubSuppressionPoints * 6) / (bTolerance + 6)) * 2 + 1 ) / 2;
+			ubPointsLost = ( ((pSoldier->ubSuppressionPoints * ubSuppressionModifier) / (bTolerance + 6)) * 2 + 1 ) / 2;
 
 			// reduce loss of APs based on stance
 			// ATE: Taken out because we can possibly supress ourselves...
@@ -5218,8 +5219,8 @@ static void HandleSuppressionFire(const SOLDIERTYPE* const targeted_merc, SOLDIE
 			ubPointsLost -= pSoldier->ubAPsLostToSuppression;
 			ubNewStance = 0;
 
-			// merc may get to react
-			if ( pSoldier->ubSuppressionPoints >= ( 130 / (6 + bTolerance) ) )
+			// merc may get to react (threshold numerator is externalized; 0 = always react)
+			if (pSoldier->ubSuppressionPoints >= (gamepolicy(suppression_fire_reaction_threshold) / (6 + bTolerance)))
 			{
 				// merc gets to use APs to react!
 				switch (gAnimControl[ pSoldier->usAnimState ].ubEndHeight)


### PR DESCRIPTION
At the moment fire suppression is almost non-existent because tolerance is often too high and we also get values less than 1 which get truncated to 0. I propose to externalize 2 values that will make suppression (and indectly burst fire) more useful and noticeable. 