### PR TITLE
Fix the garage door pathfinding and visual bugs

### DIFF
--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -386,10 +386,19 @@ static STRUCTURE* CreateStructureFromDB(DB_STRUCTURE_REF const* const pDBStructu
 
 	STRUCTURE* const pStructure = new STRUCTURE{};
 
-	// We need to clear the old STRUCTURE_HIDDEN flag, which had the same value
-	// as STRUCTURE_GARADGEDOOR to prevent problems with pathing and opening
-	// or closing doors, see PR #2348 and nightops-maps PR #11.
-	pStructure->fFlags          = pDBStructure->fFlags & ~STRUCTURE_GARAGEDOOR;
+	// fix garage doors not having a flag of their own separate from sliding doors
+	if (pDBStructure->fFlags & STRUCTURE_SLIDINGDOOR && pDBStructure->ubNumberOfTiles == 2)
+	{
+		pStructure->fFlags      = (pDBStructure->fFlags & ~STRUCTURE_SLIDINGDOOR) | STRUCTURE_GARAGEDOOR;
+	}
+	else
+	{
+		// We need to clear the old STRUCTURE_HIDDEN flag, which had the same value
+		// as STRUCTURE_GARADGEDOOR to prevent problems with pathing and opening
+		// or closing doors, see PR #2348 and nightops-maps PR #11.
+		pStructure->fFlags      = pDBStructure->fFlags & ~STRUCTURE_GARAGEDOOR;
+	}
+
 	pStructure->pShape          = &pTile->Shape;
 	pStructure->pDBStructureRef = pDBStructureRef;
 	if (pTile->sPosRelToBase != 0 && ubTileNum == 0)

--- a/src/game/TileEngine/TileDef.cc
+++ b/src/game/TileEngine/TileDef.cc
@@ -145,12 +145,6 @@ void CreateTileDatabase()
 						TileElement.pDBStructureRef[19].pDBStructure->fFlags |= STRUCTURE_DDOOR_RIGHT;
 					}
 				}
-				// fix garage doors not having a flag of their own separate from sliding doors
-				if (TileElement.pDBStructureRef->pDBStructure->fFlags & STRUCTURE_SLIDINGDOOR && TileElement.pDBStructureRef[0].pDBStructure->ubNumberOfTiles == 2)
-				{
-					TileElement.pDBStructureRef->pDBStructure->fFlags &= ~STRUCTURE_SLIDINGDOOR;
-					TileElement.pDBStructureRef->pDBStructure->fFlags |= STRUCTURE_GARAGEDOOR;
-				}
 			}			
 			gTileDatabase[gTileDatabaseSize++] = TileElement;
 		}


### PR DESCRIPTION
I somehow missed that #2352 completely destroys the garage door:
<img width="179" height="144" alt="image" src="https://github.com/user-attachments/assets/052801a7-de20-4ddc-9353-4181f51ce2d9" />
<img width="162" height="132" alt="image" src="https://github.com/user-attachments/assets/59b7f6b7-37c5-449a-8504-c7a1e3eb2aed" />
It is now (not falsely I hope) assumed that the STRUCTURE_HIDDEN flag wasn't applied to doors, so we leave their flags unchanged.