### PR TITLE
Fix items on top of destroyed structures not changing their z-level correctly

### DIFF
--- a/src/game/Tactical/Handle_Items.cc
+++ b/src/game/Tactical/Handle_Items.cc
@@ -1714,6 +1714,16 @@ INT8 GetLargestZLevelOfItemPool(ITEM_POOL const* ip)
 	return 0;
 }
 
+void PutItemPoolOnGround(GridNo const gridNo, uint8_t const level)
+{
+	const ITEM_POOL * itemPool{ GetItemPool(gridNo, level) };
+	while (itemPool)
+	{
+		WORLDITEM & wi{ GetWorldItem(itemPool->iItemIndex) };
+		wi.bRenderZHeightAboveLevel = 0;
+		itemPool = itemPool->pNext;
+	}
+}
 
 static void RemoveItemPool(INT16 sGridNo, UINT8 ubLevel)
 {

--- a/src/game/Tactical/Handle_Items.h
+++ b/src/game/Tactical/Handle_Items.h
@@ -106,6 +106,8 @@ INT8 GetZLevelOfItemPoolGivenStructure(INT16 sGridNo, UINT8 ubLevel, const STRUC
 
 INT8 GetLargestZLevelOfItemPool(const ITEM_POOL* pItemPool);
 
+void PutItemPoolOnGround(GridNo const gridNo, uint8_t const level);
+
 BOOLEAN NearbyGroundSeemsWrong( SOLDIERTYPE * pSoldier, INT16 sGridNo, BOOLEAN fCheckAroundGridno, INT16 * psProblemGridNo );
 void MineSpottedDialogueCallBack( void );
 

--- a/src/game/TileEngine/Explosion_Control.cc
+++ b/src/game/TileEngine/Explosion_Control.cc
@@ -560,6 +560,11 @@ static bool ExplosiveDamageStructureAtGridNo(STRUCTURE* const pCurrent, STRUCTUR
 			RecompileLocalMovementCostsForWall(base_grid_no, base->ubWallOrientation);
 		}
 
+		if (pCurrent->fFlags & STRUCTURE_HASITEMONTOP)
+		{
+			PutItemPoolOnGround(grid_no, level);
+		}
+
 		{ ApplyMapChangesToMapTempFile app;
 			RemoveStructFromLevelNode(base_grid_no, node);
 		}


### PR DESCRIPTION
Fixed: if a structure that has an item on top of it gets destroyed the item keeps hanging at the same height and can only be picked up from sector inventory.
<img width="127" height="104" alt="image" src="https://github.com/user-attachments/assets/d6042fc7-ee90-4108-9d23-0498cb933296" />
<img width="126" height="97" alt="image" src="https://github.com/user-attachments/assets/8397eb14-04b6-4db5-9d0c-ab41e3784368" />
