### PR TITLE
Add (reenable) hide_bullets option as game  policy

### DIFF
--- a/assets/externalized/game.json
+++ b/assets/externalized/game.json
@@ -62,6 +62,11 @@
   //  vanilla setting: false
   "all_drops_visible": false,
 
+  //  Don't draw bullets in flight; shots resolve faster. Revives the old
+  //  "hide bullets" option as a game policy.
+  //  vanilla setting: false
+  "hide_bullets": false,
+
   //  Everyone will be able to interrupt multiple times in the same turn. Vanilla behaviour is that if you skipped reacting to the first interrupt
   //  (say your buddies took care of it), you'd still get skipped for any further interrupts. Annoying in ambushes or when sneaking.
   //  vanilla setting: false

--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -19,6 +19,8 @@ DefaultGamePolicy::DefaultGamePolicy(const JsonValue& json)
 	f_drop_everything = gp.getOptionalBool("drop_everything");
 	f_all_dropped_visible = gp.getOptionalBool("all_drops_visible");
 
+	hide_bullets = gp.getOptionalBool("hide_bullets");
+
 	multiple_interrupts = gp.getOptionalBool("multiple_interrupts");
 
 	fixed_cost_to_shoot = gp.getOptionalBool("fixed_cost_to_shoot");

--- a/src/externalized/policy/GamePolicy.h
+++ b/src/externalized/policy/GamePolicy.h
@@ -42,6 +42,8 @@ public:
 	bool f_drop_everything;               /**< Enemy drop all equipment. */
 	bool f_all_dropped_visible;           /**< All dropped equipment is visible right away. */
 
+	bool hide_bullets;                    // don't draw bullets in flight; resolve shots faster (revives the old TOPTION_HIDE_BULLETS option)
+
 	bool multiple_interrupts;             // can interrupt more than once per turn
 
 	bool fixed_cost_to_shoot;    // Changes the formula for APs to shoot

--- a/src/game/Tactical/Bullets.cc
+++ b/src/game/Tactical/Bullets.cc
@@ -10,6 +10,9 @@
 #include "Random.h"
 #include "GameSettings.h"
 #include "Logger.h"
+#include "GamePolicy.h"
+#include "ContentManager.h"
+#include "GameInstance.h"
 
 #include <algorithm>
 #include <iterator>
@@ -204,7 +207,7 @@ void UpdateBullets(void)
 					continue;
 				}
 
-				//if ( !( gGameSettings.fOptions[ TOPTION_HIDE_BULLETS ] ) )
+				if ( !gamepolicy(hide_bullets) )
 				{
 					// ALRIGHTY, CHECK WHAT TYPE OF BULLET WE ARE
 
@@ -230,7 +233,7 @@ void UpdateBullets(void)
 				if (b->usFlags & BULLET_STOPPED) continue;
 
 				// Display bullet
-				//if ( !( gGameSettings.fOptions[ TOPTION_HIDE_BULLETS ] ) )
+				if ( !gamepolicy(hide_bullets) )
 				{
 					if (b->usFlags & BULLET_FLAG_KNIFE)
 					{

--- a/src/game/Tactical/LOS.cc
+++ b/src/game/Tactical/LOS.cc
@@ -39,6 +39,7 @@
 #include "GameInstance.h"
 #include "WeaponModels.h"
 #include "Logger.h"
+#include "GamePolicy.h"
 
 #define STEPS_FOR_BULLET_MOVE_TRAILS				10
 #define STEPS_FOR_BULLET_MOVE_SMALL_TRAILS			5
@@ -3156,16 +3157,18 @@ static INT8 FireBullet(BULLET* pBullet, BOOLEAN fFake)
 	else
 	{
 		pBullet->target = pFirer->target;
-		//if ( gGameSettings.fOptions[ TOPTION_HIDE_BULLETS ] )
-		//{
-		//	pBullet->uiLastUpdate = 0;
-		//	pBullet->ubTilesPerUpdate	= 4;
-		//}
-		//else
-		//{
+		if ( gamepolicy(hide_bullets) )
+		{
+			// bullets are not drawn - advance them several tiles per update so
+			// turns resolve quickly instead of waiting on the bullet animation
+			pBullet->uiLastUpdate = 0;
+			pBullet->ubTilesPerUpdate	= 4;
+		}
+		else
+		{
 			pBullet->uiLastUpdate = 0;
 			pBullet->ubTilesPerUpdate	= 1;
-		//}
+		}
 
 		// increment shots fired if shooter has a merc profile
 		if( ( pFirer->ubProfile != NO_PROFILE ) && ( pFirer->bTeam == 0 ) )


### PR DESCRIPTION
Revive the old TOPTION_HIDE_BULLETS behavior as a game policy (default false = vanilla). When enabled, bullets are not drawn in flight.