### PR TITLE
Fix incorrect wall replacement on adjacent wall destruction

### DIFF
--- a/src/game/TileEngine/Explosion_Control.cc
+++ b/src/game/TileEngine/Explosion_Control.cc
@@ -296,7 +296,16 @@ static void ReplaceWall(GridNo const grid_no, UINT8 const orientation, INT16 con
 	if (!wall_struct || !(wall_struct->fFlags & STRUCTURE_WALL)) return;
 
 	LEVELNODE* const node    = FindLevelNodeBasedOnStructure(wall_struct);
-	UINT16     const new_idx = GetTileIndexFromTypeSubIndex(gTileDatabase[node->usIndex].fType, sub_idx);
+
+	UINT16 tileType = gTileDatabase[node->usIndex].fType;
+	if (tileType > FOURTHWALL)
+	{
+		/* The subindex offsets for replacement only work if the tile type is wall.
+		 * If it's not then it's probably decorations which we shift back to wall */
+		tileType -= (FIRSTDECORATIONS - FIRSTWALL);
+	}
+
+	UINT16 const new_idx = GetTileIndexFromTypeSubIndex(tileType, sub_idx);
 	ApplyMapChangesToMapTempFile app;
 	RemoveStructFromLevelNode(grid_no, node);
 	AddWallToStructLayer(grid_no, new_idx, TRUE);

--- a/src/game/TileEngine/Explosion_Control.cc
+++ b/src/game/TileEngine/Explosion_Control.cc
@@ -290,9 +290,27 @@ static void HandleFencePartnerCheck(INT16 sStructGridNo)
 }
 
 
-static void ReplaceWall(GridNo const grid_no, UINT8 const orientation, INT16 const sub_idx)
+static void ReplaceWall(GridNo const grid_no, UINT8 orientation, INT16 const sub_idx)
 {
-	STRUCTURE* const wall_struct = GetWallStructOfSameOrientationAtGridno(grid_no, orientation);
+	STRUCTURE* wall_struct = GetWallStructOfSameOrientationAtGridno(grid_no, orientation);
+	if (!wall_struct)
+	{
+		switch (orientation)
+		{
+			case INSIDE_TOP_LEFT:
+				orientation = OUTSIDE_TOP_LEFT;
+				break;
+			case OUTSIDE_TOP_LEFT:
+				orientation = INSIDE_TOP_LEFT;
+				break;
+			case INSIDE_TOP_RIGHT:
+				orientation = OUTSIDE_TOP_RIGHT;
+				break;
+			case OUTSIDE_TOP_RIGHT:
+				orientation = INSIDE_TOP_RIGHT;
+		}
+		wall_struct = GetWallStructOfSameOrientationAtGridno(grid_no, orientation);
+	}
 	if (!wall_struct || !(wall_struct->fFlags & STRUCTURE_WALL)) return;
 
 	LEVELNODE* const node    = FindLevelNodeBasedOnStructure(wall_struct);


### PR DESCRIPTION
Issues:
- Wrong offset: some walls are replaced with unrelated structures instead of a damaged wall:
<img width="447" height="175" alt="image" src="https://github.com/user-attachments/assets/dec74b69-d0ef-4862-bad4-41f72cb6f065" />
<img width="447" height="175" alt="image" src="https://github.com/user-attachments/assets/b06ed44b-4f9c-4959-b9b8-cd8f74ed7cb8" />

- Wrong inside/outside orientation dependence:  some walls are not affected at all
<img width="200" height="177" alt="image" src="https://github.com/user-attachments/assets/399b64b1-0f3a-4f26-ba17-eafe6a7f350d" />

Fixed:
<img width="447" height="175" alt="image" src="https://github.com/user-attachments/assets/f4fea643-f3b8-4ce9-8771-ba8536379afd" />
