### PR TITLE
Make infant monsters punchable

### DIFF
--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -3367,8 +3367,8 @@ static UINT32 CalcChanceHTH(SOLDIERTYPE* pAttacker, SOLDIERTYPE* pDefender, UINT
 	if ((iDefRating > 0) && (pDefender->bBreath < 100))
 		iDefRating -= (iDefRating * (100 - pDefender->bBreath)) / 200;
 
-	if ((usInHand == CREATURE_QUEEN_TENTACLES && pDefender->ubBodyType == LARVAE_MONSTER) ||
-		pDefender->ubBodyType == INFANT_MONSTER)
+	if (usInHand == CREATURE_QUEEN_TENTACLES &&
+	    (pDefender->ubBodyType == LARVAE_MONSTER ||	pDefender->ubBodyType == INFANT_MONSTER))
 	{
 		// try to prevent queen from killing the kids, ever!
 		iDefRating += 10000;


### PR DESCRIPTION
Due to a vanilla logic bug it was impossible to hit infant monsters with an HTH attack.

An incorrect fix attempt was made in commit 31f7aff.
