### PR TITLE
Fix two problems with creature calls

### DIFF
--- a/src/game/TacticalAI/CreatureDecideAction.cc
+++ b/src/game/TacticalAI/CreatureDecideAction.cc
@@ -25,7 +25,6 @@ enum CreatureCaller
 {
 	CALLER_FEMALE  = 0,
 	CALLER_MALE,
-	CALLER_INFANT,
 	CALLER_QUEEN,
 	NUM_CREATURE_CALLERS
 };
@@ -49,18 +48,18 @@ static const INT8 gbCallPriority[NUM_CREATURE_CALLS][NUM_CREATURE_CALLERS] =
 	{6, 9, 12},//CALL_CRIPPLED
 };
 
-static const INT8 gbHuntCallPriority[NUM_CREATURE_CALLS] =
+static const INT8 gbHuntCallPriority[]
 {
+	0, //CALL_NONE
 	4, //CALL_1_PREY
 	5, //CALL_MULTIPLE_PREY
 	7, //CALL_ATTACKED
 	8  //CALL_CRIPPLED
 };
+static_assert(std::size(gbHuntCallPriority) == NUM_CREATURE_CALLS);
 
 #define PRIORITY_DECR_DISTANCE 30
 
-#define CALL_1_OPPONENT CALL_1_PREY
-#define CALL_MULTIPLE_OPPONENT CALL_MULTIPLE_PREY
 
 void CreatureCall( SOLDIERTYPE * pCaller )
 {


### PR DESCRIPTION
1. Remove the unused CALLER_INFANT from enum CreatureCaller. The CAN_CALL macro defines that infant monsters cannot call for help. This shifts the value of CALLER_QUEEN up 1, which fixes the gbCallPriority table, which was missing a column for the queen's calls.

2. Fix the gbHuntCallPriority table which was missing an explicit entry for CALL_NONE.

Also removed two unused macros.

Another [two bugs found by Claude](https://github.com/tais/1vibe13/pull/274/changes/fc4ccc90bf62ede949e8bb970fd4eea9c5551e12).