### PR TITLE
Enable hitbox visualization

### DIFF
--- a/src/sgp/CMakeLists.txt
+++ b/src/sgp/CMakeLists.txt
@@ -27,6 +27,7 @@ set(LOCAL_JA2_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/VObject_Blitters.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/VSurface.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/Video.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/Visualizer.cc
 )
 
 if (WITH_UNITTESTS)

--- a/src/sgp/FPS.cc
+++ b/src/sgp/FPS.cc
@@ -1,5 +1,6 @@
 #include "Font.h"
 #include "FPS.h"
+#include "SDL_helpers.h"
 #include "SDL3/SDL.h"
 #include <SDL3/SDL_rect.h>
 #include <SDL3/SDL_render.h>
@@ -15,13 +16,6 @@ using namespace std::chrono_literals;
 
 namespace FPS
 {
-
-struct SDLDeleter
-{
-	void operator()(SDL_Surface *s) { SDL_DestroySurface(s); }
-	void operator()(SDL_Texture *t) { SDL_DestroyTexture(t); }
-};
-
 
 GameLoopFunc_t  ActualGameLoop; // the real game loop function
 GameLoopFunc_t  GameLoopPtr;    // the function MainLoop will call

--- a/src/sgp/SDL_helpers.h
+++ b/src/sgp/SDL_helpers.h
@@ -1,0 +1,12 @@
+#ifndef SDL_HELPERS_H
+#define SDL_HELPERS_H
+
+#include "SDL3/SDL.h"
+
+struct SDLDeleter
+{
+	void operator()(SDL_Surface* s) { SDL_DestroySurface(s); }
+	void operator()(SDL_Texture* t) { SDL_DestroyTexture(t); }
+};
+
+#endif

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -10,6 +10,7 @@
 #include "SoundMan.h"
 #include "VObject.h"
 #include "Video.h"
+#include "Visualizer.h"
 #include <SDL.h>
 #include "UILayout.h"
 #include "GameRes.h"
@@ -136,10 +137,13 @@ static void MainLoop()
 					break;
 
 				case SDL_KEYDOWN:
-					if (event.key.keysym.sym == SDLK_f &&
-					    SDL_GetModState() & KMOD_CTRL)
+					if (event.key.keysym.sym == SDLK_f && SDL_GetModState() & KMOD_CTRL)
 					{
 						FPS::ToggleOnOff();
+					}
+					else if (event.key.keysym.sym == SDLK_c && SDL_GetModState() & KMOD_CTRL)
+					{
+						Visualizer::ToggleOnOff();
 					}
 					else
 					{

--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -11,6 +11,7 @@
 #include "VObject.h"
 #include "Video.h"
 #include "SDL3/SDL.h"
+#include "Visualizer.h"
 #include "UILayout.h"
 #include "GameRes.h"
 #include "GameMode.h"
@@ -158,6 +159,10 @@ static void MainLoop()
 					    SDL_GetModState() & SDL_KMOD_CTRL)
 					{
 						FPS::ToggleOnOff();
+					}
+					else if (event.key.key == SDLK_C && SDL_GetModState() & SDL_KMOD_CTRL)
+					{
+						Visualizer::ToggleOnOff();
 					}
 					else
 					{

--- a/src/sgp/VSurface.h
+++ b/src/sgp/VSurface.h
@@ -2,6 +2,7 @@
 #define VSURFACE_H
 
 #include "Buffer.h"
+#include "SDL_helpers.h"
 #include "Types.h"
 #include <memory>
 #include "SDL3/SDL.h"
@@ -17,10 +18,6 @@ inline SGPVSurface* g_back_buffer;
 inline SGPVSurface* g_frame_buffer;
 inline SGPVSurface* g_mouse_buffer;
 
-struct SDLDeleter
-{
-	void operator()(SDL_Surface *p) noexcept { SDL_DestroySurface(p); }
-};
 using SurfaceUniquePtr = std::unique_ptr<SDL_Surface, SDLDeleter>;
 
 

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -11,6 +11,7 @@
 #include "VObject_Blitters.h"
 #include "VSurface.h"
 #include "Video.h"
+#include "Visualizer.h"
 #include "UILayout.h"
 #include "Icon.h"
 #include <algorithm>
@@ -548,6 +549,11 @@ void RefreshScreen(void)
 	}
 	else {
 		SDL_RenderCopy(GameRenderer, ScreenTexture, NULL, NULL);
+	}
+
+	if (Visualizer::IsActivated())
+	{
+		Visualizer::Render(GameRenderer);
 	}
 
 	FPS::RenderPresentPtr(GameRenderer);

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -11,6 +11,7 @@
 #include "VObject_Blitters.h"
 #include "VSurface.h"
 #include "Video.h"
+#include "Visualizer.h"
 #include "UILayout.h"
 #include "Icon.h"
 #include <SDL3/SDL_video.h>
@@ -547,6 +548,11 @@ void RefreshScreen(void)
 	}
 	else {
 		SDL_RenderTexture(GameRenderer, ScreenTexture, NULL, NULL);
+	}
+
+	if (Visualizer::IsActivated())
+	{
+		Visualizer::Render(GameRenderer);
 	}
 
 	FPS::RenderPresentPtr(GameRenderer);

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -550,10 +550,7 @@ void RefreshScreen(void)
 		SDL_RenderTexture(GameRenderer, ScreenTexture, NULL, NULL);
 	}
 
-	if (Visualizer::IsActivated())
-	{
-		Visualizer::Render(GameRenderer);
-	}
+	Visualizer::Render(GameRenderer);
 
 	FPS::RenderPresentPtr(GameRenderer);
 

--- a/src/sgp/Visualizer.cc
+++ b/src/sgp/Visualizer.cc
@@ -1,0 +1,261 @@
+#include "Visualizer.h"
+
+#include "Animation_Control.h"
+#include "Cheats.h"
+#include "Handle_UI.h"
+#include "Interface.h"
+#include "JAScreens.h"
+#include "SDL.h"
+#include "Soldier_Control.h"
+#include "Structure_Internals.h"
+#include "WorldDef.h"
+
+#include <memory>
+
+namespace Visualizer
+{
+
+bool toggledOn{ };
+
+struct SDLDeleter
+{
+	void operator()(SDL_Surface* s) { SDL_FreeSurface(s); }
+	void operator()(SDL_Texture* t) { SDL_DestroyTexture(t); }
+};
+
+std::unique_ptr<SDL_Texture, SDLDeleter> bgTexture;
+std::unique_ptr<SDL_Texture, SDLDeleter> finalTexture;
+
+constexpr SDL_Rect bgRectDest{ 11, 47, 240, 320 };
+constexpr float isoToActualLengthRatio = 0.816f;
+constexpr float actualEdgeLength = 120;
+constexpr float isoEdgeLength = actualEdgeLength * isoToActualLengthRatio;
+constexpr float isoBoxEdgeLength = isoEdgeLength / PROFILE_X_SIZE;
+// lengths for an opposite and an adjacent leg of the triangle's isometric angle to the X axis
+constexpr float oppLegLength = isoEdgeLength * 0.500f; // 0.500 is sin(30)
+constexpr float adjLegLength = isoEdgeLength * 0.866f; // 0.866 is cos(30)
+constexpr float oppBoxLegLength = isoBoxEdgeLength * 0.500f;
+constexpr float adjBoxLegLength = isoBoxEdgeLength * 0.866f;
+
+constexpr float boxHeight = actualEdgeLength / PROFILE_Z_SIZE;
+
+constexpr SDL_Color tileColorLvl0   { 0,  255,        0,      SDL_ALPHA_OPAQUE }; // green
+constexpr SDL_Color tileColorLvl1   { 65,  36,       24,      SDL_ALPHA_OPAQUE }; // brown
+constexpr SDL_Color boxTopColor     { 0,  165,      255,      SDL_ALPHA_OPAQUE }; // blue
+constexpr SDL_Color boxRightColor   { 0,  165 - 30, 255 - 30, SDL_ALPHA_OPAQUE };
+constexpr SDL_Color boxLeftColor    { 0,  165 - 15, 255 - 15, SDL_ALPHA_OPAQUE };
+// Alternatives for the checkered pattern 
+constexpr SDL_Color boxTopColorAlt  { 0,  144,      255,      SDL_ALPHA_OPAQUE };
+constexpr SDL_Color boxRightColorAlt{ 0,  144 - 30, 255 - 30, SDL_ALPHA_OPAQUE };
+constexpr SDL_Color boxLeftColorAlt { 0,  144 - 15, 255 - 15, SDL_ALPHA_OPAQUE };
+
+// The coordinate that every other coordinate is calculated from
+constexpr SDL_Vertex baseCoord{ { bgRectDest.w / 2, bgRectDest.h - 5 - oppLegLength * 2}, tileColorLvl0 };
+
+// Green ground rhombus (isometric square)
+constexpr SDL_Vertex verticesLvl0[]
+{
+	   baseCoord,																						 // farthest from the viewer
+	{ {baseCoord.position.x + adjLegLength, baseCoord.position.y + oppLegLength},     baseCoord.color }, // right
+	{ {baseCoord.position.x,                baseCoord.position.y + oppLegLength * 2}, baseCoord.color }, // nearest
+	{ {baseCoord.position.x - adjLegLength, baseCoord.position.y + oppLegLength},     baseCoord.color }, // left
+};
+// Brown walkable roof rhombus
+constexpr SDL_Vertex verticesLvl1[]
+{
+	{ {verticesLvl0[0].position.x, verticesLvl0[0].position.y - PROFILE_Z_SIZE * boxHeight}, tileColorLvl1 },
+	{ {verticesLvl0[1].position.x, verticesLvl0[1].position.y - PROFILE_Z_SIZE * boxHeight}, tileColorLvl1 },
+	{ {verticesLvl0[2].position.x, verticesLvl0[2].position.y - PROFILE_Z_SIZE * boxHeight}, tileColorLvl1 },
+	{ {verticesLvl0[3].position.x, verticesLvl0[3].position.y - PROFILE_Z_SIZE * boxHeight}, tileColorLvl1 },
+};
+
+
+// Triangle rendering sequence
+const int indices[]
+{
+   0,1,2,
+   2,3,0,
+};
+
+// Texture update triggers
+GridNo lastCell{ 0 };
+int16_t lastInterfaceLvl{ I_GROUND_LEVEL };
+AnimationStates lastAnimState{ NOTUSEDANIM1 };
+
+static void DrawHitbox(SDL_Renderer * const renderer, float const x, float const y, float const z, bool const drawRoofOnly = false)
+{
+	float const offsetX = baseCoord.position.x + (x - y) * adjBoxLegLength;
+	float const offsetY = baseCoord.position.y + (x + y) * oppBoxLegLength - boxHeight * (z + 1);
+
+	// ensure checkered color pattern horizontally ...
+	bool isAlt{ (bool)fmod(x + y, 2) };
+	// ... and vertically
+	if (fmod(z, 2))
+	{
+		isAlt = !isAlt;
+	}
+
+	SDL_Vertex topFace[4];
+	SDL_Vertex rightFace[4];
+	SDL_Vertex leftFace[4];
+
+	SDL_Color currTopColor;
+	if (drawRoofOnly)
+	{
+		currTopColor = tileColorLvl1;
+	}
+	else
+	{
+		currTopColor = isAlt ? boxTopColorAlt : boxTopColor;
+	}
+	topFace[0] =   { { offsetX,                   offsetY },                       currTopColor };
+	topFace[1] =   { { offsetX + adjBoxLegLength, offsetY + oppBoxLegLength },     currTopColor };
+	topFace[2] =   { { offsetX,                   offsetY + oppBoxLegLength * 2 }, currTopColor };
+	topFace[3] =   { { offsetX - adjBoxLegLength, offsetY + oppBoxLegLength },     currTopColor };
+	SDL_RenderGeometry(renderer, nullptr, &topFace[0], 4, indices, 6);
+
+	if (drawRoofOnly)
+		return;
+
+	SDL_Color currRightColor{ isAlt ? boxRightColorAlt : boxRightColor };
+	rightFace[0] = { topFace[1].position,                                                     currRightColor };
+	rightFace[1] = { { offsetX + adjBoxLegLength, offsetY + oppBoxLegLength + boxHeight },    currRightColor };
+	rightFace[2] = { { offsetX,                   offsetY + oppBoxLegLength * 2 + boxHeight}, currRightColor };
+	rightFace[3] = { topFace[2].position,                                                     currRightColor };
+	SDL_RenderGeometry(renderer, nullptr, &rightFace[0], 4, indices, 6);
+
+	SDL_Color currLeftColor { isAlt ? boxLeftColorAlt  : boxLeftColor };
+	leftFace[0] =  { topFace[3].position,                                                  currLeftColor };
+	leftFace[1] =  { topFace[2].position,                                                  currLeftColor };
+	leftFace[2] =  { rightFace[2].position,                                                currLeftColor };
+	leftFace[3] =  { { offsetX - adjBoxLegLength, offsetY + oppBoxLegLength + boxHeight }, currLeftColor };
+	SDL_RenderGeometry(renderer, nullptr, &leftFace[0], 4, indices, 6);
+}
+
+static void UpdateTexture(SDL_Renderer * const renderer)
+{
+	SDL_SetRenderTarget(renderer, finalTexture.get());
+
+	SDL_RenderCopy( renderer, bgTexture.get(), nullptr, nullptr);
+
+	uint8_t combinedShapeLvl0[PROFILE_X_SIZE][PROFILE_Y_SIZE]{};
+	uint8_t combinedShapeLvl1[PROFILE_X_SIZE][PROFILE_Y_SIZE]{};
+	bool isWalkableRoofPresent{ (bool)gpWorldLevelData[lastCell].pRoofHead };
+	for (uint8_t loopX = 0; loopX < PROFILE_X_SIZE; loopX++)
+	{
+		for (uint8_t loopY = 0; loopY < PROFILE_Y_SIZE; loopY++)
+		{
+			STRUCTURE* structure{ gpWorldLevelData[lastCell].pStructureHead };
+			bool isAnyRoofPresent{ };
+			while (structure)
+			{
+				PROFILE* shape{ structure->pShape };
+				// Coalesce all the structures' shapes in the tile into a single shape
+				if (structure->sCubeOffset == 0)
+				{
+					combinedShapeLvl0[loopX][loopY] |= (*shape)[loopX][loopY];
+				}
+				else
+				{
+					isAnyRoofPresent = structure->fFlags & STRUCTURE_ROOF;
+					combinedShapeLvl1[loopX][loopY] |= (*shape)[loopX][loopY];
+				}
+				structure = structure->pNext;
+			}
+
+			for (uint8_t loopZ = 0; loopZ < PROFILE_Z_SIZE; loopZ++)
+			{
+				if (combinedShapeLvl0[loopX][loopY] & AtHeight[loopZ])
+				{
+					DrawHitbox(renderer, loopX, loopY, loopZ);
+				}
+				if (loopZ == PROFILE_Z_SIZE - 1 && isWalkableRoofPresent && lastInterfaceLvl == I_ROOF_LEVEL)
+				{
+					DrawHitbox(renderer, loopX, loopY, loopZ, true);
+				}
+			}
+
+			if (isAnyRoofPresent && lastInterfaceLvl == I_GROUND_LEVEL)
+				continue;
+
+			for (uint8_t loopZ = 0; loopZ < PROFILE_Z_SIZE; loopZ++)
+			{
+				if (combinedShapeLvl1[loopX][loopY] & AtHeight[loopZ])
+				{
+					DrawHitbox(renderer, loopX, loopY, loopZ + PROFILE_Z_SIZE);
+				}
+			}
+		}
+	}
+
+	SDL_SetRenderTarget(renderer, nullptr);
+}
+
+static void InitTextures(SDL_Renderer* const renderer)
+{
+	finalTexture.reset(SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_TARGET, bgRectDest.w, bgRectDest.h));
+
+	bgTexture.reset(SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_TARGET, bgRectDest.w, bgRectDest.h));
+	SDL_SetRenderTarget(renderer, bgTexture.get());
+
+	// Black background
+	SDL_SetRenderDrawColor(renderer, 10, 10, 10, SDL_ALPHA_OPAQUE);
+	SDL_RenderFillRect(renderer, nullptr);
+	// Green ground tile
+	SDL_RenderGeometry(renderer, nullptr, verticesLvl0, 4, indices, 6);
+
+	SDL_SetRenderTarget(renderer, nullptr);
+}
+
+void Render(SDL_Renderer * const renderer)
+{
+	if (guiCurrentScreen != GAME_SCREEN)
+	{
+		ToggleOnOff();
+	}
+	if (!finalTexture)
+	{
+		InitTextures(renderer);
+	}
+
+	AnimationStates currAnimState{ };
+	if (gpWorldLevelData[lastCell].pMercHead)
+	{
+		currAnimState = static_cast<AnimationStates>( gpWorldLevelData[lastCell].pMercHead->pSoldier->usAnimState);
+	}
+	else
+	{
+		lastAnimState = NOTUSEDANIM1;
+	}
+
+	if (lastCell != guiCurrentCursorGridNo || lastInterfaceLvl != gsInterfaceLevel || currAnimState != lastAnimState )
+	{
+		lastCell = guiCurrentCursorGridNo;
+		lastInterfaceLvl = gsInterfaceLevel;
+		UpdateTexture(renderer);
+	}
+
+	SDL_RenderCopy(renderer, finalTexture.get(), nullptr, &bgRectDest);
+}
+
+bool IsActivated()
+{
+	return toggledOn;
+}
+
+void ToggleOnOff()
+{
+	if (guiCurrentScreen == GAME_SCREEN && !toggledOn && CHEATER_CHEAT_LEVEL())
+	{
+		lastCell = 0;
+		toggledOn = true;
+	}
+	else if (toggledOn)
+	{
+		toggledOn = false;
+		bgTexture.reset();
+		finalTexture.reset();
+	}
+}
+
+}

--- a/src/sgp/Visualizer.cc
+++ b/src/sgp/Visualizer.cc
@@ -5,6 +5,7 @@
 #include "Handle_UI.h"
 #include "Interface.h"
 #include "JAScreens.h"
+#include "SDL_helpers.h"
 #include "SDL3/SDL.h"
 #include "Soldier_Control.h"
 #include "Structure_Internals.h"
@@ -16,12 +17,6 @@ namespace Visualizer
 {
 
 bool toggledOn{ };
-
-struct SDLDeleter
-{
-	void operator()(SDL_Surface* s) { SDL_DestroySurface(s); }
-	void operator()(SDL_Texture* t) { SDL_DestroyTexture(t); }
-};
 
 std::unique_ptr<SDL_Texture, SDLDeleter> bgTexture;
 std::unique_ptr<SDL_Texture, SDLDeleter> finalTexture;

--- a/src/sgp/Visualizer.cc
+++ b/src/sgp/Visualizer.cc
@@ -55,15 +55,6 @@ constexpr SDL_Vertex verticesLvl0[]
 	{ {baseCoord.position.x,                baseCoord.position.y + oppLegLength * 2}, baseCoord.color }, // nearest
 	{ {baseCoord.position.x - adjLegLength, baseCoord.position.y + oppLegLength},     baseCoord.color }, // left
 };
-// Brown walkable roof rhombus
-constexpr SDL_Vertex verticesLvl1[]
-{
-	{ {verticesLvl0[0].position.x, verticesLvl0[0].position.y - PROFILE_Z_SIZE * boxHeight}, tileColorLvl1 },
-	{ {verticesLvl0[1].position.x, verticesLvl0[1].position.y - PROFILE_Z_SIZE * boxHeight}, tileColorLvl1 },
-	{ {verticesLvl0[2].position.x, verticesLvl0[2].position.y - PROFILE_Z_SIZE * boxHeight}, tileColorLvl1 },
-	{ {verticesLvl0[3].position.x, verticesLvl0[3].position.y - PROFILE_Z_SIZE * boxHeight}, tileColorLvl1 },
-};
-
 
 // Triangle rendering sequence
 const int indices[]
@@ -188,9 +179,9 @@ static void UpdateTexture(SDL_Renderer * const renderer)
 
 static void InitTextures(SDL_Renderer* const renderer)
 {
-	finalTexture.reset(SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_TARGET, bgRectDest.w, bgRectDest.h));
+	finalTexture.reset(SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, bgRectDest.w, bgRectDest.h));
 
-	bgTexture.reset(SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_TARGET, bgRectDest.w, bgRectDest.h));
+	bgTexture.reset(SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, bgRectDest.w, bgRectDest.h));
 	SDL_SetRenderTarget(renderer, bgTexture.get());
 
 	// Black background
@@ -204,6 +195,11 @@ static void InitTextures(SDL_Renderer* const renderer)
 
 void Render(SDL_Renderer * const renderer)
 {
+	if (!toggledOn)
+	{
+		return;
+	}
+
 	if (guiCurrentScreen != GAME_SCREEN)
 	{
 		ToggleOnOff();
@@ -231,11 +227,8 @@ void Render(SDL_Renderer * const renderer)
 	}
 
 	SDL_RenderTexture(renderer, finalTexture.get(), nullptr, &bgRectDest);
-}
-
-bool IsActivated()
-{
-	return toggledOn;
+	// set this back to total black for subsequent SDL_RenderClear
+	SDL_SetRenderDrawColor(renderer, 0, 0, 0, SDL_ALPHA_OPAQUE);
 }
 
 void ToggleOnOff()

--- a/src/sgp/Visualizer.cc
+++ b/src/sgp/Visualizer.cc
@@ -1,0 +1,261 @@
+#include "Visualizer.h"
+
+#include "Animation_Control.h"
+#include "Cheats.h"
+#include "Handle_UI.h"
+#include "Interface.h"
+#include "JAScreens.h"
+#include "SDL3/SDL.h"
+#include "Soldier_Control.h"
+#include "Structure_Internals.h"
+#include "WorldDef.h"
+
+#include <memory>
+
+namespace Visualizer
+{
+
+bool toggledOn{ };
+
+struct SDLDeleter
+{
+	void operator()(SDL_Surface* s) { SDL_DestroySurface(s); }
+	void operator()(SDL_Texture* t) { SDL_DestroyTexture(t); }
+};
+
+std::unique_ptr<SDL_Texture, SDLDeleter> bgTexture;
+std::unique_ptr<SDL_Texture, SDLDeleter> finalTexture;
+
+constexpr SDL_FRect bgRectDest{ 11, 47, 240, 320 };
+constexpr float isoToActualLengthRatio = 0.816f;
+constexpr float actualEdgeLength = 120;
+constexpr float isoEdgeLength = actualEdgeLength * isoToActualLengthRatio;
+constexpr float isoBoxEdgeLength = isoEdgeLength / PROFILE_X_SIZE;
+// lengths for an opposite and an adjacent leg of the triangle's isometric angle to the X axis
+constexpr float oppLegLength = isoEdgeLength * 0.500f; // 0.500 is sin(30)
+constexpr float adjLegLength = isoEdgeLength * 0.866f; // 0.866 is cos(30)
+constexpr float oppBoxLegLength = isoBoxEdgeLength * 0.500f;
+constexpr float adjBoxLegLength = isoBoxEdgeLength * 0.866f;
+
+constexpr float boxHeight = actualEdgeLength / PROFILE_Z_SIZE;
+
+constexpr SDL_FColor tileColorLvl0   { 0,      1,               0,          SDL_ALPHA_OPAQUE }; // green
+constexpr SDL_FColor tileColorLvl1   { 0.254f, 0.141f,          0.94f,      SDL_ALPHA_OPAQUE }; // purple
+constexpr SDL_FColor boxTopColor     { 0,      0.647f,          1,          SDL_ALPHA_OPAQUE }; // blue
+constexpr SDL_FColor boxRightColor   { 0,      0.647f - 0.118f, 1 - 0.118f, SDL_ALPHA_OPAQUE };
+constexpr SDL_FColor boxLeftColor    { 0,      0.647f - 0.059f, 1 - 0.059f, SDL_ALPHA_OPAQUE };
+// Alternatives for the checkered pattern 
+constexpr SDL_FColor boxTopColorAlt  { 0,      0.565f,          1,          SDL_ALPHA_OPAQUE };
+constexpr SDL_FColor boxRightColorAlt{ 0,      0.565f - 0.118f, 1 - 0.118f, SDL_ALPHA_OPAQUE };
+constexpr SDL_FColor boxLeftColorAlt { 0,      0.565f - 0.059f, 1 - 0.059f, SDL_ALPHA_OPAQUE };
+
+// The coordinate that every other coordinate is calculated from
+constexpr SDL_Vertex baseCoord{ { bgRectDest.w / 2, bgRectDest.h - 5 - oppLegLength * 2}, tileColorLvl0 };
+
+// Green ground rhombus (isometric square)
+constexpr SDL_Vertex verticesLvl0[]
+{
+	   baseCoord,																						 // farthest from the viewer
+	{ {baseCoord.position.x + adjLegLength, baseCoord.position.y + oppLegLength},     baseCoord.color }, // right
+	{ {baseCoord.position.x,                baseCoord.position.y + oppLegLength * 2}, baseCoord.color }, // nearest
+	{ {baseCoord.position.x - adjLegLength, baseCoord.position.y + oppLegLength},     baseCoord.color }, // left
+};
+// Brown walkable roof rhombus
+constexpr SDL_Vertex verticesLvl1[]
+{
+	{ {verticesLvl0[0].position.x, verticesLvl0[0].position.y - PROFILE_Z_SIZE * boxHeight}, tileColorLvl1 },
+	{ {verticesLvl0[1].position.x, verticesLvl0[1].position.y - PROFILE_Z_SIZE * boxHeight}, tileColorLvl1 },
+	{ {verticesLvl0[2].position.x, verticesLvl0[2].position.y - PROFILE_Z_SIZE * boxHeight}, tileColorLvl1 },
+	{ {verticesLvl0[3].position.x, verticesLvl0[3].position.y - PROFILE_Z_SIZE * boxHeight}, tileColorLvl1 },
+};
+
+
+// Triangle rendering sequence
+const int indices[]
+{
+   0,1,2,
+   2,3,0,
+};
+
+// Texture update triggers
+GridNo lastCell{ 0 };
+int16_t lastInterfaceLvl{ I_GROUND_LEVEL };
+AnimationStates lastAnimState{ NOTUSEDANIM1 };
+
+static void DrawHitbox(SDL_Renderer * const renderer, float const x, float const y, float const z, bool const drawRoofOnly = false)
+{
+	float const offsetX = baseCoord.position.x + (x - y) * adjBoxLegLength;
+	float const offsetY = baseCoord.position.y + (x + y) * oppBoxLegLength - boxHeight * (z + 1);
+
+	// ensure checkered color pattern horizontally ...
+	bool isAlt{ (bool)fmod(x + y, 2) };
+	// ... and vertically
+	if (fmod(z, 2))
+	{
+		isAlt = !isAlt;
+	}
+
+	SDL_Vertex topFace[4];
+	SDL_Vertex rightFace[4];
+	SDL_Vertex leftFace[4];
+
+	SDL_FColor currTopColor;
+	if (drawRoofOnly)
+	{
+		currTopColor = tileColorLvl1;
+	}
+	else
+	{
+		currTopColor = isAlt ? boxTopColorAlt : boxTopColor;
+	}
+	topFace[0] =   { { offsetX,                   offsetY },                       currTopColor };
+	topFace[1] =   { { offsetX + adjBoxLegLength, offsetY + oppBoxLegLength },     currTopColor };
+	topFace[2] =   { { offsetX,                   offsetY + oppBoxLegLength * 2 }, currTopColor };
+	topFace[3] =   { { offsetX - adjBoxLegLength, offsetY + oppBoxLegLength },     currTopColor };
+	SDL_RenderGeometry(renderer, nullptr, &topFace[0], 4, indices, 6);
+
+	if (drawRoofOnly)
+		return;
+
+	SDL_FColor currRightColor{ isAlt ? boxRightColorAlt : boxRightColor };
+	rightFace[0] = { topFace[1].position,                                                     currRightColor };
+	rightFace[1] = { { offsetX + adjBoxLegLength, offsetY + oppBoxLegLength + boxHeight },    currRightColor };
+	rightFace[2] = { { offsetX,                   offsetY + oppBoxLegLength * 2 + boxHeight}, currRightColor };
+	rightFace[3] = { topFace[2].position,                                                     currRightColor };
+	SDL_RenderGeometry(renderer, nullptr, &rightFace[0], 4, indices, 6);
+
+	SDL_FColor currLeftColor { isAlt ? boxLeftColorAlt  : boxLeftColor };
+	leftFace[0] =  { topFace[3].position,                                                  currLeftColor };
+	leftFace[1] =  { topFace[2].position,                                                  currLeftColor };
+	leftFace[2] =  { rightFace[2].position,                                                currLeftColor };
+	leftFace[3] =  { { offsetX - adjBoxLegLength, offsetY + oppBoxLegLength + boxHeight }, currLeftColor };
+	SDL_RenderGeometry(renderer, nullptr, &leftFace[0], 4, indices, 6);
+}
+
+static void UpdateTexture(SDL_Renderer * const renderer)
+{
+	SDL_SetRenderTarget(renderer, finalTexture.get());
+
+	SDL_RenderTexture( renderer, bgTexture.get(), nullptr, nullptr);
+
+	uint8_t combinedShapeLvl0[PROFILE_X_SIZE][PROFILE_Y_SIZE]{};
+	uint8_t combinedShapeLvl1[PROFILE_X_SIZE][PROFILE_Y_SIZE]{};
+	bool isWalkableRoofPresent{ (bool)gpWorldLevelData[lastCell].pRoofHead };
+	for (uint8_t loopX = 0; loopX < PROFILE_X_SIZE; loopX++)
+	{
+		for (uint8_t loopY = 0; loopY < PROFILE_Y_SIZE; loopY++)
+		{
+			STRUCTURE* structure{ gpWorldLevelData[lastCell].pStructureHead };
+			bool isAnyRoofPresent{ };
+			while (structure)
+			{
+				PROFILE* shape{ structure->pShape };
+				// Coalesce all the structures' shapes in the tile into a single shape
+				if (structure->sCubeOffset == 0)
+				{
+					combinedShapeLvl0[loopX][loopY] |= (*shape)[loopX][loopY];
+				}
+				else
+				{
+					isAnyRoofPresent = structure->fFlags & STRUCTURE_ROOF;
+					combinedShapeLvl1[loopX][loopY] |= (*shape)[loopX][loopY];
+				}
+				structure = structure->pNext;
+			}
+
+			for (uint8_t loopZ = 0; loopZ < PROFILE_Z_SIZE; loopZ++)
+			{
+				if (combinedShapeLvl0[loopX][loopY] & AtHeight[loopZ])
+				{
+					DrawHitbox(renderer, loopX, loopY, loopZ);
+				}
+				if (loopZ == PROFILE_Z_SIZE - 1 && isWalkableRoofPresent && lastInterfaceLvl == I_ROOF_LEVEL)
+				{
+					DrawHitbox(renderer, loopX, loopY, loopZ, true);
+				}
+			}
+
+			if (isAnyRoofPresent && lastInterfaceLvl == I_GROUND_LEVEL)
+				continue;
+
+			for (uint8_t loopZ = 0; loopZ < PROFILE_Z_SIZE; loopZ++)
+			{
+				if (combinedShapeLvl1[loopX][loopY] & AtHeight[loopZ])
+				{
+					DrawHitbox(renderer, loopX, loopY, loopZ + PROFILE_Z_SIZE);
+				}
+			}
+		}
+	}
+
+	SDL_SetRenderTarget(renderer, nullptr);
+}
+
+static void InitTextures(SDL_Renderer* const renderer)
+{
+	finalTexture.reset(SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_TARGET, bgRectDest.w, bgRectDest.h));
+
+	bgTexture.reset(SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_TARGET, bgRectDest.w, bgRectDest.h));
+	SDL_SetRenderTarget(renderer, bgTexture.get());
+
+	// Black background
+	SDL_SetRenderDrawColor(renderer, 10, 10, 10, SDL_ALPHA_OPAQUE);
+	SDL_RenderFillRect(renderer, nullptr);
+	// Green ground tile
+	SDL_RenderGeometry(renderer, nullptr, verticesLvl0, 4, indices, 6);
+
+	SDL_SetRenderTarget(renderer, nullptr);
+}
+
+void Render(SDL_Renderer * const renderer)
+{
+	if (guiCurrentScreen != GAME_SCREEN)
+	{
+		ToggleOnOff();
+	}
+	if (!finalTexture)
+	{
+		InitTextures(renderer);
+	}
+
+	AnimationStates currAnimState{ };
+	if (gpWorldLevelData[lastCell].pMercHead)
+	{
+		currAnimState = static_cast<AnimationStates>( gpWorldLevelData[lastCell].pMercHead->pSoldier->usAnimState);
+	}
+	else
+	{
+		lastAnimState = NOTUSEDANIM1;
+	}
+
+	if (lastCell != guiCurrentCursorGridNo || lastInterfaceLvl != gsInterfaceLevel || currAnimState != lastAnimState )
+	{
+		lastCell = guiCurrentCursorGridNo;
+		lastInterfaceLvl = gsInterfaceLevel;
+		UpdateTexture(renderer);
+	}
+
+	SDL_RenderTexture(renderer, finalTexture.get(), nullptr, &bgRectDest);
+}
+
+bool IsActivated()
+{
+	return toggledOn;
+}
+
+void ToggleOnOff()
+{
+	if (guiCurrentScreen == GAME_SCREEN && !toggledOn && CHEATER_CHEAT_LEVEL())
+	{
+		lastCell = 0;
+		toggledOn = true;
+	}
+	else if (toggledOn)
+	{
+		toggledOn = false;
+		bgTexture.reset();
+		finalTexture.reset();
+	}
+}
+
+}

--- a/src/sgp/Visualizer.h
+++ b/src/sgp/Visualizer.h
@@ -1,0 +1,14 @@
+#ifndef SGP_VISUALIZER_H
+#define SGP_VISUALIZER_H
+
+struct SDL_Renderer;
+
+namespace Visualizer
+{
+	bool IsActivated();
+
+	void Render(SDL_Renderer * const renderer);
+	void ToggleOnOff();
+}
+
+#endif

--- a/src/sgp/Visualizer.h
+++ b/src/sgp/Visualizer.h
@@ -5,8 +5,6 @@ struct SDL_Renderer;
 
 namespace Visualizer
 {
-	bool IsActivated();
-
 	void Render(SDL_Renderer * const renderer);
 	void ToggleOnOff();
 }


### PR DESCRIPTION
Introducing a basic form of debugging structures' shapes.
To activate enter cheat mode with CTRL+GABBI then press CTRL+C.

<img width="392" height="349" alt="image" src="https://github.com/user-attachments/assets/70651772-90d7-425f-aeb8-cf11e25f9f04" />

<img width="363" height="216" alt="image" src="https://github.com/user-attachments/assets/dc9c7a97-57c7-4d9f-bfaf-3dd486623d85" />

<img width="324" height="144" alt="image" src="https://github.com/user-attachments/assets/2f5d9476-1825-4b07-9910-39711fea7466" />

I'll convert it to SDL3 before merging.