### PR TITLE
Prevent dismissing a bleeding merc

### DIFF
--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -5182,8 +5182,10 @@ static void HandleShadingOfLinesForContractMenu(void)
 		ShadeStringInBox(box, CONTRACT_MENU_TWO_WEEKS, true);
 	}
 
-	// if THIS soldier is involved in a fight (dismissing in a hostile sector IS ok...)
-	ShadeStringInBox(box, CONTRACT_MENU_TERMINATE, gTacticalStatus.uiFlags & INCOMBAT && s->bInSector);
+	bool const shadeTerminate =
+		(gTacticalStatus.uiFlags & INCOMBAT && s->bInSector) ||
+		s->bBleeding > MIN_BLEEDING_THRESHOLD;
+	ShadeStringInBox(box, CONTRACT_MENU_TERMINATE, shadeTerminate);
 }
 
 


### PR DESCRIPTION
Now when you can't do first aid, or when you are retreating from sector and bleeding you can simply dismiss a merc which clearly looks like abuse