### PR TITLE
Refactor the wall orientation enum

### DIFF
--- a/src/game/Editor/Edit_Sys.cc
+++ b/src/game/Editor/Edit_Sys.cc
@@ -270,7 +270,7 @@ void PasteSingleBrokenWall( UINT32 iMapIndex )
 	UINT16 usObjIndex        = sel_list[iCurBank].uiObject;
 	UINT16 usTileIndex       = GetTileIndexFromTypeSubIndex(usObjIndex, usIndex);
 	UINT16 usWallOrientation = GetWallOrientation(usTileIndex);
-	if( usWallOrientation == INSIDE_TOP_LEFT || usWallOrientation == INSIDE_TOP_RIGHT )
+	if( usWallOrientation & ORIENT_INSIDE )
 		EraseHorizontalWall( iMapIndex );
 	else
 		EraseVerticalWall( iMapIndex );

--- a/src/game/Editor/NewSmooth.cc
+++ b/src/game/Editor/NewSmooth.cc
@@ -707,8 +707,8 @@ static void EraseFloorOwnedBuildingPieces(UINT32 iMapIndex)
 			if ( (uiTileType >= FIRSTWALL && uiTileType <= LASTWALL) ||
 				(uiTileType >= FIRSTDOOR && uiTileType <= LASTDOOR) )
 			{
-				UINT16 usWallOrientation = GetWallOrientation(pStruct->usIndex);
-				if( usWallOrientation == INSIDE_TOP_RIGHT || usWallOrientation == OUTSIDE_TOP_RIGHT )
+				Orientation usWallOrientation = GetWallOrientation(pStruct->usIndex);
+				if( usWallOrientation & ORIENT_RIGHT )
 				{
 					AddToUndoList( iMapIndex - 1 );
 					RemoveStruct( iMapIndex - 1, pStruct->usIndex );
@@ -730,7 +730,7 @@ static void EraseFloorOwnedBuildingPieces(UINT32 iMapIndex)
 				(uiTileType >= FIRSTDOOR && uiTileType <= LASTDOOR) )
 			{
 				UINT16 usWallOrientation = GetWallOrientation(pStruct->usIndex);
-				if( usWallOrientation == INSIDE_TOP_LEFT || usWallOrientation == OUTSIDE_TOP_LEFT )
+				if( usWallOrientation & ORIENT_LEFT )
 				{
 					AddToUndoList( iMapIndex - WORLD_COLS );
 					RemoveStruct( iMapIndex - WORLD_COLS , pStruct->usIndex );

--- a/src/game/Editor/Smoothing_Utils.cc
+++ b/src/game/Editor/Smoothing_Utils.cc
@@ -129,7 +129,7 @@ LEVELNODE* GetVerticalWall(UINT32 const map_idx)
 				(FIRSTDOOR <= tile_type && tile_type <= LASTDOOR))
 		{
 			UINT16 const wall_orientation = GetWallOrientation(i->usIndex);
-			if (wall_orientation != INSIDE_TOP_RIGHT && wall_orientation != OUTSIDE_TOP_RIGHT) continue;
+			if (!(wall_orientation & ORIENT_RIGHT)) continue;
 			return i;
 		}
 	}
@@ -148,7 +148,7 @@ LEVELNODE* GetHorizontalWall(UINT32 const map_idx)
 				(FIRSTDOOR <= tile_type && tile_type <= LASTDOOR))
 		{
 			UINT16 const wall_orientation = GetWallOrientation(i->usIndex);
-			if (wall_orientation != INSIDE_TOP_LEFT && wall_orientation != OUTSIDE_TOP_LEFT) continue;
+			if (!(wall_orientation & ORIENT_LEFT)) continue;
 			return i;
 		}
 	}
@@ -178,7 +178,7 @@ static LEVELNODE* GetVerticalFence(UINT32 const map_idx)
 		if (GetTileType(i->usIndex) != FENCESTRUCT) continue;
 
 		UINT16 const wall_orientation = GetWallOrientation(i->usIndex);
-		if (wall_orientation != INSIDE_TOP_RIGHT && wall_orientation != OUTSIDE_TOP_RIGHT) continue;
+		if (!(wall_orientation & ORIENT_RIGHT)) continue;
 		return i;
 	}
 	return 0;
@@ -193,7 +193,7 @@ static LEVELNODE* GetHorizontalFence(UINT32 const map_idx)
 		if (GetTileType(i->usIndex) != FENCESTRUCT) continue;
 
 		UINT16 const wall_orientation = GetWallOrientation(i->usIndex);
-		if (wall_orientation != INSIDE_TOP_LEFT && wall_orientation != OUTSIDE_TOP_LEFT) continue;
+		if (!(wall_orientation & ORIENT_LEFT)) continue;
 		return i;
 	}
 	return 0;
@@ -269,8 +269,8 @@ void RestoreWalls(UINT32 const map_idx)
 		RemoveAllShadowsOfTypeRange(map_idx, FIRSTWALL, LASTWALL);
 		switch (wall_orientation)
 		{
-			case OUTSIDE_TOP_LEFT: BuildWallPiece(map_idx, INTERIOR_BOTTOM, wall_type); break;
-			case INSIDE_TOP_LEFT:  BuildWallPiece(map_idx, EXTERIOR_BOTTOM, wall_type); break;
+			case ORIENT_OUTSIDE_LEFT: BuildWallPiece(map_idx, INTERIOR_BOTTOM, wall_type); break;
+			case ORIENT_INSIDE_LEFT:  BuildWallPiece(map_idx, EXTERIOR_BOTTOM, wall_type); break;
 		}
 		done = true;
 	}
@@ -284,8 +284,8 @@ void RestoreWalls(UINT32 const map_idx)
 		RemoveAllShadowsOfTypeRange(map_idx, FIRSTWALL, LASTWALL);
 		switch (wall_orientation)
 		{
-			case OUTSIDE_TOP_RIGHT: BuildWallPiece(map_idx, INTERIOR_RIGHT, wall_type); break;
-			case INSIDE_TOP_RIGHT:  BuildWallPiece(map_idx, EXTERIOR_RIGHT, wall_type); break;
+			case ORIENT_OUTSIDE_RIGHT: BuildWallPiece(map_idx, INTERIOR_RIGHT, wall_type); break;
+			case ORIENT_INSIDE_RIGHT:  BuildWallPiece(map_idx, EXTERIOR_RIGHT, wall_type); break;
 		}
 		done = true;
 	}

--- a/src/game/Tactical/Handle_UI.cc
+++ b/src/game/Tactical/Handle_UI.cc
@@ -2166,22 +2166,17 @@ static void UIHandleMercAttack(SOLDIERTYPE* pSoldier, SOLDIERTYPE* pTargetSoldie
 		if ( sGridNo == pSoldier->sGridNo && ubItemCursor != AIDCURS )
 		{
 			// Get orientation....
-			switch( pStructure->ubWallOrientation )
+			if ( pStructure->ubWallOrientation & ORIENT_LEFT )
 			{
-				case OUTSIDE_TOP_LEFT:
-				case INSIDE_TOP_LEFT:
-
-					sNewGridNo = NewGridNo( sGridNo, DirectionInc( SOUTH ) );
-					break;
-
-				case OUTSIDE_TOP_RIGHT:
-				case INSIDE_TOP_RIGHT:
-
-					sNewGridNo = NewGridNo( sGridNo, DirectionInc( EAST ) );
-					break;
-
-				default:
-					sNewGridNo = sGridNo;
+				sNewGridNo = NewGridNo(sGridNo, DirectionInc(SOUTH));
+			}
+			else if (pStructure->ubWallOrientation & ORIENT_RIGHT)
+			{
+				sNewGridNo = NewGridNo(sGridNo, DirectionInc(EAST));
+			}
+			else
+			{
+				sNewGridNo = sGridNo;
 			}
 
 			// Set target gridno to this one...

--- a/src/game/Tactical/LOS.cc
+++ b/src/game/Tactical/LOS.cc
@@ -282,10 +282,8 @@ static BOOLEAN ResolveHitOnWall(STRUCTURE* pStructure, INT32 iGridNo, INT8 bLOSI
 	fEastWest = ((ddHorizAngle > (0) && ddHorizAngle < (PI * 1 / 2)) ||
 			(ddHorizAngle < (-PI * 1 / 2) && ddHorizAngle > (-PI)));
 
-	fTopLeft = (pStructure->ubWallOrientation == INSIDE_TOP_LEFT ||
-			pStructure->ubWallOrientation == OUTSIDE_TOP_LEFT);
-	fTopRight = (pStructure->ubWallOrientation == INSIDE_TOP_RIGHT ||
-			pStructure->ubWallOrientation == OUTSIDE_TOP_RIGHT);
+	fTopLeft = pStructure->ubWallOrientation & ORIENT_LEFT;
+	fTopRight = pStructure->ubWallOrientation & ORIENT_RIGHT;
 
 	if ( fNorthSouth )
 	{
@@ -337,13 +335,11 @@ static BOOLEAN ResolveHitOnWall(STRUCTURE* pStructure, INT32 iGridNo, INT8 bLOSI
 		else if ( bLocation == LOC_4_0 )
 		{
 			// if door is normal and OPEN and outside type then we let N-S pass
-			if ( (pStructure->fFlags & STRUCTURE_DOOR) && (pStructure->fFlags & STRUCTURE_OPEN) )
+			if ( (pStructure->fFlags & STRUCTURE_DOOR) &&
+				 (pStructure->fFlags & STRUCTURE_OPEN) &&
+				 (pStructure->ubWallOrientation & ORIENT_OUTSIDE) )
 			{
-				if (pStructure->ubWallOrientation == OUTSIDE_TOP_LEFT ||
-					pStructure->ubWallOrientation == OUTSIDE_TOP_RIGHT)
-				{
-					return( FALSE );
-				}
+				return( FALSE );
 			}
 			else if ( fTopRight )
 			{
@@ -362,7 +358,7 @@ static BOOLEAN ResolveHitOnWall(STRUCTURE* pStructure, INT32 iGridNo, INT8 bLOSI
 		// Check E-W at north corner:   4,4   4,0   0,4
 		if ( bLocation == LOC_4_4 )
 		{
-			if ( pStructure->ubWallOrientation == NO_ORIENTATION)
+			if ( pStructure->ubWallOrientation == ORIENT_NONE )
 			{
 				// very top north corner of building, and going (screenwise) west or east
 				return( FALSE );
@@ -385,13 +381,11 @@ static BOOLEAN ResolveHitOnWall(STRUCTURE* pStructure, INT32 iGridNo, INT8 bLOSI
 		else if ( bLocation == LOC_0_4 )
 		{
 			// if normal door and OPEN and inside type then we let E-W pass
-			if ( (pStructure->fFlags & STRUCTURE_DOOR) && (pStructure->fFlags & STRUCTURE_OPEN) )
+			if ( (pStructure->fFlags & STRUCTURE_DOOR) &&
+				 (pStructure->fFlags & STRUCTURE_OPEN) &&
+				 (pStructure->ubWallOrientation & ORIENT_INSIDE) )
 			{
-				if (pStructure->ubWallOrientation == INSIDE_TOP_LEFT ||
-					pStructure->ubWallOrientation == INSIDE_TOP_RIGHT)
-				{
-					return( FALSE );
-				}
+				return( FALSE );
 			}
 
 			// if wall orientation is top-left, then check W of this location
@@ -4033,7 +4027,7 @@ void MoveBullet(BULLET* const pBullet)
 												// by default knife at same tile as window
 												iKnifeGridNo = (INT16) iGridNo;
 
-												if (pStructure->ubWallOrientation == INSIDE_TOP_RIGHT || pStructure->ubWallOrientation == OUTSIDE_TOP_RIGHT)
+												if (pStructure->ubWallOrientation & ORIENT_RIGHT)
 												{
 													if ( pBullet->qIncrX > 0)
 													{
@@ -4077,16 +4071,7 @@ void MoveBullet(BULLET* const pBullet)
 										}
 										else
 										{
-											BOOLEAN blow_south;
-											if (pStructure->ubWallOrientation == INSIDE_TOP_RIGHT ||
-													pStructure->ubWallOrientation == OUTSIDE_TOP_RIGHT)
-											{
-												blow_south = pBullet->qIncrX > 0;
-											}
-											else
-											{
-												blow_south = pBullet->qIncrY > 0;
-											}
+											bool blow_south = pStructure->ubWallOrientation & ORIENT_RIGHT ? pBullet->qIncrX > 0 : pBullet->qIncrY > 0;
 											BulletHitWindow(pBullet, pBullet->iCurrTileX + pBullet->iCurrTileY * WORLD_COLS, pStructure->usStructureID, blow_south);
 											LocateBullet(pBullet);
 											// have to remove this window from future hit considerations so the deleted structure data can't be referenced!
@@ -4433,29 +4418,13 @@ INT32 CheckForCollision(FLOAT dX, FLOAT dY, FLOAT dZ, FLOAT dDeltaX, FLOAT dDelt
 						if (pStructure->fFlags & STRUCTURE_WALLNWINDOW && dZ >= WINDOW_BOTTOM_HEIGHT_UNITS &&
 							dZ <= WINDOW_TOP_HEIGHT_UNITS)
 						{
-							if (pStructure->ubWallOrientation == INSIDE_TOP_RIGHT ||
-								pStructure->ubWallOrientation == OUTSIDE_TOP_RIGHT)
+							if (pStructure->ubWallOrientation & ORIENT_RIGHT)
 							{
-
-								if (dDeltaX > 0)
-								{
-									return( COLLISION_WINDOW_SOUTHWEST );
-								}
-								else
-								{
-									return( COLLISION_WINDOW_NORTHWEST );
-								}
+								return dDeltaX > 0 ? COLLISION_WINDOW_SOUTHWEST : COLLISION_WINDOW_NORTHWEST;
 							}
 							else
 							{
-								if ( dDeltaY > 0)
-								{
-									return( COLLISION_WINDOW_SOUTHEAST );
-								}
-								else
-								{
-									return( COLLISION_WINDOW_NORTHEAST );
-								}
+								return dDeltaY > 0 ? COLLISION_WINDOW_SOUTHEAST : COLLISION_WINDOW_NORTHEAST;
 							}
 						}
 
@@ -4465,33 +4434,15 @@ INT32 CheckForCollision(FLOAT dX, FLOAT dY, FLOAT dZ, FLOAT dDeltaX, FLOAT dDelt
 							*pdNormalY = 0;
 							*pdNormalZ = 0;
 
-							if (pStructure->ubWallOrientation == INSIDE_TOP_RIGHT ||
-								pStructure->ubWallOrientation == OUTSIDE_TOP_RIGHT)
+							if (pStructure->ubWallOrientation & ORIENT_RIGHT)
 							{
-
-								if (dDeltaX > 0)
-								{
-									*pdNormalX = -1;
-									return( COLLISION_WALL_SOUTHEAST );
-								}
-								else
-								{
-									*pdNormalX = 1;
-									return( COLLISION_WALL_NORTHEAST );
-								}
+								*pdNormalX = -1;
+								return dDeltaX > 0 ? COLLISION_WALL_SOUTHEAST : COLLISION_WALL_NORTHEAST;
 							}
 							else
 							{
-								if ( dDeltaY > 0)
-								{
-									*pdNormalY = -1;
-									return( COLLISION_WALL_SOUTHWEST );
-								}
-								else
-								{
-									*pdNormalY = 1;
-									return( COLLISION_WALL_NORTHWEST );
-								}
+								*pdNormalY = -1;
+								return dDeltaY > 0 ? COLLISION_WALL_SOUTHWEST : COLLISION_WALL_NORTHWEST;
 							}
 
 						}
@@ -4505,14 +4456,7 @@ INT32 CheckForCollision(FLOAT dX, FLOAT dY, FLOAT dZ, FLOAT dDeltaX, FLOAT dDelt
 								{
 									if (!((*(pStructure->pShape))[bLOSIndexX][bLOSIndexY] & AtHeight[ iCurrCubesAboveLevelZ + 1 ]))
 									{
-										if ( ( pStructure->fFlags & STRUCTURE_ROOF ) )
-										{
-											return( COLLISION_ROOF );
-										}
-										else
-										{
-											return( COLLISION_STRUCTURE_Z );
-										}
+										return pStructure->fFlags & STRUCTURE_ROOF ? COLLISION_ROOF : COLLISION_STRUCTURE_Z;
 									}
 								}
 								else

--- a/src/game/Tactical/LOS.cc
+++ b/src/game/Tactical/LOS.cc
@@ -4433,16 +4433,17 @@ INT32 CheckForCollision(FLOAT dX, FLOAT dY, FLOAT dZ, FLOAT dDeltaX, FLOAT dDelt
 							*pdNormalX = 0;
 							*pdNormalY = 0;
 							*pdNormalZ = 0;
+							bool isDeltaXPositive{ dDeltaX > 0 };
 
 							if (pStructure->ubWallOrientation & ORIENT_RIGHT)
 							{
-								*pdNormalX = -1;
-								return dDeltaX > 0 ? COLLISION_WALL_SOUTHEAST : COLLISION_WALL_NORTHEAST;
+								*pdNormalX = isDeltaXPositive ? -1 : 1;
+								return isDeltaXPositive ? COLLISION_WALL_SOUTHEAST : COLLISION_WALL_NORTHEAST;
 							}
 							else
 							{
-								*pdNormalY = -1;
-								return dDeltaY > 0 ? COLLISION_WALL_SOUTHWEST : COLLISION_WALL_NORTHWEST;
+								*pdNormalY = isDeltaXPositive ? -1 : 1;
+								return isDeltaXPositive ? COLLISION_WALL_SOUTHWEST : COLLISION_WALL_NORTHWEST;
 							}
 
 						}

--- a/src/game/Tactical/Overhead.cc
+++ b/src/game/Tactical/Overhead.cc
@@ -3227,7 +3227,7 @@ GridNo FindAdjacentGridExAdvanced(SOLDIERTYPE* soldier, STRUCTURE& intStruct, Gr
 			}
 		}
 
-		wallRelDefs = tile.relativeTo[intStruct.ubWallOrientation - 1];
+		wallRelDefs = tile.relativeTo[GetBitPositionIndex(intStruct.ubWallOrientation)];
 		adjGridNo = baseGridNo + wallRelDefs.incRelToBase;
 		if (wallRelDefs.dirToTest != DIRECTION_IRRELEVANT) {
 			if (gubWorldMovementCosts[adjGridNo][wallRelDefs.dirToTest][soldier->bLevel] >= TRAVELCOST_BLOCKED) continue;
@@ -3311,7 +3311,7 @@ INT16 FindAdjacentGridEx(SOLDIERTYPE* pSoldier, INT16 sGridNo, UINT8* pubDirecti
 				// Get orinetation
 				ubWallOrientation = pDoor->ubWallOrientation;
 
-				if (ubWallOrientation == OUTSIDE_TOP_LEFT || ubWallOrientation == INSIDE_TOP_LEFT)
+				if (ubWallOrientation & ORIENT_LEFT)
 				{
 					// To the south!
 					sSpot = NewGridNo(sGridNo, DirectionInc(SOUTH));
@@ -3321,7 +3321,7 @@ INT16 FindAdjacentGridEx(SOLDIERTYPE* pSoldier, INT16 sGridNo, UINT8* pubDirecti
 					}
 				}
 
-				if (ubWallOrientation == OUTSIDE_TOP_RIGHT || ubWallOrientation == INSIDE_TOP_RIGHT)
+				if (ubWallOrientation & ORIENT_RIGHT)
 				{
 					// TO the east!
 					sSpot = NewGridNo(sGridNo, DirectionInc(EAST));
@@ -3437,14 +3437,14 @@ INT16 FindAdjacentGridEx(SOLDIERTYPE* pSoldier, INT16 sGridNo, UINT8* pubDirecti
 			ubWallOrientation = pDoor->ubWallOrientation;
 
 			// Refuse the south and north and west  directions if our orientation is top-right
-			if ( ubWallOrientation == OUTSIDE_TOP_RIGHT || ubWallOrientation == INSIDE_TOP_RIGHT )
+			if ( ubWallOrientation & ORIENT_RIGHT )
 			{
 				if ( sDirs[ cnt ] == NORTH || sDirs[ cnt ] == WEST || sDirs[ cnt ] == SOUTH )
 					continue;
 			}
 
 			// Refuse the north and west and east directions if our orientation is top-right
-			if ( ubWallOrientation == OUTSIDE_TOP_LEFT || ubWallOrientation == INSIDE_TOP_LEFT )
+			if ( ubWallOrientation & ORIENT_LEFT )
 			{
 				if ( sDirs[ cnt ] == NORTH || sDirs[ cnt ] == WEST || sDirs[ cnt ] == EAST )
 					continue;
@@ -3496,12 +3496,13 @@ INT16 FindAdjacentGridEx(SOLDIERTYPE* pSoldier, INT16 sGridNo, UINT8* pubDirecti
 			// ATE: Only if we have a valid door!
 			if (pDoor)
 			{
-				switch (pDoor->pDBStructureRef->pDBStructure->ubWallOrientation)
+				if (pDoor->pDBStructureRef->pDBStructure->ubWallOrientation & ORIENT_LEFT)
 				{
-					case OUTSIDE_TOP_LEFT:
-					case INSIDE_TOP_LEFT:   *pubDirection = SOUTH; break;
-					case OUTSIDE_TOP_RIGHT:
-					case INSIDE_TOP_RIGHT:  *pubDirection = EAST; break;
+					*pubDirection = SOUTH;
+				}
+				else
+				{
+					*pubDirection = EAST;
 				}
 			}
 		}
@@ -3632,14 +3633,14 @@ INT16 FindNextToAdjacentGridEx( SOLDIERTYPE *pSoldier, INT16 sGridNo, UINT8 *pub
 			ubWallOrientation = pDoor->ubWallOrientation;
 
 			// Refuse the south and north and west  directions if our orientation is top-right
-			if ( ubWallOrientation == OUTSIDE_TOP_RIGHT || ubWallOrientation == INSIDE_TOP_RIGHT )
+			if ( ubWallOrientation & ORIENT_RIGHT )
 			{
 				if ( sDirs[ cnt ] == NORTH || sDirs[ cnt ] == WEST || sDirs[ cnt ] == SOUTH )
 					continue;
 			}
 
 			// Refuse the north and west and east directions if our orientation is top-right
-			if ( ubWallOrientation == OUTSIDE_TOP_LEFT || ubWallOrientation == INSIDE_TOP_LEFT )
+			if ( ubWallOrientation & ORIENT_LEFT )
 			{
 				if ( sDirs[ cnt ] == NORTH || sDirs[ cnt ] == WEST || sDirs[ cnt ] == EAST )
 					continue;
@@ -3702,17 +3703,13 @@ INT16 FindNextToAdjacentGridEx( SOLDIERTYPE *pSoldier, INT16 sGridNo, UINT8 *pub
 			// ATE: Only if we have a valid door!
 			if (pDoor)
 			{
-				switch (pDoor->pDBStructureRef->pDBStructure->ubWallOrientation)
+				if (pDoor->pDBStructureRef->pDBStructure->ubWallOrientation & ORIENT_LEFT)
 				{
-					case OUTSIDE_TOP_LEFT:
-					case INSIDE_TOP_LEFT:
-						*pubDirection = SOUTH;
-						break;
-
-					case OUTSIDE_TOP_RIGHT:
-					case INSIDE_TOP_RIGHT:
-						*pubDirection = EAST;
-						break;
+					*pubDirection = SOUTH;
+				}
+				else
+				{
+					*pubDirection = EAST;
 				}
 			}
 		}

--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -8185,24 +8185,17 @@ void PickPickupAnimation( SOLDIERTYPE *pSoldier, INT32 iItemIndex, INT16 sGridNo
 							fDoNormalPickup = FALSE;
 
 							// OK, look at orientation
-							switch( pStructure->ubWallOrientation )
+							if ( pStructure->ubWallOrientation & ORIENT_LEFT )
 							{
-								case OUTSIDE_TOP_LEFT:
-								case INSIDE_TOP_LEFT:
-
-									bDirection = (INT8)NORTH;
-									break;
-
-								case OUTSIDE_TOP_RIGHT:
-								case INSIDE_TOP_RIGHT:
-
-									bDirection = (INT8)WEST;
-									break;
-
-								default:
-
-									bDirection = pSoldier->bDirection;
-									break;
+								bDirection = (INT8)NORTH;
+							}
+							else if ( pStructure->ubWallOrientation & ORIENT_RIGHT )
+							{
+								bDirection = (INT8)WEST;
+							}
+							else
+							{
+								bDirection = pSoldier->bDirection;
 							}
 
 							//pSoldier->ubPendingDirection = bDirection;

--- a/src/game/Tactical/Structure_Wrap.cc
+++ b/src/game/Tactical/Structure_Wrap.cc
@@ -28,16 +28,14 @@ BOOLEAN	IsJumpableWindowPresentAtGridNo( INT32 sGridNo, INT8 bStartingDir)
 		{
 			case SOUTH:
 			case NORTH:
-				if (pStructure->ubWallOrientation != OUTSIDE_TOP_LEFT &&
-					pStructure->ubWallOrientation != INSIDE_TOP_LEFT)
+				if (!(pStructure->ubWallOrientation & ORIENT_LEFT))
 				{
 					return false;
 				}
 				break;
 			case EAST:
 			case WEST:
-				if (pStructure->ubWallOrientation != OUTSIDE_TOP_RIGHT &&
-					pStructure->ubWallOrientation != INSIDE_TOP_RIGHT)
+				if (!(pStructure->ubWallOrientation & ORIENT_RIGHT))
 				{
 					return false;
 				}
@@ -73,11 +71,11 @@ BOOLEAN	IsJumpableFencePresentAtGridno( INT16 sGridNo )
 	return( FALSE );
 }
 
-STRUCTURE* GetWallStructOfSameOrientationAtGridno(GridNo const grid_no, INT8 const orientation)
+STRUCTURE* GetWallStructOfSameOrientationAtGridno(GridNo const grid_no, Orientation const orientation)
 {
 	FOR_EACH_STRUCTURE(pStructure, grid_no, STRUCTURE_WALLSTUFF)
 	{
-		if (pStructure->ubWallOrientation != orientation) continue;
+		if ( !(pStructure->ubWallOrientation & orientation) ) continue;
 
 		STRUCTURE* const base = FindBaseStructure(pStructure);
 		if (!base) continue;
@@ -98,46 +96,38 @@ BOOLEAN IsDoorVisibleAtGridNo( INT16 sGridNo )
 	if ( pStructure != NULL )
 	{
 		// Check around based on orientation
-		switch( pStructure->ubWallOrientation )
+		if (pStructure->ubWallOrientation & ORIENT_LEFT)
 		{
-			case INSIDE_TOP_LEFT:
-			case OUTSIDE_TOP_LEFT:
+			// Here, check north direction
+			sNewGridNo = NewGridNo(sGridNo, DirectionInc(NORTH));
 
-				// Here, check north direction
-				sNewGridNo = NewGridNo( sGridNo, DirectionInc( NORTH ) );
+			if (IsRoofVisible2(sNewGridNo))
+			{
+				// OK, now check south, if true, she's not visible
+				sNewGridNo = NewGridNo(sGridNo, DirectionInc(SOUTH));
 
-				if ( IsRoofVisible2( sNewGridNo ) )
+				if (IsRoofVisible2(sNewGridNo))
 				{
-					// OK, now check south, if true, she's not visible
-					sNewGridNo = NewGridNo( sGridNo, DirectionInc( SOUTH ) );
-
-					if ( IsRoofVisible2( sNewGridNo ) )
-					{
-						return( FALSE );
-					}
+					return(FALSE);
 				}
-				break;
-
-			case INSIDE_TOP_RIGHT:
-			case OUTSIDE_TOP_RIGHT:
-
-				// Here, check west direction
-				sNewGridNo = NewGridNo( sGridNo, DirectionInc( WEST ) );
-
-				if ( IsRoofVisible2( sNewGridNo ) )
-				{
-					// OK, now check south, if true, she's not visible
-					sNewGridNo = NewGridNo( sGridNo, DirectionInc( EAST ) );
-
-					if ( IsRoofVisible2( sNewGridNo ) )
-					{
-						return( FALSE );
-					}
-				}
-				break;
-
+			}
 		}
+		else
+		{
+			// Here, check west direction
+			sNewGridNo = NewGridNo(sGridNo, DirectionInc(WEST));
 
+			if (IsRoofVisible2(sNewGridNo))
+			{
+				// OK, now check south, if true, she's not visible
+				sNewGridNo = NewGridNo(sGridNo, DirectionInc(EAST));
+
+				if (IsRoofVisible2(sNewGridNo))
+				{
+					return(FALSE);
+				}
+			}
+		}
 	}
 
 	// Return true here, even if she does not exist
@@ -151,8 +141,7 @@ BOOLEAN	WallExistsOfTopLeftOrientation( INT16 sGridNo )
 	FOR_EACH_STRUCTURE(pStructure, sGridNo, STRUCTURE_WALL)
 	{
 		// Check orientation
-		if ( pStructure->ubWallOrientation == INSIDE_TOP_LEFT ||
-			pStructure->ubWallOrientation == OUTSIDE_TOP_LEFT )
+		if ( pStructure->ubWallOrientation & ORIENT_LEFT )
 		{
 			return( TRUE );
 		}
@@ -167,8 +156,7 @@ BOOLEAN	WallExistsOfTopRightOrientation( INT16 sGridNo )
 	FOR_EACH_STRUCTURE(pStructure, sGridNo, STRUCTURE_WALL)
 	{
 		// Check orientation
-		if ( pStructure->ubWallOrientation == INSIDE_TOP_RIGHT ||
-			pStructure->ubWallOrientation == OUTSIDE_TOP_RIGHT )
+		if ( pStructure->ubWallOrientation & ORIENT_RIGHT)
 		{
 			return( TRUE );
 		}
@@ -186,8 +174,7 @@ BOOLEAN WallOrClosedDoorExistsOfTopLeftOrientation( INT16 sGridNo )
 			(pStructure->fFlags & STRUCTURE_OPEN )))
 		{
 			// Check orientation
-			if (pStructure->ubWallOrientation == INSIDE_TOP_LEFT ||
-				pStructure->ubWallOrientation == OUTSIDE_TOP_LEFT)
+			if (pStructure->ubWallOrientation & ORIENT_LEFT)
 			{
 				return( TRUE );
 			}
@@ -205,8 +192,7 @@ BOOLEAN WallOrClosedDoorExistsOfTopRightOrientation( INT16 sGridNo )
 		if (!((pStructure->fFlags & STRUCTURE_ANYDOOR) && (pStructure->fFlags & STRUCTURE_OPEN)))
 		{
 			// Check orientation
-			if (pStructure->ubWallOrientation == INSIDE_TOP_RIGHT ||
-				pStructure->ubWallOrientation == OUTSIDE_TOP_RIGHT)
+			if (pStructure->ubWallOrientation & ORIENT_RIGHT)
 			{
 				return( TRUE );
 			}
@@ -222,14 +208,10 @@ BOOLEAN OpenRightOrientedDoorWithDoorOnRightOfEdgeExists( INT16 sGridNo )
 	{
 		if (!(pStructure->fFlags & STRUCTURE_OPEN)) break;
 		// Check orientation
-		if (pStructure->ubWallOrientation == INSIDE_TOP_RIGHT ||
-			pStructure->ubWallOrientation == OUTSIDE_TOP_RIGHT)
+		if (pStructure->ubWallOrientation & ORIENT_RIGHT &&
+			pStructure->fFlags & (STRUCTURE_DOOR | STRUCTURE_DDOOR_RIGHT))
 		{
-			if ((pStructure->fFlags & STRUCTURE_DOOR) ||
-				(pStructure->fFlags & STRUCTURE_DDOOR_RIGHT))
-			{
-				return( TRUE );
-			}
+			return( TRUE );
 		}
 	}
 
@@ -242,14 +224,10 @@ BOOLEAN OpenLeftOrientedDoorWithDoorOnLeftOfEdgeExists( INT16 sGridNo )
 	{
 		if (!(pStructure->fFlags & STRUCTURE_OPEN)) break;
 		// Check orientation
-		if (pStructure->ubWallOrientation == INSIDE_TOP_LEFT ||
-			pStructure->ubWallOrientation == OUTSIDE_TOP_LEFT)
+		if (pStructure->ubWallOrientation & ORIENT_LEFT &&
+			pStructure->fFlags & (STRUCTURE_DOOR | STRUCTURE_DDOOR_LEFT))
 		{
-			if ((pStructure->fFlags & STRUCTURE_DOOR) ||
-				(pStructure->fFlags & STRUCTURE_DDOOR_LEFT))
-			{
-				return( TRUE );
-			}
+			return( TRUE );
 		}
 	}
 
@@ -262,7 +240,7 @@ static STRUCTURE* FindCuttableWireFenceAtGridNo(INT16 sGridNo)
 	STRUCTURE * pStructure;
 
 	pStructure = FindStructure( sGridNo, STRUCTURE_WIREFENCE );
-	if (pStructure != NULL && pStructure->ubWallOrientation != NO_ORIENTATION &&
+	if (pStructure != NULL && pStructure->ubWallOrientation != ORIENT_NONE &&
 		!(pStructure->fFlags & STRUCTURE_OPEN))
 	{
 		return( pStructure );

--- a/src/game/Tactical/Structure_Wrap.h
+++ b/src/game/Tactical/Structure_Wrap.h
@@ -20,7 +20,7 @@ BOOLEAN	WallOrClosedDoorExistsOfTopRightOrientation( INT16 sGridNo );
 BOOLEAN OpenRightOrientedDoorWithDoorOnRightOfEdgeExists( INT16 sGridNo );
 BOOLEAN OpenLeftOrientedDoorWithDoorOnLeftOfEdgeExists( INT16 sGridNo );
 
-STRUCTURE* GetWallStructOfSameOrientationAtGridno(GridNo, INT8 orientation);
+STRUCTURE* GetWallStructOfSameOrientationAtGridno(GridNo, Orientation orientation);
 
 BOOLEAN CutWireFence( INT16 sGridNo );
 BOOLEAN IsCuttableWireFenceAtGridNo( INT16 sGridNo );

--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -1523,25 +1523,23 @@ struct OppositeSideInfo
 	StructureFlags flags;
 	bool mustBeBaseTile;
 	bool mustBeOpen;
-	WallOrientationDefines orientation;
+	Orientation orientation;
 	WorldDirections direction;
 };
 const OppositeSideInfo oppGridNoDirections[] =
 {
-	{ STRUCTURE_WALL | STRUCTURE_ANYDOOR,     true,  false, OUTSIDE_TOP_RIGHT, EAST },
-	{ STRUCTURE_WALL | STRUCTURE_ANYDOOR,     true,  false, INSIDE_TOP_RIGHT,  EAST },
-	{ STRUCTURE_WALL | STRUCTURE_ANYDOOR,     true,  false, OUTSIDE_TOP_LEFT,  SOUTH },
-	{ STRUCTURE_WALL | STRUCTURE_ANYDOOR,     true,  false, INSIDE_TOP_LEFT,   SOUTH },
-	{ STRUCTURE_GARAGEDOOR,                   false, false, OUTSIDE_TOP_RIGHT, EAST },
-	{ STRUCTURE_GARAGEDOOR,                   false, false, OUTSIDE_TOP_LEFT,  SOUTH },
-	{ STRUCTURE_DOOR | STRUCTURE_DDOOR_RIGHT, true , true,  INSIDE_TOP_RIGHT,  NORTH },
-	{ STRUCTURE_DOOR | STRUCTURE_DDOOR_RIGHT, false, true,  OUTSIDE_TOP_RIGHT, NORTH },
-	{                  STRUCTURE_DDOOR_RIGHT, true , true,  INSIDE_TOP_LEFT,   EAST },
-	{                  STRUCTURE_DDOOR_RIGHT, false, true,  OUTSIDE_TOP_LEFT,  EAST },
-	{ STRUCTURE_DOOR | STRUCTURE_DDOOR_LEFT , true , true,  INSIDE_TOP_LEFT,   WEST },
-	{ STRUCTURE_DOOR | STRUCTURE_DDOOR_LEFT , false, true,  OUTSIDE_TOP_LEFT,  WEST },
-	{                  STRUCTURE_DDOOR_LEFT , true , true,  INSIDE_TOP_RIGHT,  SOUTH },
-	{                  STRUCTURE_DDOOR_LEFT , false, true,  OUTSIDE_TOP_RIGHT, SOUTH },
+	{ STRUCTURE_WALL | STRUCTURE_ANYDOOR,     true,  false, ORIENT_RIGHT, EAST },
+	{ STRUCTURE_WALL | STRUCTURE_ANYDOOR,     true,  false, ORIENT_LEFT,  SOUTH },
+	{ STRUCTURE_GARAGEDOOR,                   false, false, ORIENT_OUTSIDE_RIGHT, EAST },
+	{ STRUCTURE_GARAGEDOOR,                   false, false, ORIENT_OUTSIDE_LEFT,  SOUTH },
+	{ STRUCTURE_DOOR | STRUCTURE_DDOOR_RIGHT, true , true,  ORIENT_INSIDE_RIGHT,  NORTH },
+	{ STRUCTURE_DOOR | STRUCTURE_DDOOR_RIGHT, false, true,  ORIENT_OUTSIDE_RIGHT, NORTH },
+	{                  STRUCTURE_DDOOR_RIGHT, true , true,  ORIENT_INSIDE_LEFT,   EAST },
+	{                  STRUCTURE_DDOOR_RIGHT, false, true,  ORIENT_OUTSIDE_LEFT,  EAST },
+	{ STRUCTURE_DOOR | STRUCTURE_DDOOR_LEFT , true , true,  ORIENT_INSIDE_LEFT,   WEST },
+	{ STRUCTURE_DOOR | STRUCTURE_DDOOR_LEFT , false, true,  ORIENT_OUTSIDE_LEFT,  WEST },
+	{                  STRUCTURE_DDOOR_LEFT , true , true,  ORIENT_INSIDE_RIGHT,  SOUTH },
+	{                  STRUCTURE_DDOOR_LEFT , false, true,  ORIENT_OUTSIDE_RIGHT, SOUTH },
 };
 
 void StructureHit(BULLET* const pBullet, const UINT16 usStructureID, const INT32 iImpact, const BOOLEAN fStopped)
@@ -1584,7 +1582,7 @@ void StructureHit(BULLET* const pBullet, const UINT16 usStructureID, const INT32
 			if (oppGridNoDir.flags & pStructure->fFlags &&
 				oppGridNoDir.mustBeBaseTile == static_cast<bool>(pStructure->fFlags & STRUCTURE_BASE_TILE) &&
 				oppGridNoDir.mustBeOpen     == static_cast<bool>(pStructure->fFlags & STRUCTURE_OPEN) &&
-				oppGridNoDir.orientation    == pStructure->ubWallOrientation)
+				oppGridNoDir.orientation    &  pStructure->ubWallOrientation)
 			{
 				oppositeSideGridNo += DirectionInc(oppGridNoDir.direction);
 				break;
@@ -1867,7 +1865,7 @@ void WindowHit( INT16 sGridNo, UINT16 usStructureID, BOOLEAN fBlowWindowSouth, B
 		return;
 	}
 	MakeNoise(NULL, sGridNo, 0, WINDOW_SMASH_VOLUME, NOISE_BULLET_IMPACT);
-	if (pWallAndWindowInDB->ubWallOrientation == INSIDE_TOP_RIGHT || pWallAndWindowInDB->ubWallOrientation == OUTSIDE_TOP_RIGHT)
+	if (pWallAndWindowInDB->ubWallOrientation & ORIENT_RIGHT)
 	{
 		/*
 		sShatterGridNo = sGridNo + 1;

--- a/src/game/Tactical/World_Items.cc
+++ b/src/game/Tactical/World_Items.cc
@@ -92,14 +92,13 @@ void FindPanicBombsAndTriggers(void)
 			const STRUCTURE* const switch_ = FindStructure(sGridNo, STRUCTURE_SWITCH);
 			if (switch_)
 			{
-				switch (switch_->ubWallOrientation)
+				if (switch_->ubWallOrientation & ORIENT_LEFT)
 				{
-					case INSIDE_TOP_LEFT:
-					case OUTSIDE_TOP_LEFT:  sGridNo += DirectionInc(SOUTH); break;
-					case INSIDE_TOP_RIGHT:
-					case OUTSIDE_TOP_RIGHT: sGridNo += DirectionInc(EAST);  break;
-
-					default: break;
+					sGridNo += DirectionInc(SOUTH);
+				}
+				else
+				{
+					sGridNo += DirectionInc(EAST);
 				}
 			}
 

--- a/src/game/TileEngine/Buildings.cc
+++ b/src/game/TileEngine/Buildings.cc
@@ -47,7 +47,6 @@ static BUILDING* GenerateBuilding(INT16 sDesiredSpot)
 	BOOLEAN	fFoundDir, fFoundWall;
 	UINT32	uiChanceIn = ROOF_LOCATION_CHANCE; // chance of a location being considered
 	INT16		sWallGridNo;
-	INT8		bDesiredOrientation;
 	INT8		bSkipSpots = 0;
 	SOLDIERTYPE 	FakeSoldier;
 	BUILDING *		pBuilding;
@@ -212,30 +211,31 @@ static BUILDING* GenerateBuilding(INT16 sDesiredSpot)
 			// if south or west, the wall would be in the gridno two clockwise
 			fFoundWall = FALSE;
 
+			Orientation	bDesiredOrientation;
 			switch( bDirection )
 			{
 				case NORTH:
 					sWallGridNo = sCurrGridNo;
-					bDesiredOrientation = OUTSIDE_TOP_RIGHT;
+					bDesiredOrientation = ORIENT_OUTSIDE_RIGHT;
 					break;
 				case EAST:
 					sWallGridNo = sCurrGridNo;
-					bDesiredOrientation = OUTSIDE_TOP_LEFT;
+					bDesiredOrientation = ORIENT_OUTSIDE_LEFT;
 					break;
 				case SOUTH:
 					sWallGridNo = (INT16)(sCurrGridNo + DirectionInc(TwoCDirection(bDirection)));
-					bDesiredOrientation = OUTSIDE_TOP_RIGHT;
+					bDesiredOrientation = ORIENT_OUTSIDE_RIGHT;
 					break;
 				case WEST:
 					sWallGridNo = (INT16)(sCurrGridNo + DirectionInc(TwoCDirection(bDirection)));
-					bDesiredOrientation = OUTSIDE_TOP_LEFT;
+					bDesiredOrientation = ORIENT_OUTSIDE_LEFT;
 					break;
 				default:
 					// what the heck?
 					return( NULL );
 			}
 
-			if (bDesiredOrientation == OUTSIDE_TOP_LEFT)
+			if (bDesiredOrientation == ORIENT_OUTSIDE_LEFT)
 			{
 				if (WallExistsOfTopLeftOrientation( sWallGridNo ))
 				{

--- a/src/game/TileEngine/Explosion_Control.cc
+++ b/src/game/TileEngine/Explosion_Control.cc
@@ -290,27 +290,11 @@ static void HandleFencePartnerCheck(INT16 sStructGridNo)
 }
 
 
-static void ReplaceWall(GridNo const grid_no, UINT8 orientation, INT16 const sub_idx)
+static void ReplaceWall(GridNo const grid_no, Orientation orientation, INT16 const sub_idx)
 {
+	orientation = orientation & ORIENT_LEFT ? ORIENT_LEFT : ORIENT_RIGHT;
 	STRUCTURE* wall_struct = GetWallStructOfSameOrientationAtGridno(grid_no, orientation);
-	if (!wall_struct)
-	{
-		switch (orientation)
-		{
-			case INSIDE_TOP_LEFT:
-				orientation = OUTSIDE_TOP_LEFT;
-				break;
-			case OUTSIDE_TOP_LEFT:
-				orientation = INSIDE_TOP_LEFT;
-				break;
-			case INSIDE_TOP_RIGHT:
-				orientation = OUTSIDE_TOP_RIGHT;
-				break;
-			case OUTSIDE_TOP_RIGHT:
-				orientation = INSIDE_TOP_RIGHT;
-		}
-		wall_struct = GetWallStructOfSameOrientationAtGridno(grid_no, orientation);
-	}
+
 	if (!wall_struct || !(wall_struct->fFlags & STRUCTURE_WALL)) return;
 
 	LEVELNODE* const node    = FindLevelNodeBasedOnStructure(wall_struct);
@@ -470,30 +454,22 @@ static bool ExplosiveDamageStructureAtGridNo(STRUCTURE* const pCurrent, STRUCTUR
 			// If we are a wall, add debris for the other side
 			if (pCurrent->fFlags & STRUCTURE_WALLSTUFF)
 			{
-				switch (pCurrent->ubWallOrientation)
+				if (pCurrent->ubWallOrientation & ORIENT_LEFT)
 				{
-					case OUTSIDE_TOP_LEFT:
-					case INSIDE_TOP_LEFT:
+					GridNo const struct_grid_no = NewGridNo(base_grid_no, DirectionInc(SOUTH));
+					if (!TypeRangeExistsInObjectLayer(struct_grid_no, FIRSTEXPLDEBRIS, SECONDEXPLDEBRIS))
 					{
-						GridNo const struct_grid_no = NewGridNo(base_grid_no, DirectionInc(SOUTH));
-						if (!TypeRangeExistsInObjectLayer(struct_grid_no, FIRSTEXPLDEBRIS, SECONDEXPLDEBRIS))
-						{
-							ApplyMapChangesToMapTempFile app;
-							AddObjectToHead(struct_grid_no, tile_idx + Random(3));
-						}
-						break;
+						ApplyMapChangesToMapTempFile app;
+						AddObjectToHead(struct_grid_no, tile_idx + Random(3));
 					}
-
-					case OUTSIDE_TOP_RIGHT:
-					case INSIDE_TOP_RIGHT:
+				}
+				else
+				{
+					GridNo const struct_grid_no = NewGridNo(base_grid_no, DirectionInc(EAST));
+					if (!TypeRangeExistsInObjectLayer(struct_grid_no, FIRSTEXPLDEBRIS, SECONDEXPLDEBRIS))
 					{
-						GridNo const struct_grid_no = NewGridNo(base_grid_no, DirectionInc(EAST));
-						if (!TypeRangeExistsInObjectLayer(struct_grid_no, FIRSTEXPLDEBRIS, SECONDEXPLDEBRIS))
-						{
-							ApplyMapChangesToMapTempFile app;
-							AddObjectToHead(struct_grid_no, tile_idx + Random(3));
-						}
-						break;
+						ApplyMapChangesToMapTempFile app;
+						AddObjectToHead(struct_grid_no, tile_idx + Random(3));
 					}
 				}
 			}
@@ -502,19 +478,15 @@ static bool ExplosiveDamageStructureAtGridNo(STRUCTURE* const pCurrent, STRUCTUR
 		else if (pCurrent->fFlags & STRUCTURE_FENCE)
 		{
 			// walk along based on orientation
-			switch (pCurrent->ubWallOrientation)
+			if (pCurrent->ubWallOrientation & ORIENT_RIGHT)
 			{
-				case OUTSIDE_TOP_RIGHT:
-				case INSIDE_TOP_RIGHT:
-					HandleFencePartnerCheck(NewGridNo(base_grid_no, DirectionInc(SOUTH)));
-					HandleFencePartnerCheck(NewGridNo(base_grid_no, DirectionInc(NORTH)));
-					break;
-
-				case OUTSIDE_TOP_LEFT:
-				case INSIDE_TOP_LEFT:
-					HandleFencePartnerCheck(NewGridNo(base_grid_no, DirectionInc(EAST)));
-					HandleFencePartnerCheck(NewGridNo(base_grid_no, DirectionInc(WEST)));
-					break;
+				HandleFencePartnerCheck(NewGridNo(base_grid_no, DirectionInc(SOUTH)));
+				HandleFencePartnerCheck(NewGridNo(base_grid_no, DirectionInc(NORTH)));
+			}
+			else
+			{
+				HandleFencePartnerCheck(NewGridNo(base_grid_no, DirectionInc(EAST)));
+				HandleFencePartnerCheck(NewGridNo(base_grid_no, DirectionInc(WEST)));
 			}
 		}
 
@@ -532,31 +504,27 @@ static bool ExplosiveDamageStructureAtGridNo(STRUCTURE* const pCurrent, STRUCTUR
 		{
 			/* Based on orientation, go either x or y dir, check for wall in both _ve
 			 * and -ve directions and if found, then replace */
-			switch (UINT8 const orientation = pCurrent->ubWallOrientation)
+			if (Orientation const orientation = pCurrent->ubWallOrientation; orientation & ORIENT_LEFT)
 			{
-				case OUTSIDE_TOP_LEFT:
-				case INSIDE_TOP_LEFT:
-					ReplaceWall(NewGridNo(base_grid_no, DirectionInc(WEST)), orientation, orientation == OUTSIDE_TOP_LEFT ? 48 : 52);
-					ReplaceWall(NewGridNo(base_grid_no, DirectionInc(EAST)), orientation, orientation == OUTSIDE_TOP_LEFT ? 49 : 53);
+				ReplaceWall(NewGridNo(base_grid_no, DirectionInc(WEST)), orientation, orientation == ORIENT_OUTSIDE_LEFT ? 48 : 52);
+				ReplaceWall(NewGridNo(base_grid_no, DirectionInc(EAST)), orientation, orientation == ORIENT_OUTSIDE_LEFT ? 49 : 53);
 
-					// look for attached structures in same tile
-					*ppNextCurrent = RemoveOnWall(base_grid_no, STRUCTURE_ON_LEFT_WALL, *ppNextCurrent);
+				// look for attached structures in same tile
+				*ppNextCurrent = RemoveOnWall(base_grid_no, STRUCTURE_ON_LEFT_WALL, *ppNextCurrent);
 
-					// Move in SOUTH, looking for attached structures to remove
-					RemoveOnWall(NewGridNo(base_grid_no, DirectionInc(SOUTH)), STRUCTURE_ON_LEFT_WALL, 0);
-					break;
+				// Move in SOUTH, looking for attached structures to remove
+				RemoveOnWall(NewGridNo(base_grid_no, DirectionInc(SOUTH)), STRUCTURE_ON_LEFT_WALL, 0);
+			}
+			else
+			{
+				ReplaceWall(NewGridNo(base_grid_no, DirectionInc(NORTH)), orientation, orientation == ORIENT_OUTSIDE_RIGHT ? 51 : 55);
+				ReplaceWall(NewGridNo(base_grid_no, DirectionInc(SOUTH)), orientation, orientation == ORIENT_OUTSIDE_RIGHT ? 50 : 54);
 
-				case OUTSIDE_TOP_RIGHT:
-				case INSIDE_TOP_RIGHT:
-					ReplaceWall(NewGridNo(base_grid_no, DirectionInc(NORTH)), orientation, orientation == OUTSIDE_TOP_RIGHT ? 51 : 55);
-					ReplaceWall(NewGridNo(base_grid_no, DirectionInc(SOUTH)), orientation, orientation == OUTSIDE_TOP_RIGHT ? 50 : 54);
+				// looking for attached structures to remove in base tile
+				*ppNextCurrent = RemoveOnWall(base_grid_no, STRUCTURE_ON_RIGHT_WALL, *ppNextCurrent);
 
-					// looking for attached structures to remove in base tile
-					*ppNextCurrent = RemoveOnWall(base_grid_no, STRUCTURE_ON_RIGHT_WALL, *ppNextCurrent);
-
-					// Move in EAST, looking for attached structures to remove
-					RemoveOnWall(NewGridNo(base_grid_no, DirectionInc(EAST)), STRUCTURE_ON_RIGHT_WALL, 0);
-					break;
+				// Move in EAST, looking for attached structures to remove
+				RemoveOnWall(NewGridNo(base_grid_no, DirectionInc(EAST)), STRUCTURE_ON_RIGHT_WALL, 0);
 			}
 		}
 

--- a/src/game/TileEngine/Interactive_Tiles.cc
+++ b/src/game/TileEngine/Interactive_Tiles.cc
@@ -503,10 +503,14 @@ static bool RefineLogicOnStruct(INT16 gridno, LEVELNODE const& n)
 			// Move south
 			gridno = NewGridNo(gridno, DirectionInc(SOUTH));
 		}
-		else
+		else if (structure.pDBStructureRef->pDBStructure->ubWallOrientation & ORIENT_RIGHT)
 		{
 			// Move east
 			gridno = NewGridNo(gridno, DirectionInc(EAST));
+		}
+		else
+		{
+			return true;
 		}
 	}
 

--- a/src/game/TileEngine/Interactive_Tiles.cc
+++ b/src/game/TileEngine/Interactive_Tiles.cc
@@ -498,21 +498,15 @@ static bool RefineLogicOnStruct(INT16 gridno, LEVELNODE const& n)
 	else if (structure.fFlags & STRUCTURE_SWITCH)
 	{ // A switch, reject in another direction
 		// Find a new gridno based on switch's orientation
-		switch (structure.pDBStructureRef->pDBStructure->ubWallOrientation)
+		if (structure.pDBStructureRef->pDBStructure->ubWallOrientation & ORIENT_LEFT)
 		{
-			case OUTSIDE_TOP_LEFT:
-			case INSIDE_TOP_LEFT:
-				// Move south
-				gridno = NewGridNo(gridno, DirectionInc(SOUTH));
-				break;
-
-			case OUTSIDE_TOP_RIGHT:
-			case INSIDE_TOP_RIGHT:
-				// Move east
-				gridno = NewGridNo(gridno, DirectionInc(EAST));
-				break;
-
-			default: return true; // XXX exception?
+			// Move south
+			gridno = NewGridNo(gridno, DirectionInc(SOUTH));
+		}
+		else
+		{
+			// Move east
+			gridno = NewGridNo(gridno, DirectionInc(EAST));
 		}
 	}
 

--- a/src/game/TileEngine/Lighting.cc
+++ b/src/game/TileEngine/Lighting.cc
@@ -421,17 +421,7 @@ static BOOLEAN LightTileHasWall(INT16 iSrcX, INT16 iSrcY, INT16 iX, INT16 iY)
 			return( TRUE );
 		}
 
-		switch(usWallOrientation)
-		{
-			case INSIDE_TOP_RIGHT:
-			case OUTSIDE_TOP_RIGHT:
-				return( iSrcX < iX );
-
-			case INSIDE_TOP_LEFT:
-			case OUTSIDE_TOP_LEFT:
-				return( iSrcY < iY );
-
-		}
+		return usWallOrientation & ORIENT_RIGHT ? iSrcX < iX : iSrcY < iY;
 	}
 
 #endif
@@ -1471,19 +1461,17 @@ static BOOLEAN LightIlluminateWall(INT16 iSourceX, INT16 iSourceY, INT16 iTileX,
 
 #if 0
 	UINT16 usWallOrientation = GetWallOrientation(pStruct->usIndex);
-	switch(usWallOrientation)
+	if (usWallOrientation == ORIENT_NONE)
 	{
-		case NO_ORIENTATION:
-			return(TRUE);
-
-		case INSIDE_TOP_RIGHT:
-		case OUTSIDE_TOP_RIGHT:
-			return(iSourceX >= iTileX);
-
-		case INSIDE_TOP_LEFT:
-		case OUTSIDE_TOP_LEFT:
-			return(iSourceY >= iTileY);
-
+		return TRUE;
+	}
+	else if (usWallOrientation & ORIENT_RIGHT)
+	{
+		return iSourceX >= iTileX;
+	}
+	else
+	{
+		return iSourceY >= iTileY;
 	}
 	return(FALSE);
 
@@ -1583,20 +1571,13 @@ static BOOLEAN LightHideWall(const INT16 sX, const INT16 sY, const INT16 sSrcX, 
 		if (i->uiFlags & LEVELNODE_CACHEDANITILE) continue;
 
 		const TILE_ELEMENT* const te = &gTileDatabase[i->usIndex];
-		switch (te->usWallOrientation)
+		if (te->usWallOrientation & ORIENT_RIGHT)
 		{
-			case INSIDE_TOP_RIGHT:
-			case OUTSIDE_TOP_RIGHT:
-				if (!fDoRightWalls) fDoLeftWalls = FALSE;
-				break;
-
-			case INSIDE_TOP_LEFT:
-			case OUTSIDE_TOP_LEFT:
-				if (!fDoLeftWalls) fDoRightWalls = FALSE;
-				break;
-
-			default:
-				break;
+			if (!fDoRightWalls) fDoLeftWalls = FALSE;
+		}
+		else if (te->usWallOrientation & ORIENT_LEFT)
+		{
+			if (!fDoLeftWalls) fDoRightWalls = FALSE;
 		}
 	}
 
@@ -1607,30 +1588,23 @@ static BOOLEAN LightHideWall(const INT16 sX, const INT16 sY, const INT16 sSrcX, 
 		if (i->uiFlags & LEVELNODE_CACHEDANITILE) continue;
 
 		const TILE_ELEMENT* const te = &gTileDatabase[i->usIndex];
-		switch (te->usWallOrientation)
+		if (te->usWallOrientation & ORIENT_RIGHT)
 		{
-			case INSIDE_TOP_RIGHT:
-			case OUTSIDE_TOP_RIGHT:
-				fHitWall = TRUE;
-				if (fDoRightWalls && sX >= sSrcX)
-				{
-					i->uiFlags &= ~LEVELNODE_REVEAL;
-					fRerender   = TRUE;
-				}
-				break;
-
-			case INSIDE_TOP_LEFT:
-			case OUTSIDE_TOP_LEFT:
-				fHitWall = TRUE;
-				if (fDoLeftWalls && sY >= sSrcY)
-				{
-					i->uiFlags &= ~LEVELNODE_REVEAL;
-					fRerender   = TRUE;
-				}
-				break;
-
-			default:
-				break;
+			fHitWall = TRUE;
+			if (fDoRightWalls && sX >= sSrcX)
+			{
+				i->uiFlags &= ~LEVELNODE_REVEAL;
+				fRerender = TRUE;
+			}
+		}
+		else if (te->usWallOrientation & ORIENT_LEFT)
+		{
+			fHitWall = TRUE;
+			if (fDoLeftWalls && sY >= sSrcY)
+			{
+				i->uiFlags &= ~LEVELNODE_REVEAL;
+				fRerender = TRUE;
+			}
 		}
 	}
 

--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -410,7 +410,7 @@ static STRUCTURE* CreateStructureFromDB(DB_STRUCTURE_REF const* const pDBStructu
 		pStructure->fFlags      |= STRUCTURE_BASE_TILE;
 		pStructure->ubHitPoints  = pDBStructure->ubHitPoints;
 	}
-	if (pDBStructure->ubWallOrientation != NO_ORIENTATION)
+	if (pDBStructure->ubWallOrientation != ORIENT_NONE)
 	{
 		/* for multi-tile walls, which are only the special corner pieces, the
 		 * non-base tile gets no orientation value because this copy will be
@@ -492,22 +492,17 @@ static BOOLEAN OkayToAddStructureToTile(INT16 const sBaseGridNo, INT16 const sCu
 					for (INT8 bLoop = 1; bLoop < 4; ++bLoop)
 					{
 						INT16 sOtherGridNo;
-						switch (pExistingStructure->ubWallOrientation)
+						if (pExistingStructure->ubWallOrientation & ORIENT_LEFT)
 						{
-							case OUTSIDE_TOP_LEFT:
-							case INSIDE_TOP_LEFT:
-								sOtherGridNo = NewGridNo(sGridNo, DirectionInc( bLoop + 2 ));
-								break;
-
-							case OUTSIDE_TOP_RIGHT:
-							case INSIDE_TOP_RIGHT:
-								sOtherGridNo = NewGridNo(sGridNo, DirectionInc(bLoop));
-								break;
-
-							default:
-								// @%?@#%?@%
-								sOtherGridNo = NewGridNo(sGridNo, DirectionInc(SOUTHEAST));
-								break;
+							sOtherGridNo = NewGridNo(sGridNo, DirectionInc(bLoop + 2));
+						}
+						else if ( pExistingStructure->ubWallOrientation & ORIENT_RIGHT )
+						{
+							sOtherGridNo = NewGridNo(sGridNo, DirectionInc(bLoop));
+						}
+						else
+						{   // @%?@#%?@%
+							sOtherGridNo = NewGridNo(sGridNo, DirectionInc(SOUTHEAST));
 						}
 						for (INT8 bLoop2 = 0; bLoop2 < pDBStructure->ubNumberOfTiles; ++bLoop2)
 						{
@@ -534,22 +529,17 @@ static BOOLEAN OkayToAddStructureToTile(INT16 const sBaseGridNo, INT16 const sCu
 				for (INT8 bLoop = 1; bLoop < 4; ++bLoop)
 				{
 					INT16 sOtherGridNo;
-					switch (pDBStructure->ubWallOrientation)
+					if (pDBStructure->ubWallOrientation & ORIENT_LEFT)
 					{
-						case OUTSIDE_TOP_LEFT:
-						case INSIDE_TOP_LEFT:
-							sOtherGridNo = NewGridNo(sGridNo, DirectionInc( bLoop + 2 ));
-							break;
-
-						case OUTSIDE_TOP_RIGHT:
-						case INSIDE_TOP_RIGHT:
-							sOtherGridNo = NewGridNo(sGridNo, DirectionInc(bLoop));
-							break;
-
-						default:
-							// @%?@#%?@%
-							sOtherGridNo = NewGridNo(sGridNo, DirectionInc(SOUTHEAST));
-							break;
+						sOtherGridNo = NewGridNo(sGridNo, DirectionInc(bLoop + 2));
+					}
+					else if (pDBStructure->ubWallOrientation & ORIENT_RIGHT)
+					{
+						sOtherGridNo = NewGridNo(sGridNo, DirectionInc(bLoop));
+					}
+					else
+					{   // @%?@#%?@%
+						sOtherGridNo = NewGridNo(sGridNo, DirectionInc(SOUTHEAST));
 					}
 					for (ubTileIndex = 0; ubTileIndex < pDBStructure->ubNumberOfTiles; ++ubTileIndex)
 					{
@@ -1212,12 +1202,13 @@ void DebugStructurePage1()
 {
 	static const ST::string WallOrientationString[] =
 	{
-		"None",
 		"Inside left",
 		"Inside right",
 		"Outside left",
 		"Outside right"
 	};
+
+	ST::string orient;
 
 	GridNo const grid_no = guiCurrentCursorGridNo;
 	if (grid_no == NOWHERE) {
@@ -1267,6 +1258,11 @@ void DebugStructurePage1()
 
 		y += h;
 
+		if (s->ubWallOrientation)
+		{
+			orient = WallOrientationString[GetBitPositionIndex(s->ubWallOrientation)];
+		}
+
 		MPrintStat(DEBUG_PAGE_FIRST_COLUMN, y += h, "Structure ID:", s->usStructureID);
 		MHeader(DEBUG_PAGE_FIRST_COLUMN, y += h, "Type:");
 		if (s->fFlags & STRUCTURE_GENERIC)
@@ -1279,19 +1275,19 @@ void DebugStructurePage1()
 		}
 		else if (s->fFlags & STRUCTURE_FENCE)
 		{
-			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("Fence with orientation {}", WallOrientationString[s->ubWallOrientation]));
+			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("Fence with orientation {}", orient));
 		}
 		else if (s->fFlags & STRUCTURE_WIREFENCE)
 		{
-			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("Wirefence with orientation {}", WallOrientationString[s->ubWallOrientation]));
+			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("Wirefence with orientation {}", orient));
 		}
 		else if (s->fFlags & STRUCTURE_WALL)
 		{
-			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("Wall with orientation {}", WallOrientationString[s->ubWallOrientation]));
+			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("Wall with orientation {}", orient));
 		}
 		else if (s->fFlags & STRUCTURE_WALLNWINDOW)
 		{
-			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("Wall with window with orientation {}", WallOrientationString[s->ubWallOrientation]));
+			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("Wall with window with orientation {}", orient));
 		}
 		else if (s->fFlags & STRUCTURE_VEHICLE)
 		{
@@ -1327,25 +1323,25 @@ void DebugStructurePage1()
 		}
 		else if (s->fFlags & STRUCTURE_DOOR)
 		{
-			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("Door with orientation {}", WallOrientationString[s->ubWallOrientation]));
+			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("Door with orientation {}", orient));
 		}
 		else if (s->fFlags & STRUCTURE_SLIDINGDOOR)
 		{
 			ST::string state = s->fFlags & STRUCTURE_OPEN ? "Open" : "Closed";
-			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("{} sliding door with orientation {}", state, WallOrientationString[s->ubWallOrientation]));
+			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("{} sliding door with orientation {}", state, orient));
 		}
 		else if (s->fFlags & STRUCTURE_GARAGEDOOR)
 		{
 			ST::string state = s->fFlags & STRUCTURE_OPEN ? "Open" : "Closed";
-			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("{} garage door with orientation {}", state, WallOrientationString[s->ubWallOrientation]));
+			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("{} garage door with orientation {}", state, orient));
 		}
 		else if (s->fFlags & STRUCTURE_DDOOR_LEFT)
 		{
-			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("DDoorLft with orientation {}", WallOrientationString[s->ubWallOrientation]));
+			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("DDoorLft with orientation {}", orient));
 		}
 		else if (s->fFlags & STRUCTURE_DDOOR_RIGHT)
 		{
-			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("DDoorRt with orientation {}", WallOrientationString[s->ubWallOrientation]));
+			MPrint(DEBUG_PAGE_FIRST_COLUMN+DEBUG_PAGE_LABEL_WIDTH, y, ST::format("DDoorRt with orientation {}", orient));
 		}
 		else
 		{
@@ -1742,12 +1738,12 @@ INT8 GetBlockingStructureInfo( INT16 sGridNo, INT8 bDir, INT8 bNextDir, INT8 bLe
 				else
 				{
 					// Check how a wall is oriented relative to the direction the test ray is coming from
-					const uint8_t orientation{ pCurrent->ubWallOrientation };
-					if ((bDir >= NORTH && bDir <= SOUTH) && (orientation == INSIDE_TOP_RIGHT || orientation == OUTSIDE_TOP_RIGHT))
+					const Orientation orientation{ pCurrent->ubWallOrientation };
+					if ((bDir >= NORTH && bDir <= SOUTH) && (orientation & ORIENT_RIGHT))
 					{
 						fOKStructOnLevel = FALSE;
 					}
-					else if ((bDir >= EAST && bDir <= WEST) && (orientation == INSIDE_TOP_LEFT || orientation == OUTSIDE_TOP_LEFT))
+					else if ((bDir >= EAST && bDir <= WEST) && (orientation & ORIENT_LEFT))
 					{
 						fOKStructOnLevel = FALSE;
 					}
@@ -1762,68 +1758,31 @@ INT8 GetBlockingStructureInfo( INT16 sGridNo, INT8 bDir, INT8 bNextDir, INT8 bLe
 			// CHECK FOR WINDOW
 			if ( pCurrent->fFlags & STRUCTURE_WALLNWINDOW )
 			{
-				switch( pCurrent->ubWallOrientation )
+				(*pStructHeight) = StructureHeight( pCurrent );
+				(*ppTallestStructure) = pCurrent;
+				if ( pCurrent->ubWallOrientation & ORIENT_LEFT )
 				{
-					case OUTSIDE_TOP_LEFT:
-					case INSIDE_TOP_LEFT:
-
-						(*pStructHeight) = StructureHeight( pCurrent );
-						(*ppTallestStructure) = pCurrent;
-
-						if ( pCurrent->fFlags & STRUCTURE_OPEN )
-						{
-							return( BLOCKING_TOPLEFT_OPEN_WINDOW );
-						}
-						else
-						{
-							return( BLOCKING_TOPLEFT_WINDOW );
-						}
-
-					case OUTSIDE_TOP_RIGHT:
-					case INSIDE_TOP_RIGHT:
-
-						(*pStructHeight) = StructureHeight( pCurrent );
-						(*ppTallestStructure) = pCurrent;
-
-						if ( pCurrent->fFlags & STRUCTURE_OPEN )
-						{
-							return( BLOCKING_TOPRIGHT_OPEN_WINDOW );
-						}
-						else
-						{
-							return( BLOCKING_TOPRIGHT_WINDOW );
-						}
+					return pCurrent->fFlags & STRUCTURE_OPEN ? BLOCKING_TOPLEFT_OPEN_WINDOW : BLOCKING_TOPLEFT_WINDOW;
+				}
+				else
+				{
+					return pCurrent->fFlags & STRUCTURE_OPEN ? BLOCKING_TOPRIGHT_OPEN_WINDOW : BLOCKING_TOPRIGHT_WINDOW;
 				}
 			}
 
 			// Check for door
 			if ( pCurrent->fFlags & STRUCTURE_ANYDOOR )
 			{
+				(*pStructHeight) = StructureHeight( pCurrent );
+				(*ppTallestStructure) = pCurrent;
 				// If we are not opem, we are full blocking!
 				if ( !(pCurrent->fFlags & STRUCTURE_OPEN ) )
 				{
-					(*pStructHeight) = StructureHeight( pCurrent );
-					(*ppTallestStructure) = pCurrent;
 					return( FULL_BLOCKING );
 				}
 				else
 				{
-					switch( pCurrent->ubWallOrientation )
-					{
-						case OUTSIDE_TOP_LEFT:
-						case INSIDE_TOP_LEFT:
-
-							(*pStructHeight) = StructureHeight( pCurrent );
-							(*ppTallestStructure) = pCurrent;
-							return( BLOCKING_TOPLEFT_DOOR );
-
-						case OUTSIDE_TOP_RIGHT:
-						case INSIDE_TOP_RIGHT:
-
-							(*pStructHeight) = StructureHeight( pCurrent );
-							(*ppTallestStructure) = pCurrent;
-							return( BLOCKING_TOPRIGHT_DOOR );
-					}
+					return pCurrent->ubWallOrientation & ORIENT_LEFT ? BLOCKING_TOPLEFT_DOOR : BLOCKING_TOPRIGHT_DOOR;
 				}
 			}
 		}

--- a/src/game/TileEngine/Structure_Internals.h
+++ b/src/game/TileEngine/Structure_Internals.h
@@ -73,6 +73,7 @@ enum StructureFlags : UINT32
 	STRUCTURE_BASE_TILE     = 0x00000001,
 	STRUCTURE_OPEN          = 0x00000002,
 	STRUCTURE_OPENABLE      = 0x00000004,
+
 	STRUCTURE_GARAGEDOOR    = 0x00000008,
 
 	STRUCTURE_MOBILE        = 0x00000010,
@@ -143,6 +144,8 @@ struct DB_STRUCTURE_TILE
 
 #define NO_PARTNER_STRUCTURE 0
 
+enum Orientation : uint8_t;
+
 struct DB_STRUCTURE
 {
 	UINT8								ubArmour;
@@ -151,7 +154,7 @@ struct DB_STRUCTURE
 	UINT8								ubNumberOfTiles;
 	StructureFlags					    fFlags;
 	UINT16							usStructureNumber;
-	UINT8								ubWallOrientation;
+	Orientation							ubWallOrientation;
 	INT8								bDestructionPartner; // >0 = debris number (bDP - 1), <0 = partner graphic
 	INT8								bPartnerDelta; // opened/closed version, etc... 0 for unused
 	INT8								bZTileOffsetX;
@@ -183,7 +186,7 @@ struct STRUCTURE
 	UINT8						  ubLockStrength;
 	GridNo						  sBaseGridNo;
 	INT16						  sCubeOffset;// height of bottom of object in profile "cubes"
-	UINT8						  ubWallOrientation;
+	Orientation					  ubWallOrientation;
 	UINT8						  ubStructureHeight; // if 0, then unset; otherwise stores height of structure when last calculated
 };
 

--- a/src/game/TileEngine/TileDef.cc
+++ b/src/game/TileEngine/TileDef.cc
@@ -83,11 +83,11 @@ void CreateTileDatabase()
 
 			TileElement.fType             = (UINT16)TileSurf->fType;
 			TileElement.ubTerrainID       = TileSurf->ubTerrainID;
-			TileElement.usWallOrientation = NO_ORIENTATION;
+			TileElement.usWallOrientation = ORIENT_NONE;
 
 			if (TileSurf->pAuxData)
 			{
-				AuxObjectData const& aux = TileSurf->pAuxData[cnt2];
+				AuxObjectData & aux = TileSurf->pAuxData[cnt2];
 				if (aux.fFlags & AUX_FULL_TILE)
 				{
 					TileElement.ubFullTile = 1;
@@ -108,7 +108,26 @@ void CreateTileDatabase()
 
 					TileElement.uiFlags |= ANIMATED_TILE;
 				}
-				TileElement.usWallOrientation = static_cast<WallOrientationDefines>(aux.ubWallOrientation);
+
+				// Convert contiguous named orientation values to flags
+				if (TileElement.pDBStructureRef)
+				{
+					switch (aux.ubWallOrientation)
+					{
+						case 2:
+							aux.ubWallOrientation = ORIENT_INSIDE_RIGHT;
+							break;
+						case 3:
+							aux.ubWallOrientation = ORIENT_OUTSIDE_LEFT;
+							break;
+						case 4:
+							aux.ubWallOrientation = ORIENT_OUTSIDE_RIGHT;
+							break;
+					}
+					TileElement.usWallOrientation = static_cast<Orientation>(aux.ubWallOrientation);
+					TileElement.pDBStructureRef->pDBStructure->ubWallOrientation = TileElement.usWallOrientation;
+				}
+
 				if (aux.ubNumberOfTiles > 0)
 				{
 					TileElement.ubNumberOfTiles = aux.ubNumberOfTiles;
@@ -118,21 +137,20 @@ void CreateTileDatabase()
 
 			SetSpecificDatabaseValues(cnt1, gTileDatabaseSize, TileElement, TileSurf->bRaisedObjectType);
 			// fix incorrect double door flags. in vanilla it only affects DOOR3 in PALACE! tileset and DOOR1 in QUEEN'S TROPICAL
-			if ((gTileSurfaceName[cnt1] == "DOOR1" || gTileSurfaceName[cnt1] == "DOOR2" || gTileSurfaceName[cnt1] == "DOOR3" || gTileSurfaceName[cnt1] == "DOOR4")
-				&& TileElement.pDBStructureRef != nullptr)
+			if (TileElement.pDBStructureRef != nullptr && cnt1 >= FIRSTDOOR && cnt1 <=FOURTHDOOR)
 			{
 				if (TileElement.usRegionIndex == 0 && (TileElement.pDBStructureRef->pDBStructure->fFlags & (STRUCTURE_DDOOR_RIGHT|STRUCTURE_DDOOR_LEFT)))
 				{
 					// if a door in an open state takes up 1 tile and is flagged as outside-oriented...
-					if (TileElement.usWallOrientation == OUTSIDE_TOP_RIGHT && TileElement.pDBStructureRef[4].pDBStructure->ubNumberOfTiles == 1)
+					if (TileElement.usWallOrientation == ORIENT_OUTSIDE_RIGHT && TileElement.pDBStructureRef[4].pDBStructure->ubNumberOfTiles == 1)
 					{
 						// ... we found our problematic tile surface to be fixed
-						TileElement.usWallOrientation = INSIDE_TOP_RIGHT;
-						TileElement.pDBStructureRef->pDBStructure->ubWallOrientation = INSIDE_TOP_RIGHT;
-						TileElement.pDBStructureRef[4].pDBStructure->ubWallOrientation = INSIDE_TOP_RIGHT;
+						TileElement.usWallOrientation = ORIENT_INSIDE_RIGHT;
+						TileElement.pDBStructureRef->pDBStructure->ubWallOrientation = ORIENT_INSIDE_RIGHT;
+						TileElement.pDBStructureRef[4].pDBStructure->ubWallOrientation = ORIENT_INSIDE_RIGHT;
 						TileElement.pDBStructureRef[4].pDBStructure->ubArmour = MATERIAL_PLYWOOD_WALL;
-						TileElement.pDBStructureRef[5].pDBStructure->ubWallOrientation = INSIDE_TOP_LEFT;
-						TileElement.pDBStructureRef[9].pDBStructure->ubWallOrientation = INSIDE_TOP_LEFT;
+						TileElement.pDBStructureRef[5].pDBStructure->ubWallOrientation = ORIENT_INSIDE_LEFT;
+						TileElement.pDBStructureRef[9].pDBStructure->ubWallOrientation = ORIENT_INSIDE_LEFT;
 						// between subindices 0-4 and 10-14 there can only be 1 right part of a double door
 						TileElement.pDBStructureRef[10].pDBStructure->fFlags &= ~STRUCTURE_DDOOR_RIGHT;
 						TileElement.pDBStructureRef[10].pDBStructure->fFlags |= STRUCTURE_DDOOR_LEFT;
@@ -301,7 +319,7 @@ bool AnyHeigherLand(UINT32 const map_idx, UINT32 const src_type, UINT8* const ou
 	return found;
 }
 
-WallOrientationDefines GetWallOrientation(UINT16 usIndex)
+Orientation GetWallOrientation(UINT16 usIndex)
 {
 	Assert(usIndex < lengthof(gTileDatabase));
 	return gTileDatabase[usIndex].usWallOrientation;

--- a/src/game/TileEngine/TileDef.cc
+++ b/src/game/TileEngine/TileDef.cc
@@ -137,7 +137,7 @@ void CreateTileDatabase()
 
 			SetSpecificDatabaseValues(cnt1, gTileDatabaseSize, TileElement, TileSurf->bRaisedObjectType);
 			// fix incorrect double door flags. in vanilla it only affects DOOR3 in PALACE! tileset and DOOR1 in QUEEN'S TROPICAL
-			if (TileElement.pDBStructureRef != nullptr && cnt1 >= FIRSTDOOR && cnt1 <=FOURTHDOOR)
+			if (TileElement.pDBStructureRef && cnt1 >= FIRSTDOOR && cnt1 <=FOURTHDOOR)
 			{
 				if (TileElement.usRegionIndex == 0 && (TileElement.pDBStructureRef->pDBStructure->fFlags & (STRUCTURE_DDOOR_RIGHT|STRUCTURE_DDOOR_LEFT)))
 				{

--- a/src/game/TileEngine/TileDef.h
+++ b/src/game/TileEngine/TileDef.h
@@ -35,11 +35,27 @@ ENUM_BITSET(TileElementFlags)
 #define ROOF_HIT_ADJUSTMENT			2
 
 
-enum WallOrientationDefines : UINT8
+enum Orientation : uint8_t
 {
-	NO_ORIENTATION, INSIDE_TOP_LEFT, INSIDE_TOP_RIGHT, OUTSIDE_TOP_LEFT,
-	OUTSIDE_TOP_RIGHT
+	ORIENT_NONE          = 0x00,
+	ORIENT_INSIDE_LEFT   = 0x01,
+	ORIENT_INSIDE_RIGHT  = 0x02,
+	ORIENT_OUTSIDE_LEFT  = 0x04,
+	ORIENT_OUTSIDE_RIGHT = 0x08,
+
+	// Combination flags
+	ORIENT_LEFT          = 0x05,
+	ORIENT_RIGHT         = 0x0A,
+	ORIENT_INSIDE        = 0x03,
+	ORIENT_OUTSIDE       = 0x0C,
 };
+ENUM_BITSET(Orientation)
+
+// Assumes the flag always has only one bit set to 1
+static inline uint8_t GetBitPositionIndex(const uint8_t flag)
+{
+	return ( 0x34572610U >> ((((flag * 29) >> 5) & 7) * 4) ) & 7;
+}
 
 // TERRAIN ID VALUES.
 enum TerrainTypeDefines : UINT8
@@ -86,7 +102,7 @@ struct TILE_ELEMENT
 	UINT8                ubNumberOfTiles;
 
 	// Land and overlay type
-	WallOrientationDefines usWallOrientation;
+	Orientation          usWallOrientation;
 	UINT8                ubFullTile;
 
 	// For animated tiles
@@ -134,7 +150,7 @@ UINT32 GetTileFlags(UINT16 usIndex);
 
 UINT8 GetTileTypeLogicalHeight(UINT32 type);
 bool  AnyHeigherLand(UINT32 map_idx, UINT32 src_type, UINT8* out_last_level);
-WallOrientationDefines GetWallOrientation(UINT16 usIndex);
+Orientation GetWallOrientation(UINT16 usIndex);
 
 void SetSpecificDatabaseValues(UINT16 type, UINT16 database_elem, TILE_ELEMENT&, bool use_raised_object_type);
 

--- a/src/game/TileEngine/WorldDef.cc
+++ b/src/game/TileEngine/WorldDef.cc
@@ -444,31 +444,27 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 					if (pStructure->fFlags & STRUCTURE_WIREFENCE && pStructure->fFlags & STRUCTURE_OPEN)
 					{
 						// prevent movement along the fence but allow in all other directions
-						switch( pStructure->ubWallOrientation )
+						if ( pStructure->ubWallOrientation & ORIENT_LEFT)
 						{
-							case OUTSIDE_TOP_LEFT:
-							case INSIDE_TOP_LEFT:
-								SET_CURRMOVEMENTCOST( NORTH, TRAVELCOST_NOT_STANDING );
-								SET_CURRMOVEMENTCOST( NORTHEAST, TRAVELCOST_NOT_STANDING );
-								SET_CURRMOVEMENTCOST( EAST, TRAVELCOST_OBSTACLE );
-								SET_CURRMOVEMENTCOST( SOUTHEAST, TRAVELCOST_NOT_STANDING );
-								SET_CURRMOVEMENTCOST( SOUTH, TRAVELCOST_NOT_STANDING );
-								SET_CURRMOVEMENTCOST( SOUTHWEST, TRAVELCOST_NOT_STANDING );
-								SET_CURRMOVEMENTCOST( WEST, TRAVELCOST_OBSTACLE );
-								SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_NOT_STANDING );
-								break;
-
-							case OUTSIDE_TOP_RIGHT:
-							case INSIDE_TOP_RIGHT:
-								SET_CURRMOVEMENTCOST( NORTH, TRAVELCOST_OBSTACLE );
-								SET_CURRMOVEMENTCOST( NORTHEAST, TRAVELCOST_NOT_STANDING );
-								SET_CURRMOVEMENTCOST( EAST, TRAVELCOST_NOT_STANDING );
-								SET_CURRMOVEMENTCOST( SOUTHEAST, TRAVELCOST_NOT_STANDING );
-								SET_CURRMOVEMENTCOST( SOUTH, TRAVELCOST_OBSTACLE );
-								SET_CURRMOVEMENTCOST( SOUTHWEST, TRAVELCOST_NOT_STANDING );
-								SET_CURRMOVEMENTCOST( WEST, TRAVELCOST_NOT_STANDING );
-								SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_NOT_STANDING );
-								break;
+							SET_CURRMOVEMENTCOST(NORTH, TRAVELCOST_NOT_STANDING);
+							SET_CURRMOVEMENTCOST(NORTHEAST, TRAVELCOST_NOT_STANDING);
+							SET_CURRMOVEMENTCOST(EAST, TRAVELCOST_OBSTACLE);
+							SET_CURRMOVEMENTCOST(SOUTHEAST, TRAVELCOST_NOT_STANDING);
+							SET_CURRMOVEMENTCOST(SOUTH, TRAVELCOST_NOT_STANDING);
+							SET_CURRMOVEMENTCOST(SOUTHWEST, TRAVELCOST_NOT_STANDING);
+							SET_CURRMOVEMENTCOST(WEST, TRAVELCOST_OBSTACLE);
+							SET_CURRMOVEMENTCOST(NORTHWEST, TRAVELCOST_NOT_STANDING);
+						}
+						else
+						{
+							SET_CURRMOVEMENTCOST(NORTH, TRAVELCOST_OBSTACLE);
+							SET_CURRMOVEMENTCOST(NORTHEAST, TRAVELCOST_NOT_STANDING);
+							SET_CURRMOVEMENTCOST(EAST, TRAVELCOST_NOT_STANDING);
+							SET_CURRMOVEMENTCOST(SOUTHEAST, TRAVELCOST_NOT_STANDING);
+							SET_CURRMOVEMENTCOST(SOUTH, TRAVELCOST_OBSTACLE);
+							SET_CURRMOVEMENTCOST(SOUTHWEST, TRAVELCOST_NOT_STANDING);
+							SET_CURRMOVEMENTCOST(WEST, TRAVELCOST_NOT_STANDING);
+							SET_CURRMOVEMENTCOST(NORTHWEST, TRAVELCOST_NOT_STANDING);
 						}
 					}
 					// all other passable structures do not block movement in any way
@@ -478,73 +474,69 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 					if ( (pStructure->fFlags & STRUCTURE_FENCE) && !(pStructure->fFlags & STRUCTURE_SPECIAL) )
 					{
 						// jumpable!
-						switch( pStructure->ubWallOrientation )
+						if ( pStructure->ubWallOrientation & ORIENT_LEFT )
 						{
-							case OUTSIDE_TOP_LEFT:
-							case INSIDE_TOP_LEFT:
-								// can be jumped north and south
-								SET_CURRMOVEMENTCOST( NORTH, TRAVELCOST_FENCE );
-								SET_CURRMOVEMENTCOST( NORTHEAST, TRAVELCOST_OBSTACLE );
-								SET_CURRMOVEMENTCOST( EAST, TRAVELCOST_OBSTACLE );
-								SET_CURRMOVEMENTCOST( SOUTHEAST, TRAVELCOST_OBSTACLE );
-								SET_CURRMOVEMENTCOST( SOUTH, TRAVELCOST_FENCE );
-								SET_CURRMOVEMENTCOST( SOUTHWEST, TRAVELCOST_OBSTACLE );
-								SET_CURRMOVEMENTCOST( WEST, TRAVELCOST_OBSTACLE );
-								SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_OBSTACLE );
-								// set values for the tiles EXITED from this location
-								if (gubWorldMovementCosts[usGridNo - WORLD_COLS][NORTH][0] < TRAVELCOST_BLOCKED)
-								{
-									// make sure no obstacle costs exists before changing path cost to 0
-									FORCE_SET_MOVEMENTCOST(usGridNo - WORLD_COLS, NORTH, 0, TRAVELCOST_NONE);
-								}
-								SET_MOVEMENTCOST( usGridNo - WORLD_COLS + 1, NORTHEAST, 0, TRAVELCOST_OBSTACLE );
-								SET_MOVEMENTCOST( usGridNo + 1, EAST, 0, TRAVELCOST_OBSTACLE );
-								SET_MOVEMENTCOST( usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_OBSTACLE );
-								if (gubWorldMovementCosts[usGridNo + WORLD_COLS][SOUTH][0] < TRAVELCOST_BLOCKED)
-								{
-									FORCE_SET_MOVEMENTCOST(usGridNo + WORLD_COLS, SOUTH, 0, TRAVELCOST_NONE);
-								}
-								SET_MOVEMENTCOST( usGridNo + WORLD_COLS - 1, SOUTHWEST, 0, TRAVELCOST_OBSTACLE );
-								SET_MOVEMENTCOST( usGridNo - 1, WEST, 0, TRAVELCOST_OBSTACLE );
-								SET_MOVEMENTCOST( usGridNo - WORLD_COLS - 1, NORTHWEST, 0, TRAVELCOST_OBSTACLE );
-								break;
-
-							case OUTSIDE_TOP_RIGHT:
-							case INSIDE_TOP_RIGHT:
-								// can be jumped east and west
-								SET_CURRMOVEMENTCOST( NORTH, TRAVELCOST_OBSTACLE );
-								SET_CURRMOVEMENTCOST( NORTHEAST, TRAVELCOST_OBSTACLE );
-								SET_CURRMOVEMENTCOST( EAST, TRAVELCOST_FENCE );
-								SET_CURRMOVEMENTCOST( SOUTHEAST, TRAVELCOST_OBSTACLE );
-								SET_CURRMOVEMENTCOST( SOUTH, TRAVELCOST_OBSTACLE );
-								SET_CURRMOVEMENTCOST( SOUTHWEST, TRAVELCOST_OBSTACLE );
-								SET_CURRMOVEMENTCOST( WEST, TRAVELCOST_FENCE );
-								SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_OBSTACLE );
-								// set values for the tiles EXITED from this location
-								SET_MOVEMENTCOST( usGridNo - WORLD_COLS, NORTH, 0, TRAVELCOST_OBSTACLE );
-								SET_MOVEMENTCOST( usGridNo - WORLD_COLS + 1, NORTHEAST, 0, TRAVELCOST_OBSTACLE );
+							// can be jumped north and south
+							SET_CURRMOVEMENTCOST(NORTH, TRAVELCOST_FENCE);
+							SET_CURRMOVEMENTCOST(NORTHEAST, TRAVELCOST_OBSTACLE);
+							SET_CURRMOVEMENTCOST(EAST, TRAVELCOST_OBSTACLE);
+							SET_CURRMOVEMENTCOST(SOUTHEAST, TRAVELCOST_OBSTACLE);
+							SET_CURRMOVEMENTCOST(SOUTH, TRAVELCOST_FENCE);
+							SET_CURRMOVEMENTCOST(SOUTHWEST, TRAVELCOST_OBSTACLE);
+							SET_CURRMOVEMENTCOST(WEST, TRAVELCOST_OBSTACLE);
+							SET_CURRMOVEMENTCOST(NORTHWEST, TRAVELCOST_OBSTACLE);
+							// set values for the tiles EXITED from this location
+							if (gubWorldMovementCosts[usGridNo - WORLD_COLS][NORTH][0] < TRAVELCOST_BLOCKED)
+							{
 								// make sure no obstacle costs exists before changing path cost to 0
-								if ( gubWorldMovementCosts[ usGridNo + 1 ][ EAST ][ 0 ] < TRAVELCOST_BLOCKED )
-								{
-									FORCE_SET_MOVEMENTCOST( usGridNo + 1, EAST, 0, TRAVELCOST_NONE );
-								}
-								SET_MOVEMENTCOST( usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_OBSTACLE );
-								SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTH, 0, TRAVELCOST_OBSTACLE );
-								SET_MOVEMENTCOST( usGridNo + WORLD_COLS - 1, SOUTHWEST, 0, TRAVELCOST_OBSTACLE );
-								if ( gubWorldMovementCosts[ usGridNo - 1 ][ WEST ][ 0 ] < TRAVELCOST_BLOCKED )
-								{
-									FORCE_SET_MOVEMENTCOST( usGridNo - 1, WEST, 0, TRAVELCOST_NONE );
-								}
-								SET_MOVEMENTCOST( usGridNo - WORLD_COLS - 1, NORTHWEST, 0, TRAVELCOST_OBSTACLE );
-								break;
-
-							default:
-								// corners aren't jumpable
-								for (ubDirLoop=0; ubDirLoop < NUM_WORLD_DIRECTIONS; ubDirLoop++)
-								{
-									SET_CURRMOVEMENTCOST( ubDirLoop, TRAVELCOST_OBSTACLE );
-								}
-								break;
+								FORCE_SET_MOVEMENTCOST(usGridNo - WORLD_COLS, NORTH, 0, TRAVELCOST_NONE);
+							}
+							SET_MOVEMENTCOST(usGridNo - WORLD_COLS + 1, NORTHEAST, 0, TRAVELCOST_OBSTACLE);
+							SET_MOVEMENTCOST(usGridNo + 1, EAST, 0, TRAVELCOST_OBSTACLE);
+							SET_MOVEMENTCOST(usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_OBSTACLE);
+							if (gubWorldMovementCosts[usGridNo + WORLD_COLS][SOUTH][0] < TRAVELCOST_BLOCKED)
+							{
+								FORCE_SET_MOVEMENTCOST(usGridNo + WORLD_COLS, SOUTH, 0, TRAVELCOST_NONE);
+							}
+							SET_MOVEMENTCOST(usGridNo + WORLD_COLS - 1, SOUTHWEST, 0, TRAVELCOST_OBSTACLE);
+							SET_MOVEMENTCOST(usGridNo - 1, WEST, 0, TRAVELCOST_OBSTACLE);
+							SET_MOVEMENTCOST(usGridNo - WORLD_COLS - 1, NORTHWEST, 0, TRAVELCOST_OBSTACLE);
+						}
+						else if ( pStructure->ubWallOrientation & ORIENT_RIGHT )
+						{
+							// can be jumped east and west
+							SET_CURRMOVEMENTCOST(NORTH, TRAVELCOST_OBSTACLE);
+							SET_CURRMOVEMENTCOST(NORTHEAST, TRAVELCOST_OBSTACLE);
+							SET_CURRMOVEMENTCOST(EAST, TRAVELCOST_FENCE);
+							SET_CURRMOVEMENTCOST(SOUTHEAST, TRAVELCOST_OBSTACLE);
+							SET_CURRMOVEMENTCOST(SOUTH, TRAVELCOST_OBSTACLE);
+							SET_CURRMOVEMENTCOST(SOUTHWEST, TRAVELCOST_OBSTACLE);
+							SET_CURRMOVEMENTCOST(WEST, TRAVELCOST_FENCE);
+							SET_CURRMOVEMENTCOST(NORTHWEST, TRAVELCOST_OBSTACLE);
+							// set values for the tiles EXITED from this location
+							SET_MOVEMENTCOST(usGridNo - WORLD_COLS, NORTH, 0, TRAVELCOST_OBSTACLE);
+							SET_MOVEMENTCOST(usGridNo - WORLD_COLS + 1, NORTHEAST, 0, TRAVELCOST_OBSTACLE);
+							// make sure no obstacle costs exists before changing path cost to 0
+							if (gubWorldMovementCosts[usGridNo + 1][EAST][0] < TRAVELCOST_BLOCKED)
+							{
+								FORCE_SET_MOVEMENTCOST(usGridNo + 1, EAST, 0, TRAVELCOST_NONE);
+							}
+							SET_MOVEMENTCOST(usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_OBSTACLE);
+							SET_MOVEMENTCOST(usGridNo + WORLD_COLS, SOUTH, 0, TRAVELCOST_OBSTACLE);
+							SET_MOVEMENTCOST(usGridNo + WORLD_COLS - 1, SOUTHWEST, 0, TRAVELCOST_OBSTACLE);
+							if (gubWorldMovementCosts[usGridNo - 1][WEST][0] < TRAVELCOST_BLOCKED)
+							{
+								FORCE_SET_MOVEMENTCOST(usGridNo - 1, WEST, 0, TRAVELCOST_NONE);
+							}
+							SET_MOVEMENTCOST(usGridNo - WORLD_COLS - 1, NORTHWEST, 0, TRAVELCOST_OBSTACLE);
+						}
+						else
+						{
+							// corners aren't jumpable
+							for (ubDirLoop = 0; ubDirLoop < NUM_WORLD_DIRECTIONS; ubDirLoop++)
+							{
+								SET_CURRMOVEMENTCOST(ubDirLoop, TRAVELCOST_OBSTACLE);
+							}
 						}
  					}
 					else if ( pStructure->pDBStructureRef->pDBStructure->ubArmour == MATERIAL_SANDBAG && StructureHeight( pStructure ) < 2 )
@@ -591,7 +583,7 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 						// double door, left side (as you look on the screen)
 						switch( pStructure->ubWallOrientation )
 						{
-							case OUTSIDE_TOP_RIGHT:
+							case ORIENT_OUTSIDE_RIGHT:
 								if (pStructure->fFlags & STRUCTURE_BASE_TILE)
 								{ // doorpost
 									SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_OBSTACLE );
@@ -615,7 +607,7 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 									SET_MOVEMENTCOST( usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_DOOR_OPEN_NW_W );
 								}
 								break;
-							case OUTSIDE_TOP_LEFT:
+							case ORIENT_OUTSIDE_LEFT:
 								if (pStructure->fFlags & STRUCTURE_BASE_TILE)
 								{	// doorframe
 									SET_CURRMOVEMENTCOST(NORTHEAST, TRAVELCOST_OBSTACLE);
@@ -642,7 +634,7 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 									SET_MOVEMENTCOST(usGridNo + WORLD_COLS - 1, SOUTHWEST, 0, TRAVELCOST_DOOR_OPEN_NE_N);
 								}
 								break;
-							case INSIDE_TOP_LEFT:
+							case ORIENT_INSIDE_LEFT:
 								// doorframe
 								SET_CURRMOVEMENTCOST(NORTHEAST, TRAVELCOST_OBSTACLE);
 								SET_CURRMOVEMENTCOST(NORTH, TRAVELCOST_DOOR_CLOSED_HERE);
@@ -664,7 +656,7 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 								SET_MOVEMENTCOST(usGridNo - WORLD_COLS, NORTHEAST, 0, TRAVELCOST_DOOR_OPEN_S);
 								SET_MOVEMENTCOST(usGridNo - WORLD_COLS - 1, NORTHWEST, 0, TRAVELCOST_DOOR_OPEN_SE);
 								break;
-							case INSIDE_TOP_RIGHT:
+							case ORIENT_INSIDE_RIGHT:
 								SET_CURRMOVEMENTCOST(NORTHWEST, TRAVELCOST_OBSTACLE);
 								SET_CURRMOVEMENTCOST(WEST, TRAVELCOST_DOOR_CLOSED_HERE);
 								SET_CURRMOVEMENTCOST(SOUTHWEST, TRAVELCOST_DOORS_CLOSED_HERE_N);
@@ -698,7 +690,7 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 						// double door, right side (as you look on the screen)
 						switch( pStructure->ubWallOrientation )
 						{
-							case OUTSIDE_TOP_LEFT:
+							case ORIENT_OUTSIDE_LEFT:
 								if (pStructure->fFlags & STRUCTURE_BASE_TILE)
 								{	// doorpost
 									SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_OBSTACLE );
@@ -723,7 +715,7 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 									SET_MOVEMENTCOST( usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_DOOR_OPEN_NW_N );
 								}
 								break;
-							case OUTSIDE_TOP_RIGHT:
+							case ORIENT_OUTSIDE_RIGHT:
 								if (pStructure->fFlags & STRUCTURE_BASE_TILE)
 								{ // doorframe
 									SET_CURRMOVEMENTCOST(SOUTHWEST, TRAVELCOST_OBSTACLE);
@@ -748,7 +740,7 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 									SET_MOVEMENTCOST(usGridNo - WORLD_COLS + 1, NORTHEAST, 0, TRAVELCOST_DOOR_OPEN_SW_W);
 								}
 								break;
-							case INSIDE_TOP_RIGHT:
+							case ORIENT_INSIDE_RIGHT:
 								SET_CURRMOVEMENTCOST(SOUTHWEST, TRAVELCOST_OBSTACLE);
 								SET_CURRMOVEMENTCOST(WEST, TRAVELCOST_DOOR_CLOSED_HERE);
 								SET_CURRMOVEMENTCOST(NORTHWEST, TRAVELCOST_DOORS_CLOSED_HERE_S);
@@ -771,7 +763,7 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 								SET_MOVEMENTCOST(usGridNo - 1, SOUTHWEST, 0, TRAVELCOST_DOOR_OPEN_E);
 								SET_MOVEMENTCOST(usGridNo - WORLD_COLS - 1, NORTHWEST, 0, TRAVELCOST_DOOR_OPEN_SE);
 								break;
-							case INSIDE_TOP_LEFT:
+							case ORIENT_INSIDE_LEFT:
 								SET_CURRMOVEMENTCOST(NORTHEAST, TRAVELCOST_DOORS_CLOSED_HERE_W);
 								SET_CURRMOVEMENTCOST(NORTH, TRAVELCOST_DOOR_CLOSED_HERE);
 								SET_CURRMOVEMENTCOST(NORTHWEST, TRAVELCOST_OBSTACLE);
@@ -800,62 +792,59 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 					}
 					else if (pStructure->fFlags & STRUCTURE_GARAGEDOOR)
 					{
-						switch( pStructure->ubWallOrientation )
+						if (pStructure->ubWallOrientation & ORIENT_LEFT)
 						{
-							case OUTSIDE_TOP_LEFT:
-							case INSIDE_TOP_LEFT:
-								// doorframe post in one corner of each of the tiles
-								if (pStructure->fFlags & STRUCTURE_BASE_TILE)
-								{
-									SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_WALL );
-									SET_CURRMOVEMENTCOST( NORTH, TRAVELCOST_DOOR_CLOSED_HERE );
-									SET_CURRMOVEMENTCOST( NORTHEAST, TRAVELCOST_DOOR_CLOSED_HERE );
-									SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_WALL );
-									SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTH, 0, TRAVELCOST_DOOR_CLOSED_N );
-									SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHEAST, 0, TRAVELCOST_DOOR_CLOSED_N );
-									SET_MOVEMENTCOST(usGridNo + 1, NORTHEAST, 0, TRAVELCOST_WALL);
-									SET_MOVEMENTCOST(usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_WALL);
-								}
-								else
-								{
-									SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_DOOR_CLOSED_HERE );
-									SET_CURRMOVEMENTCOST( NORTH, TRAVELCOST_DOOR_CLOSED_HERE );
-									SET_CURRMOVEMENTCOST( NORTHEAST, TRAVELCOST_WALL );
-									SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_DOOR_CLOSED_N);
-									SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTH, 0, TRAVELCOST_DOOR_CLOSED_N);
-									SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHEAST, 0, TRAVELCOST_WALL );
-									SET_MOVEMENTCOST(usGridNo + WORLD_COLS - 1, SOUTHWEST, 0, TRAVELCOST_WALL);
-									SET_MOVEMENTCOST(usGridNo - 1, NORTHWEST, 0, TRAVELCOST_WALL);
-								}
-								break;
-							case OUTSIDE_TOP_RIGHT:
-							case INSIDE_TOP_RIGHT:
-								// doorframe post in one corner of each of the tiles
-								if (pStructure->fFlags & STRUCTURE_BASE_TILE)
-								{
-									SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_WALL );
-									SET_CURRMOVEMENTCOST( WEST, TRAVELCOST_DOOR_CLOSED_HERE );
-									SET_CURRMOVEMENTCOST( SOUTHWEST, TRAVELCOST_DOOR_CLOSED_HERE );
+							// doorframe post in one corner of each of the tiles
+							if (pStructure->fFlags & STRUCTURE_BASE_TILE)
+							{
+								SET_CURRMOVEMENTCOST(NORTHWEST, TRAVELCOST_WALL);
+								SET_CURRMOVEMENTCOST(NORTH, TRAVELCOST_DOOR_CLOSED_HERE);
+								SET_CURRMOVEMENTCOST(NORTHEAST, TRAVELCOST_DOOR_CLOSED_HERE);
+								SET_MOVEMENTCOST(usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_WALL);
+								SET_MOVEMENTCOST(usGridNo + WORLD_COLS, SOUTH, 0, TRAVELCOST_DOOR_CLOSED_N);
+								SET_MOVEMENTCOST(usGridNo + WORLD_COLS, SOUTHEAST, 0, TRAVELCOST_DOOR_CLOSED_N);
+								SET_MOVEMENTCOST(usGridNo + 1, NORTHEAST, 0, TRAVELCOST_WALL);
+								SET_MOVEMENTCOST(usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_WALL);
+							}
+							else
+							{
+								SET_CURRMOVEMENTCOST(NORTHWEST, TRAVELCOST_DOOR_CLOSED_HERE);
+								SET_CURRMOVEMENTCOST(NORTH, TRAVELCOST_DOOR_CLOSED_HERE);
+								SET_CURRMOVEMENTCOST(NORTHEAST, TRAVELCOST_WALL);
+								SET_MOVEMENTCOST(usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_DOOR_CLOSED_N);
+								SET_MOVEMENTCOST(usGridNo + WORLD_COLS, SOUTH, 0, TRAVELCOST_DOOR_CLOSED_N);
+								SET_MOVEMENTCOST(usGridNo + WORLD_COLS, SOUTHEAST, 0, TRAVELCOST_WALL);
+								SET_MOVEMENTCOST(usGridNo + WORLD_COLS - 1, SOUTHWEST, 0, TRAVELCOST_WALL);
+								SET_MOVEMENTCOST(usGridNo - 1, NORTHWEST, 0, TRAVELCOST_WALL);
+							}
+						}
+						else
+						{
+							// doorframe post in one corner of each of the tiles
+							if (pStructure->fFlags & STRUCTURE_BASE_TILE)
+							{
+								SET_CURRMOVEMENTCOST(NORTHWEST, TRAVELCOST_WALL);
+								SET_CURRMOVEMENTCOST(WEST, TRAVELCOST_DOOR_CLOSED_HERE);
+								SET_CURRMOVEMENTCOST(SOUTHWEST, TRAVELCOST_DOOR_CLOSED_HERE);
 
-									SET_MOVEMENTCOST( usGridNo + 1, NORTHEAST, 0, TRAVELCOST_WALL );
-									SET_MOVEMENTCOST( usGridNo + 1, EAST, 0, TRAVELCOST_DOOR_CLOSED_W );
-									SET_MOVEMENTCOST( usGridNo + 1, SOUTHEAST, 0, TRAVELCOST_DOOR_CLOSED_W );
-									SET_MOVEMENTCOST(usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_WALL);
-									SET_MOVEMENTCOST(usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_WALL)
-								}
-								else
-								{
-									SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_DOOR_CLOSED_HERE );
-									SET_CURRMOVEMENTCOST( WEST, TRAVELCOST_DOOR_CLOSED_HERE );
-									SET_CURRMOVEMENTCOST( SOUTHWEST, TRAVELCOST_WALL );
+								SET_MOVEMENTCOST(usGridNo + 1, NORTHEAST, 0, TRAVELCOST_WALL);
+								SET_MOVEMENTCOST(usGridNo + 1, EAST, 0, TRAVELCOST_DOOR_CLOSED_W);
+								SET_MOVEMENTCOST(usGridNo + 1, SOUTHEAST, 0, TRAVELCOST_DOOR_CLOSED_W);
+								SET_MOVEMENTCOST(usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_WALL);
+								SET_MOVEMENTCOST(usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_WALL)
+							}
+							else
+							{
+								SET_CURRMOVEMENTCOST(NORTHWEST, TRAVELCOST_DOOR_CLOSED_HERE);
+								SET_CURRMOVEMENTCOST(WEST, TRAVELCOST_DOOR_CLOSED_HERE);
+								SET_CURRMOVEMENTCOST(SOUTHWEST, TRAVELCOST_WALL);
 
-									SET_MOVEMENTCOST( usGridNo + 1, NORTHEAST, 0, TRAVELCOST_DOOR_CLOSED_W );
-									SET_MOVEMENTCOST( usGridNo + 1, EAST, 0, TRAVELCOST_DOOR_CLOSED_W );
-									SET_MOVEMENTCOST( usGridNo + 1, SOUTHEAST, 0, TRAVELCOST_WALL );
-									SET_MOVEMENTCOST(usGridNo - WORLD_COLS, NORTHWEST, 0, TRAVELCOST_WALL);
-									SET_MOVEMENTCOST(usGridNo - WORLD_COLS + 1, NORTHEAST, 0, TRAVELCOST_WALL);
-								}
-								break;
+								SET_MOVEMENTCOST(usGridNo + 1, NORTHEAST, 0, TRAVELCOST_DOOR_CLOSED_W);
+								SET_MOVEMENTCOST(usGridNo + 1, EAST, 0, TRAVELCOST_DOOR_CLOSED_W);
+								SET_MOVEMENTCOST(usGridNo + 1, SOUTHEAST, 0, TRAVELCOST_WALL);
+								SET_MOVEMENTCOST(usGridNo - WORLD_COLS, NORTHWEST, 0, TRAVELCOST_WALL);
+								SET_MOVEMENTCOST(usGridNo - WORLD_COLS + 1, NORTHEAST, 0, TRAVELCOST_WALL);
+							}
 						}
 					}
 					else
@@ -863,7 +852,7 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 						// standard door
 						switch( pStructure->ubWallOrientation )
 						{
-							case OUTSIDE_TOP_LEFT:
+							case ORIENT_OUTSIDE_LEFT:
 								if (pStructure->fFlags & STRUCTURE_BASE_TILE)
 								{	// doorframe
 									SET_CURRMOVEMENTCOST( NORTHEAST, TRAVELCOST_WALL );
@@ -879,14 +868,6 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 									SET_MOVEMENTCOST( usGridNo + 1, NORTHEAST, 0, TRAVELCOST_WALL );
 									SET_MOVEMENTCOST( usGridNo + WORLD_COLS - 1, SOUTHWEST, 0, TRAVELCOST_WALL );
 									SET_MOVEMENTCOST( usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_WALL );
-
-
-									//SET_CURRMOVEMENTCOST( NORTHEAST, TRAVELCOST_OBSTACLE );
-									//SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_OBSTACLE );
-									//SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHEAST, 0, TRAVELCOST_OBSTACLE );
-									//SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_OBSTACLE );
-									// corner
-									//SET_MOVEMENTCOST( usGridNo + 1 ,NORTHEAST, 0, TRAVELCOST_OBSTACLE );
 								}
 								else if (!(pStructure->fFlags & STRUCTURE_SLIDINGDOOR))
 								{ // door
@@ -899,7 +880,7 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 								}
 								break;
 
-							case INSIDE_TOP_LEFT:
+							case ORIENT_INSIDE_LEFT:
 								SET_CURRMOVEMENTCOST( NORTHEAST, TRAVELCOST_WALL );
 								SET_CURRMOVEMENTCOST( NORTH, TRAVELCOST_DOOR_CLOSED_HERE );
 								SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_WALL );
@@ -914,14 +895,6 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 								SET_MOVEMENTCOST( usGridNo + WORLD_COLS - 1, SOUTHWEST, 0, TRAVELCOST_OBSTACLE );
 								SET_MOVEMENTCOST( usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_OBSTACLE );
 
-								// doorframe
-								//SET_CURRMOVEMENTCOST( NORTHEAST, TRAVELCOST_OBSTACLE );
-								//SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_OBSTACLE );
-								//SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHEAST, 0, TRAVELCOST_OBSTACLE );
-								//SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_OBSTACLE );
-								// corner
-								//SET_MOVEMENTCOST( usGridNo + 1 ,NORTHEAST, 0, TRAVELCOST_OBSTACLE );
-								// door
 								if (!(pStructure->fFlags & STRUCTURE_SLIDINGDOOR))
 								{
 									SET_CURRMOVEMENTCOST( EAST, TRAVELCOST_DOOR_OPEN_HERE );
@@ -933,7 +906,7 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 								}
 								break;
 
-							case OUTSIDE_TOP_RIGHT:
+							case ORIENT_OUTSIDE_RIGHT:
 								if (pStructure->fFlags & STRUCTURE_BASE_TILE)
 								{ // doorframe
 									SET_CURRMOVEMENTCOST( SOUTHWEST, TRAVELCOST_OBSTACLE );
@@ -949,13 +922,6 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 									SET_MOVEMENTCOST( usGridNo - WORLD_COLS, NORTHWEST, 0, TRAVELCOST_OBSTACLE );
 									SET_MOVEMENTCOST( usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_OBSTACLE );
 									SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_OBSTACLE );
-
-									//SET_CURRMOVEMENTCOST( SOUTHWEST, TRAVELCOST_OBSTACLE );
-									//SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_OBSTACLE );
-									//SET_MOVEMENTCOST( usGridNo + 1, SOUTHEAST, 0, TRAVELCOST_OBSTACLE );
-									//SET_MOVEMENTCOST( usGridNo + 1, NORTHEAST, 0, TRAVELCOST_OBSTACLE );
-									// corner
-									//SET_MOVEMENTCOST( usGridNo + 1 + WORLD_COLS, SOUTHEAST, 0, TRAVELCOST_OBSTACLE );
 								}
 								else if (!(pStructure->fFlags & STRUCTURE_SLIDINGDOOR))
 								{	// door
@@ -968,7 +934,7 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 								}
 								break;
 
-							case INSIDE_TOP_RIGHT:
+							case ORIENT_INSIDE_RIGHT:
 								SET_CURRMOVEMENTCOST( SOUTHWEST, TRAVELCOST_OBSTACLE );
 								SET_CURRMOVEMENTCOST( WEST, TRAVELCOST_DOOR_CLOSED_HERE );
 								SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_OBSTACLE );
@@ -983,15 +949,6 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 								SET_MOVEMENTCOST( usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_OBSTACLE );
 								SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_OBSTACLE );
 
-								// doorframe
-								/*
-								SET_CURRMOVEMENTCOST( SOUTHWEST, TRAVELCOST_OBSTACLE );
-								SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_OBSTACLE );
-								SET_MOVEMENTCOST( usGridNo + 1,SOUTHEAST, 0, TRAVELCOST_OBSTACLE );
-								SET_MOVEMENTCOST( usGridNo + 1,NORTHEAST, 0, TRAVELCOST_OBSTACLE );
-								// corner
-								SET_MOVEMENTCOST( usGridNo - WORLD_COLS,  NORTHWEST, 0, TRAVELCOST_OBSTACLE );
-								*/
 								if (!(pStructure->fFlags & STRUCTURE_SLIDINGDOOR))
 								{
 									// door
@@ -1009,92 +966,39 @@ static void CompileTileMovementCosts(UINT16 usGridNo)
 								break;
 						}
 					}
-
-					/*
-					switch( pStructure->ubWallOrientation )
-					{
-						case OUTSIDE_TOP_LEFT:
-						case INSIDE_TOP_LEFT:
-							SET_CURRMOVEMENTCOST( NORTHEAST, TRAVELCOST_OBSTACLE );
-							SET_CURRMOVEMENTCOST( NORTH, TRAVELCOST_DOOR_CLOSED_HERE );
-							SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_OBSTACLE );
-
-							SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHEAST, 0, TRAVELCOST_OBSTACLE );
-							SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTH, 0, TRAVELCOST_DOOR_CLOSED_N );
-							SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_OBSTACLE );
-
-							// DO CORNERS
-							SET_MOVEMENTCOST( usGridNo - 1, NORTHWEST, 0, TRAVELCOST_OBSTACLE );
-							SET_MOVEMENTCOST( usGridNo + 1, NORTHEAST, 0, TRAVELCOST_OBSTACLE );
-							SET_MOVEMENTCOST( usGridNo + WORLD_COLS - 1, SOUTHWEST, 0, TRAVELCOST_OBSTACLE );
-							SET_MOVEMENTCOST( usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_OBSTACLE );
-							break;
-
-						case OUTSIDE_TOP_RIGHT:
-						case INSIDE_TOP_RIGHT:
-							SET_CURRMOVEMENTCOST( SOUTHWEST, TRAVELCOST_OBSTACLE );
-							SET_CURRMOVEMENTCOST( WEST, TRAVELCOST_DOOR_CLOSED_HERE );
-							SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_OBSTACLE );
-
-							SET_MOVEMENTCOST( usGridNo + 1, SOUTHEAST, 0, TRAVELCOST_OBSTACLE );
-							SET_MOVEMENTCOST( usGridNo + 1, EAST, 0, TRAVELCOST_DOOR_CLOSED_W );
-							SET_MOVEMENTCOST( usGridNo + 1, NORTHEAST, 0, TRAVELCOST_OBSTACLE );
-
-							// DO CORNERS
-							SET_MOVEMENTCOST( usGridNo - WORLD_COLS + 1, NORTHEAST, 0, TRAVELCOST_OBSTACLE );
-							SET_MOVEMENTCOST( usGridNo - WORLD_COLS, NORTHWEST, 0, TRAVELCOST_OBSTACLE );
-							SET_MOVEMENTCOST( usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_OBSTACLE );
-							SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_OBSTACLE );
-							break;
-
-						default:
-							// wall with no orientation specified!?
-							break;
-					}
-					*/
-
-
 				}
 				else if (pStructure->fFlags & STRUCTURE_WALLSTUFF )
 				{
 					//ATE: IF a closed door, set to door value
-					switch( pStructure->ubWallOrientation )
+					if (pStructure->ubWallOrientation & ORIENT_LEFT)
 					{
-						case OUTSIDE_TOP_LEFT:
-						case INSIDE_TOP_LEFT:
-							SET_CURRMOVEMENTCOST( NORTHEAST, TRAVELCOST_WALL );
-							SET_CURRMOVEMENTCOST( NORTH, TRAVELCOST_WALL );
-							SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_WALL );
-							SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHEAST, 0, TRAVELCOST_WALL );
-							SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTH, 0, TRAVELCOST_WALL );
-							SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_WALL );
+						SET_CURRMOVEMENTCOST(NORTHEAST, TRAVELCOST_WALL);
+						SET_CURRMOVEMENTCOST(NORTH, TRAVELCOST_WALL);
+						SET_CURRMOVEMENTCOST(NORTHWEST, TRAVELCOST_WALL);
+						SET_MOVEMENTCOST(usGridNo + WORLD_COLS, SOUTHEAST, 0, TRAVELCOST_WALL);
+						SET_MOVEMENTCOST(usGridNo + WORLD_COLS, SOUTH, 0, TRAVELCOST_WALL);
+						SET_MOVEMENTCOST(usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_WALL);
 
-							// DO CORNERS
-							SET_MOVEMENTCOST( usGridNo - 1, NORTHWEST, 0, TRAVELCOST_WALL );
-							SET_MOVEMENTCOST( usGridNo + 1, NORTHEAST, 0, TRAVELCOST_WALL );
-							SET_MOVEMENTCOST( usGridNo + WORLD_COLS - 1, SOUTHWEST, 0, TRAVELCOST_WALL );
-							SET_MOVEMENTCOST( usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_WALL );
-							break;
+						// DO CORNERS
+						SET_MOVEMENTCOST(usGridNo - 1, NORTHWEST, 0, TRAVELCOST_WALL);
+						SET_MOVEMENTCOST(usGridNo + 1, NORTHEAST, 0, TRAVELCOST_WALL);
+						SET_MOVEMENTCOST(usGridNo + WORLD_COLS - 1, SOUTHWEST, 0, TRAVELCOST_WALL);
+						SET_MOVEMENTCOST(usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_WALL);
+					}
+					else
+					{
+						SET_CURRMOVEMENTCOST(SOUTHWEST, TRAVELCOST_WALL);
+						SET_CURRMOVEMENTCOST(WEST, TRAVELCOST_WALL);
+						SET_CURRMOVEMENTCOST(NORTHWEST, TRAVELCOST_WALL);
+						SET_MOVEMENTCOST(usGridNo + 1, SOUTHEAST, 0, TRAVELCOST_WALL);
+						SET_MOVEMENTCOST(usGridNo + 1, EAST, 0, TRAVELCOST_WALL);
+						SET_MOVEMENTCOST(usGridNo + 1, NORTHEAST, 0, TRAVELCOST_WALL);
 
-						case OUTSIDE_TOP_RIGHT:
-						case INSIDE_TOP_RIGHT:
-							SET_CURRMOVEMENTCOST( SOUTHWEST, TRAVELCOST_WALL );
-							SET_CURRMOVEMENTCOST( WEST, TRAVELCOST_WALL );
-							SET_CURRMOVEMENTCOST( NORTHWEST, TRAVELCOST_WALL );
-							SET_MOVEMENTCOST( usGridNo + 1, SOUTHEAST, 0, TRAVELCOST_WALL );
-							SET_MOVEMENTCOST( usGridNo + 1, EAST, 0, TRAVELCOST_WALL );
-							SET_MOVEMENTCOST( usGridNo + 1, NORTHEAST, 0, TRAVELCOST_WALL );
-
-							// DO CORNERS
-							SET_MOVEMENTCOST( usGridNo - WORLD_COLS + 1, NORTHEAST, 0, TRAVELCOST_WALL );
-							SET_MOVEMENTCOST( usGridNo - WORLD_COLS, NORTHWEST, 0, TRAVELCOST_WALL );
-							SET_MOVEMENTCOST( usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_WALL );
-							SET_MOVEMENTCOST( usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_WALL );
-							break;
-
-						default:
-							// wall with no orientation specified!?
-							break;
+						// DO CORNERS
+						SET_MOVEMENTCOST(usGridNo - WORLD_COLS + 1, NORTHEAST, 0, TRAVELCOST_WALL);
+						SET_MOVEMENTCOST(usGridNo - WORLD_COLS, NORTHWEST, 0, TRAVELCOST_WALL);
+						SET_MOVEMENTCOST(usGridNo + WORLD_COLS + 1, SOUTHEAST, 0, TRAVELCOST_WALL);
+						SET_MOVEMENTCOST(usGridNo + WORLD_COLS, SOUTHWEST, 0, TRAVELCOST_WALL);
 					}
 				}
 			}
@@ -1317,24 +1221,23 @@ void RecompileLocalMovementCostsForWall( INT16 sGridNo, UINT8 ubOrientation )
 	INT16		sUp, sDown, sLeft, sRight;
 	INT16		sX, sY, sTempGridNo;
 
-	switch( ubOrientation )
+	if ( ubOrientation & ORIENT_RIGHT)
 	{
-		case OUTSIDE_TOP_RIGHT:
-		case INSIDE_TOP_RIGHT:
-			sUp = -1;
-			sDown = 1;
-			sLeft = 0;
-			sRight = 1;
-			break;
-		case OUTSIDE_TOP_LEFT:
-		case INSIDE_TOP_LEFT:
-			sUp = 0;
-			sDown = 1;
-			sLeft = -1;
-			sRight = 1;
-			break;
-		default:
-			return;
+		sUp = -1;
+		sDown = 1;
+		sLeft = 0;
+		sRight = 1;
+	}
+	else if (ubOrientation & ORIENT_LEFT)
+	{
+		sUp = 0;
+		sDown = 1;
+		sLeft = -1;
+		sRight = 1;
+	}
+	else
+	{
+		return;
 	}
 
 	for ( sY = sUp; sY <= sDown; sY++ )
@@ -2743,12 +2646,13 @@ static UINT16 GetWireframeGraphicNumToUseForWall(const INT16 sGridNo, STRUCTURE*
 		}
 	}
 
-	switch (s->ubWallOrientation)
+	if (s->ubWallOrientation & ORIENT_LEFT)
 	{
-		case OUTSIDE_TOP_LEFT:
-		case INSIDE_TOP_LEFT:   return WIREFRAMES6; break;
-		case OUTSIDE_TOP_RIGHT:
-		case INSIDE_TOP_RIGHT:  return WIREFRAMES5; break;
+		return WIREFRAMES6;
+	}
+	else
+	{
+		return WIREFRAMES5;
 	}
 
 	return 0;
@@ -2802,32 +2706,23 @@ void CalculateWorldWireFrameTiles( BOOLEAN fForce )
 						// Based on orientation
 						ubWallOrientation = pStructure->ubWallOrientation;
 
-						switch( ubWallOrientation )
+						if (ubWallOrientation & ORIENT_LEFT)
 						{
-							case OUTSIDE_TOP_LEFT:
-							case INSIDE_TOP_LEFT:
+							sGridNo = NewGridNo((INT16)cnt, DirectionInc(SOUTH));
 
-								// Get gridno
-								sGridNo = NewGridNo( (INT16)cnt, DirectionInc( SOUTH ) );
+							if (IsRoofVisibleForWireframe(sGridNo) && !(gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED))
+							{
+								AddWireFrame((INT16)cnt, WIREFRAMES4, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
+							}
+						}
+						else
+						{
+							sGridNo = NewGridNo((INT16)cnt, DirectionInc(EAST));
 
-								if ( IsRoofVisibleForWireframe( sGridNo ) && !( gpWorldLevelData[ sGridNo ].uiFlags & MAPELEMENT_REVEALED ) )
-								{
-									AddWireFrame((INT16)cnt, WIREFRAMES4, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
-								}
-								break;
-
-							case OUTSIDE_TOP_RIGHT:
-							case INSIDE_TOP_RIGHT:
-
-								// Get gridno
-								sGridNo = NewGridNo( (INT16)cnt, DirectionInc( EAST ) );
-
-								if ( IsRoofVisibleForWireframe( sGridNo ) && !( gpWorldLevelData[ sGridNo ].uiFlags & MAPELEMENT_REVEALED ) )
-								{
-									AddWireFrame((INT16)cnt, WIREFRAMES3, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
-								}
-								break;
-
+							if (IsRoofVisibleForWireframe(sGridNo) && !(gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED))
+							{
+								AddWireFrame((INT16)cnt, WIREFRAMES3, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
+							}
 						}
 					}
 				}
@@ -2840,34 +2735,24 @@ void CalculateWorldWireFrameTiles( BOOLEAN fForce )
 						// Based on orientation
 						ubWallOrientation = pStructure->ubWallOrientation;
 
-						switch( ubWallOrientation )
+						if ( ubWallOrientation & ORIENT_LEFT )
 						{
-							case OUTSIDE_TOP_LEFT:
-							case INSIDE_TOP_LEFT:
+							sGridNo = NewGridNo((INT16)cnt, DirectionInc(SOUTH));
 
-								// Get gridno
-								sGridNo = NewGridNo( (INT16)cnt, DirectionInc( SOUTH ) );
-
-								if ( IsRoofVisibleForWireframe( sGridNo ) && !( gpWorldLevelData[ sGridNo ].uiFlags & MAPELEMENT_REVEALED ) )
-								{
-									AddWireFrame((INT16)cnt, WIREFRAMES2, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
-								}
-								break;
-
-							case OUTSIDE_TOP_RIGHT:
-							case INSIDE_TOP_RIGHT:
-
-								// Get gridno
-								sGridNo = NewGridNo( (INT16)cnt, DirectionInc( EAST ) );
-
-								if ( IsRoofVisibleForWireframe( sGridNo ) && !( gpWorldLevelData[ sGridNo ].uiFlags & MAPELEMENT_REVEALED ) )
-								{
-									AddWireFrame((INT16)cnt, WIREFRAMES1, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
-								}
-								break;
-
+							if (IsRoofVisibleForWireframe(sGridNo) && !(gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED))
+							{
+								AddWireFrame((INT16)cnt, WIREFRAMES2, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
+							}
 						}
+						else
+						{
+							sGridNo = NewGridNo((INT16)cnt, DirectionInc(EAST));
 
+							if (IsRoofVisibleForWireframe(sGridNo) && !(gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED))
+							{
+								AddWireFrame((INT16)cnt, WIREFRAMES1, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
+							}
+						}
 					}
 
 					// Check for walls
@@ -2879,55 +2764,46 @@ void CalculateWorldWireFrameTiles( BOOLEAN fForce )
 
 						usWireFrameIndex = GetWireframeGraphicNumToUseForWall( (UINT16)cnt, pStructure );
 
-						switch( ubWallOrientation )
+						if ( ubWallOrientation & ORIENT_LEFT )
 						{
-							case OUTSIDE_TOP_LEFT:
-							case INSIDE_TOP_LEFT:
+							sGridNo = NewGridNo((INT16)cnt, DirectionInc(SOUTH));
 
-								// Get gridno
-								sGridNo = NewGridNo( (INT16)cnt, DirectionInc( SOUTH ) );
+							if (IsRoofVisibleForWireframe(sGridNo))
+							{
+								bNumWallsSameGridNo++;
 
-								if ( IsRoofVisibleForWireframe( sGridNo ) )
+								AddWireFrame((INT16)cnt, usWireFrameIndex, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
+
+								// Check along our direction to see if we are a corner
+								sGridNo = NewGridNo((INT16)cnt, DirectionInc(WEST));
+								sGridNo = NewGridNo(sGridNo, DirectionInc(SOUTH));
+								if (!IsHiddenTileMarkerThere(sGridNo))
 								{
-									bNumWallsSameGridNo++;
-
-									AddWireFrame((INT16)cnt, usWireFrameIndex, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
-
-									// Check along our direction to see if we are a corner
-									sGridNo = NewGridNo( (INT16)cnt, DirectionInc( WEST ) );
-									sGridNo = NewGridNo( sGridNo, DirectionInc( SOUTH ) );
-									if (!IsHiddenTileMarkerThere(sGridNo))
-									{
-										// Place corner!
-										AddWireFrame((INT16)cnt, WIREFRAMES9, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
-									}
+									// Place corner!
+									AddWireFrame((INT16)cnt, WIREFRAMES9, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
 								}
-								break;
+							}
+						}
+						else
+						{
+							sGridNo = NewGridNo((INT16)cnt, DirectionInc(EAST));
 
-							case OUTSIDE_TOP_RIGHT:
-							case INSIDE_TOP_RIGHT:
+							if (IsRoofVisibleForWireframe(sGridNo))
+							{
+								bNumWallsSameGridNo++;
 
-								// Get gridno
-								sGridNo = NewGridNo( (INT16)cnt, DirectionInc( EAST ) );
+								AddWireFrame((INT16)cnt, usWireFrameIndex, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
 
-								if ( IsRoofVisibleForWireframe( sGridNo ) )
+								// Check along our direction to see if we are a corner
+								sGridNo = NewGridNo((INT16)cnt, DirectionInc(NORTH));
+								sGridNo = NewGridNo(sGridNo, DirectionInc(EAST));
+								if (!IsHiddenTileMarkerThere(sGridNo))
 								{
-									bNumWallsSameGridNo++;
-
-									AddWireFrame((INT16)cnt, usWireFrameIndex, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
-
-									// Check along our direction to see if we are a corner
-									sGridNo = NewGridNo( (INT16)cnt, DirectionInc( NORTH ) );
-									sGridNo = NewGridNo( sGridNo, DirectionInc( EAST ) );
-									if (!IsHiddenTileMarkerThere(sGridNo))
-									{
-										// Place corner!
-										AddWireFrame((INT16)cnt, WIREFRAMES8, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
-									}
-
+									// Place corner!
+									AddWireFrame((INT16)cnt, WIREFRAMES8, (gpWorldLevelData[sGridNo].uiFlags & MAPELEMENT_REVEALED) != 0);
 								}
-								break;
 
+							}
 						}
 
 						// Check for both walls

--- a/src/game/TileEngine/WorldMan.cc
+++ b/src/game/TileEngine/WorldMan.cc
@@ -843,10 +843,8 @@ bool AddWallToStructLayer(INT32 const map_idx, UINT16 const idx, bool const repl
 		 * then we insert it. */
 		if (check_wall_orient > wall_orientation)
 		{
-			if (((wall_orientation  == INSIDE_TOP_RIGHT || wall_orientation  == OUTSIDE_TOP_RIGHT) &&
-					(check_wall_orient == INSIDE_TOP_LEFT  || check_wall_orient == OUTSIDE_TOP_LEFT)) ||
-					((wall_orientation  == INSIDE_TOP_LEFT  || wall_orientation  == OUTSIDE_TOP_LEFT) &&
-					(check_wall_orient == INSIDE_TOP_RIGHT || check_wall_orient == OUTSIDE_TOP_RIGHT)))
+			if ( ((wall_orientation & ORIENT_RIGHT) && (check_wall_orient & ORIENT_LEFT)) ||
+				 ((wall_orientation & ORIENT_LEFT)  && (check_wall_orient & ORIENT_RIGHT)) )
 			{
 				insert_found = true;
 			}
@@ -862,10 +860,8 @@ bool AddWallToStructLayer(INT32 const map_idx, UINT16 const idx, bool const repl
 		/* Kris: We want to check for walls being parallel to each other.  If so,
 		 * then we we want to replace it.  This is because of an existing problem
 		 * with say, INSIDE_TOP_LEFT and OUTSIDE_TOP_LEFT walls coexisting. */
-		if (((wall_orientation  == INSIDE_TOP_RIGHT || wall_orientation  == OUTSIDE_TOP_RIGHT) &&
-			(check_wall_orient == INSIDE_TOP_RIGHT || check_wall_orient == OUTSIDE_TOP_RIGHT)) ||
-			((wall_orientation  == INSIDE_TOP_LEFT  || wall_orientation  == OUTSIDE_TOP_LEFT) &&
-			(check_wall_orient == INSIDE_TOP_LEFT  || check_wall_orient == OUTSIDE_TOP_LEFT)))
+		if ( ((wall_orientation & ORIENT_RIGHT) && (check_wall_orient & ORIENT_RIGHT)) ||
+			 ((wall_orientation & ORIENT_LEFT)  && (check_wall_orient & ORIENT_LEFT)) )
 		{
 			// Same, if replace, replace here
 			return replace ? ReplaceStructIndex(map_idx, i->usIndex, idx) : false;

--- a/src/sgp/Types.h
+++ b/src/sgp/Types.h
@@ -162,12 +162,12 @@ typedef SGPFile* HWFILE;
 
 
 #ifdef __cplusplus
-#	define ENUM_BITSET(type)                                                                 \
-		constexpr type operator ~  (type  a)         { return     (type)~(int)a;           } \
-		constexpr type operator &  (type  a, type b) { return     (type)((int)a & (int)b); } \
-		constexpr type operator &= (type& a, type b) { return a = (type)((int)a & (int)b); } \
-		constexpr type operator |  (type  a, type b) { return     (type)((int)a | (int)b); } \
-		constexpr type operator |= (type& a, type b) { return a = (type)((int)a | (int)b); }
+#	define ENUM_BITSET(type)                                                               \
+		constexpr type operator ~  (type  a)         { return     (type)~(std::underlying_type_t<type>)a;                                    } \
+		constexpr type operator &  (type  a, type b) { return     (type)((std::underlying_type_t<type>)a & (std::underlying_type_t<type>)b); } \
+		constexpr type operator &= (type& a, type b) { return a = (type)((std::underlying_type_t<type>)a & (std::underlying_type_t<type>)b); } \
+		constexpr type operator |  (type  a, type b) { return     (type)((std::underlying_type_t<type>)a | (std::underlying_type_t<type>)b); } \
+		constexpr type operator |= (type& a, type b) { return a = (type)((std::underlying_type_t<type>)a | (std::underlying_type_t<type>)b); }
 #else
 #	define ENUM_BITSET(type)
 #endif


### PR DESCRIPTION
Turning the wall orientation values into bitwise flags. This will make it more convenient working with them.
The main changes are in:
[TileDef.h](https://github.com/ja2-stracciatella/ja2-stracciatella/compare/master...ShishkinP:refactor-wall-orientation-enum?expand=1#diff-802148ea4a4c696fc58fe1e426a2439dd57c881d9631568e870e630c75c33286)
[TileDef.cc](https://github.com/ja2-stracciatella/ja2-stracciatella/compare/master...ShishkinP:refactor-wall-orientation-enum?expand=1#diff-96da0b7fe95ccb74091c55218ff3f7deea87f13096201b8f3db58c038141a917)
[Types.h](https://github.com/ja2-stracciatella/ja2-stracciatella/compare/master...ShishkinP:refactor-wall-orientation-enum?expand=1#diff-71522e7c264f0d583c851444876f0be8edaaa133686458d67f336d33701d9aea)