### PR TITLE
Give the sungoggles to-hit bonus only in glare

### DIFF
--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -19,6 +19,8 @@
 #include "Points.h"
 #include "AI.h"
 #include "LOS.h"
+#include "Lighting.h"
+#include "Environment.h"
 #include "RenderWorld.h"
 #include "OppList.h"
 #include "Interface.h"
@@ -2223,7 +2225,10 @@ UINT32 CalcChanceToHitGun(SOLDIERTYPE *pSoldier, UINT16 sGridNo, UINT8 ubAimTime
 	if ( iSightRange > 0 )
 	{
 
-		if (IsWearingHeadGear(*pSoldier, SUNGOGGLES))
+		// Sun goggles only help when the target is standing in light brighter than
+		// normal daylight (e.g. glare); 12:00-14:00 or at desert sectors.
+		if (IsWearingHeadGear(*pSoldier, SUNGOGGLES) &&
+			LightTrueLevel(sGridNo, pSoldier->bTargetLevel) < NORMAL_LIGHTLEVEL_DAY)
 		{
 			// decrease effective range by 10% when using sungoggles (w or w/o scope)
 			iSightRange -= iRange / 10; //basically, +1% to hit per every 2 squares
@@ -3641,7 +3646,10 @@ UINT32 CalcThrownChanceToHit(SOLDIERTYPE *pSoldier, INT16 sGridNo, UINT8 ubAimTi
 	// calculate actual range (in world units)
 	iRange = (INT16)GetRangeInCellCoordsFromGridNoDiff( pSoldier->sGridNo, sGridNo );
 
-	if (IsWearingHeadGear(*pSoldier, SUNGOGGLES))
+	// Sun goggles only help when the target is standing in light brighter than
+	// normal daylight.
+	if (IsWearingHeadGear(*pSoldier, SUNGOGGLES) &&
+		LightTrueLevel(sGridNo, pSoldier->bTargetLevel) < NORMAL_LIGHTLEVEL_DAY)
 	{
 		// decrease effective range by 10% when using sungoggles (w or w/o scope)
 		iRange -= iRange / 10;	//basically, +1% to hit per every 2 squares


### PR DESCRIPTION
Sun goggles used to reduce the effective range of every shot by 10% unconditionally - day or night, indoors or out. Restrict the bonus to targets standing in light brighter than normal daylight

Applies to both CalcChanceToHitGun and CalcThrownChanceToHit.