### PR TITLE
ShowVehicles: skip destroyed vehicles

### DIFF
--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -722,6 +722,7 @@ static INT32 ShowVehicles(const SGPSector& sSector, INT32 icon_pos)
 		// skip the chopper, it has its own icon and displays in airspace mode
 		if (IsHelicopter(v))                          continue;
 		if (v.sSector != sSector)                     continue;
+		if (v.fDestroyed)                             continue;
 		if (PlayerIDGroupInMotion(v.ubMovementGroup)) continue;
 
 		SOLDIERTYPE const& vs = GetSoldierStructureForVehicle(v);

--- a/src/game/Tactical/Vehicles.cc
+++ b/src/game/Tactical/Vehicles.cc
@@ -118,7 +118,10 @@ INT32 AddVehicleToList(const SGPSector& sMap, const INT16 sGridNo, const UINT8 u
 void RemoveVehicleFromList(VEHICLETYPE& v)
 {
 	v.pMercPath = ClearStrategicPathList(v.pMercPath, 0);
-	v = VEHICLETYPE{};
+	// We cannot really remove a vehicle from the vector because
+	// SOLDIERTYPE::bVehicleID is an index into this vector, so just
+	// mark this entry as invalid.
+	v.fValid = false;
 }
 
 


### PR DESCRIPTION
A destroyed vehicles might not have a corresponding SOLDIERTYPE, which would cause GetSoldierStructureForVehicle to throw an exception.

This commit also changes RemoveVehicleFromList to only reset the vehicles fValid flag, the only thing in VEHICLETYPE that matters at this point.

Fixes #2406.