### PR TITLE
RemovePlayerFromGroup: cleanup

### DIFF
--- a/src/game/Strategic/StrategicMap.cc
+++ b/src/game/Strategic/StrategicMap.cc
@@ -1581,7 +1581,6 @@ void HandleSoldierLeavingSectorByThemSelf( SOLDIERTYPE *pSoldier )
 		{
 			// remove from group
 			RemovePlayerFromGroup(*pSoldier);
-			pSoldier->ubGroupID = 0;
 		}
 	}
 	else

--- a/src/game/Strategic/Strategic_Movement.cc
+++ b/src/game/Strategic/Strategic_Movement.cc
@@ -224,10 +224,13 @@ void RemovePlayerFromGroup(SOLDIERTYPE& s)
 	//KM : August 6, 1999 Patch fix
 	//     Because the release build has no assertions, it was still possible for the group to be null,
 	//     causing a crash.  Instead of crashing, it'll simply return false.
-	if (!pGroup) return;
+	if (!pGroup)
+	{
+		SLOGE("RemovePlayerFromGroup failed, soldier ID {} ({}), group ID {}", s.ubID, s.name, s.ubGroupID);
+		s.ubGroupID = 0;
+		return;
+	}
 	//end
-
-	AssertMsg(pGroup, ST::format("Attempting to RemovePlayerFromGroup({}, {}) from non-existant group", s.ubGroupID, s.ubProfile));
 
 	RemovePlayerFromPGroup(*pGroup, s);
 }

--- a/src/game/Tactical/Squads.cc
+++ b/src/game/Tactical/Squads.cc
@@ -131,13 +131,15 @@ BOOLEAN AddCharacterToSquad(SOLDIERTYPE* const s, INT8 const bSquadValue)
 		if (s->ubGroupID != 0)
 		{
 			// in valid group, remove from that group
+			// RemovePlayerGromGroup clears the ID, save it first.
+			auto const oldGroupID = s->ubGroupID;
 			RemovePlayerFromGroup(*s);
 
 			// character not on a reserved group
 			if (s->bAssignment >= ON_DUTY && s->bAssignment != VEHICLE)
 			{
 				// if valid group, delete it
-				GROUP* const pGroup = GetGroup(s->ubGroupID);
+				GROUP* const pGroup = GetGroup(oldGroupID);
 				if (pGroup) RemoveGroup(*pGroup);
 			}
 		}
@@ -300,7 +302,6 @@ BOOLEAN RemoveCharacterFromSquads(SOLDIERTYPE* const s)
 			s->pMercPath = ClearStrategicPathList(s->pMercPath, -1);
 
 			RemovePlayerFromGroup(*s);
-			s->ubGroupID = 0;
 
 			if (s->fBetweenSectors && s->uiStatusFlags & SOLDIER_VEHICLE)
 			{

--- a/src/game/Tactical/Vehicles.cc
+++ b/src/game/Tactical/Vehicles.cc
@@ -313,7 +313,6 @@ static bool RemoveSoldierFromVehicle(SOLDIERTYPE& s)
 
 	RemovePlayerFromGroup(s);
 
-	s.ubGroupID      = 0;
 	s.sSector        = v.sSector;
 	s.uiStatusFlags &= ~(SOLDIER_DRIVER | SOLDIER_PASSENGER);
 


### PR DESCRIPTION
• Since a vanilla patch it was impossible that the assertion in this
  function failed. However, it is still useful to log diagnostics
  if GetGroup fails.
• Several callers set ubGroupID to 0 even though this function
  already does that.
• AddCharacterToSquad used ubGroupID after is was already cleared.