### PR TITLE
Allow to merge silver and gold ore stacks in the sector inventory

### DIFF
--- a/src/game/Strategic/Map_Screen_Interface_Map_Inventory.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map_Inventory.cc
@@ -856,9 +856,9 @@ static BOOLEAN PlaceObjectInInventoryStash(OBJECTTYPE* pInventorySlot, OBJECTTYP
 
 		if (pItemPtr->usItem == pInventorySlot->usItem)
 		{
-			if (pItemPtr->usItem == MONEY)
+			if (GCM->getItem(pItemPtr->usItem)->isMoney())
 			{
-				// always allow money to be combined!
+				// always allow money to be combined! this covers silver and gold ore too
 				// status of money is always 100
 				pInventorySlot->bMoneyStatus = 100;
 				pInventorySlot->uiMoneyAmount += pItemPtr->uiMoneyAmount;


### PR DESCRIPTION
PlaceObjectInInventoryStash() tested the dragged object against the MONEY item index directly, so only cash took the merge branch. 

Dropping one ore onto another in the sector inventory therefore just traded the two objects' places, which reads as a click that did nothing. Test the item class instead so all three merge.