### PR TITLE
Fix blowing sam computers after loading games

### DIFF
--- a/src/game/Strategic/SAM_Sites.cc
+++ b/src/game/Strategic/SAM_Sites.cc
@@ -16,11 +16,14 @@ Observable<> OnAirspaceControlUpdated = {};
 
 static void UpdateAndDamageSAMIfFound(INT16 sSectorX, INT16 sSectorY, INT16 sSectorZ, INT16 sGridNo, void*, UINT8 ubDamage, BOOLEAN fIsDestroyed);
 
-void InitializeSAMSites()
+void InitSAMSitesEngine()
 {
 	// handle SAM site damages
 	OnStructureDamaged.addListener("default:sam", UpdateAndDamageSAMIfFound);
+}
 
+void InitializeSAMSites()
+{
 	// All SAM sites start game in perfect working condition.
 	for (auto samSite : GCM->getSamSites())
 	{

--- a/src/game/Strategic/SAM_Sites.h
+++ b/src/game/Strategic/SAM_Sites.h
@@ -10,6 +10,9 @@
 
 extern Observable<> OnAirspaceControlUpdated;
 
+// Registers the engine-level hooks. Runs once per application run.
+void InitSAMSitesEngine();
+
 void InitializeSAMSites();
 
 void UpdateSAMDoneRepair(const SGPSector& sector);

--- a/src/game/Strategic/StrategicMap.cc
+++ b/src/game/Strategic/StrategicMap.cc
@@ -269,6 +269,8 @@ void InitStrategicEngine()
 	BuildListOfTownSectors( );
 
 	OnAirspaceControlUpdated.addListener("default", HandleAirspaceControlUpdated);
+
+	InitSAMSitesEngine();
 }
 
 


### PR DESCRIPTION
The listener was registered in InitializeSAMSites(), which only runs from InitStrategicLayer() -> InitNewGame(). Loading a saved game never goes through there, so in a process that starts by loading a save nothing is subscribed and blowing up the computer does nothing at all: the condition stays where it was, the airspace stays hostile and the site keeps shooting.

Split the registration out into InitSAMSitesEngine() and call it from InitStrategicEngine(), which runs once per application run and is where every other engine-level listener is registered. InitializeSAMSites() keeps only the per-game part, resetting every site to condition 100.