### PR TITLE
Remove VEHICLETYPE::sGridNo

### DIFF
--- a/src/game/Tactical/LoadSaveVehicleType.cc
+++ b/src/game/Tactical/LoadSaveVehicleType.cc
@@ -22,8 +22,7 @@ void ExtractVehicleTypeFromFile(HWFILE const file, VEHICLETYPE* const v, UINT32 
 	EXTR_I16(d, v->sSector.y)
 	EXTR_I16(d, v->sSector.z)
 	EXTR_BOOL(d, v->fBetweenSectors)
-	EXTR_SKIP(d, 1)
-	EXTR_I16(d, v->sGridNo);
+	EXTR_SKIP(d, 3)
 	const ProfileID noone = (savegame_version < 86 ? 0 : NO_PROFILE);
 	// The ProfileID of the passengers gets stored, not their SoldierID
 	for (auto & soldier : v->pPassengers)
@@ -90,7 +89,7 @@ void InjectVehicleTypeIntoFile(HWFILE const file, VEHICLETYPE const* const v)
 	INJ_I16(d, v->sSector.z)
 	INJ_BOOL(d, v->fBetweenSectors)
 	INJ_SKIP(d, 1)
-	INJ_I16(d, v->sGridNo);
+	INJ_I16(d, NOWHERE); // was the unused v->sGridNo
 	// The ProfileID of the passengers gets stored, not their SoldierID
 	FOR_EACH(SOLDIERTYPE* const, i, v->pPassengers)
 	{

--- a/src/game/Tactical/Vehicles.cc
+++ b/src/game/Tactical/Vehicles.cc
@@ -72,7 +72,7 @@ void SetVehicleValuesIntoSoldierType(SOLDIERTYPE* const vs)
 }
 
 
-INT32 AddVehicleToList(const SGPSector& sMap, const INT16 sGridNo, const UINT8 ubType)
+INT32 AddVehicleToList(const SGPSector& sMap, INT16, const UINT8 ubType)
 {
 	INT32 vid;
 	for (vid = 0;; ++vid)
@@ -91,7 +91,6 @@ INT32 AddVehicleToList(const SGPSector& sMap, const INT16 sGridNo, const UINT8 u
 	*v = VEHICLETYPE{};
 	v->ubMovementGroup = 0;
 	v->sSector         = sMap;
-	v->sGridNo         = sGridNo;
 	v->fValid          = TRUE;
 	v->ubVehicleType   = ubType;
 	v->pMercPath       = NULL;

--- a/src/game/Tactical/Vehicles.h
+++ b/src/game/Tactical/Vehicles.h
@@ -29,11 +29,10 @@ struct VEHICLETYPE
 	UINT8   ubMovementGroup; // the movement group this vehicle belongs to
 	UINT8   ubVehicleType; // type of vehicle
 	SGPSector sSector; // position on the Stategic Map
-	BOOLEAN fBetweenSectors; // between sectors?
-	INT16   sGridNo; // location in tactical
 	SOLDIERTYPE *pPassengers[MAX_PASSENGERS_IN_VEHICLE];
-	BOOLEAN fDestroyed;
 	UINT32  uiMovementSoundID;
+	BOOLEAN fBetweenSectors; // between sectors?
+	BOOLEAN fDestroyed;
 	BOOLEAN fValid;
 };
 


### PR DESCRIPTION
It was not used anywhere. While we are here, also reorder the VEHICLETYPE members to reduce padding.