### PR TITLE
Bugfix: causing damage with explosives incorrectly marked as FROM_FAILURE

### DIFF
--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -5795,7 +5795,7 @@ UINT8 SoldierTakeDamage(SOLDIERTYPE* const pSoldier, INT16 sLifeDeduct, INT16 sB
 			if ( ubReason == TAKE_DAMAGE_EXPLOSION )
 			{
 				// EXPLOSIVES GAIN (combLoss):  Causing wounds in battle
-				StatChange(*attacker, EXPLODEAMT, 10 * ubCombinedLoss, FROM_FAILURE);
+				StatChange(*attacker, EXPLODEAMT, 10 * ubCombinedLoss, FROM_SUCCESS);
 			}
 			/*
 			else if ( ubReason == TAKE_DAMAGE_GUNFIRE )


### PR DESCRIPTION
Causing damage with explosives marked the stat change reason as `FROM_FAILURE` meaning mercs cannot level up or cross stat gain thresholds from causing damage with them.