### PR TITLE
Require enemies in sector to manually enter turn based

### DIFF
--- a/src/game/Tactical/Turn_Based_Input.cc
+++ b/src/game/Tactical/Turn_Based_Input.cc
@@ -1447,9 +1447,11 @@ static void HandleModNone(UINT32 const key, UIEventKind* const new_event)
 				*new_event = I_ENDTURN;
 			}
 
-			if (gamepolicy(can_enter_turnbased))
+			// Go through the regular entry point so the battle state gets set up
+			// properly. It refuses when there is nothing in the sector to fight.
+			if (gamepolicy(can_enter_turnbased) && !(gTacticalStatus.uiFlags & INCOMBAT))
 			{
-				gTacticalStatus.uiFlags |= INCOMBAT;
+				EnterCombatMode(OUR_TEAM);
 			}
 			break;
 


### PR DESCRIPTION
Pressing 'd' only raised the INCOMBAT flag, skipping EnterCombatMode and its setup. bNumFoughtInBattle was left holding the count from the last real fight, so ending the turn in an empty sector counted as a won battle and paid out morale and loyalty. Route the key through EnterCombatMode, which declines when no capable enemy is present.