### PR TITLE
Fix commit f2bfc4d regression

### DIFF
--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -364,6 +364,8 @@ static void CreateFileStructureArrays(STRUCTURE_FILE_REF & pFileRef)
 				case 4:
 					dbs->ubWallOrientation = ORIENT_OUTSIDE_RIGHT;
 					break;
+				default:
+					break;
 			}
 			pFileRef.pAuxData[usIndex].ubWallOrientation = dbs->ubWallOrientation;
 		}

--- a/src/game/TileEngine/Structure.cc
+++ b/src/game/TileEngine/Structure.cc
@@ -353,6 +353,21 @@ static void CreateFileStructureArrays(STRUCTURE_FILE_REF & pFileRef)
 
 		NormalizeStructureTiles(tiles, dbs->ubNumberOfTiles);
 
+		// Convert contiguous orientation values to flags
+		if (pFileRef.pAuxData.size() && dbs->ubWallOrientation > 2)
+		{
+			switch (dbs->ubWallOrientation)
+			{	// skip cases 1 and 2 which are identical to their bitwise counterparts
+				case 3:
+					dbs->ubWallOrientation = ORIENT_OUTSIDE_LEFT;
+					break;
+				case 4:
+					dbs->ubWallOrientation = ORIENT_OUTSIDE_RIGHT;
+					break;
+			}
+			pFileRef.pAuxData[usIndex].ubWallOrientation = dbs->ubWallOrientation;
+		}
+
 		// scale hit points down to something reasonable...
 		uiHitPoints = uiHitPoints * 100 / 255;
 		dbs->ubHitPoints = (UINT8)uiHitPoints;

--- a/src/game/TileEngine/TileDef.cc
+++ b/src/game/TileEngine/TileDef.cc
@@ -109,25 +109,6 @@ void CreateTileDatabase()
 					TileElement.uiFlags |= ANIMATED_TILE;
 				}
 
-				// Convert contiguous named orientation values to flags
-				if (TileElement.pDBStructureRef)
-				{
-					switch (aux.ubWallOrientation)
-					{
-						case 2:
-							aux.ubWallOrientation = ORIENT_INSIDE_RIGHT;
-							break;
-						case 3:
-							aux.ubWallOrientation = ORIENT_OUTSIDE_LEFT;
-							break;
-						case 4:
-							aux.ubWallOrientation = ORIENT_OUTSIDE_RIGHT;
-							break;
-					}
-					TileElement.usWallOrientation = static_cast<Orientation>(aux.ubWallOrientation);
-					TileElement.pDBStructureRef->pDBStructure->ubWallOrientation = TileElement.usWallOrientation;
-				}
-
 				if (aux.ubNumberOfTiles > 0)
 				{
 					TileElement.ubNumberOfTiles = aux.ubNumberOfTiles;


### PR DESCRIPTION
Bug from #2405: enum conversion is applied to cached orientations which leads to double conversion.
Solution: apply it only to freshly extracted values