### PR TITLE
Add failable alternative for GetSoldierStructureForVehicle

### DIFF
--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -724,9 +724,7 @@ static INT32 ShowVehicles(const SGPSector& sSector, INT32 icon_pos)
 		if (v.sSector != sSector)                     continue;
 		if (v.fDestroyed)                             continue;
 		if (PlayerIDGroupInMotion(v.ubMovementGroup)) continue;
-
-		SOLDIERTYPE const& vs = GetSoldierStructureForVehicle(v);
-		if (vs.bTeam != OUR_TEAM) continue;
+		if (auto s = FindSoldierType(v); !s || s->bTeam != OUR_TEAM) continue;
 
 		DrawMapBoxIcon(guiCHARICONS, SMALL_WHITE_BOX, sSector, icon_pos++);
 	}

--- a/src/game/Tactical/Vehicles.cc
+++ b/src/game/Tactical/Vehicles.cc
@@ -709,14 +709,21 @@ INT8 RepairVehicle(VEHICLETYPE const& v, INT8 const bRepairPtsLeft, BOOLEAN* con
 }
 
 
-SOLDIERTYPE& GetSoldierStructureForVehicle(VEHICLETYPE const& v)
+SOLDIERTYPE * FindSoldierType(VEHICLETYPE const& v)
 {
 	FOR_EACH_SOLDIER(s)
 	{
 		if (!(s->uiStatusFlags & SOLDIER_VEHICLE)) continue;
 		if (s->bVehicleID != VEHICLE2ID(v))        continue;
-		return *s;
+		return s;
 	}
+	return nullptr;
+}
+
+
+SOLDIERTYPE& GetSoldierStructureForVehicle(VEHICLETYPE const& v)
+{
+	if (auto pSoldier = FindSoldierType(v); pSoldier) return *pSoldier;
 	throw std::logic_error("Vehicle has no corresponding soldier");
 }
 

--- a/src/game/Tactical/Vehicles.h
+++ b/src/game/Tactical/Vehicles.h
@@ -102,6 +102,9 @@ BOOLEAN ExitVehicle( SOLDIERTYPE *pSoldier );
 void VehicleTakeDamage(UINT8 ubID, UINT8 ubReason, INT16 sDamage, INT16 sGridNo, SOLDIERTYPE* att);
 
 // the soldiertype containing this tactical incarnation of this vehicle
+// This version returns nullptr if there is no corresponding soldier.
+SOLDIERTYPE * FindSoldierType(VEHICLETYPE const& v);
+// This version throws an exception if there is no corresponding soldier.
 SOLDIERTYPE& GetSoldierStructureForVehicle(VEHICLETYPE const&);
 
 // does it need fixing?


### PR DESCRIPTION
Apparently `ShowVehicles` needs either this or a try/catch clause to work reliably. This seems cleaner.

I don't really like this because I still don't know why we now need it at all. Only good thing I can say about it is that it allows the save from #2419 to load without crashing.