### PR TITLE
Release the whole pellet budget when a buckshot shot jams

### DIFF
--- a/src/game/Tactical/Soldier_Ani.cc
+++ b/src/game/Tactical/Soldier_Ani.cc
@@ -1042,8 +1042,20 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 						// XXX Code and comment do not match. Should we really skip 5 frames in total?
 						pSoldier->usAniCode += 4;
 
-						// Reduce by a bullet...
-						pSoldier->bBulletsLeft--;
+						// Reduce by a bullet... give back everything this shot reserved, as
+						// none of it gets fired. Buckshot reserves a whole spread of pellets
+						// (see EVENT_FireSoldierWeapon), and unless all of them are given back
+						// bBulletsLeft never reaches zero, FreeUpAttacker() below does nothing
+						// and the attack busy count is left standing, which locks the interface
+						// until the busy-state watchdog trips seconds later.
+						INT8 const bBulletsThisShot =
+							pSoldier->inv[pSoldier->ubAttackingHand].ubGunAmmoType == AMMO_BUCKSHOT ?
+								NUM_BUCKSHOT_PELLETS : 1;
+						pSoldier->bBulletsLeft -= bBulletsThisShot;
+						if ( pSoldier->bBulletsLeft < 0 )
+						{
+							pSoldier->bBulletsLeft = 0;
+						}
 
 						PlayLocationJA2Sample(pSoldier->sGridNo, S_DRYFIRE1, MIDVOLUME, 1);
 

--- a/src/game/Tactical/Soldier_Ani.cc
+++ b/src/game/Tactical/Soldier_Ani.cc
@@ -63,6 +63,7 @@
 #include "GameInstance.h"
 #include "WeaponModels.h"
 #include "Logger.h"
+#include "Debug.h"
 #include "MercProfile.h"
 
 #define NO_JUMP			0
@@ -1051,11 +1052,10 @@ BOOLEAN AdjustToNextAnimationFrame( SOLDIERTYPE *pSoldier )
 						INT8 const bBulletsThisShot =
 							pSoldier->inv[pSoldier->ubAttackingHand].ubGunAmmoType == AMMO_BUCKSHOT ?
 								NUM_BUCKSHOT_PELLETS : 1;
+
+						Assert(pSoldier->bBulletsLeft >= bBulletsThisShot);
+
 						pSoldier->bBulletsLeft -= bBulletsThisShot;
-						if ( pSoldier->bBulletsLeft < 0 )
-						{
-							pSoldier->bBulletsLeft = 0;
-						}
 
 						PlayLocationJA2Sample(pSoldier->sGridNo, S_DRYFIRE1, MIDVOLUME, 1);
 


### PR DESCRIPTION
EVENT_FireSoldierWeapon reserves NUM_BUCKSHOT_PELLETS rounds in bBulletsLeft for a buckshot shot, but the jam path gave back only one. The remaining eight kept FreeUpAttacker from decrementing the attack busy count, so the interface stayed locked behind the wait cursor until the 25 second watchdog in HandleTacticalUI reset it.