### PR TITLE
Properly remove destroyed tanks from the vehicle list

### DIFF
--- a/src/game/Tactical/Soldier_Create.cc
+++ b/src/game/Tactical/Soldier_Create.cc
@@ -1,7 +1,6 @@
 #include "Soldier_Create.h"
 #include "ItemModel.h"
 #include "Overhead.h"
-#include "Soldier_Macros.h"
 #include "Soldier_Profile.h"
 #include "Animation_Control.h"
 #include "Animation_Data.h"
@@ -47,6 +46,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <stdexcept>
 #include <math.h>
 
 // THESE 3 DIFFICULTY FACTORS MUST ALWAYS ADD UP TO 100% EXACTLY!!!
@@ -979,9 +979,14 @@ void InternalTacticalRemoveSoldier(SOLDIERTYPE& s, BOOLEAN const fRemoveVehicle)
 
 	if (s.ubScheduleID) DeleteSchedule(s.ubScheduleID);
 
-	if (EnterableVehicle(s) && fRemoveVehicle)
+	if ((s.uiStatusFlags & SOLDIER_VEHICLE) && fRemoveVehicle)
 	{
-		RemoveVehicleFromList(GetVehicle(s.bVehicleID));
+		try {
+			RemoveVehicleFromList(GetVehicle(s.bVehicleID));
+		}
+		catch (std::logic_error const&) {
+			// GetVehicle can fail for tanks added in map editor, issue #1933.
+		}
 	}
 
 	if (s.ubBodyType == CROW) HandleCrowLeave(&s);
@@ -2092,7 +2097,7 @@ void TrashAllSoldiers(int const team)
 }
 
 
-static UINT8 GetLocationModifier(UINT8 ubSoldierClass)
+static UINT8 GetLocationModifier(UINT8)
 {
 	UINT8 ubLocationModifier;
 	UINT8 ubPalaceDistance;

--- a/src/game/Tactical/Vehicles.cc
+++ b/src/game/Tactical/Vehicles.cc
@@ -142,6 +142,7 @@ bool IsThisVehicleAccessibleToSoldier(SOLDIERTYPE const& s, VEHICLETYPE const& v
 	return !s.fBetweenSectors &&
 		!v.fBetweenSectors &&
 		s.sSector == v.sSector &&
+		!v.fDestroyed &&
 		OKUseVehicle(GCM->getVehicle(v.ubVehicleType)->profile);
 }
 


### PR DESCRIPTION
Due to a bug introduced in commit 2396553, tanks were kept on the vehicle list after being destroyed, causing several problems. This restores the old check in InternalTacticalRemoveSoldier() and uses a try/catch block to avoid issue #1933.

The new check in IsThisVehicleAccessibleToSoldier() is needed to help out save files were the vehicle list was corrupted by this bug, issue #2424.