### PR TITLE
Check the firing hand for a silencer when making gunfire noise

### DIFF
--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -842,12 +842,14 @@ static void UseGun(SOLDIERTYPE * const pSoldier, GridNo const sTargetGridNo)
 	}
 	else
 	{
-		// if the weapon has a silencer attached
-		bSilencerPos = FindAttachment( &(pSoldier->inv[HANDPOS]), SILENCER );
-		if (bSilencerPos != -1)
+		// if the weapon we are firing has a silencer attached (which is not necessarily
+		// the one in the main hand - two-pistol shooting fires each hand separately)
+		OBJECTTYPE& gun = pSoldier->inv[ pSoldier->ubAttackingHand ];
+		bSilencerPos = FindAttachment( &gun, SILENCER );
+		if (bSilencerPos != NO_SLOT)
 		{
 			// reduce volume by a percentage equal to silencer's work %age (min 1)
-			ubVolume = 1 + ((100 - WEAPON_STATUS_MOD(pSoldier->inv[HANDPOS].bAttachStatus[bSilencerPos])) / (100 / (ubVolume - 1)));
+			ubVolume = 1 + ((100 - WEAPON_STATUS_MOD(gun.bAttachStatus[bSilencerPos])) / (100 / (ubVolume - 1)));
 		}
 	}
 


### PR DESCRIPTION
Two-pistol shooting fires each hand as its own shot, but the noise volume always looked for a silencer in the main hand. A silenced off-hand pistol was therefore as loud as an unsilenced one, and a silenced main-hand pistol quieted the off-hand shot too. Read the attachment from ubAttackingHand instead.