### PR TITLE
AddVehicleToList: mark zombie entries as not valid

### DIFF
--- a/src/game/Strategic/Strategic_Movement.cc
+++ b/src/game/Strategic/Strategic_Movement.cc
@@ -60,7 +60,7 @@ static GROUP* gpPendingSimultaneousGroup = NULL;
 
 extern BOOLEAN gubNumAwareBattles;
 extern INT8 SquadMovementGroups[ ];
-extern INT8 gubVehicleMovementGroups[ ];
+extern UINT8 gubVehicleMovementGroups[];
 
 BOOLEAN gfDelayAutoResolveStart = FALSE;
 

--- a/src/game/Tactical/Vehicles.cc
+++ b/src/game/Tactical/Vehicles.cc
@@ -41,7 +41,7 @@
 #include <vector>
 
 
-INT8 gubVehicleMovementGroups[ MAX_VEHICLES ];
+UINT8 gubVehicleMovementGroups[MAX_VEHICLES];
 
 // the list of vehicle slots
 std::vector<VEHICLETYPE> pVehicleList;
@@ -74,10 +74,16 @@ void SetVehicleValuesIntoSoldierType(SOLDIERTYPE* const vs)
 
 INT32 AddVehicleToList(const SGPSector& sMap, INT16, const UINT8 ubType)
 {
+	// Garbage collection: due to a bug the vehicle list might contain
+	// tanks destroyed in another section and reach the MAX_VEHICLES limit.
+	for (auto & v : pVehicleList)
+	{
+		if (v.fDestroyed && v.sSector != sMap) v.fValid = false;
+	}
+
 	INT32 vid;
 	for (vid = 0;; ++vid)
 	{
-		Assert(pVehicleList.size() <= INT32_MAX);
 		if (vid == static_cast<INT32>(pVehicleList.size()))
 		{
 			pVehicleList.push_back(VEHICLETYPE{});
@@ -85,6 +91,7 @@ INT32 AddVehicleToList(const SGPSector& sMap, INT16, const UINT8 ubType)
 		}
 		if (!pVehicleList[vid].fValid) break;
 	}
+	Assert(pVehicleList.size() <= MAX_VEHICLES);
 	VEHICLETYPE* const v = &pVehicleList[vid];
 
 	// found a slot
@@ -811,7 +818,7 @@ void LoadVehicleMovementInfoFromSavedGameFile(HWFILE const hFile)
 	INT32 cnt;
 
 	//Load in the Squad movement id's
-	hFile->read(gubVehicleMovementGroups, sizeof(INT8) * 5);
+	hFile->read(gubVehicleMovementGroups, sizeof(UINT8) * 5);
 
 	for( cnt = 5; cnt <  MAX_VEHICLES; cnt++ )
 	{
@@ -826,14 +833,14 @@ void LoadVehicleMovementInfoFromSavedGameFile(HWFILE const hFile)
 void NewSaveVehicleMovementInfoToSavedGameFile(HWFILE const hFile)
 {
 	//Save all the vehicle movement id's
-	hFile->write(gubVehicleMovementGroups, sizeof(INT8) * MAX_VEHICLES);
+	hFile->write(gubVehicleMovementGroups);
 }
 
 
 void NewLoadVehicleMovementInfoFromSavedGameFile(HWFILE const hFile)
 {
 	//Load in the Squad movement id's
-	hFile->read(gubVehicleMovementGroups, sizeof(INT8) * MAX_VEHICLES);
+	hFile->read(gubVehicleMovementGroups);
 }
 
 


### PR DESCRIPTION
Saved games may contain a vehicle list with tanks that were already destroyed which could cause the list size to exceed MAX_VEHICLES (10). In this case we run out of movement groups for a new vehicle.

This commit adresses the problem by marking all destroyed vehicles not in the same sector where we are adding the new vehicle as invalid.

Closes #2429.