### PR TITLE
fix: increase MAX_MONEY_PER_SLOT to 30000 for Carmen bounty hunter quest

### DIFF
--- a/src/game/Tactical/Item_Types.h
+++ b/src/game/Tactical/Item_Types.h
@@ -37,7 +37,7 @@ enum ItemCursor
 
 #define MAX_OBJECTS_PER_SLOT		8
 #define MAX_ATTACHMENTS		4
-#define MAX_MONEY_PER_SLOT		20000
+#define MAX_MONEY_PER_SLOT		30000
 
 enum DetonatorType
 {


### PR DESCRIPTION
Attempts to address #1953

This PR assumes that the "intended spirit" of original devs was to permit returning 3 heads at once, along with equivalent reward.