### PR TITLE
Stop suppression AP debt from being refunded

### DIFF
--- a/src/game/Tactical/Overhead.cc
+++ b/src/game/Tactical/Overhead.cc
@@ -5231,17 +5231,12 @@ static void HandleSuppressionFire(const SOLDIERTYPE* const targeted_merc, SOLDIE
 							sClosestOpponent = ClosestKnownOpponent( pSoldier, &sClosestOppLoc, NULL );
 							if (sClosestOpponent == NOWHERE || SpacesAway( pSoldier->sGridNo, sClosestOppLoc ) > 8)
 							{
-								if (ubPointsLost < AP_PRONE)
-								{
-									// Have to give APs back so that we can change stance without
-									// losing more APs
-									pSoldier->bActionPoints += (AP_PRONE - ubPointsLost);
-									ubPointsLost = 0;
-								}
-								else
-								{
-									ubPointsLost -= AP_PRONE;
-								}
+								// The stance change below is issued with
+								// fDontChargeAPsForStanceChange, so it costs nothing and
+								// ubPointsLost is the whole price of being suppressed - same as
+								// the standing branch. Discounting AP_PRONE here used to pay for
+								// a deduction that never lands, and for a small ubPointsLost it
+								// handed the merc more APs than the suppression took away.
 								ubNewStance = ANIM_PRONE;
 							}
 						}

--- a/src/game/Tactical/Points.cc
+++ b/src/game/Tactical/Points.cc
@@ -506,11 +506,17 @@ void DeductPoints( SOLDIERTYPE *pSoldier, INT16 sAPCost, INT16 sBPCost )
 		fInterfacePanelDirty = DIRTYLEVEL1;
 	}
 
-	// If we cannot deduct points, return FALSE
-	if ( sNewAP < 0 )
+	// Floor the cost at 0 APs, but only for someone who still had points to spend.
+	// Suppression can leave a merc in AP debt that is meant to carry into the next
+	// turn, and flooring that at 0 would hand the points back - so getting shot while
+	// suppressed used to *raise* the merc's APs.
+	if ( sNewAP < 0 && pSoldier->bActionPoints > 0 )
 	{
 		sNewAP = 0;
 	}
+
+	// bActionPoints is an INT8, so keep the debt from wrapping around into a windfall
+	sNewAP = std::max<INT16>( sNewAP, -MAX_AP_DEBT );
 
 	pSoldier->bActionPoints = (INT8)sNewAP;
 

--- a/src/game/Tactical/Points.h
+++ b/src/game/Tactical/Points.h
@@ -11,6 +11,7 @@
 #define AP_VEHICLE_MAXIMUM		50 // no merc can have more for his turn
 #define AP_INCREASE			10 // optional across-the-board AP boost
 #define MAX_AP_CARRIED			5 // APs carried from turn-to-turn
+#define MAX_AP_DEBT			100 // deepest AP hole (suppression, wounds) an INT8 can safely hold
 
 // monster AP bonuses, expressed in 10ths (12 = 120% normal)
 #define AP_YOUNG_MONST_FACTOR		15

--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -4134,6 +4134,7 @@ say_personality_quote:
 	s.usQuoteSaidExtFlags &= ~SOLDIER_QUOTE_SAID_EXT_CLOSE_CALL;
 	s.bNumHitsThisTurn     = 0;
 	s.ubSuppressionPoints  = 0;
+	s.ubAPsLostToSuppression = 0;
 	s.fCloseCall           = FALSE;
 	s.ubMovementNoiseHeard = 0;
 


### PR DESCRIPTION
This one touches 3 things, all related to suppression fire. The most important one is in src/game/Tactical/Soldier_Control.cc. What's happening during suppression fire is that when soldier's ubAPsLostToSuppression reaches MAX_APS_SUPPRESSED (which is 8) the soldier becomes immune to any suppression because we never reset it at the start of the turn. 

Another thing is that suppression fire can make APs a negative (which is the whole point of suppression fire) but if soldier is hit when their AP is negative the ap goes up instead of going even lower.

Third thing is in HandleSuppressionFire. When we reach exactly 1 ubPointLost and the current stance is crouched instead of losing 2 points we actually get 1 instead.

If someone for some reason prefers a vanilla no suppression behaviour we can now do it by adjusting suppression_fire_modifier game policy