### PR TITLE
Do not automatically open a locked door when enemies are in a sector

### DIFF
--- a/src/game/Tactical/Handle_Doors.cc
+++ b/src/game/Tactical/Handle_Doors.cc
@@ -29,6 +29,7 @@
 #include "Soldier_Macros.h"
 #include "Debug.h"
 #include "GameRes.h"
+#include "GamePolicy.h"
 
 #include <string_theory/string>
 
@@ -568,7 +569,23 @@ BOOLEAN HandleOpenableStruct( SOLDIERTYPE *pSoldier, INT16 sGridNo, STRUCTURE *p
 							if ( AttemptToPickLock( pSoldier, pDoor ) )
 							{
 								DoMercBattleSound( pSoldier, BATTLE_SOUND_COOL1 );
-								fHandleDoor = TRUE;
+
+								// If there are enemies in the sector, picking the lock only
+								// unlocks the door and leaves it closed, so the player can
+								// decide when to open it (swinging it open right away can be
+								// deadly if there are enemies waiting on the other side).
+								// This covers both turn-based combat and realtime mode. When
+								// the sector is clear, keep the original behaviour of opening
+								// it immediately.
+								if ( gamepolicy(diagonally_interactable_doors) && NumCapableEnemyInSector() > 0 )
+								{
+									ChangeSoldierState(pSoldier, GetAnimStateForInteraction(*pSoldier, fDoor, END_OPEN_LOCKED_DOOR), 0, FALSE);
+									UpdateDoorPerceivedValue( pDoor, HANDLE_DOOR_LOCKPICK );
+								}
+								else
+								{
+									fHandleDoor = TRUE;
+								}
 							}
 							ProcessImplicationsOfPCMessingWithDoor( pSoldier );
 						}
@@ -631,10 +648,24 @@ BOOLEAN HandleOpenableStruct( SOLDIERTYPE *pSoldier, INT16 sGridNo, STRUCTURE *p
 							{
 								//DoMercBattleSound( pSoldier, BATTLE_SOUND_COOL1 );
 
-								ChangeSoldierState(pSoldier, GetAnimStateForInteraction(*pSoldier, fDoor, END_OPEN_DOOR), 0, FALSE);
 								UpdateDoorPerceivedValue( pDoor, HANDLE_DOOR_UNLOCK );
 
-								fHandleDoor = TRUE;
+								// If there are enemies in the sector, unlocking the door with
+								// the key only unlocks it and leaves it closed, so the player
+								// can decide when to open it (swinging it open right away can
+								// be deadly if there are enemies waiting on the other side).
+								// This covers both turn-based combat and realtime mode. When
+								// the sector is clear, keep the original behaviour of opening
+								// it immediately.
+								if ( gamepolicy(diagonally_interactable_doors) && NumCapableEnemyInSector() > 0 )
+								{
+									ChangeSoldierState(pSoldier, GetAnimStateForInteraction(*pSoldier, fDoor, END_OPEN_LOCKED_DOOR), 0, FALSE);
+								}
+								else
+								{
+									ChangeSoldierState(pSoldier, GetAnimStateForInteraction(*pSoldier, fDoor, END_OPEN_DOOR), 0, FALSE);
+									fHandleDoor = TRUE;
+								}
 							}
 							else
 							{

--- a/src/game/Tactical/Handle_Doors.cc
+++ b/src/game/Tactical/Handle_Doors.cc
@@ -29,6 +29,8 @@
 #include "Soldier_Macros.h"
 #include "Debug.h"
 #include "GameRes.h"
+#include "ContentManager.h"
+#include "GameInstance.h"
 #include "GamePolicy.h"
 
 #include <string_theory/string>


### PR DESCRIPTION
Now we can open unlocked doors diagonally, however the doors are still very deadly especially when you play on dead is dead because a locked door cannot be unlocked diagonally (which makes sense), and unlocking a door automatically opens it. This change allows to pick lock and use key without automatically open the door. It only works when there are enemies in sector and diagonally_interactable_doors game policy is turned on (I don't want to create a separate policy just for this and overwhelm users)