### PR TITLE
Only block interrupts while shots are still coming in

### DIFF
--- a/assets/externalized/game.json
+++ b/assets/externalized/game.json
@@ -66,6 +66,13 @@
   //  (say your buddies took care of it), you'd still get skipped for any further interrupts. Annoying in ambushes or when sneaking.
   //  vanilla setting: false
   "multiple_interrupts": false,
+  
+  //  Allow interrupts after being shot at on an earlier turn. In vanilla, being under fire blocks a
+  //  soldier's interrupts until their own turn begins, so an attack silences them for the whole next
+  //  turn as well. With this on, only being shot at during the turn in progress blocks the reaction.
+  //  Mercs and enemies alike react a turn sooner, so the AI can punish 'shoot and hide' tactics.
+  //  vanilla setting: false
+  "interrupt_after_being_under_fire": false,
 
   // Boosting stats like agility, dexterity, exp. level and health absurdly increases the action points cost to shoot.
   // With this option on: the better the stats the fewer APs will be needed.

--- a/rust/stracciatella/src/schemas/yaml/game.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/game.schema.yaml
@@ -169,6 +169,16 @@ properties:
       - threshold_cth_legs
       - avoid_ambushes
       - stay_on_rooftop
+  interrupt_after_being_under_fire:
+    type: boolean
+    title: Interrupt after being under fire
+    description: |
+      A soldier who is under fire cannot interrupt. The mark is only cleared when the soldier's own turn begins, so in
+      the original game it silences their interrupts through the whole next turn as well, long after the attack. With
+      this enabled only being shot at during the turn in progress blocks the reaction, so mercs and enemies alike react
+      again a turn sooner - fights get a bit more challenging.
+
+      Vanilla setting: `false`
   enemy_elite_minimum_level:
     $ref: types/int8.schema.yaml
     title: Elite enemies minimum level

--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -36,6 +36,8 @@ DefaultGamePolicy::DefaultGamePolicy(const JsonValue& json)
 	avoid_ambushes = ai.getOptionalBool("avoid_ambushes");
 	stay_on_rooftop = ai.getOptionalBool("stay_on_rooftop");
 
+	interrupt_after_being_under_fire = gp.getOptionalBool("interrupt_after_being_under_fire", true);
+
 	enemy_elite_minimum_level = gp.getOptionalInt("enemy_elite_minimum_level", 6);
 	enemy_elite_maximum_level = gp.getOptionalInt("enemy_elite_maximum_level", 10);
 

--- a/src/externalized/policy/GamePolicy.h
+++ b/src/externalized/policy/GamePolicy.h
@@ -64,6 +64,8 @@ public:
 	bool avoid_ambushes;                  // AI able to recognize and avoid ambushes on seeing friendlies' corpses
 	bool stay_on_rooftop;                 // AI on guard on rooftop are disallowed to go down
 
+	bool interrupt_after_being_under_fire; // only being shot at during the turn in progress blocks a soldier's interrupts; vanilla keeps them blocked through the next turn too, since the under-fire mark is only cleared once their own turn begins. Applies to mercs and AI alike
+
 	int8_t enemy_elite_minimum_level;     // increase challenge: minimum experience level for enemy elite soldier
 	int8_t enemy_elite_maximum_level;     // maximum experience level for enemy elite soldier
 

--- a/src/game/Tactical/TeamTurns.cc
+++ b/src/game/Tactical/TeamTurns.cc
@@ -980,7 +980,13 @@ BOOLEAN StandardInterruptConditionsMet(const SOLDIERTYPE* const pSoldier, const 
 
 	// a soldier already engaged in a life & death battle is too busy doing his
 	// best to survive to worry about "getting the jump" on additional threats
-	if (pSoldier->bUnderFire)
+	//
+	// bUnderFire is set to 2 by the attack and decayed by EVENT_BeginMercTurn, which
+	// only runs for the soldier's own team. So 2 means "shot at during the turn now in
+	// progress" and 1 means "shot at a turn ago". With interrupt_after_being_under_fire
+	// only the former counts as a life & death battle; vanilla tests bUnderFire outright
+	// and keeps the soldier flinching through the whole turn after the attack as well.
+	if (gamepolicy(interrupt_after_being_under_fire) ? pSoldier->bUnderFire == 2 : pSoldier->bUnderFire != 0)
 	{
 		return(FALSE);
 	}


### PR DESCRIPTION
so underfire can have 3 values, but we only interested in two: 2 means a soldier is shot during this exact turn and 1 means soldier was shot last turn. At the moment when a soldier is underfire they cannot interrupt. This has several side effects for ai. First, when ai soldier decides to watch (wait for interrupt) they never check underfire which means this decision is simply useless. Second, when player 'abuse' a tactic of crouch->shoot->prone (behind an obstacle that blocks los) the only counter that ai has is actually interrupt (which never happens because they have underfire=1). And btw the shot can be absolutely horrible and not even close to target but underfire will be set. Interestingly being blown with a grenade is not considered a big deal and allows to interrupt in this specific scenario.

This change will make ai a bit stronger, and I think it will also benefit player as currently it's really not obvious that you can't interrupt if someone shot at you during the last turn.