### PR TITLE
Personnel: do not constantly reload two STI files

### DIFF
--- a/src/game/Laptop/Personnel.cc
+++ b/src/game/Laptop/Personnel.cc
@@ -244,6 +244,8 @@ cache_key_t const guiSCREEN { LAPTOPDIR "/personnelwindow.sti" };
 cache_key_t const guiDEPARTEDTEAM{ LAPTOPDIR "/departed.sti" };
 cache_key_t const guiCURRENTTEAM{ LAPTOPDIR "/currentteam.sti" };
 cache_key_t const guiPersonnelInventory{ LAPTOPDIR "/personnel_inventory.sti" };
+cache_key_t const guiBox{ LAPTOPDIR "/atmbuttons.sti" };
+cache_key_t const guiPicBorder{ LAPTOPDIR "/picborde.sti" };
 }
 
 static struct
@@ -379,6 +381,8 @@ static void RemovePersonnelGraphics(void)
 	// delete graphics needed for personnel screen
 	RemoveVObject(guiSCREEN);
 	RemoveVObject(guiPersonnelInventory);
+	RemoveVObject(guiBox);
+	RemoveVObject(guiPicBorder);
 }
 
 
@@ -1885,7 +1889,7 @@ static void DisplayHighLightBox(INT32 const sel_id)
 	// will display highlight box around selected merc
 	const INT32 x = SMALL_PORTRAIT_START_X + sel_id % PERSONNEL_PORTRAIT_NUMBER_WIDTH * SMALL_PORT_WIDTH  - 2;
 	const INT32 y = SMALL_PORTRAIT_START_Y + sel_id / PERSONNEL_PORTRAIT_NUMBER_WIDTH * SMALL_PORT_HEIGHT - 3;
-	BltVideoObjectOnce(FRAME_BUFFER, LAPTOPDIR "/picborde.sti", 0, x, y);
+	BltVideoObject(FRAME_BUFFER, guiPicBorder, 0, x, y);
 }
 
 
@@ -2021,15 +2025,12 @@ static SOLDIERTYPE const& GetSoldierOfCurrentSlot(void)
 
 
 static void RenderAtmPanel(void)
-try
 {
 	// just show basic panel
 	// bounding
-	AutoSGPVObject uiBox(AddVideoObjectFromFile(LAPTOPDIR "/atmbuttons.sti"));
-	BltVideoObject(FRAME_BUFFER, uiBox.get(), 0, ATM_UL_X,     ATM_UL_Y);
-	BltVideoObject(FRAME_BUFFER, uiBox.get(), 1, ATM_UL_X + 1, ATM_UL_Y + 18);
+	BltVideoObject(FRAME_BUFFER, guiBox, 0, ATM_UL_X,     ATM_UL_Y);
+	BltVideoObject(FRAME_BUFFER, guiBox, 1, ATM_UL_X + 1, ATM_UL_Y + 18);
 }
-catch (...) { /* XXX ignore */ }
 
 
 static void MakeButton(UINT idx, INT16 y, GUI_CALLBACK click, const ST::string& text)


### PR DESCRIPTION
The files needed to render the ATM panel and the highlight border around the mercs face were frequently reloaded for no good reason. Both now use the object cache.