### PR TITLE
Remove InitializeVideoManager

### DIFF
--- a/src/sgp/SGP.cc
+++ b/src/sgp/SGP.cc
@@ -392,9 +392,6 @@ int main(int argc, char* argv[])
 		InitializeVideoManager(scalingQuality, GCM->getGamePolicy()->target_fps);
 		VideoSetBrightness(brightness);
 
-		SLOGD("Initializing Video Object Manager");
-		InitializeVideoObjectManager();
-
 		SLOGD("Initializing Video Surface Manager");
 		InitializeVideoSurfaceManager();
 

--- a/src/sgp/VObject.cc
+++ b/src/sgp/VObject.cc
@@ -30,11 +30,11 @@ static SGPVObject* gpVObjectHead = 0;
 
 
 SGPVObject::SGPVObject(SGPImage * const img) :
-	flags_(),
 	palette16_(),
 	pix_data_{ img->pImageData.moveToUnique() },
 	etrle_object_{ img->pETRLEObject.moveToUnique() },
 	current_shade_(),
+	flags_(),
 	subregion_count_{ img->usNumberOfObjects },
 	bit_depth_{ img->ubBitDepth },
 	next_(gpVObjectHead)

--- a/src/sgp/VObject.cc
+++ b/src/sgp/VObject.cc
@@ -198,15 +198,6 @@ void SGPVObject::ShareShadetables(SGPVObject* const other)
 }
 
 
-void InitializeVideoObjectManager(void)
-{
-	//Shouldn't be calling this if the video object manager already exists.
-	//Call shutdown first...
-	Assert(gpVObjectHead == NULL);
-	gpVObjectHead = NULL;
-}
-
-
 void ShutdownVideoObjectManager(void)
 {
 	extern void ClearObjectCache();

--- a/src/sgp/VObject.h
+++ b/src/sgp/VObject.h
@@ -65,7 +65,6 @@ class SGPVObject
 		};
 
 	private:
-		Flags                        flags_;                         // Special flags
 		std::unique_ptr<SGPPaletteEntry const []> palette_;          // 8BPP Palette
 		UINT16*                      palette16_;                     // A 16BPP palette used for 8->16 blits
 
@@ -80,6 +79,7 @@ class SGPVObject
 		std::unique_ptr<std::unique_ptr<ZStripInfo> []> ppZStripInfo;// Z-value strip info arrays
 
 	private:
+		Flags                        flags_;                         // Special flags
 		UINT16                       subregion_count_;               // Total number of objects
 		UINT8                        bit_depth_;                     // BPP
 
@@ -91,9 +91,6 @@ ENUM_BITSET(SGPVObject::Flags)
 // A pair of a VObject and one of its SubRegions to specify one particular image.
 using SubVObject  = std::pair<SGPVObject *, UINT16>;
 using CSubVObject = std::pair<SGPVObject const *, UINT16>;
-
-// Creates a list to contain video objects
-void InitializeVideoObjectManager(void);
 
 // Deletes any video object placed into list
 void ShutdownVideoObjectManager(void);


### PR DESCRIPTION
If this function does not exist we do not have to assert that it was called at the right time. All it does is set the head of a linked list that was already NULL to NULL again.

Also move SGPVObject::Flags down a bit to reduce padding.