### PR TITLE
Fix light flares that land on an occupied tile

### DIFF
--- a/src/game/TileEngine/Physics.cc
+++ b/src/game/TileEngine/Physics.cc
@@ -2138,10 +2138,8 @@ static void HandleArmedObjectImpact(REAL_OBJECT* pObject)
 
 		if (lightEffect)
 		{
-			//if the light object will be created OFF the ground
-			if (pObject->Position.z > 0)
+			if (GET_OBJECT_LEVEL(pObject->Position.z) > 0)
 			{
-				//we cannot create the light source above the ground, or on a roof.  The system doesnt support it.
 				//if it causes any other type of effect we still make it explode, otherwise we just add the item
 				if (!causesExplosion) {
 					AddItemToPool(pObject->sGridNo, &(pObject->Obj), VISIBLE, 1, 0, -1);


### PR DESCRIPTION
A thrown flare stops on top of whatever it hits, so aiming at a soldier's gridno left it resting at shoulder height. The light effect was skipped for any Position.z above 0 and the flare dropped as an item instead.