### PR TITLE
Fix militia visual offset

### DIFF
--- a/assets/externalized/strategic-map-towns.json
+++ b/assets/externalized/strategic-map-towns.json
@@ -5,6 +5,9 @@
  *  - townId:    The numeric ID of the town as set in codebase
  *  - internalName:    The name to refer to this town from other json files
  *  - sectors:    List of sectors belonging to the town.
+ *  - militiaMapBaseSector:    Top left corner of the 3x3 grid the militia panel draws for this
+ *      town. It must match the town's cutout in interface/militiamaps.sti, so it is art data and
+ *      not always the town's own top left sector. Defaults to the town's own top left sector.
  *  - townPoint:    Position of town names on the map. These are no longer PIXELS, but 10 * the X,Y position in SECTORS (fractions possible) to the X-CENTER of the town.
  *  - isMilitiaTrainingAllowed:   Whether or not militia is allowed in town
  */
@@ -13,6 +16,7 @@
 		"townId": 1,
 		"internalName": "OMERTA",
 		"sectors": [ "A9", "A10" ],
+		"militiaMapBaseSector": "A9",
 		"townPoint": { "x": 90, "y": 10 },
 		"isMilitiaTrainingAllowed": false
 	},
@@ -20,6 +24,7 @@
 		"townId": 2,
 		"internalName": "DRASSEN",
 		"sectors": [ "B13", "C13", "D13" ],
+		"militiaMapBaseSector": "B13",
 		"townPoint": { "x": 125, "y": 40 },
 		"isMilitiaTrainingAllowed": true
 	},
@@ -27,6 +32,7 @@
 		"townId": 3,
 		"internalName": "ALMA",
 		"sectors": [ "H13", "H14", "I13", "I14" ],
+		"militiaMapBaseSector": "H13",
 		"townPoint": { "x": 130, "y": 90 },
 		"isMilitiaTrainingAllowed": true
 	},
@@ -34,6 +40,7 @@
 		"townId": 4,
 		"internalName": "GRUMM",
 		"sectors": [ "G1", "G2", "H1", "H2", "H3" ],
+		"militiaMapBaseSector": "G1",
 		"townPoint": { "x": 15, "y": 80 },
 		"isMilitiaTrainingAllowed": true
 	},
@@ -41,6 +48,7 @@
 		"townId": 5,
 		"internalName": "TIXA",
 		"sectors": [ "J9" ],
+		"militiaMapBaseSector": "I8",
 		"townPoint": { "x": 85, "y": 100 },
 		"isMilitiaTrainingAllowed": false
 	},
@@ -48,6 +56,7 @@
 		"townId": 6,
 		"internalName": "CAMBRIA",
 		"sectors": [ "F8", "F9", "G8", "G9", "H8" ],
+		"militiaMapBaseSector": "F8",
 		"townPoint": { "x": 95, "y": 70 },
 		"isMilitiaTrainingAllowed": true
 	},
@@ -55,6 +64,7 @@
 		"townId": 7,
 		"internalName": "SAN_MONA",
 		"sectors": [ "C5", "C6", "D4", "D5" ],
+		"militiaMapBaseSector": "B4",
 		"townPoint": { "x": 45, "y": 40 },
 		"isMilitiaTrainingAllowed": false
 	},
@@ -62,6 +72,7 @@
 		"townId": 8,
 		"internalName": "ESTONI",
 		"sectors": [ "I6" ],
+		"militiaMapBaseSector": "H5",
 		"townPoint": { "x": 55, "y": 90 },
 		"isMilitiaTrainingAllowed": false
 	},
@@ -69,6 +80,7 @@
 		"townId": 9,
 		"internalName": "ORTA",
 		"sectors": [ "K4" ],
+		"militiaMapBaseSector": "J3",
 		"townPoint": { "x": 35, "y": 110 },
 		"isMilitiaTrainingAllowed": false
 	},
@@ -76,6 +88,7 @@
 		"townId": 10,
 		"internalName": "BALIME",
 		"sectors": [ "L11", "L12" ],
+		"militiaMapBaseSector": "K11",
 		"townPoint": { "x": 110, "y": 120 },
 		"isMilitiaTrainingAllowed": true
 	},
@@ -83,6 +96,7 @@
 		"townId": 11,
 		"internalName": "MEDUNA",
 		"sectors": [ "N3", "N4", "N5", "O3", "O4", "P3" ],
+		"militiaMapBaseSector": "N3",
 		"townPoint": { "x": 45, "y": 150 },
 		"isMilitiaTrainingAllowed": true
 	},
@@ -90,6 +104,7 @@
 		"townId": 12,
 		"internalName": "CHITZENA",
 		"sectors": [ "A2", "B2" ],
+		"militiaMapBaseSector": "A2",
 		"townPoint": { "x": 15, "y": 20 },
 		"isMilitiaTrainingAllowed": true
 	}

--- a/src/externalized/strategic/TownModel.cc
+++ b/src/externalized/strategic/TownModel.cc
@@ -2,13 +2,14 @@
 
 #include "JsonUtility.h"
 #include "TranslatableString.h"
+#include <algorithm>
 #include <cstdint>
 
 const ST::string TownModel::NAME_TRANSLATION_PREFIX = "strings/strategic-map-town-names";
 const ST::string TownModel::NAME_LOCATIVE_TRANSLATION_PREFIX = "strings/strategic-map-town-name-locatives";
 
-TownModel::TownModel(int8_t townId_, ST::string&& internalName_, ST::string&& name_, ST::string&& nameLocative_, std::vector<uint8_t>&& sectorIDs_, SGPPoint townPoint_, bool isMilitiaTrainingAllowed_)
-	: townId(townId_), internalName(std::move(internalName_)), name(std::move(name_)), nameLocative(std::move(nameLocative_)), sectorIDs(std::move(sectorIDs_)), townPoint(townPoint_), isMilitiaTrainingAllowed(isMilitiaTrainingAllowed_) {}
+TownModel::TownModel(int8_t townId_, ST::string&& internalName_, ST::string&& name_, ST::string&& nameLocative_, std::vector<uint8_t>&& sectorIDs_, uint8_t militiaMapBaseSectorID_, SGPPoint townPoint_, bool isMilitiaTrainingAllowed_)
+	: townId(townId_), internalName(std::move(internalName_)), name(std::move(name_)), nameLocative(std::move(nameLocative_)), sectorIDs(std::move(sectorIDs_)), militiaMapBaseSectorID(militiaMapBaseSectorID_), townPoint(townPoint_), isMilitiaTrainingAllowed(isMilitiaTrainingAllowed_) {}
 
 SGPSector TownModel::getBaseSector() const
 {
@@ -20,11 +21,22 @@ SGPSector TownModel::getBaseSector() const
 	return min;
 }
 
+SGPSector TownModel::getMilitiaMapBaseSector() const
+{
+	return SGPSector(militiaMapBaseSectorID);
+}
+
 TownModel* TownModel::deserialize(const JsonValue& json, TranslatableString::Loader& stringLoader)
 {
 	std::vector<uint8_t> sectorIDs = JsonUtility::parseSectorList(json, "sectors");
 	auto obj = json.toObject();
 	auto townId = static_cast<int8_t>(obj.GetInt("townId"));
+
+	/* The militia panel draws a fixed 3x3 cutout per town, so where that grid starts is a property
+	 * of the artwork rather than of the sector list.  Fall back to the town's own top left sector. */
+	uint8_t militiaMapBaseSectorID = obj.has("militiaMapBaseSector") ?
+		JsonUtility::parseSectorID(obj["militiaMapBaseSector"]) :
+		(sectorIDs.empty() ? 0 : *std::min_element(sectorIDs.begin(), sectorIDs.end()));
 
 	auto tp = obj["townPoint"].toObject();
 	SGPPoint townPoint = SGPPoint();
@@ -37,6 +49,7 @@ TownModel* TownModel::deserialize(const JsonValue& json, TranslatableString::Loa
 		TranslatableString::Utils::resolveOptionalProperty(stringLoader, obj, "name", std::make_unique<TranslatableString::Json>(NAME_TRANSLATION_PREFIX, townId)),
 		TranslatableString::Utils::resolveOptionalProperty(stringLoader, obj, "nameLocative", std::make_unique<TranslatableString::Json>(NAME_LOCATIVE_TRANSLATION_PREFIX, townId)),
 		std::move(sectorIDs),
+		militiaMapBaseSectorID,
 		townPoint,
 		obj.getOptionalBool("isMilitiaTrainingAllowed")
 		);

--- a/src/externalized/strategic/TownModel.h
+++ b/src/externalized/strategic/TownModel.h
@@ -9,10 +9,14 @@
 class TownModel
 {
 public:
-	TownModel(int8_t townId_, ST::string&& internalName_, ST::string&& name, ST::string&& nameLocative, std::vector<uint8_t>&& sectorIDs_, SGPPoint townPoint_, bool isMilitiaTrainingAllowed_ );
+	TownModel(int8_t townId_, ST::string&& internalName_, ST::string&& name, ST::string&& nameLocative, std::vector<uint8_t>&& sectorIDs_, uint8_t militiaMapBaseSectorID_, SGPPoint townPoint_, bool isMilitiaTrainingAllowed_ );
 
 	// Returns the top-left corner of the town on map. It may or may not belong to the town.
 	SGPSector getBaseSector() const;
+	/* Returns the top-left corner of the 3x3 grid the militia panel draws for this town.  It has to
+	 * line up with the town's cutout in interface/militiamaps.sti, which for some towns sits a row
+	 * or a column outside the town itself, so it is not the same as getBaseSector(). */
+	SGPSector getMilitiaMapBaseSector() const;
 	static TownModel* deserialize(const JsonValue& obj, TranslatableString::Loader& stringLoader);
 
 	int8_t townId;
@@ -20,6 +24,7 @@ public:
 	ST::string name;
 	ST::string nameLocative;
 	std::vector<uint8_t> sectorIDs;
+	uint8_t militiaMapBaseSectorID;
 	SGPPoint townPoint;
 	bool isMilitiaTrainingAllowed;
 private:

--- a/src/game/Strategic/Map_Screen_Interface_Map.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map.cc
@@ -413,7 +413,7 @@ void InitMapScreenInterfaceMap()
 	for (auto const& pair : GCM->getTowns())
 	{
 		auto town = pair.second;
-		sBaseSectorList.push_back(town->getBaseSector());
+		sBaseSectorList.push_back(town->getMilitiaMapBaseSector());
 		pTownPoints.push_back(town->townPoint);
 	}
 


### PR DESCRIPTION
Externalizing town data introduced a bug where militia presentation is broken. So far I've only seen it in Balime:
<img width="453" height="425" alt="Screenshot From 2026-08-28 21-51-45" src="https://github.com/user-attachments/assets/21460e8e-9bac-4a7c-bf30-db2b985b5025" />
