### PR TITLE
Use the enemy's own leader in autoresolve

### DIFF
--- a/src/game/Strategic/Auto_Resolve.cc
+++ b/src/game/Strategic/Auto_Resolve.cc
@@ -2595,7 +2595,7 @@ static void CalculateAttackValues(void)
 												pSoldier->bMedical +
 												pSoldier->bMorale;
 		//100 team leadership adds a bonus of 10%
-		usBonus = 100 + gpAR->ubPlayerLeadership/10;// + sOutnumberBonus;
+		usBonus = 100 + gpAR->ubEnemyLeadership/10;// + sOutnumberBonus;
 		//bExpLevel adds a bonus of 7% per level after 2, level 1 soldiers get a 7% decrease
 		//usBonus += 7 * (pSoldier->bExpLevel-2);
 		usBonus += gpAR->ubEnemyDefenceAdvantage;


### PR DESCRIPTION
Probably another typo. During autoresolve both sides select a soldier with highest leadership, and their leadership is applied to both attack and defense of each and every member of the team. Player's  leadership bonus was applied to both teams which is a bug.