### PR TITLE
allow up to six IMPs

### DIFF
--- a/assets/externalized/game.json
+++ b/assets/externalized/game.json
@@ -189,9 +189,11 @@
     "bonus_attribute_points": 40,
 
     //  Number of I.M.P. characters that can be created over a campaign.
-    //  Each character keeps one of the merc profiles marked as an I.M.P. slot in
-    //  mercs-profile-info.json for the rest of the campaign, so the ceiling is how
-    //  many of those the data declares. Voices and portraits may be reused freely.
+    //  0 switches the I.M.P. site off entirely.
+    //  A character holds one of the merc profiles that mercs-profile-info.json
+    //  marks as an I.M.P. slot for the rest of the campaign, so that is the upper
+    //  end: eleven as the game ships, more if the data declares more. Voices and
+    //  portraits may be reused freely and do not limit it.
     //  vanilla setting: 1
     "max_characters": 1,
 

--- a/assets/externalized/game.json
+++ b/assets/externalized/game.json
@@ -188,10 +188,10 @@
     "zero_attribute_points_bonus": 15,
     "bonus_attribute_points": 40,
 
-    //  Number of I.M.P. characters that can be created over a campaign, 1 to 6.
-    //  Each character keeps one of the player generated merc profile slots, of which
-    //  there are three per gender, so at most three men and three women. Voices and
-    //  portraits already in use are skipped when profiling a further character.
+    //  Number of I.M.P. characters that can be created over a campaign.
+    //  Each character keeps one of the merc profiles marked as an I.M.P. slot in
+    //  mercs-profile-info.json for the rest of the campaign, so the ceiling is how
+    //  many of those the data declares. Voices and portraits may be reused freely.
     //  vanilla setting: 1
     "max_characters": 1,
 

--- a/assets/externalized/game.json
+++ b/assets/externalized/game.json
@@ -188,6 +188,13 @@
     "zero_attribute_points_bonus": 15,
     "bonus_attribute_points": 40,
 
+    //  Number of I.M.P. characters that can be created over a campaign, 1 to 6.
+    //  Each character keeps one of the player generated merc profile slots, of which
+    //  there are three per gender, so at most three men and three women. Voices and
+    //  portraits already in use are skipped when profiling a further character.
+    //  vanilla setting: 1
+    "max_characters": 1,
+
     // Replace the IMP personality quiz with a form to select skills directly
     // NOTE: does not set any personality
     // vanilla setting: false

--- a/assets/externalized/imp.json
+++ b/assets/externalized/imp.json
@@ -6,6 +6,46 @@
     // vanilla setting: 1
     "starting_level": 1,
 
+    // The voices an I.M.P. character can be offered, in the order the site shows
+    // them. A voice is a set of speech, dialogue text and battle sounds, all named
+    // after the merc profile they were recorded for: SPEECH/051_*.wav,
+    // MERCEDT/051.edt and BATTLESNDS/051_*.wav make up voice 51. The voice picked
+    // is written to the character's own profile, so any number of characters may
+    // share one.
+    "voices": [
+        { "gender": "MALE",   "profile": 51 },
+        { "gender": "MALE",   "profile": 52 },
+        { "gender": "MALE",   "profile": 53 },
+        { "gender": "FEMALE", "profile": 54 },
+        { "gender": "FEMALE", "profile": 55 },
+        { "gender": "FEMALE", "profile": 56 }
+    ],
+
+    // The portraits an I.M.P. character can be offered, in the order the site shows
+    // them. "face" names FACES/<face>.sti, with FACES/bigfaces/<face>.sti shown
+    // while picking; "eyes" and "mouth" are the offsets the talking head animates
+    // at; "skin" and "hair" are the palettes the body is rendered with; "big_body"
+    // marks the burly portraits, which are given the big male body when the
+    // character is strong enough to carry it.
+    "portraits": [
+        { "gender": "MALE",   "face": 200, "skin": "BLACKSKIN", "hair": "BROWNHEAD", "eyes": [  8, 5 ], "mouth": [  8, 21 ], "big_body": true },
+        { "gender": "MALE",   "face": 201, "skin": "TANSKIN",   "hair": "BROWNHEAD", "eyes": [  9, 4 ], "mouth": [  9, 23 ] },
+        { "gender": "MALE",   "face": 202, "skin": "TANSKIN",   "hair": "BROWNHEAD", "eyes": [  8, 5 ], "mouth": [  7, 24 ] },
+        { "gender": "MALE",   "face": 203, "skin": "DARKSKIN",  "hair": "BROWNHEAD", "eyes": [  6, 6 ], "mouth": [  7, 25 ] },
+        { "gender": "MALE",   "face": 204, "skin": "TANSKIN",   "hair": "BROWNHEAD", "eyes": [ 13, 5 ], "mouth": [ 11, 23 ] },
+        { "gender": "MALE",   "face": 205, "skin": "DARKSKIN",  "hair": "BLACKHEAD", "eyes": [ 11, 5 ], "mouth": [ 10, 24 ] },
+        { "gender": "MALE",   "face": 206, "skin": "TANSKIN",   "hair": "BROWNHEAD", "eyes": [  8, 4 ], "mouth": [  8, 24 ], "big_body": true },
+        { "gender": "MALE",   "face": 207, "skin": "TANSKIN",   "hair": "BROWNHEAD", "eyes": [  8, 4 ], "mouth": [  8, 24 ], "big_body": true },
+        { "gender": "FEMALE", "face": 208, "skin": "TANSKIN",   "hair": "BROWNHEAD", "eyes": [  4, 4 ], "mouth": [  5, 25 ] },
+        { "gender": "FEMALE", "face": 209, "skin": "PINKSKIN",  "hair": "BROWNHEAD", "eyes": [  5, 5 ], "mouth": [  6, 24 ] },
+        { "gender": "FEMALE", "face": 210, "skin": "TANSKIN",   "hair": "BLACKHEAD", "eyes": [  7, 5 ], "mouth": [  7, 24 ] },
+        { "gender": "FEMALE", "face": 211, "skin": "TANSKIN",   "hair": "BLACKHEAD", "eyes": [  5, 7 ], "mouth": [  6, 26 ] },
+        { "gender": "FEMALE", "face": 212, "skin": "PINKSKIN",  "hair": "BROWNHEAD", "eyes": [  7, 6 ], "mouth": [  7, 24 ] },
+        { "gender": "FEMALE", "face": 213, "skin": "BLACKSKIN", "hair": "BROWNHEAD", "eyes": [ 11, 5 ], "mouth": [  9, 23 ] },
+        { "gender": "FEMALE", "face": 214, "skin": "TANSKIN",   "hair": "REDHEAD",   "eyes": [  8, 5 ], "mouth": [  7, 24 ] },
+        { "gender": "FEMALE", "face": 215, "skin": "TANSKIN",   "hair": "BLONDHEAD", "eyes": [  5, 6 ], "mouth": [  5, 26 ] }
+    ],
+
     // Base and additional inventory items dependent on attributes and skills.
     // Conditions come in pairs of values. Skill checks need to be paired with 'SKILL'.
     // Conditions evaluate as a greater-or-equal relation; if there are several, all need to be true.

--- a/assets/externalized/mercs-profile-info.json
+++ b/assets/externalized/mercs-profile-info.json
@@ -223,11 +223,14 @@
     { "profileID": 161, "internalName": "PROF_ELDERODO", "type": "VEHICLE" },
     { "profileID": 162, "internalName": "PROF_ICECREAM", "type": "VEHICLE" },
     { "profileID": 163, "internalName": "PROF_HELICOPTER", "type": "VEHICLE" },
-     /* Unused slots */
-    { "profileID": 164, "internalName": "NPC164", "type": "NOT_USED" },
-    { "profileID": 165, "internalName": "NPC165", "type": "NOT_USED" },
-    { "profileID": 166, "internalName": "NPC166", "type": "NOT_USED" },
-    { "profileID": 167, "internalName": "NPC167", "type": "NOT_USED" },
-    { "profileID": 168, "internalName": "NPC168", "type": "NOT_USED" },
-    { "profileID": 169, "internalName": "NPC169", "type": "NOT_USED" }
+     /* Unused slot */
+    { "profileID": 164, "internalName": "NPC164", "type": "NOT_USED" }, // in use as the placeholder profile of the unused vehicles
+    /* Spare profiles, handed out to player generated characters as they are made.
+       A character takes the first free one and carries its own voice, so these
+       need no files of their own. */
+    { "profileID": 165, "internalName": "NPC165", "type": "IMP" },
+    { "profileID": 166, "internalName": "NPC166", "type": "IMP" },
+    { "profileID": 167, "internalName": "NPC167", "type": "IMP" },
+    { "profileID": 168, "internalName": "NPC168", "type": "IMP" },
+    { "profileID": 169, "internalName": "NPC169", "type": "IMP" }
 ]

--- a/assets/externalized/mercs-profile-info.json
+++ b/assets/externalized/mercs-profile-info.json
@@ -105,13 +105,15 @@
     { "profileID": 48, "internalName": "COUGAR", "type": "MERC" },
     { "profileID": 49, "internalName": "NUMB", "type": "MERC" },
     { "profileID": 50, "internalName": "BUBBA", "type": "MERC" },
-     /* IMP */
-    { "profileID": 51, "internalName": "PGMALE1", "type": "IMP" },
-    { "profileID": 52, "internalName": "PGMALE2", "type": "IMP" },
-    { "profileID": 53, "internalName": "PGMALE3", "type": "IMP" },
-    { "profileID": 54, "internalName": "PGLADY1", "type": "IMP" },
-    { "profileID": 55, "internalName": "PGLADY2", "type": "IMP" },
-    { "profileID": 56, "internalName": "PGLADY3", "type": "IMP" },
+     /* IMP: the clothes a player generated character is dressed in. The six the
+        game shipped carry them in prof.dat too, the spare slots at the end carry
+        nothing at all, so they are declared here for all of them alike. */
+    { "profileID": 51, "internalName": "PGMALE1", "type": "IMP", "pantsColor": "BLACKPANTS", "vestColor": "WHITEVEST" },
+    { "profileID": 52, "internalName": "PGMALE2", "type": "IMP", "pantsColor": "BLACKPANTS", "vestColor": "WHITEVEST" },
+    { "profileID": 53, "internalName": "PGMALE3", "type": "IMP", "pantsColor": "BLACKPANTS", "vestColor": "WHITEVEST" },
+    { "profileID": 54, "internalName": "PGLADY1", "type": "IMP", "pantsColor": "BLACKPANTS", "vestColor": "WHITEVEST" },
+    { "profileID": 55, "internalName": "PGLADY2", "type": "IMP", "pantsColor": "BLACKPANTS", "vestColor": "WHITEVEST" },
+    { "profileID": 56, "internalName": "PGLADY3", "type": "IMP", "pantsColor": "BLACKPANTS", "vestColor": "WHITEVEST" },
      /* RPC (rebels) */
     { "profileID": 57, "internalName": "MIGUEL", "type": "RPC" },
     { "profileID": 58, "internalName": "CARLOS", "type": "RPC" },
@@ -228,9 +230,9 @@
     /* Spare profiles, handed out to player generated characters as they are made.
        A character takes the first free one and carries its own voice, so these
        need no files of their own. */
-    { "profileID": 165, "internalName": "NPC165", "type": "IMP" },
-    { "profileID": 166, "internalName": "NPC166", "type": "IMP" },
-    { "profileID": 167, "internalName": "NPC167", "type": "IMP" },
-    { "profileID": 168, "internalName": "NPC168", "type": "IMP" },
-    { "profileID": 169, "internalName": "NPC169", "type": "IMP" }
+    { "profileID": 165, "internalName": "NPC165", "type": "IMP", "pantsColor": "BLACKPANTS", "vestColor": "WHITEVEST" },
+    { "profileID": 166, "internalName": "NPC166", "type": "IMP", "pantsColor": "BLACKPANTS", "vestColor": "WHITEVEST" },
+    { "profileID": 167, "internalName": "NPC167", "type": "IMP", "pantsColor": "BLACKPANTS", "vestColor": "WHITEVEST" },
+    { "profileID": 168, "internalName": "NPC168", "type": "IMP", "pantsColor": "BLACKPANTS", "vestColor": "WHITEVEST" },
+    { "profileID": 169, "internalName": "NPC169", "type": "IMP", "pantsColor": "BLACKPANTS", "vestColor": "WHITEVEST" }
 ]

--- a/rust/stracciatella/src/schemas/yaml/game.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/game.schema.yaml
@@ -371,7 +371,7 @@ properties:
         description: |
           Number of I.M.P. characters that can be created over a campaign.
 
-          Note: each character keeps one of the player generated merc profile slots, of which there are three per gender, so at most three men and three women can be made. Values outside 1 to 6 are clamped.
+          Note: each character keeps one of the merc profiles marked as an I.M.P. slot in mercs-profile-info.json for the rest of the campaign, so the ceiling is how many of those the data declares. Voices and portraits may be reused freely.
 
           Vanilla setting: `1`
       pick_skills_directly:

--- a/rust/stracciatella/src/schemas/yaml/game.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/game.schema.yaml
@@ -369,9 +369,9 @@ properties:
         $ref: types/uint8.schema.yaml
         title: Maximum number of I.M.P. characters
         description: |
-          Number of I.M.P. characters that can be created over a campaign.
+          Number of I.M.P. characters that can be created over a campaign. `0` switches the I.M.P. site off entirely.
 
-          Note: each character keeps one of the merc profiles marked as an I.M.P. slot in mercs-profile-info.json for the rest of the campaign, so the ceiling is how many of those the data declares. Voices and portraits may be reused freely.
+          Note: a character holds one of the merc profiles that mercs-profile-info.json marks as an I.M.P. slot for the rest of the campaign, so that is the upper end: eleven as the game ships, more if the data declares more. Voices and portraits may be reused freely and do not limit it.
 
           Vanilla setting: `1`
       pick_skills_directly:

--- a/rust/stracciatella/src/schemas/yaml/game.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/game.schema.yaml
@@ -365,6 +365,15 @@ properties:
           Bonus attribute points is your initial pool of points to distribute.
 
           Vanilla setting: `40`
+      max_characters:
+        $ref: types/uint8.schema.yaml
+        title: Maximum number of I.M.P. characters
+        description: |
+          Number of I.M.P. characters that can be created over a campaign.
+
+          Note: each character keeps one of the player generated merc profile slots, of which there are three per gender, so at most three men and three women can be made. Values outside 1 to 6 are clamped.
+
+          Vanilla setting: `1`
       pick_skills_directly:
         type: boolean
         title: Pick skills directly

--- a/rust/stracciatella/src/schemas/yaml/imp.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/imp.schema.yaml
@@ -13,6 +13,72 @@ properties:
     $ref: types/uint8.schema.yaml
     title: Starting level
     description: The starting level of a created IMP merc.
+  voices:
+    type: array
+    title: Voices
+    description: |
+      The voices an I.M.P. character can be offered, in the order the site shows them.
+
+      A voice is a set of speech, dialogue text and battle sound files, all named after the merc profile they were recorded for. The voice picked is stored on the character's own profile, so any number of characters may share one.
+    minItems: 1
+    items:
+      type: object
+      title: Voice
+      properties:
+        gender:
+          $ref: types/gender.schema.yaml
+          title: Gender
+          description: The gender this voice is offered for.
+        profile:
+          $ref: types/uint8.schema.yaml
+          title: Profile
+          description: The merc profile whose speech, dialogue text and battle sound files make up this voice.
+      required:
+      - gender
+      - profile
+  portraits:
+    type: array
+    title: Portraits
+    description: The portraits an I.M.P. character can be offered, in the order the site shows them.
+    minItems: 1
+    items:
+      type: object
+      title: Portrait
+      properties:
+        gender:
+          $ref: types/gender.schema.yaml
+          title: Gender
+          description: The gender this portrait is offered for.
+        face:
+          $ref: types/uint8.schema.yaml
+          title: Face
+          description: The face image, `FACES/<face>.sti`, with `FACES/bigfaces/<face>.sti` shown while picking.
+        skin:
+          type: string
+          title: Skin colour
+          description: The palette the character's skin is rendered with, for example `TANSKIN`.
+        hair:
+          type: string
+          title: Hair colour
+          description: The palette the character's hair is rendered with, for example `BROWNHEAD`.
+        eyes:
+          $ref: types/face-offset.schema.yaml
+        mouth:
+          $ref: types/face-offset.schema.yaml
+        big_body:
+          type: boolean
+          title: Big body
+          description: |
+            Whether this portrait is a burly one, which is given the big male body when the character is strong enough to carry it.
+
+            Defaults to `false`.
+      required:
+      - gender
+      - face
+      - skin
+      - hair
+      - eyes
+      - mouth
   inventory:
     type: array
     title: Inventory
@@ -43,4 +109,6 @@ properties:
     - items
 required:
 - activation_codes
+- voices
+- portraits
 - inventory

--- a/rust/stracciatella/src/schemas/yaml/types/gender.schema.yaml
+++ b/rust/stracciatella/src/schemas/yaml/types/gender.schema.yaml
@@ -1,0 +1,6 @@
+title: Gender
+description: The gender of a merc.
+type: string
+enum:
+  - MALE
+  - FEMALE

--- a/src/externalized/content/Dialogs.cc
+++ b/src/externalized/content/Dialogs.cc
@@ -42,7 +42,7 @@ ST::string Content::GetDialogueTextFilename(const MercProfile &profile,
 	{
 		{
 			// assume EDT files are in EDT directory on HARD DRIVE
-			zFileName = ST::format("{}/{03d}.edt", MERCEDTDIR, profile.getID());
+			zFileName = ST::format("{}/{03d}.edt", MERCEDTDIR, profile.getStruct().ubVoiceId);
 		}
 	}
 
@@ -84,22 +84,23 @@ ST::string Content::GetDialogueVoiceFilename(const MercProfile &profile, uint16_
 	else
 	{
 		{
+			uint8_t const ubVoiceId = profile.getStruct().ubVoiceId;
 			if(isRussianVersion)
 			{
 				if (profile.isNPCorRPC() && profile.isRecruited())
 				{
-					zFileName = ST::format("{}/r_{03d}_{03d}.wav", SPEECHDIR, profile.getID(), usQuoteNum);
+					zFileName = ST::format("{}/r_{03d}_{03d}.wav", SPEECHDIR, ubVoiceId, usQuoteNum);
 				}
 				else
 				{
 					// build name of wav file (characternum + quotenum)
-					zFileName = ST::format("{}/{03d}_{03d}.wav", SPEECHDIR, profile.getID(), usQuoteNum);
+					zFileName = ST::format("{}/{03d}_{03d}.wav", SPEECHDIR, ubVoiceId, usQuoteNum);
 				}
 			}
 			else
 			{
 				// build name of wav file (characternum + quotenum)
-				zFileName = ST::format("{}/{03d}_{03d}.wav", SPEECHDIR, profile.getID(), usQuoteNum);
+				zFileName = ST::format("{}/{03d}_{03d}.wav", SPEECHDIR, ubVoiceId, usQuoteNum);
 			}
 		}
 	}

--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -1,5 +1,8 @@
 #include "DefaultGamePolicy.h"
+#include "Logger.h"
 #include "Types.h"
+
+#include <algorithm>
 
 DefaultGamePolicy::DefaultGamePolicy(const JsonValue& json)
 {
@@ -72,6 +75,16 @@ DefaultGamePolicy::DefaultGamePolicy(const JsonValue& json)
 	imp_attribute_zero_bonus = imp.getOptionalInt("zero_attribute_points_bonus", 15);
 	imp_attribute_bonus = imp.getOptionalInt("bonus_attribute_points", 40);
 	imp_pick_skills_directly = imp.getOptionalBool("pick_skills_directly");
+
+	// Three I.M.P.s per gender is the most that can be handed out: player generated
+	// characters draw from a fixed block of merc profile slots, one per voice, and
+	// anything beyond that would overwrite a character that already exists.
+	imp_max_characters = imp.getOptionalUInt("max_characters", 1);
+	if (imp_max_characters < 1 || imp_max_characters > IMP_MAX_CHARACTERS_LIMIT)
+	{
+		SLOGW("imp.max_characters must be between 1 and {}, clamping {}", IMP_MAX_CHARACTERS_LIMIT, imp_max_characters);
+		imp_max_characters = std::clamp<uint8_t>(imp_max_characters, 1, IMP_MAX_CHARACTERS_LIMIT);
+	}
 
 	merc_online_min_days = gp.getOptionalUInt("merc_online_min_days", 1);
 	merc_online_max_days = gp.getOptionalUInt("merc_online_max_days", 2);

--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -1,5 +1,5 @@
 #include "DefaultGamePolicy.h"
-#include "Logger.h"
+#include "IMP_Compile_Character.h"
 #include "Types.h"
 
 #include <algorithm>
@@ -76,15 +76,7 @@ DefaultGamePolicy::DefaultGamePolicy(const JsonValue& json)
 	imp_attribute_bonus = imp.getOptionalInt("bonus_attribute_points", 40);
 	imp_pick_skills_directly = imp.getOptionalBool("pick_skills_directly");
 
-	// Three I.M.P.s per gender is the most that can be handed out: player generated
-	// characters draw from a fixed block of merc profile slots, one per voice, and
-	// anything beyond that would overwrite a character that already exists.
-	imp_max_characters = imp.getOptionalUInt("max_characters", 1);
-	if (imp_max_characters < 1 || imp_max_characters > IMP_MAX_CHARACTERS_LIMIT)
-	{
-		SLOGW("imp.max_characters must be between 1 and {}, clamping {}", IMP_MAX_CHARACTERS_LIMIT, imp_max_characters);
-		imp_max_characters = std::clamp<uint8_t>(imp_max_characters, 1, IMP_MAX_CHARACTERS_LIMIT);
-	}
+	imp_max_characters = std::clamp<unsigned int>(imp.getOptionalUInt("max_characters", 1), 1, NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS);
 
 	merc_online_min_days = gp.getOptionalUInt("merc_online_min_days", 1);
 	merc_online_max_days = gp.getOptionalUInt("merc_online_max_days", 2);

--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -1,8 +1,6 @@
 #include "DefaultGamePolicy.h"
 #include "Types.h"
 
-#include <algorithm>
-
 DefaultGamePolicy::DefaultGamePolicy(const JsonValue& json)
 {
 	auto gp = json.toObject();
@@ -75,7 +73,7 @@ DefaultGamePolicy::DefaultGamePolicy(const JsonValue& json)
 	imp_attribute_bonus = imp.getOptionalInt("bonus_attribute_points", 40);
 	imp_pick_skills_directly = imp.getOptionalBool("pick_skills_directly");
 
-	imp_max_characters = std::max<unsigned int>(imp.getOptionalUInt("max_characters", 1), 1);
+	imp_max_characters = imp.getOptionalUInt("max_characters", 1);
 
 	merc_online_min_days = gp.getOptionalUInt("merc_online_min_days", 1);
 	merc_online_max_days = gp.getOptionalUInt("merc_online_max_days", 2);

--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -1,5 +1,4 @@
 #include "DefaultGamePolicy.h"
-#include "IMP_Compile_Character.h"
 #include "Types.h"
 
 #include <algorithm>
@@ -76,7 +75,7 @@ DefaultGamePolicy::DefaultGamePolicy(const JsonValue& json)
 	imp_attribute_bonus = imp.getOptionalInt("bonus_attribute_points", 40);
 	imp_pick_skills_directly = imp.getOptionalBool("pick_skills_directly");
 
-	imp_max_characters = std::clamp<unsigned int>(imp.getOptionalUInt("max_characters", 1), 1, NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS);
+	imp_max_characters = std::max<unsigned int>(imp.getOptionalUInt("max_characters", 1), 1);
 
 	merc_online_min_days = gp.getOptionalUInt("merc_online_min_days", 1);
 	merc_online_max_days = gp.getOptionalUInt("merc_online_max_days", 2);

--- a/src/externalized/policy/DefaultIMPPolicy.cc
+++ b/src/externalized/policy/DefaultIMPPolicy.cc
@@ -59,6 +59,52 @@ static void readListOfItems(const JsonValue& value, std::vector<IMPStartingItemS
 	}
 }
 
+static bool readIsMale(const JsonObject& json)
+{
+	return json.GetString("gender") == "MALE";
+}
+
+
+// an [x, y] pair, the same shape the merc profile and RPC face offsets use
+static void readOffset(const JsonValue& value, uint16_t& x, uint16_t& y)
+{
+	auto const xy = value.toVec();
+	x = xy[0].toUInt();
+	y = xy[1].toUInt();
+}
+
+
+static void readVoices(const JsonValue& value, std::vector<IMPVoice>& voices)
+{
+	for (auto& entry : value.toVec())
+	{
+		auto obj = entry.toObject();
+		IMPVoice voice;
+		voice.profile = obj.GetUInt("profile");
+		voice.isMale  = readIsMale(obj);
+		voices.push_back(std::move(voice));
+	}
+}
+
+
+static void readPortraits(const JsonValue& value, std::vector<IMPPortrait>& portraits)
+{
+	for (auto& entry : value.toVec())
+	{
+		auto obj = entry.toObject();
+		IMPPortrait portrait;
+		portrait.face    = obj.GetUInt("face");
+		portrait.isMale  = readIsMale(obj);
+		portrait.bigBody = obj.getOptionalBool("big_body");
+		portrait.skin    = obj.GetString("skin");
+		portrait.hair    = obj.GetString("hair");
+		readOffset(obj["eyes"],  portrait.eyesX,  portrait.eyesY);
+		readOffset(obj["mouth"], portrait.mouthX, portrait.mouthY);
+		portraits.push_back(std::move(portrait));
+	}
+}
+
+
 DefaultIMPPolicy::DefaultIMPPolicy(const JsonValue& json, const ItemSystem *itemSystem)
 {
 	auto r = json.toObject();
@@ -66,6 +112,9 @@ DefaultIMPPolicy::DefaultIMPPolicy(const JsonValue& json, const ItemSystem *item
 	JsonUtility::parseListStrings(r["activation_codes"], m_activationCodes);
 
 	m_startingLevel = r.getOptionalUInt("starting_level", 1);
+
+	readVoices(r["voices"], m_voices);
+	readPortraits(r["portraits"], m_portraits);
 
 	readListOfItems(r["inventory"], m_inventory, itemSystem);
 }
@@ -87,4 +136,14 @@ uint8_t DefaultIMPPolicy::getStartingLevel() const
 const std::vector<IMPStartingItemSet>& DefaultIMPPolicy::getInventory() const
 {
 	return m_inventory;
+}
+
+const std::vector<IMPVoice>& DefaultIMPPolicy::getVoices() const
+{
+	return m_voices;
+}
+
+const std::vector<IMPPortrait>& DefaultIMPPolicy::getPortraits() const
+{
+	return m_portraits;
 }

--- a/src/externalized/policy/DefaultIMPPolicy.h
+++ b/src/externalized/policy/DefaultIMPPolicy.h
@@ -17,9 +17,13 @@ public:
 	virtual bool isCodeAccepted(const ST::string& code) const;
 	virtual uint8_t getStartingLevel() const;
 	virtual const std::vector<IMPStartingItemSet>& getInventory() const;
+	virtual const std::vector<IMPVoice>& getVoices() const;
+	virtual const std::vector<IMPPortrait>& getPortraits() const;
 
 protected:
 	uint8_t m_startingLevel;
 	std::vector<ST::string> m_activationCodes;
 	std::vector<IMPStartingItemSet> m_inventory;
+	std::vector<IMPVoice> m_voices;
+	std::vector<IMPPortrait> m_portraits;
 };

--- a/src/externalized/policy/GamePolicy.h
+++ b/src/externalized/policy/GamePolicy.h
@@ -19,6 +19,11 @@ enum HotkeyModifier
 
 #define gamepolicy(element) (GCM->getGamePolicy()->element)
 
+/** Upper limit for imp_max_characters.
+ * Player generated characters live in a fixed set of merc profile slots, three
+ * for each gender, and there is nowhere to put a character beyond those. */
+#define IMP_MAX_CHARACTERS_LIMIT 6
+
 class GamePolicy
 {
 public:
@@ -97,6 +102,7 @@ public:
 	int32_t imp_attribute_bonus;          // IMP character attribute unallocated bonus points, vanilla 40
 	int32_t imp_attribute_zero_bonus;     // IMP character attribute points given instead of imp_attribute_min, vanilla 15
 	bool imp_pick_skills_directly;        // Use the IMP_SkillTrait selection screen from JA2.5, skipping the personality quiz, vanilla falase
+	uint8_t imp_max_characters;           // Number of IMP characters that can be created in one campaign, 1 to 6, vanilla 1
 
 	/* M.E.R.C. */
 	uint8_t merc_online_min_days;         // The earliest day on or after which M.E.R.C. goes online

--- a/src/externalized/policy/GamePolicy.h
+++ b/src/externalized/policy/GamePolicy.h
@@ -19,11 +19,6 @@ enum HotkeyModifier
 
 #define gamepolicy(element) (GCM->getGamePolicy()->element)
 
-/** Upper limit for imp_max_characters.
- * Player generated characters live in a fixed set of merc profile slots, three
- * for each gender, and there is nowhere to put a character beyond those. */
-#define IMP_MAX_CHARACTERS_LIMIT 6
-
 class GamePolicy
 {
 public:

--- a/src/externalized/policy/GamePolicy.h
+++ b/src/externalized/policy/GamePolicy.h
@@ -97,7 +97,7 @@ public:
 	int32_t imp_attribute_bonus;          // IMP character attribute unallocated bonus points, vanilla 40
 	int32_t imp_attribute_zero_bonus;     // IMP character attribute points given instead of imp_attribute_min, vanilla 15
 	bool imp_pick_skills_directly;        // Use the IMP_SkillTrait selection screen from JA2.5, skipping the personality quiz, vanilla falase
-	uint8_t imp_max_characters;           // Number of IMP characters that can be created in one campaign, 1 to 6, vanilla 1
+	uint8_t imp_max_characters;           // Number of IMP characters that can be created in one campaign, capped by the I.M.P. slots the data declares, vanilla 1
 
 	/* M.E.R.C. */
 	uint8_t merc_online_min_days;         // The earliest day on or after which M.E.R.C. goes online

--- a/src/externalized/policy/IMPPolicy.h
+++ b/src/externalized/policy/IMPPolicy.h
@@ -14,12 +14,39 @@ struct IMPStartingItemSet;
 class ItemSystem;
 using Condition = std::variant<uint8_t, std::string>;
 
+/** A voice an I.M.P. character can be given: the merc profile whose speech,
+ * dialogue text and battle sound files it is made of. Several characters may
+ * be given the same one. */
+struct IMPVoice
+{
+	uint8_t profile;
+	bool isMale;
+};
+
+/** A portrait an I.M.P. character can be given, and everything the character's
+ * looks are made of: the face image, the palettes the body is rendered with,
+ * the offsets the talking head animates at, and whether it is a burly one. */
+struct IMPPortrait
+{
+	uint8_t face;
+	bool isMale;
+	bool bigBody;
+	ST::string skin;
+	ST::string hair;
+	uint16_t eyesX;
+	uint16_t eyesY;
+	uint16_t mouthX;
+	uint16_t mouthY;
+};
+
 class IMPPolicy
 {
 public:
 	virtual bool isCodeAccepted(const ST::string& code) const = 0;
 	virtual uint8_t getStartingLevel() const = 0;
 	virtual const std::vector<IMPStartingItemSet>& getInventory() const = 0;
+	virtual const std::vector<IMPVoice>& getVoices() const = 0;
+	virtual const std::vector<IMPPortrait>& getPortraits() const = 0;
 	virtual ~IMPPolicy() = default;
 };
 

--- a/src/game/GameVersion.h
+++ b/src/game/GameVersion.h
@@ -17,6 +17,6 @@ extern const char g_version_number[16];
 //	you will invalidate the saved game file
 //
 
-constexpr UINT32 SAVE_GAME_VERSION = 103;
+constexpr UINT32 SAVE_GAME_VERSION = 104;
 
 #endif

--- a/src/game/Laptop/EMail.cc
+++ b/src/game/Laptop/EMail.cc
@@ -1907,7 +1907,7 @@ static void HandleIMPCharProfileResultsMessage(Email const* const pMail)
 		gMercProfiles[mailProfile].impSlotState == IMPSlotState::TAKEN;
 	MERCPROFILESTRUCT const& imp = fMailNamesCharacter ?
 		GetProfile(mailProfile) : GetProfile(PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId);
-	INT32 const iPortrait = imp.ubFaceIndex - 200;
+	INT32 const iPortrait = FindIMPPortraitByFace(imp.ubFaceIndex);
 
 	// Use initial stats (current minus any gains since creation) so the e-mail
 	// reflects what IMP actually assessed, not stats grinded up after arrival.
@@ -2172,6 +2172,10 @@ static void HandleIMPCharProfileResultsMessage(Email const* const pMail)
 		case 12: iOffSet = IMP_PORTRAIT_FEMALE_4; break;
 		case 13:
 		case 14: iOffSet = IMP_PORTRAIT_FEMALE_5; break;
+		// the blurb describing the character's looks only covers the portraits
+		// the game shipped with; any others are described by the first of their
+		// gender rather than by whatever ran last
+		default: iOffSet = imp.bSex == MALE ? IMP_PORTRAIT_MALE_1 : IMP_PORTRAIT_FEMALE_1; break;
 	}
 
 	if (iRand % 2 == 0) iOffSet += 2;

--- a/src/game/Laptop/EMail.cc
+++ b/src/game/Laptop/EMail.cc
@@ -1898,14 +1898,15 @@ static void HandleIMPCharProfileResultsMessage(Email const* const pMail)
 	if (pMessageRecordList != NULL) return;
 	// list doesn't exist, reload
 
-	// The mail carries the voice id of the character it reports on, so with several
+	// The mail carries the profile of the character it reports on, so with several
 	// I.M.P.s in the campaign each report still describes its own. Mails written
-	// before that was recorded carry a zero, which is only a voice id if an I.M.P.
-	// actually holds that slot; otherwise fall back to the character last profiled.
-	INT32 const iMailVoiceId = pMail->iFirstData;
-	bool const fMailNamesCharacter = GetIMPVoiceSlotFlag(iMailVoiceId) != 0 && IsIMPVoiceTaken(iMailVoiceId);
-	INT32 const iVoiceId = fMailNamesCharacter ? iMailVoiceId : LaptopSaveInfo.iVoiceId;
-	MERCPROFILESTRUCT const& imp = GetProfile(PLAYER_GENERATED_CHARACTER_ID + iVoiceId);
+	// before that was recorded carry a zero, which is not an I.M.P. profile;
+	// those fall back to the character profiled last.
+	ProfileID const mailProfile = static_cast<ProfileID>(pMail->iFirstData);
+	bool const fMailNamesCharacter = mailProfile < NUM_PROFILES &&
+		gMercProfiles[mailProfile].ubIMPSlotState == IMP_SLOT_TAKEN;
+	MERCPROFILESTRUCT const& imp = fMailNamesCharacter ?
+		GetProfile(mailProfile) : GetProfile(PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId);
 	INT32 const iPortrait = imp.ubFaceIndex - 200;
 
 	// Use initial stats (current minus any gains since creation) so the e-mail

--- a/src/game/Laptop/EMail.cc
+++ b/src/game/Laptop/EMail.cc
@@ -1904,7 +1904,7 @@ static void HandleIMPCharProfileResultsMessage(Email const* const pMail)
 	// those fall back to the character profiled last.
 	ProfileID const mailProfile = static_cast<ProfileID>(pMail->iFirstData);
 	bool const fMailNamesCharacter = mailProfile < NUM_PROFILES &&
-		gMercProfiles[mailProfile].ubIMPSlotState == IMP_SLOT_TAKEN;
+		gMercProfiles[mailProfile].impSlotState == IMPSlotState::TAKEN;
 	MERCPROFILESTRUCT const& imp = fMailNamesCharacter ?
 		GetProfile(mailProfile) : GetProfile(PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId);
 	INT32 const iPortrait = imp.ubFaceIndex - 200;

--- a/src/game/Laptop/EMail.cc
+++ b/src/game/Laptop/EMail.cc
@@ -2155,16 +2155,23 @@ static void HandleIMPCharProfileResultsMessage(Email const* const pMail)
 	iEndOfSection = IMP_RESULTS_PORTRAIT_LENGTH;
 	for (INT32 i = 0; i < iEndOfSection; ++i) AddIMPResultText(iOffSet + i);
 
+	/* Which blurb describes the character's looks. The burly portraits only get
+	 * the burly description if the character also had the strength to be given
+	 * that build, so the report and the merc who turns up are the same person.
+	 * A portrait the game did not ship with has no description of its own and
+	 * falls back on the plainest one of its build. */
+	bool const fBigBody = IMPCharacterHasBigBody(imp);
+
 	switch (iPortrait)
 	{
-		case  0: iOffSet = IMP_PORTRAIT_MALE_1;   break;
+		case  0: iOffSet = fBigBody ? IMP_PORTRAIT_MALE_1 : IMP_PORTRAIT_MALE_2; break;
 		case  1: iOffSet = IMP_PORTRAIT_MALE_2;   break;
 		case  2: iOffSet = IMP_PORTRAIT_MALE_3;   break;
 		case  3: iOffSet = IMP_PORTRAIT_MALE_4;   break;
 		case  4:
 		case  5: iOffSet = IMP_PORTRAIT_MALE_5;   break;
 		case  6:
-		case  7: iOffSet = IMP_PORTRAIT_MALE_6;   break;
+		case  7: iOffSet = fBigBody ? IMP_PORTRAIT_MALE_6 : IMP_PORTRAIT_MALE_2; break;
 		case  8: iOffSet = IMP_PORTRAIT_FEMALE_1; break;
 		case  9: iOffSet = IMP_PORTRAIT_FEMALE_2; break;
 		case 10: iOffSet = IMP_PORTRAIT_FEMALE_3; break;
@@ -2172,10 +2179,12 @@ static void HandleIMPCharProfileResultsMessage(Email const* const pMail)
 		case 12: iOffSet = IMP_PORTRAIT_FEMALE_4; break;
 		case 13:
 		case 14: iOffSet = IMP_PORTRAIT_FEMALE_5; break;
-		// the blurb describing the character's looks only covers the portraits
-		// the game shipped with; any others are described by the first of their
-		// gender rather than by whatever ran last
-		default: iOffSet = imp.bSex == MALE ? IMP_PORTRAIT_MALE_1 : IMP_PORTRAIT_FEMALE_1; break;
+		default:
+			iOffSet =
+				imp.bSex != MALE ? IMP_PORTRAIT_FEMALE_1 :
+				fBigBody         ? IMP_PORTRAIT_MALE_1   :
+				                   IMP_PORTRAIT_MALE_2;
+			break;
 	}
 
 	if (iRand % 2 == 0) iOffSet += 2;

--- a/src/game/Laptop/EMail.cc
+++ b/src/game/Laptop/EMail.cc
@@ -1672,7 +1672,7 @@ static void ReDisplayBoxes(void)
 }
 
 
-static void HandleIMPCharProfileResultsMessage(void);
+static void HandleIMPCharProfileResultsMessage(Email const* pMail);
 static void ModifyInsuranceEmails(UINT16 usMessageId, Email* pMail, UINT8 ubNumberOfRecords);
 
 
@@ -1683,7 +1683,7 @@ static void HandleMailSpecialMessages(UINT16 usMessageId, Email* pMail)
 	{
 		case( IMP_EMAIL_PROFILE_RESULTS ):
 
-			HandleIMPCharProfileResultsMessage( );
+			HandleIMPCharProfileResultsMessage( pMail );
 		break;
 		case( MERC_INTRO ):
 			SetBookMark( MERC_BOOKMARK );
@@ -1887,7 +1887,7 @@ static void AddSkillTraitText(MERCPROFILESTRUCT const& imp, SkillTrait const Ski
 }
 
 
-static void HandleIMPCharProfileResultsMessage(void)
+static void HandleIMPCharProfileResultsMessage(Email const* const pMail)
 {
 	// special case, IMP profile return
 	INT32 iOffSet;
@@ -1898,7 +1898,15 @@ static void HandleIMPCharProfileResultsMessage(void)
 	if (pMessageRecordList != NULL) return;
 	// list doesn't exist, reload
 
-	MERCPROFILESTRUCT const& imp = GetProfile(PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId);
+	// The mail carries the voice id of the character it reports on, so with several
+	// I.M.P.s in the campaign each report still describes its own. Mails written
+	// before that was recorded carry a zero, which is only a voice id if an I.M.P.
+	// actually holds that slot; otherwise fall back to the character last profiled.
+	INT32 const iMailVoiceId = pMail->iFirstData;
+	bool const fMailNamesCharacter = GetIMPVoiceSlotFlag(iMailVoiceId) != 0 && IsIMPVoiceTaken(iMailVoiceId);
+	INT32 const iVoiceId = fMailNamesCharacter ? iMailVoiceId : LaptopSaveInfo.iVoiceId;
+	MERCPROFILESTRUCT const& imp = GetProfile(PLAYER_GENERATED_CHARACTER_ID + iVoiceId);
+	INT32 const iPortrait = imp.ubFaceIndex - 200;
 
 	// Use initial stats (current minus any gains since creation) so the e-mail
 	// reflects what IMP actually assessed, not stats grinded up after arrival.
@@ -2146,7 +2154,7 @@ static void HandleIMPCharProfileResultsMessage(void)
 	iEndOfSection = IMP_RESULTS_PORTRAIT_LENGTH;
 	for (INT32 i = 0; i < iEndOfSection; ++i) AddIMPResultText(iOffSet + i);
 
-	switch (iPortraitNumber)
+	switch (iPortrait)
 	{
 		case  0: iOffSet = IMP_PORTRAIT_MALE_1;   break;
 		case  1: iOffSet = IMP_PORTRAIT_MALE_2;   break;

--- a/src/game/Laptop/IMP_Begin_Screen.cc
+++ b/src/game/Laptop/IMP_Begin_Screen.cc
@@ -133,7 +133,19 @@ void EnterIMPBeginScreen( void )
 {
 	InitImpBeginScreeenTextInputBoxes();
 
+	// Every character starts out here, including a restored one, which only sets
+	// the flag further down in the done callback. Clearing it now keeps a merc
+	// imported earlier from robbing the next I.M.P. of its starting gear.
+	fLoadingCharacterForPreviousImpProfile = FALSE;
+
 	bGenderFlag = iCurrentProfileMode != 0 ? fCharacterIsMale : -1;
+
+	// Each gender has its own block of profile slots, so one of the two can run out
+	// while the other still has room. When it does, make the choice for the player
+	// instead of leaving them to click a box that cannot be picked.
+	bool const fMaleFree   = CanCreateIMPCharacterOfGender(true);
+	bool const fFemaleFree = CanCreateIMPCharacterOfGender(false);
+	if (fMaleFree != fFemaleFree) bGenderFlag = fMaleFree ? IMP_MALE : IMP_FEMALE;
 
 	ubFocus = OTHER_INPUT;
 
@@ -293,6 +305,17 @@ static void BtnIMPBeginScreenDoneCallback(GUI_BUTTON *btn, UINT32 reason)
 		}
 		else if (GCM->getGamePolicy()->imp_load_saved_merc_by_nickname && IMPSavedProfileDoesFileExist(pNickNameString))
 		{
+			// Restoring the merc writes straight into its old profile slot, so check
+			// up front that no I.M.P. is occupying that slot already.
+			int const iSavedVoiceId = IMPSavedProfileReadVoiceId(pNickNameString);
+			if (iSavedVoiceId < 0 || IsIMPVoiceTaken(iSavedVoiceId) ||
+				!CanCreateAnotherIMPCharacter())
+			{
+				DoLapTopMessageBox(MSG_BOX_IMP_STYLE, pImpPopUpStrings[4], LAPTOP_SCREEN, MSG_BOX_FLAG_OK, NULL);
+				iCurrentProfileMode = 0;
+				return;
+			}
+
 			fLoadingCharacterForPreviousImpProfile = true;
 			LaptopSaveInfo.iVoiceId = IMPSavedProfileLoadMercProfile(pNickNameString);
 			MERCPROFILESTRUCT& profile_saved = gMercProfiles[PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId];
@@ -324,7 +347,10 @@ static void GetPlayerKeyBoardInputForIMPBeginScreen(void)
 				case SDLK_RETURN:
 				case SDLK_SPACE:
 					if (ubFocus != OTHER_INPUT) {
-						bGenderFlag = ubFocus == MALE_GENDER ? IMP_MALE : IMP_FEMALE;
+						bool const fMale = ubFocus == MALE_GENDER;
+						if (CanCreateIMPCharacterOfGender(fMale)) {
+							bGenderFlag = fMale ? IMP_MALE : IMP_FEMALE;
+						}
 					}
 					SetActiveField(0);
 					break;
@@ -403,6 +429,9 @@ static void SelectMaleRegionCallBack(MOUSE_REGION* pRegion, UINT32 iReason)
 {
 	if (iReason & MSYS_CALLBACK_REASON_POINTER_UP)
 	{
+		// an I.M.P. of this gender already exists, its slot is not up for grabs
+		if (!CanCreateIMPCharacterOfGender(true)) return;
+
 		// set mode to nick name type in
 		bGenderFlag = IMP_MALE;
 		InvalidateCheckboxes();
@@ -414,6 +443,9 @@ static void SelectFemaleRegionCallBack(MOUSE_REGION* pRegion, UINT32 iReason)
 {
 	if (iReason & MSYS_CALLBACK_REASON_POINTER_UP)
 	{
+		// an I.M.P. of this gender already exists, its slot is not up for grabs
+		if (!CanCreateIMPCharacterOfGender(false)) return;
+
 		// set mode to nick name type in
 		bGenderFlag = IMP_FEMALE;
 		InvalidateCheckboxes();

--- a/src/game/Laptop/IMP_Begin_Screen.cc
+++ b/src/game/Laptop/IMP_Begin_Screen.cc
@@ -307,7 +307,11 @@ static void BtnIMPBeginScreenDoneCallback(GUI_BUTTON *btn, UINT32 reason)
 
 			fLoadingCharacterForPreviousImpProfile = true;
 			MERCPROFILESTRUCT& profile_saved = gMercProfiles[IMPSavedProfileLoadMercProfile(pNickNameString)];
-			iPortraitNumber = profile_saved.ubFaceIndex - 200;
+			// the imported character keeps its own face where the data still
+			// offers it, and is given the first one of its gender where it does not
+			INT32 const iSavedPortrait = FindIMPPortraitByFace(profile_saved.ubFaceIndex);
+			iPortraitNumber = iSavedPortrait >= 0 ?
+				iSavedPortrait : GetIMPPortraitIndex(profile_saved.bSex == MALE, 0);
 			fCharacterIsMale = ( profile_saved.bSex == MALE );
 			iCurrentImpPage = IMP_CONFIRM;
 			fButtonPendingFlag = TRUE;

--- a/src/game/Laptop/IMP_Begin_Screen.cc
+++ b/src/game/Laptop/IMP_Begin_Screen.cc
@@ -140,13 +140,6 @@ void EnterIMPBeginScreen( void )
 
 	bGenderFlag = iCurrentProfileMode != 0 ? fCharacterIsMale : -1;
 
-	// Each gender has its own block of profile slots, so one of the two can run out
-	// while the other still has room. When it does, make the choice for the player
-	// instead of leaving them to click a box that cannot be picked.
-	bool const fMaleFree   = CanCreateIMPCharacterOfGender(true);
-	bool const fFemaleFree = CanCreateIMPCharacterOfGender(false);
-	if (fMaleFree != fFemaleFree) bGenderFlag = fMaleFree ? IMP_MALE : IMP_FEMALE;
-
 	ubFocus = OTHER_INPUT;
 
 	// render the screen on entry
@@ -305,11 +298,7 @@ static void BtnIMPBeginScreenDoneCallback(GUI_BUTTON *btn, UINT32 reason)
 		}
 		else if (GCM->getGamePolicy()->imp_load_saved_merc_by_nickname && IMPSavedProfileDoesFileExist(pNickNameString))
 		{
-			// Restoring the merc writes straight into its old profile slot, so check
-			// up front that no I.M.P. is occupying that slot already.
-			int const iSavedVoiceId = IMPSavedProfileReadVoiceId(pNickNameString);
-			if (iSavedVoiceId < 0 || IsIMPVoiceTaken(iSavedVoiceId) ||
-				!CanCreateAnotherIMPCharacter())
+			if (!CanCreateAnotherIMPCharacter())
 			{
 				DoLapTopMessageBox(MSG_BOX_IMP_STYLE, pImpPopUpStrings[4], LAPTOP_SCREEN, MSG_BOX_FLAG_OK, NULL);
 				iCurrentProfileMode = 0;
@@ -317,8 +306,7 @@ static void BtnIMPBeginScreenDoneCallback(GUI_BUTTON *btn, UINT32 reason)
 			}
 
 			fLoadingCharacterForPreviousImpProfile = true;
-			LaptopSaveInfo.iVoiceId = IMPSavedProfileLoadMercProfile(pNickNameString);
-			MERCPROFILESTRUCT& profile_saved = gMercProfiles[PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId];
+			MERCPROFILESTRUCT& profile_saved = gMercProfiles[IMPSavedProfileLoadMercProfile(pNickNameString)];
 			iPortraitNumber = profile_saved.ubFaceIndex - 200;
 			fCharacterIsMale = ( profile_saved.bSex == MALE );
 			iCurrentImpPage = IMP_CONFIRM;
@@ -348,9 +336,7 @@ static void GetPlayerKeyBoardInputForIMPBeginScreen(void)
 				case SDLK_SPACE:
 					if (ubFocus != OTHER_INPUT) {
 						bool const fMale = ubFocus == MALE_GENDER;
-						if (CanCreateIMPCharacterOfGender(fMale)) {
-							bGenderFlag = fMale ? IMP_MALE : IMP_FEMALE;
-						}
+						bGenderFlag = fMale ? IMP_MALE : IMP_FEMALE;
 					}
 					SetActiveField(0);
 					break;
@@ -429,8 +415,7 @@ static void SelectMaleRegionCallBack(MOUSE_REGION* pRegion, UINT32 iReason)
 {
 	if (iReason & MSYS_CALLBACK_REASON_POINTER_UP)
 	{
-		// an I.M.P. of this gender already exists, its slot is not up for grabs
-		if (!CanCreateIMPCharacterOfGender(true)) return;
+		if (!CanCreateAnotherIMPCharacter()) return;
 
 		// set mode to nick name type in
 		bGenderFlag = IMP_MALE;
@@ -443,8 +428,7 @@ static void SelectFemaleRegionCallBack(MOUSE_REGION* pRegion, UINT32 iReason)
 {
 	if (iReason & MSYS_CALLBACK_REASON_POINTER_UP)
 	{
-		// an I.M.P. of this gender already exists, its slot is not up for grabs
-		if (!CanCreateIMPCharacterOfGender(false)) return;
+		if (!CanCreateAnotherIMPCharacter()) return;
 
 		// set mode to nick name type in
 		bGenderFlag = IMP_FEMALE;

--- a/src/game/Laptop/IMP_Compile_Character.cc
+++ b/src/game/Laptop/IMP_Compile_Character.cc
@@ -465,7 +465,7 @@ void ResetSkillsAttributesAndPersonality( void )
 }
 
 
-static void SetMercSkinAndHairColors(void);
+static void SetMercPalettes(void);
 
 
 static void SelectMercFace(void)
@@ -485,16 +485,23 @@ static void SelectMercFace(void)
 	p.usMouthY = 0;
 
 	// set merc skins and hair color
-	SetMercSkinAndHairColors();
+	SetMercPalettes();
 }
 
 
-static void SetMercSkinAndHairColors(void)
+static void SetMercPalettes(void)
 {
 	IMPPortrait const& portrait = GetCurrentIMPPortrait();
 	MERCPROFILESTRUCT& p = GetProfile(GetIMPSlotInProgress());
 	p.HAIR = portrait.hair;
 	p.SKIN = portrait.skin;
+
+	// The clothes were never set here: the six profiles the game shipped for
+	// player characters carry them in prof.dat, so they arrived with the slot.
+	// Every other profile carries an empty palette name, which renders as a
+	// colour the player did not pick, so set what those six declare.
+	p.PANTS = "BLACKPANTS";
+	p.VEST  = "WHITEVEST";
 }
 
 

--- a/src/game/Laptop/IMP_Compile_Character.cc
+++ b/src/game/Laptop/IMP_Compile_Character.cc
@@ -29,10 +29,6 @@ static INT32 iLastElementInPersonalityList = 0;
 static void SelectMercFace(void);
 
 
-static_assert(IMP_MAX_CHARACTERS_LIMIT == NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS,
-	"the policy ceiling must be the number of player generated profile slots");
-
-
 UINT8 GetIMPVoiceSlotFlag(INT32 const iVoiceId)
 {
 	if (iVoiceId < 0 || iVoiceId >= NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS) return 0;

--- a/src/game/Laptop/IMP_Compile_Character.cc
+++ b/src/game/Laptop/IMP_Compile_Character.cc
@@ -4,6 +4,8 @@
 #include "GamePolicy.h"
 #include "IMPPolicy.h"
 #include "ContentManager.h"
+#include "MercProfileInfo.h"
+#include "Soldier_Control.h"
 #include "IMP_Portraits.h"
 #include "IMP_SkillTraits.h"
 #include "IMP_Compile_Character.h"
@@ -29,93 +31,75 @@ static INT32 iLastElementInPersonalityList = 0;
 static void SelectMercFace(void);
 
 
-UINT8 GetIMPVoiceSlotFlag(INT32 const iVoiceId)
+static bool IsIMPSlot(ProfileID const profile)
 {
-	if (iVoiceId < 0 || iVoiceId >= NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS) return 0;
-	return 1 << iVoiceId;
+	return GCM->getMercProfileInfo(profile)->mercType == MercType::IMP;
 }
 
 
-bool IsIMPVoiceTaken(INT32 const iVoiceId)
+UINT8 GetNumberOfIMPSlots(void)
 {
-	UINT8 const ubSlot = GetIMPVoiceSlotFlag(iVoiceId);
-	return ubSlot == 0 || (LaptopSaveInfo.ubIMPCreatedSlots & ubSlot) != 0;
-}
-
-
-bool IsIMPPortraitTaken(INT32 const iPortraitNumber)
-{
-	// Which portraits are gone is not recorded separately: the face every
-	// character created so far ended up with is the record.
-	for (INT32 iSlot = 0; iSlot < NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS; ++iSlot)
+	UINT8 ubSlots = 0;
+	for (ProfileID profile = 0; profile < NUM_PROFILES; ++profile)
 	{
-		if (!(LaptopSaveInfo.ubIMPCreatedSlots & (1 << iSlot))) continue;
-		if (gMercProfiles[PLAYER_GENERATED_CHARACTER_ID + iSlot].ubFaceIndex == 200 + iPortraitNumber) return true;
+		if (IsIMPSlot(profile)) ++ubSlots;
 	}
-	return false;
+	return ubSlots;
 }
 
 
 UINT8 GetNumberOfIMPCharactersCreated(void)
 {
 	UINT8 ubCreated = 0;
-	for (INT32 iSlot = 0; iSlot < NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS; ++iSlot)
+	for (ProfileID profile = 0; profile < NUM_PROFILES; ++profile)
 	{
-		if (LaptopSaveInfo.ubIMPCreatedSlots & (1 << iSlot)) ++ubCreated;
+		if (IsIMPSlot(profile) && gMercProfiles[profile].ubIMPSlotState == IMP_SLOT_TAKEN) ++ubCreated;
 	}
 	return ubCreated;
 }
 
 
+ProfileID GetIMPSlotInProgress(void)
+{
+	// The set of taken slots does not change while a character is being built,
+	// so the first free one stays the same one across the whole process and
+	// over a save and load in the middle of it.
+	for (ProfileID profile = 0; profile < NUM_PROFILES; ++profile)
+	{
+		if (IsIMPSlot(profile) && gMercProfiles[profile].ubIMPSlotState == IMP_SLOT_FREE) return profile;
+	}
+	return NO_PROFILE;
+}
+
+
 bool CanCreateAnotherIMPCharacter(void)
 {
+	if (GetIMPSlotInProgress() == NO_PROFILE) return false;
 	return GetNumberOfIMPCharactersCreated() < gamepolicy(imp_max_characters);
 }
 
 
-bool CanCreateIMPCharacterOfGender(bool const fMale)
+void MarkIMPCharacterCreated(ProfileID const profile)
 {
-	return CanCreateAnotherIMPCharacter() && GetFirstFreeIMPVoice(fMale) >= 0;
-}
-
-
-INT32 GetFirstFreeIMPVoice(bool const fMale)
-{
-	INT32 const iBase = fMale ? 0 : NUMBER_OF_PLAYER_VOICES_PER_GENDER;
-	for (INT32 i = 0; i < NUMBER_OF_PLAYER_VOICES_PER_GENDER; ++i)
-	{
-		if (!IsIMPVoiceTaken(iBase + i)) return i;
-	}
-	return -1;
-}
-
-
-INT32 GetFirstFreeIMPPortrait(bool const fMale)
-{
-	INT32 const iBase = fMale ? 0 : NUMBER_OF_PLAYER_PORTRAITS_PER_GENDER;
-	for (INT32 i = 0; i < NUMBER_OF_PLAYER_PORTRAITS_PER_GENDER; ++i)
-	{
-		if (!IsIMPPortraitTaken(iBase + i)) return i;
-	}
-	return -1;
-}
-
-
-void MarkIMPCharacterCreated(INT32 const iVoiceId)
-{
-	LaptopSaveInfo.ubIMPCreatedSlots |= GetIMPVoiceSlotFlag(iVoiceId);
+	gMercProfiles[profile].ubIMPSlotState = IMP_SLOT_TAKEN;
 	LaptopSaveInfo.fIMPCompletedFlag = TRUE;
 }
 
 
 void CreateACharacterFromPlayerEnteredStats(void)
 {
-	MERCPROFILESTRUCT& p = GetProfile(PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId);
+	MERCPROFILESTRUCT& p = GetProfile(GetIMPSlotInProgress());
 
 	p.zName = pFullName;
 	p.zNickname = pNickName;
 
 	p.bSex = fCharacterIsMale ? MALE : FEMALE;
+
+	// The voice the player picked, which is where this character's speech,
+	// dialogue text and battle sounds come from. Slots past the six the game
+	// shipped with have none of their own, so this also makes it hireable.
+	p.ubVoiceId   = PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId;
+	p.bMercStatus = MERC_OK;
 
 	p.bLifeMax    = iHealth;
 	p.bLife       = iHealth;
@@ -243,7 +227,7 @@ static void ValidateSkillsList(void)
 {
 	// remove from the generated traits list any traits that don't match
 	// the character's skills
-	MERCPROFILESTRUCT& p = GetProfile(PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId);
+	MERCPROFILESTRUCT& p = GetProfile(GetIMPSlotInProgress());
 
 	if (p.bMechanical == 0)
 	{
@@ -409,7 +393,7 @@ static void SetMercSkinAndHairColors(void);
 static void SelectMercFace(void)
 {
 	// this procedure will select the approriate face for the merc and save offsets
-	MERCPROFILESTRUCT& p = GetProfile(PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId);
+	MERCPROFILESTRUCT& p = GetProfile(GetIMPSlotInProgress());
 
 	// now the offsets
 	p.ubFaceIndex = 200 + iPortraitNumber;
@@ -465,7 +449,7 @@ static void SetMercSkinAndHairColors(void)
 	};
 
 	Assert(iPortraitNumber < static_cast<INT32>(lengthof(Colors)));
-	MERCPROFILESTRUCT& p = GetProfile(PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId);
+	MERCPROFILESTRUCT& p = GetProfile(GetIMPSlotInProgress());
 	p.HAIR = Colors[iPortraitNumber].Hair;
 	p.SKIN = Colors[iPortraitNumber].Skin;
 }
@@ -480,7 +464,7 @@ void HandleMercStatsForChangesInFace(void)
 
 	CreatePlayerSkills();
 
-	MERCPROFILESTRUCT& p = GetProfile(PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId);
+	MERCPROFILESTRUCT& p = GetProfile(GetIMPSlotInProgress());
 
 	// body type
 	if (fCharacterIsMale)
@@ -514,5 +498,5 @@ static BOOLEAN ShouldThisMercHaveABigBody(void)
 	// should this merc be a big body typ
 	return
 		(iPortraitNumber == 0 || iPortraitNumber == 6 || iPortraitNumber == 7) &&
-		gMercProfiles[PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId].bStrength >= 75;
+		gMercProfiles[GetIMPSlotInProgress()].bStrength >= 75;
 }

--- a/src/game/Laptop/IMP_Compile_Character.cc
+++ b/src/game/Laptop/IMP_Compile_Character.cc
@@ -29,6 +29,89 @@ static INT32 iLastElementInPersonalityList = 0;
 static void SelectMercFace(void);
 
 
+static_assert(IMP_MAX_CHARACTERS_LIMIT == NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS,
+	"the policy ceiling must be the number of player generated profile slots");
+
+
+UINT8 GetIMPVoiceSlotFlag(INT32 const iVoiceId)
+{
+	if (iVoiceId < 0 || iVoiceId >= NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS) return 0;
+	return 1 << iVoiceId;
+}
+
+
+bool IsIMPVoiceTaken(INT32 const iVoiceId)
+{
+	UINT8 const ubSlot = GetIMPVoiceSlotFlag(iVoiceId);
+	return ubSlot == 0 || (LaptopSaveInfo.ubIMPCreatedSlots & ubSlot) != 0;
+}
+
+
+bool IsIMPPortraitTaken(INT32 const iPortraitNumber)
+{
+	// Which portraits are gone is not recorded separately: the face every
+	// character created so far ended up with is the record.
+	for (INT32 iSlot = 0; iSlot < NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS; ++iSlot)
+	{
+		if (!(LaptopSaveInfo.ubIMPCreatedSlots & (1 << iSlot))) continue;
+		if (gMercProfiles[PLAYER_GENERATED_CHARACTER_ID + iSlot].ubFaceIndex == 200 + iPortraitNumber) return true;
+	}
+	return false;
+}
+
+
+UINT8 GetNumberOfIMPCharactersCreated(void)
+{
+	UINT8 ubCreated = 0;
+	for (INT32 iSlot = 0; iSlot < NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS; ++iSlot)
+	{
+		if (LaptopSaveInfo.ubIMPCreatedSlots & (1 << iSlot)) ++ubCreated;
+	}
+	return ubCreated;
+}
+
+
+bool CanCreateAnotherIMPCharacter(void)
+{
+	return GetNumberOfIMPCharactersCreated() < gamepolicy(imp_max_characters);
+}
+
+
+bool CanCreateIMPCharacterOfGender(bool const fMale)
+{
+	return CanCreateAnotherIMPCharacter() && GetFirstFreeIMPVoice(fMale) >= 0;
+}
+
+
+INT32 GetFirstFreeIMPVoice(bool const fMale)
+{
+	INT32 const iBase = fMale ? 0 : NUMBER_OF_PLAYER_VOICES_PER_GENDER;
+	for (INT32 i = 0; i < NUMBER_OF_PLAYER_VOICES_PER_GENDER; ++i)
+	{
+		if (!IsIMPVoiceTaken(iBase + i)) return i;
+	}
+	return -1;
+}
+
+
+INT32 GetFirstFreeIMPPortrait(bool const fMale)
+{
+	INT32 const iBase = fMale ? 0 : NUMBER_OF_PLAYER_PORTRAITS_PER_GENDER;
+	for (INT32 i = 0; i < NUMBER_OF_PLAYER_PORTRAITS_PER_GENDER; ++i)
+	{
+		if (!IsIMPPortraitTaken(iBase + i)) return i;
+	}
+	return -1;
+}
+
+
+void MarkIMPCharacterCreated(INT32 const iVoiceId)
+{
+	LaptopSaveInfo.ubIMPCreatedSlots |= GetIMPVoiceSlotFlag(iVoiceId);
+	LaptopSaveInfo.fIMPCompletedFlag = TRUE;
+}
+
+
 void CreateACharacterFromPlayerEnteredStats(void)
 {
 	MERCPROFILESTRUCT& p = GetProfile(PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId);

--- a/src/game/Laptop/IMP_Compile_Character.cc
+++ b/src/game/Laptop/IMP_Compile_Character.cc
@@ -53,7 +53,7 @@ UINT8 GetNumberOfIMPCharactersCreated(void)
 	UINT8 ubCreated = 0;
 	for (ProfileID profile = 0; profile < NUM_PROFILES; ++profile)
 	{
-		if (IsIMPSlot(profile) && gMercProfiles[profile].ubIMPSlotState == IMP_SLOT_TAKEN) ++ubCreated;
+		if (IsIMPSlot(profile) && gMercProfiles[profile].impSlotState == IMPSlotState::TAKEN) ++ubCreated;
 	}
 	return ubCreated;
 }
@@ -66,7 +66,7 @@ ProfileID GetIMPSlotInProgress(void)
 	// over a save and load in the middle of it.
 	for (ProfileID profile = 0; profile < NUM_PROFILES; ++profile)
 	{
-		if (IsIMPSlot(profile) && gMercProfiles[profile].ubIMPSlotState == IMP_SLOT_FREE) return profile;
+		if (IsIMPSlot(profile) && gMercProfiles[profile].impSlotState == IMPSlotState::FREE) return profile;
 	}
 	return NO_PROFILE;
 }
@@ -81,7 +81,7 @@ bool CanCreateAnotherIMPCharacter(void)
 
 void MarkIMPCharacterCreated(ProfileID const profile)
 {
-	gMercProfiles[profile].ubIMPSlotState = IMP_SLOT_TAKEN;
+	gMercProfiles[profile].impSlotState = IMPSlotState::TAKEN;
 	LaptopSaveInfo.fIMPCompletedFlag = TRUE;
 }
 

--- a/src/game/Laptop/IMP_Compile_Character.cc
+++ b/src/game/Laptop/IMP_Compile_Character.cc
@@ -174,11 +174,8 @@ void CreateACharacterFromPlayerEnteredStats(void)
 	p.bSex = fCharacterIsMale ? MALE : FEMALE;
 
 	// The voice the player picked, which is where this character's speech,
-	// dialogue text and battle sounds come from. A slot with no dialogue file of
-	// its own was left unhireable when the profiles were read, so borrowing one
-	// is also what makes it hireable.
-	p.ubVoiceId   = GetIMPVoices()[LaptopSaveInfo.iVoiceId].profile;
-	p.bMercStatus = MERC_OK;
+	// dialogue text and battle sounds come from.
+	p.ubVoiceId = GetIMPVoices()[LaptopSaveInfo.iVoiceId].profile;
 
 	p.bLifeMax    = iHealth;
 	p.bLife       = iHealth;
@@ -199,8 +196,10 @@ void CreateACharacterFromPlayerEnteredStats(void)
 
 	p.bExpLevel = GCM->getIMPPolicy()->getStartingLevel();
 
-	// set time away
-	p.bMercStatus = 0;
+	// Clears MERC_HAS_NO_TEXT_FILE, which loading the profiles stamps on every
+	// slot with no dialogue file named after it. That is all of them past the six
+	// the game shipped with, until the voice picked above lends them one.
+	p.bMercStatus = MERC_OK;
 
 	SelectMercFace();
 }

--- a/src/game/Laptop/IMP_Compile_Character.cc
+++ b/src/game/Laptop/IMP_Compile_Character.cc
@@ -18,6 +18,9 @@
 
 #define ATTITUDE_LIST_SIZE 20
 
+// the strength a burly portrait has to be carried by to become a burly body
+#define IMP_BIG_BODY_MIN_STRENGTH 75
+
 
 static INT32 AttitudeList[ATTITUDE_LIST_SIZE];
 static INT32 iLastElementInAttitudeList = 0;
@@ -150,6 +153,19 @@ IMPPortrait const& GetCurrentIMPPortrait(void)
 	std::vector<IMPPortrait> const& portraits = GetIMPPortraits();
 	Assert(iPortraitNumber >= 0 && iPortraitNumber < static_cast<INT32>(portraits.size()));
 	return portraits[iPortraitNumber];
+}
+
+
+bool IMPCharacterHasBigBody(MERCPROFILESTRUCT const& p)
+{
+	if (p.bSex != MALE) return false;
+
+	INT32 const iPortrait = FindIMPPortraitByFace(p.ubFaceIndex);
+	if (iPortrait < 0 || !GetIMPPortraits()[iPortrait].bigBody) return false;
+
+	// the strength the character was made with, which is what the build was
+	// decided on: training up afterwards does not change anyone's shape
+	return p.bStrength - p.bStrengthDelta >= IMP_BIG_BODY_MIN_STRENGTH;
 }
 
 
@@ -498,7 +514,6 @@ static void SetMercSkinAndHairColors(void)
 }
 
 
-static BOOLEAN ShouldThisMercHaveABigBody(void);
 
 
 void HandleMercStatsForChangesInFace(void)
@@ -512,7 +527,7 @@ void HandleMercStatsForChangesInFace(void)
 	// body type
 	if (fCharacterIsMale)
 	{
-		if (ShouldThisMercHaveABigBody())
+		if (IMPCharacterHasBigBody(p))
 		{
 			p.ubBodyType = BIGMALE;
 			if (iSkillA == MARTIALARTS) iSkillA = HANDTOHAND;
@@ -533,13 +548,4 @@ void HandleMercStatsForChangesInFace(void)
 	// skill trait
 	p.bSkillTrait  = iSkillA;
 	p.bSkillTrait2 = iSkillB;
-}
-
-
-static BOOLEAN ShouldThisMercHaveABigBody(void)
-{
-	// should this merc be a big body typ
-	return
-		GetCurrentIMPPortrait().bigBody &&
-		gMercProfiles[GetIMPSlotInProgress()].bStrength >= 75;
 }

--- a/src/game/Laptop/IMP_Compile_Character.cc
+++ b/src/game/Laptop/IMP_Compile_Character.cc
@@ -465,7 +465,7 @@ void ResetSkillsAttributesAndPersonality( void )
 }
 
 
-static void SetMercPalettes(void);
+static void SetMercSkinAndHairColors(void);
 
 
 static void SelectMercFace(void)
@@ -485,23 +485,16 @@ static void SelectMercFace(void)
 	p.usMouthY = 0;
 
 	// set merc skins and hair color
-	SetMercPalettes();
+	SetMercSkinAndHairColors();
 }
 
 
-static void SetMercPalettes(void)
+static void SetMercSkinAndHairColors(void)
 {
 	IMPPortrait const& portrait = GetCurrentIMPPortrait();
 	MERCPROFILESTRUCT& p = GetProfile(GetIMPSlotInProgress());
 	p.HAIR = portrait.hair;
 	p.SKIN = portrait.skin;
-
-	// The clothes were never set here: the six profiles the game shipped for
-	// player characters carry them in prof.dat, so they arrived with the slot.
-	// Every other profile carries an empty palette name, which renders as a
-	// colour the player did not pick, so set what those six declare.
-	p.PANTS = "BLACKPANTS";
-	p.VEST  = "WHITEVEST";
 }
 
 

--- a/src/game/Laptop/IMP_Compile_Character.cc
+++ b/src/game/Laptop/IMP_Compile_Character.cc
@@ -86,6 +86,84 @@ void MarkIMPCharacterCreated(ProfileID const profile)
 }
 
 
+const std::vector<IMPVoice>& GetIMPVoices(void)
+{
+	return GCM->getIMPPolicy()->getVoices();
+}
+
+
+const std::vector<IMPPortrait>& GetIMPPortraits(void)
+{
+	return GCM->getIMPPolicy()->getPortraits();
+}
+
+
+template<typename T> static INT32 CountForGender(std::vector<T> const& entries, bool const fMale)
+{
+	INT32 iCount = 0;
+	for (T const& entry : entries)
+	{
+		if (entry.isMale == fMale) ++iCount;
+	}
+	return iCount;
+}
+
+
+template<typename T> static INT32 IndexForGender(std::vector<T> const& entries, bool const fMale, INT32 const iNth)
+{
+	INT32 iSeen = 0;
+	for (size_t i = 0; i != entries.size(); ++i)
+	{
+		if (entries[i].isMale != fMale) continue;
+		if (iSeen++ == iNth) return static_cast<INT32>(i);
+	}
+	return -1;
+}
+
+
+INT32 GetNumberOfIMPVoices(bool const fMale)
+{
+	return CountForGender(GetIMPVoices(), fMale);
+}
+
+
+INT32 GetNumberOfIMPPortraits(bool const fMale)
+{
+	return CountForGender(GetIMPPortraits(), fMale);
+}
+
+
+INT32 GetIMPVoiceIndex(bool const fMale, INT32 const iNth)
+{
+	return IndexForGender(GetIMPVoices(), fMale, iNth);
+}
+
+
+INT32 GetIMPPortraitIndex(bool const fMale, INT32 const iNth)
+{
+	return IndexForGender(GetIMPPortraits(), fMale, iNth);
+}
+
+
+IMPPortrait const& GetCurrentIMPPortrait(void)
+{
+	std::vector<IMPPortrait> const& portraits = GetIMPPortraits();
+	Assert(iPortraitNumber >= 0 && iPortraitNumber < static_cast<INT32>(portraits.size()));
+	return portraits[iPortraitNumber];
+}
+
+
+INT32 FindIMPPortraitByFace(UINT8 const ubFaceIndex)
+{
+	std::vector<IMPPortrait> const& portraits = GetIMPPortraits();
+	for (size_t i = 0; i != portraits.size(); ++i)
+	{
+		if (portraits[i].face == ubFaceIndex) return static_cast<INT32>(i);
+	}
+	return -1;
+}
+
+
 void CreateACharacterFromPlayerEnteredStats(void)
 {
 	MERCPROFILESTRUCT& p = GetProfile(GetIMPSlotInProgress());
@@ -96,9 +174,10 @@ void CreateACharacterFromPlayerEnteredStats(void)
 	p.bSex = fCharacterIsMale ? MALE : FEMALE;
 
 	// The voice the player picked, which is where this character's speech,
-	// dialogue text and battle sounds come from. Slots past the six the game
-	// shipped with have none of their own, so this also makes it hireable.
-	p.ubVoiceId   = PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId;
+	// dialogue text and battle sounds come from. A slot with no dialogue file of
+	// its own was left unhireable when the profiles were read, so borrowing one
+	// is also what makes it hireable.
+	p.ubVoiceId   = GetIMPVoices()[LaptopSaveInfo.iVoiceId].profile;
 	p.bMercStatus = MERC_OK;
 
 	p.bLifeMax    = iHealth;
@@ -396,7 +475,7 @@ static void SelectMercFace(void)
 	MERCPROFILESTRUCT& p = GetProfile(GetIMPSlotInProgress());
 
 	// now the offsets
-	p.ubFaceIndex = 200 + iPortraitNumber;
+	p.ubFaceIndex = GetCurrentIMPPortrait().face;
 
 	// eyes
 	p.usEyesX = 0;
@@ -413,45 +492,10 @@ static void SelectMercFace(void)
 
 static void SetMercSkinAndHairColors(void)
 {
-#define PINKSKIN  "PINKSKIN"
-#define TANSKIN   "TANSKIN"
-#define DARKSKIN  "DARKSKIN"
-#define BLACKSKIN "BLACKSKIN"
-
-#define BROWNHEAD "BROWNHEAD"
-#define BLACKHEAD "BLACKHEAD" // black skin till here
-#define WHITEHEAD "WHITEHEAD" // dark skin till here
-#define BLONDHEAD "BLONDHEAD"
-#define REDHEAD   "REDHEAD"   // pink/tan skin till here
-
-	static const struct
-	{
-		const char* Skin;
-		const char* Hair;
-	} Colors[] =
-	{
-		{ BLACKSKIN, BROWNHEAD },
-		{ TANSKIN,   BROWNHEAD },
-		{ TANSKIN,   BROWNHEAD },
-		{ DARKSKIN,  BROWNHEAD },
-		{ TANSKIN,   BROWNHEAD },
-		{ DARKSKIN,  BLACKHEAD },
-		{ TANSKIN,   BROWNHEAD },
-		{ TANSKIN,   BROWNHEAD },
-		{ TANSKIN,   BROWNHEAD },
-		{ PINKSKIN,  BROWNHEAD },
-		{ TANSKIN,   BLACKHEAD },
-		{ TANSKIN,   BLACKHEAD },
-		{ PINKSKIN,  BROWNHEAD },
-		{ BLACKSKIN, BROWNHEAD },
-		{ TANSKIN,   REDHEAD   },
-		{ TANSKIN,   BLONDHEAD }
-	};
-
-	Assert(iPortraitNumber < static_cast<INT32>(lengthof(Colors)));
+	IMPPortrait const& portrait = GetCurrentIMPPortrait();
 	MERCPROFILESTRUCT& p = GetProfile(GetIMPSlotInProgress());
-	p.HAIR = Colors[iPortraitNumber].Hair;
-	p.SKIN = Colors[iPortraitNumber].Skin;
+	p.HAIR = portrait.hair;
+	p.SKIN = portrait.skin;
 }
 
 
@@ -497,6 +541,6 @@ static BOOLEAN ShouldThisMercHaveABigBody(void)
 {
 	// should this merc be a big body typ
 	return
-		(iPortraitNumber == 0 || iPortraitNumber == 6 || iPortraitNumber == 7) &&
+		GetCurrentIMPPortrait().bigBody &&
 		gMercProfiles[GetIMPSlotInProgress()].bStrength >= 75;
 }

--- a/src/game/Laptop/IMP_Compile_Character.h
+++ b/src/game/Laptop/IMP_Compile_Character.h
@@ -6,6 +6,15 @@
 #define PLAYER_GENERATED_CHARACTER_ID 51
 #define NUMBER_OF_PLAYER_PORTRAITS 16
 
+/* The player generated character profiles are laid out as one block of male
+ * voices followed by one block of female ones, the slot being picked by
+ * PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId. There is exactly one
+ * slot per voice and a finished character keeps its slot for the rest of the
+ * campaign, so the hard ceiling is three I.M.P.s of each gender. */
+#define NUMBER_OF_PLAYER_VOICES_PER_GENDER 3
+#define NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS (2 * NUMBER_OF_PLAYER_VOICES_PER_GENDER)
+#define NUMBER_OF_PLAYER_PORTRAITS_PER_GENDER (NUMBER_OF_PLAYER_PORTRAITS / 2)
+
 void AddAnAttitudeToAttitudeList( INT8 bAttitude );
 void CreateACharacterFromPlayerEnteredStats( void );
 void CreatePlayersPersonalitySkillsAndAttitude( void );
@@ -13,5 +22,35 @@ void AddAPersonalityToPersonalityList( INT8 bPersonlity );
 void AddSkillToSkillList( INT8 bSkill );
 void ResetSkillsAttributesAndPersonality( void );
 void HandleMercStatsForChangesInFace( void );
+
+/** Bit that a voice id stands for in LaptopSaveInfo.ubIMPCreatedSlots. */
+UINT8 GetIMPVoiceSlotFlag( INT32 iVoiceId );
+
+/** Whether the profile slot behind a voice id is spoken for. Out of range counts
+ * as taken, so a caller cycling through voices cannot settle on one. */
+bool IsIMPVoiceTaken( INT32 iVoiceId );
+
+/** Whether one of the I.M.P.s created so far already wears this portrait. */
+bool IsIMPPortraitTaken( INT32 iPortraitNumber );
+
+/** Number of I.M.P. characters created in this campaign so far. */
+UINT8 GetNumberOfIMPCharactersCreated( void );
+
+/** Whether the game policy still allows another I.M.P. character. */
+bool CanCreateAnotherIMPCharacter( void );
+
+/** Whether another I.M.P. character may be created with the given gender. */
+bool CanCreateIMPCharacterOfGender( bool fMale );
+
+/** First voice of a gender whose slot is still free, counted within the gender
+ * as iCurrentVoices is, or -1 when that gender has no slot left. */
+INT32 GetFirstFreeIMPVoice( bool fMale );
+
+/** First portrait of a gender that no I.M.P. wears yet, counted within the
+ * gender as iCurrentPortrait is, or -1 when there is none. */
+INT32 GetFirstFreeIMPPortrait( bool fMale );
+
+/** Record a finished I.M.P. character so its slot cannot be handed out again. */
+void MarkIMPCharacterCreated( INT32 iVoiceId );
 
 #endif

--- a/src/game/Laptop/IMP_Compile_Character.h
+++ b/src/game/Laptop/IMP_Compile_Character.h
@@ -1,20 +1,16 @@
 #ifndef __IMP_COMPILE_H
 #define __IMP_COMPILE_H
 
+#include "IMPPolicy.h"
 #include "JA2Types.h"
 #include "Types.h"
 
-#define PLAYER_GENERATED_CHARACTER_ID 51
-#define NUMBER_OF_PLAYER_PORTRAITS 16
+#include <vector>
 
-/* The voices and portraits the I.M.P. screens offer. Voices are the shipped
- * sets of speech, dialogue text and battle sounds, named after the profiles
- * they were recorded for, one block of male ones followed by a female block.
- * Which profile a character ends up in is unrelated: it takes the first free
- * slot and its voice is written to its profile, so any number of characters
- * may share a voice or a portrait. */
-#define NUMBER_OF_PLAYER_VOICES_PER_GENDER 3
-#define NUMBER_OF_PLAYER_PORTRAITS_PER_GENDER (NUMBER_OF_PLAYER_PORTRAITS / 2)
+/* The first of the six profiles the shipped voices were recorded for. Nothing
+ * is derived from it any more: it is only what an I.M.P. saved before the voice
+ * id was stored has to be read against. */
+#define PLAYER_GENERATED_CHARACTER_ID 51
 
 void AddAnAttitudeToAttitudeList( INT8 bAttitude );
 void CreateACharacterFromPlayerEnteredStats( void );
@@ -40,5 +36,31 @@ bool CanCreateAnotherIMPCharacter( void );
 /** Hold the profile the finished character was built in for the rest of the
  * campaign. */
 void MarkIMPCharacterCreated( ProfileID profile );
+
+
+/* The voices and portraits the data offers, in the order imp.json lists them.
+ * The I.M.P. screens page through the entries of the gender being profiled;
+ * what the character keeps is an index into the whole list. */
+
+const std::vector<IMPVoice>& GetIMPVoices( void );
+const std::vector<IMPPortrait>& GetIMPPortraits( void );
+
+/** How many entries one gender is offered. Never zero for a gender the site
+ * lets the player pick. */
+INT32 GetNumberOfIMPVoices( bool fMale );
+INT32 GetNumberOfIMPPortraits( bool fMale );
+
+/** Where the n-th entry offered for one gender sits in the whole list. */
+INT32 GetIMPVoiceIndex( bool fMale, INT32 iNth );
+INT32 GetIMPPortraitIndex( bool fMale, INT32 iNth );
+
+/** Where the portrait wearing this face image sits in the whole list, or -1
+ * when the data no longer offers it. */
+INT32 FindIMPPortraitByFace( UINT8 ubFaceIndex );
+
+/** The portrait the character being built wears. Every screen takes its index
+ * from GetIMPPortraitIndex, so it is only ever out of range if the data changed
+ * under a half built character. */
+const IMPPortrait& GetCurrentIMPPortrait( void );
 
 #endif

--- a/src/game/Laptop/IMP_Compile_Character.h
+++ b/src/game/Laptop/IMP_Compile_Character.h
@@ -1,18 +1,19 @@
 #ifndef __IMP_COMPILE_H
 #define __IMP_COMPILE_H
 
+#include "JA2Types.h"
 #include "Types.h"
 
 #define PLAYER_GENERATED_CHARACTER_ID 51
 #define NUMBER_OF_PLAYER_PORTRAITS 16
 
-/* The player generated character profiles are laid out as one block of male
- * voices followed by one block of female ones, the slot being picked by
- * PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId. There is exactly one
- * slot per voice and a finished character keeps its slot for the rest of the
- * campaign, so the hard ceiling is three I.M.P.s of each gender. */
+/* The voices and portraits the I.M.P. screens offer. Voices are the shipped
+ * sets of speech, dialogue text and battle sounds, named after the profiles
+ * they were recorded for, one block of male ones followed by a female block.
+ * Which profile a character ends up in is unrelated: it takes the first free
+ * slot and its voice is written to its profile, so any number of characters
+ * may share a voice or a portrait. */
 #define NUMBER_OF_PLAYER_VOICES_PER_GENDER 3
-#define NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS (2 * NUMBER_OF_PLAYER_VOICES_PER_GENDER)
 #define NUMBER_OF_PLAYER_PORTRAITS_PER_GENDER (NUMBER_OF_PLAYER_PORTRAITS / 2)
 
 void AddAnAttitudeToAttitudeList( INT8 bAttitude );
@@ -23,34 +24,21 @@ void AddSkillToSkillList( INT8 bSkill );
 void ResetSkillsAttributesAndPersonality( void );
 void HandleMercStatsForChangesInFace( void );
 
-/** Bit that a voice id stands for in LaptopSaveInfo.ubIMPCreatedSlots. */
-UINT8 GetIMPVoiceSlotFlag( INT32 iVoiceId );
-
-/** Whether the profile slot behind a voice id is spoken for. Out of range counts
- * as taken, so a caller cycling through voices cannot settle on one. */
-bool IsIMPVoiceTaken( INT32 iVoiceId );
-
-/** Whether one of the I.M.P.s created so far already wears this portrait. */
-bool IsIMPPortraitTaken( INT32 iPortraitNumber );
+/** Number of profiles the data marks as I.M.P. slots. */
+UINT8 GetNumberOfIMPSlots( void );
 
 /** Number of I.M.P. characters created in this campaign so far. */
 UINT8 GetNumberOfIMPCharactersCreated( void );
 
-/** Whether the game policy still allows another I.M.P. character. */
+/** The profile the character being built lives in, which is always the first
+ * free I.M.P. slot, or NO_PROFILE when every slot is taken. */
+ProfileID GetIMPSlotInProgress( void );
+
+/** Whether there is a free slot and the game policy allows another character. */
 bool CanCreateAnotherIMPCharacter( void );
 
-/** Whether another I.M.P. character may be created with the given gender. */
-bool CanCreateIMPCharacterOfGender( bool fMale );
-
-/** First voice of a gender whose slot is still free, counted within the gender
- * as iCurrentVoices is, or -1 when that gender has no slot left. */
-INT32 GetFirstFreeIMPVoice( bool fMale );
-
-/** First portrait of a gender that no I.M.P. wears yet, counted within the
- * gender as iCurrentPortrait is, or -1 when there is none. */
-INT32 GetFirstFreeIMPPortrait( bool fMale );
-
-/** Record a finished I.M.P. character so its slot cannot be handed out again. */
-void MarkIMPCharacterCreated( INT32 iVoiceId );
+/** Hold the profile the finished character was built in for the rest of the
+ * campaign. */
+void MarkIMPCharacterCreated( ProfileID profile );
 
 #endif

--- a/src/game/Laptop/IMP_Compile_Character.h
+++ b/src/game/Laptop/IMP_Compile_Character.h
@@ -58,6 +58,12 @@ INT32 GetIMPPortraitIndex( bool fMale, INT32 iNth );
  * when the data no longer offers it. */
 INT32 FindIMPPortraitByFace( UINT8 ubFaceIndex );
 
+/** Whether a character was built with the heavy male build: one of the portraits
+ * the data marks as burly, carried by someone with the strength for it. Both the
+ * body the character is given and the way the I.M.P. report describes it hang off
+ * this, so the two cannot describe different people. */
+bool IMPCharacterHasBigBody( const MERCPROFILESTRUCT& p );
+
 /** The portrait the character being built wears. Every screen takes its index
  * from GetIMPPortraitIndex, so it is only ever out of range if the data changed
  * under a half built character. */

--- a/src/game/Laptop/IMP_Confirm.cc
+++ b/src/game/Laptop/IMP_Confirm.cc
@@ -37,35 +37,6 @@ static BUTTON_PICS* giIMPConfirmButtonImage[2];
 GUIButtonRef giIMPConfirmButton[2];
 
 
-struct FacePosInfo
-{
-	UINT8 eye_x;
-	UINT8 eye_y;
-	UINT8 mouth_x;
-	UINT8 mouth_y;
-};
-
-static const FacePosInfo g_face_info[] =
-{
-	{  8,  5,  8, 21 },
-	{  9,  4,  9, 23 },
-	{  8,  5,  7, 24 },
-	{  6,  6,  7, 25 },
-	{ 13,  5, 11, 23 },
-	{ 11,  5, 10, 24 },
-	{  8,  4,  8, 24 },
-	{  8,  4,  8, 24 },
-	{  4,  4,  5, 25 },
-	{  5,  5,  6, 24 },
-	{  7,  5,  7, 24 },
-	{  5,  7,  6, 26 },
-	{  7,  6,  7, 24 },
-	{ 11,  5,  9, 23 },
-	{  8,  5,  7, 24 },
-	{  5,  6,  5, 26 }
-};
-
-
 static void BtnIMPConfirmNo(GUI_BUTTON *btn, UINT32 reason);
 static void BtnIMPConfirmYes(GUI_BUTTON *btn, UINT32 reason);
 
@@ -176,8 +147,8 @@ static BOOLEAN AddCharacterToPlayersTeam(void)
 	HireMercStruct.ubInsertionCode	= INSERTION_CODE_ARRIVING_GAME;
 	HireMercStruct.uiTimeTillMercArrives = GetMercArrivalTimeOfDay( );
 
-	const FacePosInfo* const fi = &g_face_info[iPortraitNumber];
-	SetProfileFaceData(HireMercStruct.ubProfileID, 200 + iPortraitNumber, fi->eye_x, fi->eye_y, fi->mouth_x, fi->mouth_y);
+	IMPPortrait const& portrait = GetCurrentIMPPortrait();
+	SetProfileFaceData(HireMercStruct.ubProfileID, portrait.face, portrait.eyesX, portrait.eyesY, portrait.mouthX, portrait.mouthY);
 
 	//if we succesfully hired the merc
 	return HireMerc(HireMercStruct);
@@ -306,12 +277,15 @@ static void GiveItemsToPC(UINT8 ubProfileId)
 
 void ResetIMPCharactersEyesAndMouthOffsets(const UINT8 ubMercProfileID)
 {
-	MERCPROFILESTRUCT& p = GetProfile(ubMercProfileID);
-	if (p.ubFaceIndex < 200 || p.ubFaceIndex >= 200 + lengthof(g_face_info) || ubMercProfileID >= PROF_HUMMER) return;
+	if (ubMercProfileID >= PROF_HUMMER) return;
 
-	const FacePosInfo* const fi = &g_face_info[p.ubFaceIndex - 200];
-	p.usEyesX  = fi->eye_x;
-	p.usEyesY  = fi->eye_y;
-	p.usMouthX = fi->mouth_x;
-	p.usMouthY = fi->mouth_y;
+	MERCPROFILESTRUCT& p = GetProfile(ubMercProfileID);
+	INT32 const iPortrait = FindIMPPortraitByFace(p.ubFaceIndex);
+	if (iPortrait < 0) return;
+
+	IMPPortrait const& portrait = GetIMPPortraits()[iPortrait];
+	p.usEyesX  = portrait.eyesX;
+	p.usEyesY  = portrait.eyesY;
+	p.usMouthX = portrait.mouthX;
+	p.usMouthY = portrait.mouthY;
 }

--- a/src/game/Laptop/IMP_Confirm.cc
+++ b/src/game/Laptop/IMP_Confirm.cc
@@ -155,7 +155,7 @@ static BOOLEAN AddCharacterToPlayersTeam(void)
 		HandleMercStatsForChangesInFace();
 	}
 
-	HireMercStruct.ubProfileID = ( UINT8 )( PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId ) ;
+	HireMercStruct.ubProfileID = GetIMPSlotInProgress() ;
 
 	if (!fLoadingCharacterForPreviousImpProfile)
 	{
@@ -199,18 +199,22 @@ static void BtnIMPConfirmYes(GUI_BUTTON *btn, UINT32 reason)
 			return;
 		}
 
+		// Taken before the slot is claimed, after which the first free slot is
+		// the next character's, not this one's.
+		ProfileID const profile = GetIMPSlotInProgress();
+
 		// line moved by CJC Nov 28 2002 to AFTER the check for money
 		if (!AddCharacterToPlayersTeam()) return; // only if merc hiring failed: no charge, give it another go
 
-		// claims this character's gender, so a further I.M.P. cannot reuse its profile slot
-		MarkIMPCharacterCreated(LaptopSaveInfo.iVoiceId);
+		// holds the profile for the rest of the campaign
+		MarkIMPCharacterCreated(profile);
 
-		SOLDIERTYPE* const pSoldier = FindSoldierByProfileID(PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId);
+		SOLDIERTYPE* const pSoldier = FindSoldierByProfileID(profile);
 		if (!pSoldier) return;
 
 		if (fLoadingCharacterForPreviousImpProfile && gamepolicy(imp_load_keep_inventory))
 		{
-			IMPSavedProfileLoadInventory(gMercProfiles[PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId].zNickname, pSoldier);
+			IMPSavedProfileLoadInventory(gMercProfiles[profile].zNickname, pSoldier);
 			// re-add letter, since it just got wiped and almost certainly is not present in the import
 			if (pSoldier->ubID == 0 && FindObj(pSoldier, LETTER) == NO_SLOT) {
 				CreateSpecialItem(pSoldier, LETTER);
@@ -218,7 +222,7 @@ static void BtnIMPConfirmYes(GUI_BUTTON *btn, UINT32 reason)
 		}
 
 		// charge the player
-		AddTransactionToPlayersBook(IMP_PROFILE, (UINT8)(PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId), GetWorldTotalMin(), -COST_OF_PROFILE);
+		AddTransactionToPlayersBook(IMP_PROFILE, profile, GetWorldTotalMin(), -COST_OF_PROFILE);
 		AddHistoryToPlayersLog(HISTORY_CHARACTER_GENERATED, 0, GetWorldTotalMin(), SGPSector(-1, -1));
 
 		fButtonPendingFlag = TRUE;
@@ -226,7 +230,7 @@ static void BtnIMPConfirmYes(GUI_BUTTON *btn, UINT32 reason)
 
 		// send email notice, naming the character it reports on: by the time the mail
 		// arrives a further I.M.P. may be the one iVoiceId points at
-		AddFutureDayStrategicEvent(EVENT_DAY2_ADD_EMAIL_FROM_IMP, 60 * 7, LaptopSaveInfo.iVoiceId, 2);
+		AddFutureDayStrategicEvent(EVENT_DAY2_ADD_EMAIL_FROM_IMP, 60 * 7, profile, 2);
 
 		ResetCharacterStats();
 

--- a/src/game/Laptop/IMP_Confirm.cc
+++ b/src/game/Laptop/IMP_Confirm.cc
@@ -187,9 +187,9 @@ static void BtnIMPConfirmYes(GUI_BUTTON *btn, UINT32 reason)
 {
 	if (reason & MSYS_CALLBACK_REASON_POINTER_UP)
 	{
-		if (LaptopSaveInfo.fIMPCompletedFlag)
+		if (!CanCreateAnotherIMPCharacter())
 		{
-			// already here, leave
+			// already made as many I.M.P. characters as allowed, leave
 			return;
 		}
 
@@ -200,8 +200,10 @@ static void BtnIMPConfirmYes(GUI_BUTTON *btn, UINT32 reason)
 		}
 
 		// line moved by CJC Nov 28 2002 to AFTER the check for money
-		LaptopSaveInfo.fIMPCompletedFlag = AddCharacterToPlayersTeam();
-		if (!LaptopSaveInfo.fIMPCompletedFlag) return; // only if merc hiring failed: no charge, give it another go
+		if (!AddCharacterToPlayersTeam()) return; // only if merc hiring failed: no charge, give it another go
+
+		// claims this character's gender, so a further I.M.P. cannot reuse its profile slot
+		MarkIMPCharacterCreated(LaptopSaveInfo.iVoiceId);
 
 		SOLDIERTYPE* const pSoldier = FindSoldierByProfileID(PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId);
 		if (!pSoldier) return;
@@ -222,8 +224,9 @@ static void BtnIMPConfirmYes(GUI_BUTTON *btn, UINT32 reason)
 		fButtonPendingFlag = TRUE;
 		iCurrentImpPage = IMP_HOME_PAGE;
 
-		// send email notice
-		AddFutureDayStrategicEvent(EVENT_DAY2_ADD_EMAIL_FROM_IMP, 60 * 7, 0, 2);
+		// send email notice, naming the character it reports on: by the time the mail
+		// arrives a further I.M.P. may be the one iVoiceId points at
+		AddFutureDayStrategicEvent(EVENT_DAY2_ADD_EMAIL_FROM_IMP, 60 * 7, LaptopSaveInfo.iVoiceId, 2);
 
 		ResetCharacterStats();
 

--- a/src/game/Laptop/IMP_HomePage.cc
+++ b/src/game/Laptop/IMP_HomePage.cc
@@ -2,6 +2,7 @@
 #include "Directories.h"
 #include "Font.h"
 #include "HImage.h"
+#include "IMP_Compile_Character.h"
 #include "IMP_HomePage.h"
 #include "IMPVideoObjects.h"
 #include "MessageBoxScreen.h"
@@ -60,7 +61,7 @@ static void ProcessPlayerInputActivationString(void)
 	ST::string str = GetStringFromField(0);
 	bool stringMatchesCode = GCM->getIMPPolicy()->isCodeAccepted(str);
 
-	if (stringMatchesCode && !LaptopSaveInfo.fIMPCompletedFlag) {
+	if (stringMatchesCode && CanCreateAnotherIMPCharacter()) {
 		iCurrentImpPage = IMP_MAIN_PAGE;
 		return;
 	}

--- a/src/game/Laptop/IMP_MainPage.cc
+++ b/src/game/Laptop/IMP_MainPage.cc
@@ -10,6 +10,7 @@
 #include "Cursors.h"
 #include "Laptop.h"
 #include "IMP_Attribute_Selection.h"
+#include "IMP_Compile_Character.h"
 #include "IMP_Finish.h"
 #include "MouseSystem.h"
 #include "LaptopSave.h"
@@ -472,7 +473,7 @@ static void IMPMainPageNotSelectableBtnCallback(MOUSE_REGION* pRegion, UINT32 iR
 
 SGPVObject* LoadIMPPortait()
 {
-	ST::string filename = ST::format(FACESDIR "/{}.sti", 200 + iPortraitNumber);
+	ST::string filename = ST::format(FACESDIR "/{}.sti", GetCurrentIMPPortrait().face);
 	return AddVideoObjectFromFile(filename);
 }
 

--- a/src/game/Laptop/IMP_Portraits.cc
+++ b/src/game/Laptop/IMP_Portraits.cc
@@ -44,14 +44,6 @@ static INT32 PortraitSlot(INT32 const iPortrait)
 
 void EnterIMPPortraits( void )
 {
-	// The picture left over from an earlier character is that character's face by
-	// now, so open on one that is still free.
-	if (IsIMPPortraitTaken(PortraitSlot(iCurrentPortrait)))
-	{
-		INT32 const iFree = GetFirstFreeIMPPortrait(fCharacterIsMale);
-		if (iFree >= 0) iCurrentPortrait = iFree;
-	}
-
 	// create buttons
 	CreateIMPPortraitButtons( );
 
@@ -114,38 +106,24 @@ static void RenderPortrait(INT16 const x, INT16 const y)
 
 static void IncrementPictureIndex(void)
 {
-	// cycle to the next picture, stepping over the faces earlier I.M.P.s wear. There
-	// are more pictures than profile slots, so one is always free, but bound the
-	// walk anyway so it cannot spin.
-	for (INT32 i = 0; i <= iLastPicture; ++i)
+	iCurrentPortrait++;
+
+	// gone too far?
+	if( iCurrentPortrait > iLastPicture )
 	{
-		iCurrentPortrait++;
-
-		// gone too far?
-		if( iCurrentPortrait > iLastPicture )
-		{
-			iCurrentPortrait = 0;
-		}
-
-		if (!IsIMPPortraitTaken(PortraitSlot(iCurrentPortrait))) return;
+		iCurrentPortrait = 0;
 	}
 }
 
 
 static void DecrementPicture(void)
 {
-	// cycle to the previous picture, stepping over the faces earlier I.M.P.s wear
-	for (INT32 i = 0; i <= iLastPicture; ++i)
+	iCurrentPortrait--;
+
+	// gone too far?
+	if( iCurrentPortrait < 0 )
 	{
-		iCurrentPortrait--;
-
-		// gone too far?
-		if( iCurrentPortrait < 0 )
-		{
-			iCurrentPortrait = iLastPicture;
-		}
-
-		if (!IsIMPPortraitTaken(PortraitSlot(iCurrentPortrait))) return;
+		iCurrentPortrait = iLastPicture;
 	}
 }
 

--- a/src/game/Laptop/IMP_Portraits.cc
+++ b/src/game/Laptop/IMP_Portraits.cc
@@ -17,9 +17,8 @@
 #include <string_theory/string>
 
 
-//current and last pages
+// which of the portraits offered for this gender is on show
 INT32 iCurrentPortrait = 0;
-INT32 iLastPicture = 7;
 
 // buttons needed for the IMP portrait screen
 GUIButtonRef giIMPPortraitButton[3];
@@ -35,15 +34,12 @@ INT32 iPortraitNumber = 0;
 static void CreateIMPPortraitButtons(void);
 
 
-// the face index a portrait of the gender being profiled stands for
-static INT32 PortraitSlot(INT32 const iPortrait)
-{
-	return iPortrait + (fCharacterIsMale ? 0 : NUMBER_OF_PLAYER_PORTRAITS_PER_GENDER);
-}
-
-
 void EnterIMPPortraits( void )
 {
+	// the data may offer a different number of portraits per gender, so an index
+	// left over from profiling the other one can be past the end
+	if (iCurrentPortrait >= GetNumberOfIMPPortraits(fCharacterIsMale)) iCurrentPortrait = 0;
+
 	// create buttons
 	CreateIMPPortraitButtons( );
 
@@ -98,8 +94,10 @@ void HandleIMPPortraits( void )
 
 static void RenderPortrait(INT16 const x, INT16 const y)
 { // Render the portrait of the current picture
-	INT32 const portrait = (fCharacterIsMale ? 200 : 208) + iCurrentPortrait;
-	ST::string filename = ST::format(FACESDIR "/bigfaces/{}.sti", portrait);
+	INT32 const portrait = GetIMPPortraitIndex(fCharacterIsMale, iCurrentPortrait);
+	if (portrait < 0) return;
+
+	ST::string filename = ST::format(FACESDIR "/bigfaces/{}.sti", GetIMPPortraits()[portrait].face);
 	BltVideoObjectOnce(FRAME_BUFFER, filename.c_str(), 0, LAPTOP_SCREEN_UL_X + x, LAPTOP_SCREEN_WEB_UL_Y + y);
 }
 
@@ -109,7 +107,7 @@ static void IncrementPictureIndex(void)
 	iCurrentPortrait++;
 
 	// gone too far?
-	if( iCurrentPortrait > iLastPicture )
+	if( iCurrentPortrait >= GetNumberOfIMPPortraits(fCharacterIsMale) )
 	{
 		iCurrentPortrait = 0;
 	}
@@ -123,7 +121,7 @@ static void DecrementPicture(void)
 	// gone too far?
 	if( iCurrentPortrait < 0 )
 	{
-		iCurrentPortrait = iLastPicture;
+		iCurrentPortrait = GetNumberOfIMPPortraits(fCharacterIsMale) - 1;
 	}
 }
 
@@ -208,7 +206,7 @@ static void BtnIMPPortraitDoneCallback(GUI_BUTTON *btn, UINT32 reason)
 		if (iCurrentProfileMode == 5) iCurrentImpPage = IMP_FINISH;
 
 		// grab picture number
-		iPortraitNumber = PortraitSlot(iCurrentPortrait);
+		iPortraitNumber = GetIMPPortraitIndex(fCharacterIsMale, iCurrentPortrait);
 
 		fButtonPendingFlag = TRUE;
 	}

--- a/src/game/Laptop/IMP_Portraits.cc
+++ b/src/game/Laptop/IMP_Portraits.cc
@@ -1,6 +1,7 @@
 #include "CharProfile.h"
 #include "Directories.h"
 #include "Font.h"
+#include "IMP_Compile_Character.h"
 #include "IMP_Portraits.h"
 #include "IMP_MainPage.h"
 #include "IMPVideoObjects.h"
@@ -34,8 +35,23 @@ INT32 iPortraitNumber = 0;
 static void CreateIMPPortraitButtons(void);
 
 
+// the face index a portrait of the gender being profiled stands for
+static INT32 PortraitSlot(INT32 const iPortrait)
+{
+	return iPortrait + (fCharacterIsMale ? 0 : NUMBER_OF_PLAYER_PORTRAITS_PER_GENDER);
+}
+
+
 void EnterIMPPortraits( void )
 {
+	// The picture left over from an earlier character is that character's face by
+	// now, so open on one that is still free.
+	if (IsIMPPortraitTaken(PortraitSlot(iCurrentPortrait)))
+	{
+		INT32 const iFree = GetFirstFreeIMPPortrait(fCharacterIsMale);
+		if (iFree >= 0) iCurrentPortrait = iFree;
+	}
+
 	// create buttons
 	CreateIMPPortraitButtons( );
 
@@ -98,26 +114,38 @@ static void RenderPortrait(INT16 const x, INT16 const y)
 
 static void IncrementPictureIndex(void)
 {
-	// cycle to next picture
-	iCurrentPortrait++;
-
-	// gone too far?
-	if( iCurrentPortrait > iLastPicture )
+	// cycle to the next picture, stepping over the faces earlier I.M.P.s wear. There
+	// are more pictures than profile slots, so one is always free, but bound the
+	// walk anyway so it cannot spin.
+	for (INT32 i = 0; i <= iLastPicture; ++i)
 	{
-		iCurrentPortrait = 0;
+		iCurrentPortrait++;
+
+		// gone too far?
+		if( iCurrentPortrait > iLastPicture )
+		{
+			iCurrentPortrait = 0;
+		}
+
+		if (!IsIMPPortraitTaken(PortraitSlot(iCurrentPortrait))) return;
 	}
 }
 
 
 static void DecrementPicture(void)
 {
-	// cycle to previous picture
-	iCurrentPortrait--;
-
-	// gone too far?
-	if( iCurrentPortrait < 0 )
+	// cycle to the previous picture, stepping over the faces earlier I.M.P.s wear
+	for (INT32 i = 0; i <= iLastPicture; ++i)
 	{
-		iCurrentPortrait = iLastPicture;
+		iCurrentPortrait--;
+
+		// gone too far?
+		if( iCurrentPortrait < 0 )
+		{
+			iCurrentPortrait = iLastPicture;
+		}
+
+		if (!IsIMPPortraitTaken(PortraitSlot(iCurrentPortrait))) return;
 	}
 }
 
@@ -202,7 +230,7 @@ static void BtnIMPPortraitDoneCallback(GUI_BUTTON *btn, UINT32 reason)
 		if (iCurrentProfileMode == 5) iCurrentImpPage = IMP_FINISH;
 
 		// grab picture number
-		iPortraitNumber = iCurrentPortrait + (fCharacterIsMale ? 0 : 8);
+		iPortraitNumber = PortraitSlot(iCurrentPortrait);
 
 		fButtonPendingFlag = TRUE;
 	}

--- a/src/game/Laptop/IMP_Voices.cc
+++ b/src/game/Laptop/IMP_Voices.cc
@@ -20,11 +20,8 @@
 #include <string_theory/string>
 
 
-//current and last pages
+// which of the voices offered for this gender is on show
 INT32 iCurrentVoices = 0;
-static INT32 const iLastVoice = 2;
-
-//INT32 iVoiceId = 0;
 
 
 static UINT32 uiVocVoiceSound = 0;
@@ -47,6 +44,10 @@ static void PlayVoice();
 
 void EnterIMPVoices( void )
 {
+	// the data may offer a different number of voices per gender, so an index
+	// left over from profiling the other one can be past the end
+	if (iCurrentVoices >= GetNumberOfIMPVoices(fCharacterIsMale)) iCurrentVoices = 0;
+
 	// create buttons
 	CreateIMPVoicesButtons( );
 
@@ -117,7 +118,7 @@ static void IncrementVoice(void)
 	iCurrentVoices++;
 
 	// gone too far?
-	if( iCurrentVoices > iLastVoice )
+	if( iCurrentVoices >= GetNumberOfIMPVoices(fCharacterIsMale) )
 	{
 		iCurrentVoices = 0;
 	}
@@ -131,7 +132,7 @@ static void DecrementVoice(void)
 	// gone too far?
 	if( iCurrentVoices < 0 )
 	{
-		iCurrentVoices = iLastVoice;
+		iCurrentVoices = GetNumberOfIMPVoices(fCharacterIsMale) - 1;
 	}
 }
 
@@ -231,7 +232,7 @@ static void BtnIMPVoicesDoneCallback(GUI_BUTTON *btn, UINT32 reason)
 		}
 
 		// the voice the character will speak with, counted over both genders
-		LaptopSaveInfo.iVoiceId = iCurrentVoices + (fCharacterIsMale ? 0 : NUMBER_OF_PLAYER_VOICES_PER_GENDER);
+		LaptopSaveInfo.iVoiceId = GetIMPVoiceIndex(fCharacterIsMale, iCurrentVoices);
 
 		// set button up image pending
 		fButtonPendingFlag = TRUE;
@@ -241,28 +242,12 @@ static void BtnIMPVoicesDoneCallback(GUI_BUTTON *btn, UINT32 reason)
 
 static void PlayVoice()
 {
-	char const* filename;
-	if (fCharacterIsMale)
-	{
-		switch (iCurrentVoices)
-		{
-			case 0:  filename = SPEECHDIR "/051_001.wav"; break;
-			case 1:  filename = SPEECHDIR "/052_001.wav"; break;
-			case 2:  filename = SPEECHDIR "/053_001.wav"; break;
-			default: return;
-		}
-	}
-	else
-	{
-		switch (iCurrentVoices)
-		{
-			case 0:  filename = SPEECHDIR "/054_001.wav"; break;
-			case 1:  filename = SPEECHDIR "/055_001.wav"; break;
-			case 2:  filename = SPEECHDIR "/056_001.wav"; break;
-			default: return;
-		}
-	}
-	uiVocVoiceSound = PlayJA2SampleFromFile(filename, MIDVOLUME, 1, MIDDLEPAN);
+	INT32 const iVoice = GetIMPVoiceIndex(fCharacterIsMale, iCurrentVoices);
+	if (iVoice < 0) return;
+
+	// the first quote of the voice's own speech files
+	ST::string filename = ST::format(SPEECHDIR "/{03d}_001.wav", GetIMPVoices()[iVoice].profile);
+	uiVocVoiceSound = PlayJA2SampleFromFile(filename.c_str(), MIDVOLUME, 1, MIDDLEPAN);
 }
 
 

--- a/src/game/Laptop/IMP_Voices.cc
+++ b/src/game/Laptop/IMP_Voices.cc
@@ -45,23 +45,8 @@ static void CreateIMPVoicesButtons(void);
 static void PlayVoice();
 
 
-// the profile slot a voice of the gender being profiled would claim
-static INT32 VoiceSlot(INT32 const iVoice)
-{
-	return iVoice + (fCharacterIsMale ? 0 : NUMBER_OF_PLAYER_VOICES_PER_GENDER);
-}
-
-
 void EnterIMPVoices( void )
 {
-	// The voice left over from an earlier character may be one that character now
-	// owns, so open on a free one rather than on a silhouette that cannot be taken.
-	if (IsIMPVoiceTaken(VoiceSlot(iCurrentVoices)))
-	{
-		INT32 const iFree = GetFirstFreeIMPVoice(fCharacterIsMale);
-		if (iFree >= 0) iCurrentVoices = iFree;
-	}
-
 	// create buttons
 	CreateIMPVoicesButtons( );
 
@@ -129,38 +114,24 @@ void HandleIMPVoices( void )
 
 static void IncrementVoice(void)
 {
-	// cycle to the next voice, stepping over the ones an earlier I.M.P. took. All
-	// of them being taken cannot happen on a screen that was reached at all, but
-	// bound the walk anyway so it cannot spin.
-	for (INT32 i = 0; i <= iLastVoice; ++i)
+	iCurrentVoices++;
+
+	// gone too far?
+	if( iCurrentVoices > iLastVoice )
 	{
-		iCurrentVoices++;
-
-		// gone too far?
-		if( iCurrentVoices > iLastVoice )
-		{
-			iCurrentVoices = 0;
-		}
-
-		if (!IsIMPVoiceTaken(VoiceSlot(iCurrentVoices))) return;
+		iCurrentVoices = 0;
 	}
 }
 
 
 static void DecrementVoice(void)
 {
-	// cycle to the previous voice, stepping over the ones an earlier I.M.P. took
-	for (INT32 i = 0; i <= iLastVoice; ++i)
+	iCurrentVoices--;
+
+	// gone too far?
+	if( iCurrentVoices < 0 )
 	{
-		iCurrentVoices--;
-
-		// gone too far?
-		if( iCurrentVoices < 0 )
-		{
-			iCurrentVoices = iLastVoice;
-		}
-
-		if (!IsIMPVoiceTaken(VoiceSlot(iCurrentVoices))) return;
+		iCurrentVoices = iLastVoice;
 	}
 }
 
@@ -259,8 +230,8 @@ static void BtnIMPVoicesDoneCallback(GUI_BUTTON *btn, UINT32 reason)
 			iCurrentImpPage = IMP_FINISH;
 		}
 
-		// set voice id, to grab character slot
-		LaptopSaveInfo.iVoiceId = VoiceSlot(iCurrentVoices);
+		// the voice the character will speak with, counted over both genders
+		LaptopSaveInfo.iVoiceId = iCurrentVoices + (fCharacterIsMale ? 0 : NUMBER_OF_PLAYER_VOICES_PER_GENDER);
 
 		// set button up image pending
 		fButtonPendingFlag = TRUE;

--- a/src/game/Laptop/IMP_Voices.cc
+++ b/src/game/Laptop/IMP_Voices.cc
@@ -1,6 +1,7 @@
 #include "CharProfile.h"
 #include "Directories.h"
 #include "Font.h"
+#include "IMP_Compile_Character.h"
 #include "IMP_Voices.h"
 #include "IMP_MainPage.h"
 #include "IMPVideoObjects.h"
@@ -44,8 +45,23 @@ static void CreateIMPVoicesButtons(void);
 static void PlayVoice();
 
 
+// the profile slot a voice of the gender being profiled would claim
+static INT32 VoiceSlot(INT32 const iVoice)
+{
+	return iVoice + (fCharacterIsMale ? 0 : NUMBER_OF_PLAYER_VOICES_PER_GENDER);
+}
+
+
 void EnterIMPVoices( void )
 {
+	// The voice left over from an earlier character may be one that character now
+	// owns, so open on a free one rather than on a silhouette that cannot be taken.
+	if (IsIMPVoiceTaken(VoiceSlot(iCurrentVoices)))
+	{
+		INT32 const iFree = GetFirstFreeIMPVoice(fCharacterIsMale);
+		if (iFree >= 0) iCurrentVoices = iFree;
+	}
+
 	// create buttons
 	CreateIMPVoicesButtons( );
 
@@ -113,26 +129,38 @@ void HandleIMPVoices( void )
 
 static void IncrementVoice(void)
 {
-	// cycle to next voice
-	iCurrentVoices++;
-
-	// gone too far?
-	if( iCurrentVoices > iLastVoice )
+	// cycle to the next voice, stepping over the ones an earlier I.M.P. took. All
+	// of them being taken cannot happen on a screen that was reached at all, but
+	// bound the walk anyway so it cannot spin.
+	for (INT32 i = 0; i <= iLastVoice; ++i)
 	{
-		iCurrentVoices = 0;
+		iCurrentVoices++;
+
+		// gone too far?
+		if( iCurrentVoices > iLastVoice )
+		{
+			iCurrentVoices = 0;
+		}
+
+		if (!IsIMPVoiceTaken(VoiceSlot(iCurrentVoices))) return;
 	}
 }
 
 
 static void DecrementVoice(void)
 {
-	// cycle to previous voice
-	iCurrentVoices--;
-
-	// gone too far?
-	if( iCurrentVoices < 0 )
+	// cycle to the previous voice, stepping over the ones an earlier I.M.P. took
+	for (INT32 i = 0; i <= iLastVoice; ++i)
 	{
-		iCurrentVoices = iLastVoice;
+		iCurrentVoices--;
+
+		// gone too far?
+		if( iCurrentVoices < 0 )
+		{
+			iCurrentVoices = iLastVoice;
+		}
+
+		if (!IsIMPVoiceTaken(VoiceSlot(iCurrentVoices))) return;
 	}
 }
 
@@ -232,7 +260,7 @@ static void BtnIMPVoicesDoneCallback(GUI_BUTTON *btn, UINT32 reason)
 		}
 
 		// set voice id, to grab character slot
-		LaptopSaveInfo.iVoiceId = iCurrentVoices + (fCharacterIsMale ? 0 : 3);
+		LaptopSaveInfo.iVoiceId = VoiceSlot(iCurrentVoices);
 
 		// set button up image pending
 		fButtonPendingFlag = TRUE;

--- a/src/game/Laptop/Laptop.cc
+++ b/src/game/Laptop/Laptop.cc
@@ -394,7 +394,6 @@ void InitLaptopAndLaptopScreens(void)
 
 	//Reset the flags so we can create a new IMP character
 	LaptopSaveInfo.fIMPCompletedFlag = FALSE;
-	LaptopSaveInfo.ubIMPCreatedSlots = 0;
 
 	//Reset the flag so that BOBBYR's isnt available at the begining of the game
 	LaptopSaveInfo.fBobbyRSiteCanBeAccessed = FALSE;
@@ -3305,8 +3304,7 @@ void SaveLaptopInfoToSavedGame(HWFILE const f)
 	INJ_U32(  d, l.uiFlowerOrderNumber)
 	INJ_U32(  d, l.uiTotalMoneyPaidToSpeck)
 	INJ_U8(   d, l.ubLastMercAvailableId)
-	INJ_U8(   d, l.ubIMPCreatedSlots)
-	INJ_SKIP( d, 86)
+	INJ_SKIP( d, 87)
 	Assert(d.getConsumed() == lengthof(data));
 
 	f->write(data, sizeof(data));
@@ -3393,23 +3391,8 @@ void LoadLaptopInfoFromSavedGame(HWFILE const f)
 	EXTR_U32(  d, l.uiFlowerOrderNumber)
 	EXTR_U32(  d, l.uiTotalMoneyPaidToSpeck)
 	EXTR_U8(   d, l.ubLastMercAvailableId)
-	EXTR_U8(   d, l.ubIMPCreatedSlots)
-	EXTR_SKIP( d, 86)
+	EXTR_SKIP( d, 87)
 	Assert(d.getConsumed() == lengthof(data));
-
-	// This byte was part of the block older saves skipped, so what it holds cannot
-	// be trusted. It is only believed when it agrees with iVoiceId, which back when
-	// one I.M.P. was the limit pointed at that one character; anything else is a
-	// pre-feature save and is reconstructed from iVoiceId alone.
-	l.ubIMPCreatedSlots &= (1 << NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS) - 1;
-	if (!l.fIMPCompletedFlag)
-	{
-		l.ubIMPCreatedSlots = 0;
-	}
-	else if (!(l.ubIMPCreatedSlots & GetIMPVoiceSlotFlag(l.iVoiceId)))
-	{
-		l.ubIMPCreatedSlots = GetIMPVoiceSlotFlag(l.iVoiceId);
-	}
 
 	// Handle old saves in M.E.R.C. module
 	SyncLastMercFromSaveGame();

--- a/src/game/Laptop/Laptop.cc
+++ b/src/game/Laptop/Laptop.cc
@@ -61,6 +61,7 @@
 #include "Environment.h"
 #include "Music_Control.h"
 #include "ContentMusic.h"
+#include "IMP_Compile_Character.h"
 #include "LaptopSave.h"
 #include "RenderWorld.h"
 #include "GameLoop.h"
@@ -391,8 +392,9 @@ void InitLaptopAndLaptopScreens(void)
 	GameInitFinances();
 	GameInitHistory();
 
-	//Reset the flag so we can create a new IMP character
+	//Reset the flags so we can create a new IMP character
 	LaptopSaveInfo.fIMPCompletedFlag = FALSE;
+	LaptopSaveInfo.ubIMPCreatedSlots = 0;
 
 	//Reset the flag so that BOBBYR's isnt available at the begining of the game
 	LaptopSaveInfo.fBobbyRSiteCanBeAccessed = FALSE;
@@ -3303,7 +3305,8 @@ void SaveLaptopInfoToSavedGame(HWFILE const f)
 	INJ_U32(  d, l.uiFlowerOrderNumber)
 	INJ_U32(  d, l.uiTotalMoneyPaidToSpeck)
 	INJ_U8(   d, l.ubLastMercAvailableId)
-	INJ_SKIP( d, 87)
+	INJ_U8(   d, l.ubIMPCreatedSlots)
+	INJ_SKIP( d, 86)
 	Assert(d.getConsumed() == lengthof(data));
 
 	f->write(data, sizeof(data));
@@ -3390,8 +3393,23 @@ void LoadLaptopInfoFromSavedGame(HWFILE const f)
 	EXTR_U32(  d, l.uiFlowerOrderNumber)
 	EXTR_U32(  d, l.uiTotalMoneyPaidToSpeck)
 	EXTR_U8(   d, l.ubLastMercAvailableId)
-	EXTR_SKIP( d, 87)
+	EXTR_U8(   d, l.ubIMPCreatedSlots)
+	EXTR_SKIP( d, 86)
 	Assert(d.getConsumed() == lengthof(data));
+
+	// This byte was part of the block older saves skipped, so what it holds cannot
+	// be trusted. It is only believed when it agrees with iVoiceId, which back when
+	// one I.M.P. was the limit pointed at that one character; anything else is a
+	// pre-feature save and is reconstructed from iVoiceId alone.
+	l.ubIMPCreatedSlots &= (1 << NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS) - 1;
+	if (!l.fIMPCompletedFlag)
+	{
+		l.ubIMPCreatedSlots = 0;
+	}
+	else if (!(l.ubIMPCreatedSlots & GetIMPVoiceSlotFlag(l.iVoiceId)))
+	{
+		l.ubIMPCreatedSlots = GetIMPVoiceSlotFlag(l.iVoiceId);
+	}
 
 	// Handle old saves in M.E.R.C. module
 	SyncLastMercFromSaveGame();

--- a/src/game/Laptop/LaptopSave.h
+++ b/src/game/Laptop/LaptopSave.h
@@ -75,8 +75,9 @@ struct LaptopSaveInfoStruct
 
 
 	//IMP Information
-	BOOLEAN fIMPCompletedFlag; // Has the player Completed the IMP process
+	BOOLEAN fIMPCompletedFlag; // Has the player Completed the IMP process at least once
 	BOOLEAN fSentImpWarningAlready; // Has the Imp email warning already been sent
+	UINT8   ubIMPCreatedSlots; // bit per player generated profile slot an I.M.P. character occupies
 
 
 	//Personnel Info

--- a/src/game/Laptop/LaptopSave.h
+++ b/src/game/Laptop/LaptopSave.h
@@ -77,7 +77,6 @@ struct LaptopSaveInfoStruct
 	//IMP Information
 	BOOLEAN fIMPCompletedFlag; // Has the player Completed the IMP process at least once
 	BOOLEAN fSentImpWarningAlready; // Has the Imp email warning already been sent
-	UINT8   ubIMPCreatedSlots; // bit per player generated profile slot an I.M.P. character occupies
 
 
 	//Personnel Info

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -1205,6 +1205,12 @@ static void SaveMercProfiles(HWFILE const f)
 		InjectMercProfile(data, *i);
 		NewJA2EncryptedFileWrite(f, data, sizeof(data));
 	}
+
+	// The profile record is full, and its layout is also prof.dat's, so the
+	// voice ids follow the records as a block of their own.
+	BYTE voiceIds[NUM_PROFILES];
+	for (UINT32 i = 0; i != NUM_PROFILES; ++i) voiceIds[i] = gMercProfiles[i].ubVoiceId;
+	f->write(voiceIds, sizeof(voiceIds));
 }
 
 ST::string IMPSavedProfileCreateFilename(const ST::string& nickname)
@@ -1318,6 +1324,18 @@ static void LoadSavedMercProfiles(HWFILE const f, UINT32 const savegame_version,
 			throw std::runtime_error("Merc profile checksum mismatch");
 		}
 	}
+
+	if (savegame_version < 104)
+	{
+		// Before the voice id existed every character spoke with the files
+		// named after its own profile.
+		for (UINT32 i = 0; i != NUM_PROFILES; ++i) gMercProfiles[i].ubVoiceId = i;
+		return;
+	}
+
+	BYTE voiceIds[NUM_PROFILES];
+	f->read(voiceIds, sizeof(voiceIds));
+	for (UINT32 i = 0; i != NUM_PROFILES; ++i) gMercProfiles[i].ubVoiceId = voiceIds[i];
 }
 
 

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -1206,11 +1206,15 @@ static void SaveMercProfiles(HWFILE const f)
 		NewJA2EncryptedFileWrite(f, data, sizeof(data));
 	}
 
-	// The profile record is full, and its layout is also prof.dat's, so the
-	// voice ids follow the records as a block of their own.
+	// The profile record is full, and its layout is also prof.dat's, so fields
+	// added since follow the records, one block per field.
 	BYTE voiceIds[NUM_PROFILES];
 	for (UINT32 i = 0; i != NUM_PROFILES; ++i) voiceIds[i] = gMercProfiles[i].ubVoiceId;
 	f->write(voiceIds, sizeof(voiceIds));
+
+	BYTE impSlotStates[NUM_PROFILES];
+	for (UINT32 i = 0; i != NUM_PROFILES; ++i) impSlotStates[i] = gMercProfiles[i].ubIMPSlotState;
+	f->write(impSlotStates, sizeof(impSlotStates));
 }
 
 ST::string IMPSavedProfileCreateFilename(const ST::string& nickname)
@@ -1241,22 +1245,10 @@ static SGPFile* IMPSavedProfileOpenFileForWrite(const ST::string& nickname)
 	return f;
 }
 
-/* Reads the profile slot a saved I.M.P. would be restored into, without touching
- * gMercProfiles. Returns -1 if there is no usable profile under that nickname. */
-int IMPSavedProfileReadVoiceId(const ST::string& nickname)
-{
-	if (!IMPSavedProfileDoesFileExist(nickname)) return -1;
-	SGPFile *f = IMPSavedProfileOpenFileForRead(nickname);
-	MERCPROFILESTRUCT profile_saved;
-	f->read(&profile_saved, sizeof(MERCPROFILESTRUCT));
-	delete f;
-
-	int const voiceid = profile_saved.ubSuspiciousDeath;
-	if (voiceid >= NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS) return -1;
-	return voiceid;
-}
-
-int IMPSavedProfileLoadMercProfile(const ST::string& nickname)
+/* Restores a saved I.M.P. into the slot the character being built would take.
+ * The character keeps the voice it was made with, which the saved profile
+ * carries itself. */
+ProfileID IMPSavedProfileLoadMercProfile(const ST::string& nickname)
 {
 	if (!IMPSavedProfileDoesFileExist(nickname)) {
 		throw std::runtime_error(ST::format("Lost IMP with nickname '{}'!", nickname).to_std_string());
@@ -1265,11 +1257,14 @@ int IMPSavedProfileLoadMercProfile(const ST::string& nickname)
 	MERCPROFILESTRUCT profile_saved;
 	f->read(&profile_saved, sizeof(MERCPROFILESTRUCT));
 	delete f;
-	int voiceid = profile_saved.ubSuspiciousDeath;
-	MERCPROFILESTRUCT& profile_new = gMercProfiles[PLAYER_GENERATED_CHARACTER_ID + voiceid];
+
+	ProfileID const profile = GetIMPSlotInProgress();
+	MERCPROFILESTRUCT& profile_new = gMercProfiles[profile];
 	profile_new = profile_saved;
 	profile_new.bMercStatus = MERC_OK;
-	return voiceid;
+	// The slot is not held until the player confirms the character.
+	profile_new.ubIMPSlotState = IMP_SLOT_FREE;
+	return profile;
 }
 
 void IMPSavedProfileLoadInventory(const ST::string& nickname, SOLDIERTYPE *pSoldier)
@@ -1300,7 +1295,6 @@ void SaveIMPPlayerProfiles()
 		SGPFile *f = IMPSavedProfileOpenFileForWrite(mercprofile->zNickname);
 		if (!f) continue;
 
-		mercprofile->ubSuspiciousDeath = i - PLAYER_GENERATED_CHARACTER_ID; // save voice_id, field not used for resuscitated merc
 		f->write(mercprofile, sizeof(MERCPROFILESTRUCT));
 		f->write(pSoldier->inv, sizeof(OBJECTTYPE) * NUM_INV_SLOTS);
 		delete f;
@@ -1330,12 +1324,23 @@ static void LoadSavedMercProfiles(HWFILE const f, UINT32 const savegame_version,
 		// Before the voice id existed every character spoke with the files
 		// named after its own profile.
 		for (UINT32 i = 0; i != NUM_PROFILES; ++i) gMercProfiles[i].ubVoiceId = i;
+
+		// One I.M.P. was the limit, and it lived in the slot iVoiceId pointed
+		// at. The laptop block is read before this one, so it can be believed.
+		if (LaptopSaveInfo.fIMPCompletedFlag)
+		{
+			gMercProfiles[PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId].ubIMPSlotState = IMP_SLOT_TAKEN;
+		}
 		return;
 	}
 
 	BYTE voiceIds[NUM_PROFILES];
 	f->read(voiceIds, sizeof(voiceIds));
 	for (UINT32 i = 0; i != NUM_PROFILES; ++i) gMercProfiles[i].ubVoiceId = voiceIds[i];
+
+	BYTE impSlotStates[NUM_PROFILES];
+	f->read(impSlotStates, sizeof(impSlotStates));
+	for (UINT32 i = 0; i != NUM_PROFILES; ++i) gMercProfiles[i].ubIMPSlotState = impSlotStates[i];
 }
 
 

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -1235,6 +1235,21 @@ static SGPFile* IMPSavedProfileOpenFileForWrite(const ST::string& nickname)
 	return f;
 }
 
+/* Reads the profile slot a saved I.M.P. would be restored into, without touching
+ * gMercProfiles. Returns -1 if there is no usable profile under that nickname. */
+int IMPSavedProfileReadVoiceId(const ST::string& nickname)
+{
+	if (!IMPSavedProfileDoesFileExist(nickname)) return -1;
+	SGPFile *f = IMPSavedProfileOpenFileForRead(nickname);
+	MERCPROFILESTRUCT profile_saved;
+	f->read(&profile_saved, sizeof(MERCPROFILESTRUCT));
+	delete f;
+
+	int const voiceid = profile_saved.ubSuspiciousDeath;
+	if (voiceid >= NUMBER_OF_PLAYER_GENERATED_CHARACTER_SLOTS) return -1;
+	return voiceid;
+}
+
 int IMPSavedProfileLoadMercProfile(const ST::string& nickname)
 {
 	if (!IMPSavedProfileDoesFileExist(nickname)) {

--- a/src/game/SaveLoadGame.cc
+++ b/src/game/SaveLoadGame.cc
@@ -1213,7 +1213,7 @@ static void SaveMercProfiles(HWFILE const f)
 	f->write(voiceIds, sizeof(voiceIds));
 
 	BYTE impSlotStates[NUM_PROFILES];
-	for (UINT32 i = 0; i != NUM_PROFILES; ++i) impSlotStates[i] = gMercProfiles[i].ubIMPSlotState;
+	for (UINT32 i = 0; i != NUM_PROFILES; ++i) impSlotStates[i] = static_cast<BYTE>(gMercProfiles[i].impSlotState);
 	f->write(impSlotStates, sizeof(impSlotStates));
 }
 
@@ -1263,7 +1263,7 @@ ProfileID IMPSavedProfileLoadMercProfile(const ST::string& nickname)
 	profile_new = profile_saved;
 	profile_new.bMercStatus = MERC_OK;
 	// The slot is not held until the player confirms the character.
-	profile_new.ubIMPSlotState = IMP_SLOT_FREE;
+	profile_new.impSlotState = IMPSlotState::FREE;
 	return profile;
 }
 
@@ -1329,7 +1329,7 @@ static void LoadSavedMercProfiles(HWFILE const f, UINT32 const savegame_version,
 		// at. The laptop block is read before this one, so it can be believed.
 		if (LaptopSaveInfo.fIMPCompletedFlag)
 		{
-			gMercProfiles[PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId].ubIMPSlotState = IMP_SLOT_TAKEN;
+			gMercProfiles[PLAYER_GENERATED_CHARACTER_ID + LaptopSaveInfo.iVoiceId].impSlotState = IMPSlotState::TAKEN;
 		}
 		return;
 	}
@@ -1340,7 +1340,7 @@ static void LoadSavedMercProfiles(HWFILE const f, UINT32 const savegame_version,
 
 	BYTE impSlotStates[NUM_PROFILES];
 	f->read(impSlotStates, sizeof(impSlotStates));
-	for (UINT32 i = 0; i != NUM_PROFILES; ++i) gMercProfiles[i].ubIMPSlotState = impSlotStates[i];
+	for (UINT32 i = 0; i != NUM_PROFILES; ++i) gMercProfiles[i].impSlotState = static_cast<IMPSlotState>(impSlotStates[i]);
 }
 
 

--- a/src/game/SaveLoadGame.h
+++ b/src/game/SaveLoadGame.h
@@ -103,8 +103,7 @@ extern UINT32 guiJA2EncryptionSet;
 ST::string IMPSavedProfileCreateFilename(const ST::string& nickname);
 bool IMPSavedProfileDoesFileExist(const ST::string& nickname);
 SGPFile* IMPSavedProfileOpenFileForRead(const ST::string& nickname);
-int IMPSavedProfileReadVoiceId(const ST::string& nickname);
-int IMPSavedProfileLoadMercProfile(const ST::string& nickname);
+ProfileID IMPSavedProfileLoadMercProfile(const ST::string& nickname);
 void IMPSavedProfileLoadInventory(const ST::string& nickname, SOLDIERTYPE *pSoldier);
 
 class SaveGameInfo {

--- a/src/game/SaveLoadGame.h
+++ b/src/game/SaveLoadGame.h
@@ -103,6 +103,7 @@ extern UINT32 guiJA2EncryptionSet;
 ST::string IMPSavedProfileCreateFilename(const ST::string& nickname);
 bool IMPSavedProfileDoesFileExist(const ST::string& nickname);
 SGPFile* IMPSavedProfileOpenFileForRead(const ST::string& nickname);
+int IMPSavedProfileReadVoiceId(const ST::string& nickname);
 int IMPSavedProfileLoadMercProfile(const ST::string& nickname);
 void IMPSavedProfileLoadInventory(const ST::string& nickname, SOLDIERTYPE *pSoldier);
 

--- a/src/game/Strategic/Game_Event_Hook.cc
+++ b/src/game/Strategic/Game_Event_Hook.cc
@@ -124,7 +124,7 @@ BOOLEAN ExecuteStrategicEvent( STRATEGICEVENT *pEvent )
 			AddEmail(MERC_INTRO, MERC_INTRO_LENGTH, SPECK_FROM_MERC, GetWorldTotalMin( ) );
 			break;
 		case EVENT_DAY2_ADD_EMAIL_FROM_IMP:
-			// the parameter is the voice id of the character being reported on
+			// the parameter is the profile of the character being reported on
 			AddEmailWithSpecialData(IMP_EMAIL_PROFILE_RESULTS, IMP_EMAIL_PROFILE_RESULTS_LENGTH, IMP_PROFILE_RESULTS, GetWorldTotalMin( ), pEvent->uiParam, 0 );
 			break;
 		//If a merc gets hired and they dont show up immediately, the merc gets added to the queue and shows up

--- a/src/game/Strategic/Game_Event_Hook.cc
+++ b/src/game/Strategic/Game_Event_Hook.cc
@@ -124,7 +124,8 @@ BOOLEAN ExecuteStrategicEvent( STRATEGICEVENT *pEvent )
 			AddEmail(MERC_INTRO, MERC_INTRO_LENGTH, SPECK_FROM_MERC, GetWorldTotalMin( ) );
 			break;
 		case EVENT_DAY2_ADD_EMAIL_FROM_IMP:
-			AddEmail(IMP_EMAIL_PROFILE_RESULTS, IMP_EMAIL_PROFILE_RESULTS_LENGTH, IMP_PROFILE_RESULTS, GetWorldTotalMin( ) );
+			// the parameter is the voice id of the character being reported on
+			AddEmailWithSpecialData(IMP_EMAIL_PROFILE_RESULTS, IMP_EMAIL_PROFILE_RESULTS_LENGTH, IMP_PROFILE_RESULTS, GetWorldTotalMin( ), pEvent->uiParam, 0 );
 			break;
 		//If a merc gets hired and they dont show up immediately, the merc gets added to the queue and shows up
 		// uiTimeTillMercArrives  minutes later

--- a/src/game/Tactical/Merc_Hiring.cc
+++ b/src/game/Tactical/Merc_Hiring.cc
@@ -370,21 +370,25 @@ bool IsMercDead(MERCPROFILESTRUCT const& p)
 }
 
 
-/* Whether someone already on the ground speaks with this merc's voice. Several
- * player generated characters may be given the same one, and they then share
- * every recording, so anything both of them say is the second one repeating the
- * first word for word. */
-static bool VoiceHasAlreadyLanded(SOLDIERTYPE const& s)
+/* Whether this merc is the one that speaks for its voice. Several player
+ * generated characters may be given the same voice, and a voice is one set of
+ * recordings, so letting each of them talk plays the same line back twice over.
+ * A whole team is dropped from the helicopter at once, which leaves no "who
+ * spoke first" to go by, so the lowest numbered profile sharing a voice speaks
+ * for it: exactly one character of each voice talks, in any order of dropping,
+ * and every voice on the team is heard. */
+static bool SpeaksForItsVoice(SOLDIERTYPE const& s)
 {
 	UINT8 const ubVoiceId = GetProfile(s.ubProfile).ubVoiceId;
 	FOR_EACH_IN_TEAM(other, OUR_TEAM)
 	{
 		if (other == &s) continue;
-		// still on its way, so it has not said anything yet
+		// still on its way, so not part of this arrival
 		if (other->bAssignment == IN_TRANSIT) continue;
-		if (GetProfile(other->ubProfile).ubVoiceId == ubVoiceId) return true;
+		if (GetProfile(other->ubProfile).ubVoiceId != ubVoiceId) continue;
+		if (other->ubProfile < s.ubProfile) return false;
 	}
-	return false;
+	return true;
 }
 
 
@@ -393,12 +397,11 @@ void HandleMercArrivesQuotes(SOLDIERTYPE& s)
 	// If we are approaching with helicopter, don't say any ( yet )
 	if (s.ubStrategicInsertionCode == INSERTION_CODE_CHOPPER) return;
 
-	// Player-generated characters issue a comment about arriving in Omerta, but
-	// only the first of a voice to land: the rest would be playing the same
-	// recording back.
+	// Player-generated characters issue a comment about arriving in Omerta, one
+	// character per voice: the others would be playing the same recording back.
 	if (s.ubWhatKindOfMercAmI == MERC_TYPE__PLAYER_CHARACTER &&
 		gubQuest[QUEST_DELIVER_LETTER] == QUESTINPROGRESS &&
-		!VoiceHasAlreadyLanded(s))
+		SpeaksForItsVoice(s))
 	{
 		TacticalCharacterDialogue(&s, QUOTE_PC_DROPPED_OMERTA);
 	}

--- a/src/game/Tactical/Merc_Hiring.cc
+++ b/src/game/Tactical/Merc_Hiring.cc
@@ -370,14 +370,35 @@ bool IsMercDead(MERCPROFILESTRUCT const& p)
 }
 
 
+/* Whether someone already on the ground speaks with this merc's voice. Several
+ * player generated characters may be given the same one, and they then share
+ * every recording, so anything both of them say is the second one repeating the
+ * first word for word. */
+static bool VoiceHasAlreadyLanded(SOLDIERTYPE const& s)
+{
+	UINT8 const ubVoiceId = GetProfile(s.ubProfile).ubVoiceId;
+	FOR_EACH_IN_TEAM(other, OUR_TEAM)
+	{
+		if (other == &s) continue;
+		// still on its way, so it has not said anything yet
+		if (other->bAssignment == IN_TRANSIT) continue;
+		if (GetProfile(other->ubProfile).ubVoiceId == ubVoiceId) return true;
+	}
+	return false;
+}
+
+
 void HandleMercArrivesQuotes(SOLDIERTYPE& s)
 {
 	// If we are approaching with helicopter, don't say any ( yet )
 	if (s.ubStrategicInsertionCode == INSERTION_CODE_CHOPPER) return;
 
-	// Player-generated characters issue a comment about arriving in Omerta.
+	// Player-generated characters issue a comment about arriving in Omerta, but
+	// only the first of a voice to land: the rest would be playing the same
+	// recording back.
 	if (s.ubWhatKindOfMercAmI == MERC_TYPE__PLAYER_CHARACTER &&
-		gubQuest[QUEST_DELIVER_LETTER] == QUESTINPROGRESS)
+		gubQuest[QUEST_DELIVER_LETTER] == QUESTINPROGRESS &&
+		!VoiceHasAlreadyLanded(s))
 	{
 		TacticalCharacterDialogue(&s, QUOTE_PC_DROPPED_OMERTA);
 	}

--- a/src/game/Tactical/Soldier_Control.cc
+++ b/src/game/Tactical/Soldier_Control.cc
@@ -6004,7 +6004,7 @@ no_sub:
 	ST::string basename;
 	if (s->ubProfile != NO_PROFILE)
 	{
-		basename = ST::format("{03d}", s->ubProfile);
+		basename = ST::format("{03d}", GetProfile(s->ubProfile).ubVoiceId);
 	}
 	else
 	{

--- a/src/game/Tactical/Soldier_Profile.cc
+++ b/src/game/Tactical/Soldier_Profile.cc
@@ -127,6 +127,11 @@ void LoadMercProfiles()
 		{
 			MERCPROFILESTRUCT& p = gMercProfiles[i];
 
+			// Voice independent of ID num, default is the profile ID. Must
+			// precede the dialogue check below, which looks up the text file
+			// by voice.
+			p.ubVoiceId = i;
+
 			// // dumping std inventory
 			// printf("%03d/%s\n", i, p.zNickname.c_str());
 			// FOR_EACH(UINT16, k, p.inv)

--- a/src/game/Tactical/Soldier_Profile_Type.h
+++ b/src/game/Tactical/Soldier_Profile_Type.h
@@ -237,6 +237,10 @@ struct MERCPROFILESTRUCT
 	UINT16 usMouthY;
 	UINT32 uiBlinkFrequency{ 3000 };
 	UINT32 uiExpressionFrequency{ 2000 };
+	/* Voice: the profile whose speech, dialogue text and battle sounds this
+	 * character uses. Independent of the character's own ID, like ubFaceIndex,
+	 * and defaults to it on profile load. */
+	UINT8 ubVoiceId{};
 
 	ST::string PANTS;
 	ST::string VEST;

--- a/src/game/Tactical/Soldier_Profile_Type.h
+++ b/src/game/Tactical/Soldier_Profile_Type.h
@@ -216,6 +216,15 @@ enum HatedSlot
 	NUM_HATED_SLOTS
 };
 
+/* Whether a profile the data marks as an I.M.P. slot holds a player generated
+ * character. There is no "being built" state: that character is always the
+ * first free slot, which stays the same one across a save and load. */
+enum class IMPSlotState : UINT8
+{
+	FREE,
+	TAKEN
+};
+
 struct MERCPROFILESTRUCT
 {
 	ST::string zName;
@@ -241,9 +250,9 @@ struct MERCPROFILESTRUCT
 	 * character uses. Independent of the character's own ID, like ubFaceIndex,
 	 * and defaults to it on profile load. */
 	UINT8 ubVoiceId{};
-	/* I.M.P.: whether a player generated character is being built in this
-	 * profile, or has been. Only ever set on profiles of type IMP. */
-	UINT8 ubIMPSlotState{};
+	/* I.M.P.: whether a player generated character holds this profile. Only
+	 * ever set on profiles of type IMP. */
+	IMPSlotState impSlotState{ IMPSlotState::FREE };
 
 	ST::string PANTS;
 	ST::string VEST;
@@ -394,15 +403,6 @@ static inline bool HasSkillTrait(MERCPROFILESTRUCT const& p, SkillTrait const sk
 {
 	return p.bSkillTrait == skill || p.bSkillTrait2 == skill;
 }
-
-
-// The following values are used with the 'ubIMPSlotState' variable
-
-// No player generated character lives here. The character being built, if any,
-// is always the first free slot, so being part way through needs no state.
-#define IMP_SLOT_FREE						0
-// A finished character holds this profile for the rest of the campaign
-#define IMP_SLOT_TAKEN						1
 
 
 #define TIME_BETWEEN_HATED_COMPLAINTS				24

--- a/src/game/Tactical/Soldier_Profile_Type.h
+++ b/src/game/Tactical/Soldier_Profile_Type.h
@@ -241,6 +241,9 @@ struct MERCPROFILESTRUCT
 	 * character uses. Independent of the character's own ID, like ubFaceIndex,
 	 * and defaults to it on profile load. */
 	UINT8 ubVoiceId{};
+	/* I.M.P.: whether a player generated character is being built in this
+	 * profile, or has been. Only ever set on profiles of type IMP. */
+	UINT8 ubIMPSlotState{};
 
 	ST::string PANTS;
 	ST::string VEST;
@@ -391,6 +394,15 @@ static inline bool HasSkillTrait(MERCPROFILESTRUCT const& p, SkillTrait const sk
 {
 	return p.bSkillTrait == skill || p.bSkillTrait2 == skill;
 }
+
+
+// The following values are used with the 'ubIMPSlotState' variable
+
+// No player generated character lives here. The character being built, if any,
+// is always the first free slot, so being part way through needs no state.
+#define IMP_SLOT_FREE						0
+// A finished character holds this profile for the rest of the campaign
+#define IMP_SLOT_TAKEN						1
 
 
 #define TIME_BETWEEN_HATED_COMPLAINTS				24


### PR DESCRIPTION
As per #2454 (and taking #1516 into account), I submit for your consideration this PR that adds the option to create up to six IMPs. why six? why not over 9000? because there are only six voices, three male, three female, and each occupy one merc slot. to anything up to six IMPs is simple, more would be rather... hard.

this feature is gated: the max num of custom characters mus be set to 6 in the game.json

faces that were chosen for an IMP become unavailable for subsequent IMPs. same for voices. once three male IMPs are created, new IMPs can only be female (and vice versa) until all six IMPs are created, then the xep624 code is simply no longer accepted.

disclaimer: the actual code is written by claude code. I have playtested the changes.

below this line you can find an AI-generated summary:

---

Closes #1516.

Adds an `imp.max_characters` policy that lets a campaign hold more than one
self-made merc. It defaults to `1`, so nothing changes unless the option is set.

## Why six is the ceiling

The I.M.P. site was gated by a single `fIMPCompletedFlag`, but the real limit
behind that flag is the profile slots. Player generated characters occupy one
block of male voice slots followed by one block of female ones, indexed by
`PLAYER_GENERATED_CHARACTER_ID + iVoiceId`, and a finished character keeps its
slot for the rest of the campaign. There are three voices per gender, so the
hard ceiling is three men and three women. `imp.max_characters` accepts 1 to 6
and clamps anything else with a warning.

## What the change does

`fIMPCompletedFlag` is replaced by a `ubIMPCreatedSlots` bitmask recording which
slots are spoken for. Everything that used to ask whether an I.M.P. exists now
asks whether another one may be created. The flag itself is kept as "at least
one has been made", which is all the laptop's nag e-mail uses it for.

The profiling screens will not hand out anything an earlier character already
owns:

- the voice and portrait arrows step over taken entries, and both screens open
  on a free one instead of on whatever the previous character left behind
- a gender whose three slots are gone cannot be picked, and when only one gender
  still has room it is preselected, so the player is not left clicking a dead box
- once every slot is filled the activation code is no longer accepted

Portraits are not tracked separately. There are eight per gender against three
slots, and the face each created character ended up with already says which ones
are gone, so `IsIMPPortraitTaken` reads them back out of `gMercProfiles`.

Restoring a merc by nickname writes straight into its old slot, so the saved
voice id is now read up front, without disturbing `gMercProfiles`, and the
restore is rejected if that slot is occupied. The same path also clears
`fLoadingCharacterForPreviousImpProfile` on entry, which otherwise leaked from an
earlier import and robbed the next I.M.P. of its starting gear.

## The results e-mail

`HandleIMPCharProfileResultsMessage` rendered from whichever character
`iVoiceId` and `iPortraitNumber` happened to point at when the mail was opened,
so with more than one I.M.P. every report described the newest merc. The mail now
carries the voice id of the character it reports on, handed to it through the
strategic event that delivers it two days later, and takes the portrait from that
character's profile. Mails saved before this carry a zero, which is only treated
as a voice id when an I.M.P. actually holds that slot.

## Save compatibility

The mask goes into one of the bytes the laptop save block was already skipping,
so the save format is unchanged in size. What that byte holds in an older save
cannot be trusted, so it is only believed when it agrees with `iVoiceId`, which
back when one I.M.P. was the limit pointed at that one character. Anything else
is reconstructed from `iVoiceId` alone.

## Testing

- `.ci/ci-build.sh` green, 132/132 unit tests pass
- clean start with `resversion` GERMAN at `max_characters: 6`; the clamp warning
  confirmed firing at `9`
- played: created several I.M.P.s in one campaign, checked that taken voices and
  portraits are skipped, that a full gender cannot be selected, that the code is
  refused once all six exist, and that each report e-mail describes its own merc

## One open question

The issue suggests naming the option `max_imp_mercs`. This PR puts it at
`imp.max_characters` instead, since `game.json` already has an `imp` block that
holds the other I.M.P. settings. Happy to rename it if you would rather it match
the issue.
