### PR TITLE
Inventory for the Hummer and Ice Cream Truck

### DIFF
--- a/assets/externalized/game.json
+++ b/assets/externalized/game.json
@@ -135,6 +135,12 @@
   //  vanilla setting: false
   "extra_attachments": false,
 
+  //  Gives the hummer and the ice cream truck a cargo hold of eighteen slots, opened from
+  //  the mapscreen while the vehicle is the selected character. Cargo travels with the
+  //  vehicle and is tipped onto the ground if it is destroyed.
+  //  vanilla setting: false
+  "vehicle_cargo": false,
+
   //  Packages at Drassen airport never get stolen, no need to bribe Pablo.
   //  vanilla_setting: false
   "pablo_wont_steal": false,

--- a/src/externalized/policy/DefaultGamePolicy.cc
+++ b/src/externalized/policy/DefaultGamePolicy.cc
@@ -44,6 +44,7 @@ DefaultGamePolicy::DefaultGamePolicy(const JsonValue& json)
 	gui_extras = gp.getOptionalBool("gui_extras", true);
 	informative_tooltips = gp.getOptionalBool("informative_tooltips", false);
 	extra_attachments = gp.getOptionalBool("extra_attachments");
+	vehicle_cargo = gp.getOptionalBool("vehicle_cargo", false);
 	skip_sleep_explanation = gp.getOptionalBool("skip_sleep_explanation");
 
 	pablo_wont_steal = gp.getOptionalBool("pablo_wont_steal");

--- a/src/externalized/policy/GamePolicy.h
+++ b/src/externalized/policy/GamePolicy.h
@@ -122,6 +122,8 @@ public:
 	uint16_t start_sector;        // Starting sector
 	bool reveal_start_sector;     // Should the start sector radar map be shown at start
 
+	bool vehicle_cargo;           // Let the hummer and the ice cream truck carry cargo of their own
+
 	uint8_t suppression_fire_modifier; // Scales AP loss from suppression (numerator of the AP-loss formula); vanilla 6, 0 disables AP loss
 	uint16_t suppression_fire_reaction_threshold; // Numerator of the stance-reaction threshold; vanilla 130, 0 = always react (1.13 behaviour), higher = more resistant
 

--- a/src/game/GameVersion.h
+++ b/src/game/GameVersion.h
@@ -17,6 +17,6 @@ extern const char g_version_number[16];
 //	you will invalidate the saved game file
 //
 
-constexpr UINT32 SAVE_GAME_VERSION = 103;
+constexpr UINT32 SAVE_GAME_VERSION = 104;
 
 #endif

--- a/src/game/Strategic/MapScreen.cc
+++ b/src/game/Strategic/MapScreen.cc
@@ -76,6 +76,7 @@
 #include "Timer_Control.h"
 #include "Town_Militia.h"
 #include "TownModel.h"
+#include "Vehicles.h"
 #include "Video.h"
 #include "VObject.h"
 #include "VObject_Blitters.h"
@@ -3453,17 +3454,39 @@ static void MAPInvMoveCamoCallback(MOUSE_REGION* pRegion, UINT32 iReason);
 void CreateDestroyMapInvButton()
 {
 	static BOOLEAN fOldShowInventoryFlag=FALSE;
+	static BOOLEAN fOldVehiclePanel=FALSE;
+
+	/* A vehicle's cargo grid and a merc's paper doll are two different panels in the
+	 * same place, so switching the selection from one to the other has to swap the
+	 * mouse regions over as well as redraw. */
+	BOOLEAN const fVehiclePanel = fShowInventoryFlag && GetStashVehicleForSoldier(GetSelectedInfoChar()) != NULL;
+
+	if (fShowInventoryFlag && fOldShowInventoryFlag && fVehiclePanel != fOldVehiclePanel)
+	{
+		// tear the old panel down and let the branch below build the other one
+		if (fOldVehiclePanel) CreateDestroyVehicleStashSlots(FALSE);
+		else                  ShutdownInvSlotInterface();
+		fOldShowInventoryFlag = FALSE;
+	}
 
 	if( fShowInventoryFlag && !fOldShowInventoryFlag )
 	{
 		// create inventory button
 		fOldShowInventoryFlag=TRUE;
+		fOldVehiclePanel=fVehiclePanel;
 		// disable allmouse regions in this space
 		fTeamPanelDirty=TRUE;
 
-		INV_REGION_DESC gSCamoXY = {INV_BODY_X, INV_BODY_Y};
+		if (fVehiclePanel)
+		{
+			CreateDestroyVehicleStashSlots(TRUE);
+		}
+		else
+		{
+			INV_REGION_DESC gSCamoXY = {INV_BODY_X, INV_BODY_Y};
 
-		InitInvSlotInterface(g_ui.m_invSlotPositionMap, &gSCamoXY, MAPInvMoveCallback, MouseCallbackPrimarySecondary(MAPInvClickCallbackPrimary, MAPInvClickCallbackSecondary, MAPInvClickCallbackCancelMessage), MAPInvMoveCamoCallback, MAPInvClickCamoCallback);
+			InitInvSlotInterface(g_ui.m_invSlotPositionMap, &gSCamoXY, MAPInvMoveCallback, MouseCallbackPrimarySecondary(MAPInvClickCallbackPrimary, MAPInvClickCallbackSecondary, MAPInvClickCallbackCancelMessage), MAPInvMoveCamoCallback, MAPInvClickCamoCallback);
+		}
 		gMPanelRegion.Enable();
 
 		// switch hand region help text to "Exit Inventory"
@@ -3475,8 +3498,10 @@ void CreateDestroyMapInvButton()
 	else if( !fShowInventoryFlag && fOldShowInventoryFlag )
 	{
 		// destroy inventory button
-		ShutdownInvSlotInterface( );
+		if (fOldVehiclePanel) CreateDestroyVehicleStashSlots(FALSE);
+		else                  ShutdownInvSlotInterface( );
 		fOldShowInventoryFlag=FALSE;
+		fOldVehiclePanel=FALSE;
 		fTeamPanelDirty=TRUE;
 		gMPanelRegion.Disable();
 
@@ -4983,6 +5008,10 @@ static void RenderTeamRegionBackground()
 		DisplayCharacterList();
 		DisplayIconsForMercsAsleep();
 	}
+	else if (GetStashVehicleForSoldier(GetSelectedInfoChar()) != NULL)
+	{
+		BltVehicleStashPanel();
+	}
 	else
 	{
 		BltCharInvPanel();
@@ -5899,26 +5928,50 @@ static void UpdateStatusOfMapSortButtons(void)
 static void DoneInventoryMapBtnCallback(GUI_BUTTON* btn, UINT32 reason);
 
 
+/* The trash can and the key ring are painted into mapinv.sti, so they only exist as
+ * pictures while the paper doll is on screen.  The vehicle cargo panel does not blit
+ * that background, so creating their regions there would leave invisible click
+ * targets sitting on top of the cargo slots.  Follows the selection so that
+ * switching between a merc and a vehicle swaps them in and out. */
+static void CreateDestroyMercInventoryFurniture(BOOLEAN const fWanted)
+{
+	static BOOLEAN fCreated = FALSE;
+
+	if (fWanted && !fCreated)
+	{
+		fCreated = TRUE;
+
+		// trash can
+		MSYS_DefineRegion( &gTrashCanRegion, 	TRASH_CAN_X, TRASH_CAN_Y, TRASH_CAN_X + TRASH_CAN_WIDTH, TRASH_CAN_Y + TRASH_CAN_HEIGHT , MSYS_PRIORITY_HIGHEST - 4 ,
+					MSYS_NO_CURSOR, TrashCanMoveCallback, TrashCanBtnCallback );
+		gTrashCanRegion.SetFastHelpText(pMiscMapScreenMouseRegionHelpText[1]);
+
+		InitMapKeyRingInterface( KeyRingItemPanelButtonCallback );
+	}
+	else if (!fWanted && fCreated)
+	{
+		fCreated = FALSE;
+		MSYS_RemoveRegion( &gTrashCanRegion );
+		ShutdownKeyRingInterface( );
+	}
+}
+
+
 static void CreateDestroyTrashCanRegion(void)
 {
 	static BOOLEAN fCreated = FALSE;
+
+	CreateDestroyMercInventoryFurniture(fShowInventoryFlag &&
+		GetStashVehicleForSoldier(GetSelectedInfoChar()) == NULL);
 
 	if (fShowInventoryFlag && !fCreated)
 	{
 
 		fCreated = TRUE;
 
-		// trash can
-		MSYS_DefineRegion( &gTrashCanRegion, 	TRASH_CAN_X, TRASH_CAN_Y, TRASH_CAN_X + TRASH_CAN_WIDTH, TRASH_CAN_Y + TRASH_CAN_HEIGHT , MSYS_PRIORITY_HIGHEST - 4 ,
-					MSYS_NO_CURSOR, TrashCanMoveCallback, TrashCanBtnCallback );
-
 		// done inventory button define
 		giMapInvDoneButton = QuickCreateButtonImg(INTERFACEDIR "/done_button2.sti", 0, 1, INV_BTN_X, INV_BTN_Y, MSYS_PRIORITY_HIGHEST - 1, DoneInventoryMapBtnCallback);
 		giMapInvDoneButton->SetFastHelpText(pMiscMapScreenMouseRegionHelpText[2]);
-
-		gTrashCanRegion.SetFastHelpText(pMiscMapScreenMouseRegionHelpText[1]);
-
-		InitMapKeyRingInterface( KeyRingItemPanelButtonCallback );
 
 			// reset the compatable item array at this point
 		ResetCompatibleItemArray( );
@@ -5926,14 +5979,10 @@ static void CreateDestroyTrashCanRegion(void)
 	}
 	else if (!fShowInventoryFlag && fCreated)
 	{
-		// trash can region
 		fCreated = FALSE;
-		MSYS_RemoveRegion( &gTrashCanRegion );
 
 		// map inv done button
 		RemoveButton( giMapInvDoneButton );
-
-		ShutdownKeyRingInterface( );
 
 		if (fShowDescriptionFlag)
 		{
@@ -6649,8 +6698,10 @@ static bool CanToggleSelectedCharInventory()
 	// nobody selected?
 	if (pSoldier == NULL) return FALSE;
 
-	// does the selected guy have inventory and can we get at it?
-	if (!MapCharacterHasAccessibleInventory(*pSoldier)) return FALSE;
+	// does the selected guy have inventory and can we get at it?  A vehicle has no
+	// pockets but may have cargo, which opens in the same panel slot.
+	if (!MapCharacterHasAccessibleInventory(*pSoldier) &&
+		GetStashVehicleForSoldier(pSoldier) == NULL) return FALSE;
 
 	// if not in inventory, and holding an item from sector inventory
 	if( !fShowInventoryFlag &&
@@ -7007,7 +7058,8 @@ void ChangeSelectedInfoChar( INT8 bCharNumber, BOOLEAN fResetSelectedList )
 		if ( fShowInventoryFlag )
 		{
 			// and we're changing to nobody or a guy whose inventory can't be accessed
-			if (!s || !MapCharacterHasAccessibleInventory(*s))
+			if (!s || (!MapCharacterHasAccessibleInventory(*s) &&
+					GetStashVehicleForSoldier(s) == NULL))
 			{
 				// then get out of inventory mode
 				fShowInventoryFlag = FALSE;

--- a/src/game/Strategic/Map_Screen_Interface.cc
+++ b/src/game/Strategic/Map_Screen_Interface.cc
@@ -55,6 +55,7 @@
 #include "Text.h"
 #include "Timer_Control.h"
 #include "TownModel.h"
+#include "Vehicles.h"
 #include "Video.h"
 #include "VObject.h"
 #include "VSurface.h"
@@ -1441,7 +1442,8 @@ static bool ValidSelectableCharForNextOrPrev(SOLDIERTYPE const& s)
 	return
 		/* If showing merc inventory or holding an item, then the new guy must have
 			* accessible inventory */
-		((!holding_item && !fShowInventoryFlag) || MapCharacterHasAccessibleInventory(s)) &&
+		((!holding_item && !fShowInventoryFlag) || MapCharacterHasAccessibleInventory(s) ||
+			GetStashVehicleForSoldier(&s) != NULL) &&
 		(!holding_item || MapscreenCanPassItemToChar(&s));
 }
 

--- a/src/game/Strategic/Map_Screen_Interface_Map_Inventory.cc
+++ b/src/game/Strategic/Map_Screen_Interface_Map_Inventory.cc
@@ -12,6 +12,7 @@
 #include "Object_Cache.h"
 #include "Timer_Control.h"
 #include "VObject.h"
+#include "VObject_Blitters.h"
 #include "SysUtil.h"
 #include "Map_Screen_Interface_Border.h"
 #include "Map_Screen_Interface.h"
@@ -24,6 +25,7 @@
 #include "StrategicMap.h"
 #include "World_Items.h"
 #include "Tactical_Save.h"
+#include "Vehicles.h"
 #include "Soldier_Control.h"
 #include "English.h"
 #include "MapScreen.h"
@@ -1360,4 +1362,267 @@ static BOOLEAN CanPlayerUseSectorInventory(void)
 		sSelMap.x           != sector.x ||
 		sSelMap.y           != sector.y ||
 		iCurrentMapSectorZ != sector.z;
+}
+
+
+/* ------------------------------------------------------------------------- *
+ * Vehicle cargo panel
+ *
+ * A vehicle carries its cargo in VEHICLETYPE::stash rather than in the inventory
+ * of the SOLDIERTYPE that represents it, so none of the merc pocket rules apply:
+ * every cargo slot behaves like a big pocket.  The panel takes over the team
+ * panel while a vehicle is the selected character, and is deliberately plain -
+ * a truck has no head, hands, armour or camouflage to draw.
+ * ------------------------------------------------------------------------- */
+
+/* The cargo grid is drawn with the sector inventory's own slot artwork.  That
+ * artwork is baked into the one big sector_inventory.sti background rather than
+ * being a sub-image we could blit on its own, so the background is blitted with a
+ * clipping rectangle over the target grid and an offset that lines its slot lattice
+ * up with ours.  That fixes the cell size at the sector inventory's 72x32, which is
+ * what makes the grid three columns of six rather than two columns of nine. */
+#define VEHICLE_STASH_COLS 3
+#define VEHICLE_STASH_ROWS (VEHICLE_STASH_SLOTS / VEHICLE_STASH_COLS)
+
+// Where the slot lattice sits inside sector_inventory.sti itself.
+#define VEHICLE_STASH_SRC_X (g_sector_inv_slot_box.x - g_sector_inv_box.x)
+#define VEHICLE_STASH_SRC_Y (g_sector_inv_slot_box.y - g_sector_inv_box.y)
+
+// panel backdrop, behind and around the borrowed slot artwork
+#define VEHICLE_STASH_PANEL_COLOR FROMRGB( 24,  22,  18)
+
+// The team panel the grid takes over, and the grid centred inside it.  The cells
+// themselves keep the sector inventory's geometry so the artwork lines up.
+static const SGPBox g_vehicle_stash_box       = {   0, 107, 261, 252 };
+static const SGPBox g_vehicle_stash_title_box = {   5, 108, 251,  13 };
+// The grid stops short of INV_BTN_Y, where the done button sits.
+static const SGPBox g_vehicle_stash_grid_box  = {  22, 122, VEHICLE_STASH_COLS * 72, VEHICLE_STASH_ROWS * 32 };
+
+static MOUSE_REGION VehicleStashSlots[VEHICLE_STASH_SLOTS];
+static MOUSE_REGION VehicleStashMask;
+
+
+// the vehicle the cargo panel is currently showing, if any
+static VEHICLETYPE* GetPanelVehicle(void)
+{
+	return GetStashVehicleForSoldier(GetSelectedInfoChar());
+}
+
+
+// Cargo can only be handled while the vehicle is parked in the sector on display,
+// for the same reason the sector inventory insists the merc be standing in it.
+static bool IsVehicleParkedInSelectedSector(SOLDIERTYPE const& vs)
+{
+	return
+		vs.sSector.x == sSelMap.x &&
+		vs.sSector.y == sSelMap.y &&
+		vs.sSector.z == iCurrentMapSectorZ &&
+		!vs.fBetweenSectors;
+}
+
+
+static void VehicleStashSlotOrigin(INT32 const slot, INT32* const px, INT32* const py)
+{
+	const SGPBox* const gb = &g_vehicle_stash_grid_box;
+	const SGPBox* const sb = &g_sector_inv_slot_box;
+	*px = STD_SCREEN_X + gb->x + sb->w * (slot / VEHICLE_STASH_ROWS);
+	*py = STD_SCREEN_Y + gb->y + sb->h * (slot % VEHICLE_STASH_ROWS);
+}
+
+
+// Borrow the empty slot lattice out of the sector inventory background.
+static void BltVehicleStashSlotFrames(void)
+{
+	const SGPBox* const gb = &g_vehicle_stash_grid_box;
+	const INT32 x = STD_SCREEN_X + gb->x;
+	const INT32 y = STD_SCREEN_Y + gb->y;
+
+	SGPRect clip;
+	clip.set(x, y, x + gb->w, y + gb->h);
+	SGPRect const old_clip = SetClippingRect(clip);
+
+	// offset the background so its lattice origin lands on ours
+	BltVideoObject(guiSAVEBUFFER, guiMapInventoryPoolBackground, 0,
+		x - VEHICLE_STASH_SRC_X, y - VEHICLE_STASH_SRC_Y);
+
+	SetClippingRect(old_clip);
+}
+
+
+static void RenderVehicleStashSlot(VEHICLETYPE const& v, INT32 const slot, bool const reachable)
+{
+	OBJECTTYPE const& o = v.stash[slot];
+	if (o.ubNumberOfObjects == 0) return;
+
+	INT32 dx;
+	INT32 dy;
+	VehicleStashSlotOrigin(slot, &dx, &dy);
+
+	// the item, positioned in the cell exactly as the sector inventory positions its own
+	const SGPBox* const ib = &g_sector_inv_item_box;
+	INVRenderItem(guiSAVEBUFFER, NULL, o, dx + ib->x, dy + ib->y, ib->w, ib->h, DIRTYLEVEL2, 0, SGP_TRANSPARENT);
+
+	// condition bar down the left edge
+	const UINT16 col0 = Get16BPPColor(DESC_STATUS_BAR);
+	const UINT16 col1 = Get16BPPColor(DESC_STATUS_BAR_SHADOW);
+	const SGPBox* const bb = &g_sector_inv_bar_box;
+	DrawItemUIBarEx(o, 0, dx + bb->x, dy + bb->y + bb->h - 1, bb->h, col0, col1, guiSAVEBUFFER);
+
+	// out of reach - the vehicle is parked somewhere else
+	if (!reachable) DrawHatchOnInventory(guiSAVEBUFFER, dx + ib->x, dy + ib->y, ib->w, ib->h);
+
+	// the name, on the label strip the borrowed artwork already provides
+	const SGPBox* const nb = &g_sector_inv_name_box;
+	auto const sString = ReduceStringLength(GCM->getItem(o.usItem)->getShortName(), nb->w, MAP_IVEN_FONT);
+	SetFontAttributes(MAP_IVEN_FONT, FONT_WHITE);
+	MPrintCenteredInBox(dx, dy, sString, *nb);
+}
+
+
+static void UpdateHelpTextForVehicleStashSlots(VEHICLETYPE const& v)
+{
+	for (INT32 i = 0; i != VEHICLE_STASH_SLOTS; ++i)
+	{
+		OBJECTTYPE const& o = v.stash[i];
+		ST::string help;
+		if (o.ubNumberOfObjects > 0) help = GetHelpTextForItem(o);
+		VehicleStashSlots[i].SetFastHelpText(help);
+	}
+}
+
+
+void BltVehicleStashPanel(void)
+{
+	VEHICLETYPE const* const v = GetPanelVehicle();
+	if (v == NULL) return;
+
+	const SGPBox* const box = &g_vehicle_stash_box;
+	const INT32 x = STD_SCREEN_X + box->x;
+	const INT32 y = STD_SCREEN_Y + box->y;
+	ColorFillVideoSurfaceArea(guiSAVEBUFFER, x, y, x + box->w, y + box->h, Get16BPPColor(VEHICLE_STASH_PANEL_COLOR));
+
+	BltVehicleStashSlotFrames();
+
+	SetFontDestBuffer(guiSAVEBUFFER);
+
+	// the vehicle's name across the top, where the team list header would be
+	SetFontAttributes(BLOCKFONT2, FONT_WHITE);
+	MPrintCenteredInBox(STD_SCREEN_X, STD_SCREEN_Y, pVehicleStrings[v->ubVehicleType], g_vehicle_stash_title_box);
+
+	SOLDIERTYPE const* const vs = GetSelectedInfoChar();
+	const bool reachable = vs != NULL && IsVehicleParkedInSelectedSector(*vs) && CanPlayerUseSectorInventory();
+
+	for (INT32 i = 0; i != VEHICLE_STASH_SLOTS; ++i)
+	{
+		RenderVehicleStashSlot(*v, i, reachable);
+	}
+
+	SetFontDestBuffer(FRAME_BUFFER);
+
+	UpdateHelpTextForVehicleStashSlots(*v);
+}
+
+
+static void VehicleStashSlotsMove(MOUSE_REGION* pRegion, UINT32 iReason);
+static void VehicleStashSlotsPrimary(MOUSE_REGION* pRegion, UINT32 iReason);
+static void VehicleStashSlotsSecondary(MOUSE_REGION* pRegion, UINT32 iReason);
+
+
+void CreateDestroyVehicleStashSlots(BOOLEAN const fCreate)
+{
+	static BOOLEAN fCreated = FALSE;
+
+	if (fCreate && !fCreated)
+	{
+		fCreated = TRUE;
+
+		// mask the team panel underneath so its rows cannot be clicked through
+		const SGPBox* const box = &g_vehicle_stash_box;
+		const UINT16 mx = STD_SCREEN_X + box->x;
+		const UINT16 my = STD_SCREEN_Y + box->y;
+		MSYS_DefineRegion(&VehicleStashMask, mx, my, mx + box->w - 1, my + box->h - 1, MSYS_PRIORITY_HIGH, MSYS_NO_CURSOR, MSYS_NO_CALLBACK, MSYS_NO_CALLBACK);
+
+		const SGPBox* const rb = &g_sector_inv_region_box;
+		for (INT32 i = 0; i != VEHICLE_STASH_SLOTS; ++i)
+		{
+			INT32 dx;
+			INT32 dy;
+			VehicleStashSlotOrigin(i, &dx, &dy);
+
+			MOUSE_REGION* const r = &VehicleStashSlots[i];
+			MSYS_DefineRegion(r, dx + rb->x, dy + rb->y, dx + rb->x + rb->w - 1, dy + rb->y + rb->h - 1,
+				MSYS_PRIORITY_HIGH, MSYS_NO_CURSOR, VehicleStashSlotsMove,
+				MouseCallbackPrimarySecondary(VehicleStashSlotsPrimary, VehicleStashSlotsSecondary));
+			MSYS_SetRegionUserData(r, 0, i);
+		}
+	}
+	else if (!fCreate && fCreated)
+	{
+		fCreated = FALSE;
+		FOR_EACH(MOUSE_REGION, i, VehicleStashSlots) MSYS_RemoveRegion(&*i);
+		MSYS_RemoveRegion(&VehicleStashMask);
+	}
+}
+
+
+static void VehicleStashSlotsMove(MOUSE_REGION* const pRegion, UINT32 const iReason)
+{
+	if (iReason & (MSYS_CALLBACK_REASON_GAIN_MOUSE | MSYS_CALLBACK_REASON_LOST_MOUSE))
+	{
+		fTeamPanelDirty = TRUE;
+	}
+}
+
+
+static void VehicleStashSlotsPrimary(MOUSE_REGION* const pRegion, UINT32 const iReason)
+{
+	VEHICLETYPE* const v = GetPanelVehicle();
+	if (v == NULL) return;
+
+	OBJECTTYPE& slot = v->stash[MSYS_GetRegionUserData(pRegion, 0)];
+
+	// nothing in hand and nothing in the slot
+	if (gpItemPointer == NULL && slot.usItem == NOTHING) return;
+
+	// If in battle inform player they will have to do this in tactical
+	if (!CanPlayerUseSectorInventory())
+	{
+		ST::string const& msg = gpItemPointer == NULL ? pMapInventoryErrorString[2] : pMapInventoryErrorString[3];
+		DoMapMessageBox(MSG_BOX_BASIC_STYLE, msg, MAP_SCREEN, MSG_BOX_FLAG_OK, NULL);
+		return;
+	}
+
+	SOLDIERTYPE const* const vs = GetSelectedInfoChar();
+	if (vs == NULL || !IsVehicleParkedInSelectedSector(*vs))
+	{
+		ST::string const& msg = gpItemPointer == NULL ? pMapInventoryErrorString[1] : pMapInventoryErrorString[4];
+		ST::string const buf = st_format_printf(msg, vs != NULL ? vs->name : ST::string{});
+		DoMapMessageBox(MSG_BOX_BASIC_STYLE, buf, MAP_SCREEN, MSG_BOX_FLAG_OK, NULL);
+		return;
+	}
+
+	if (gpItemPointer == NULL)
+	{
+		// cargo has no gridno of its own until it is put down somewhere
+		sObjectSourceGridNo = NOWHERE;
+		BeginInventoryPoolPtr(&slot);
+	}
+	else if (PlaceObjectInInventoryStash(&slot, gpItemPointer))
+	{
+		if (gpItemPointer->ubNumberOfObjects == 0) MAPEndItemPointer();
+		else                                      SetMapCursorItem();
+	}
+
+	fTeamPanelDirty = TRUE;
+	fMapPanelDirty  = TRUE;
+}
+
+
+static void VehicleStashSlotsSecondary(MOUSE_REGION* const pRegion, UINT32 const iReason)
+{
+	// right click leaves the cargo panel, as it leaves a merc's inventory
+	if (gpItemPointer != NULL) return;
+
+	fShowInventoryFlag = FALSE;
+	fTeamPanelDirty    = TRUE;
 }

--- a/src/game/Strategic/Map_Screen_Interface_Map_Inventory.h
+++ b/src/game/Strategic/Map_Screen_Interface_Map_Inventory.h
@@ -45,4 +45,15 @@ extern BOOLEAN fMapInventoryItemCompatable[ ];
 
 BOOLEAN IsMapScreenWorldItemVisibleInMapInventory(const WORLDITEM& wi);
 
+
+/* The vehicle cargo panel.  It takes over the team panel the same way a merc's
+ * inventory does, but draws a plain grid of cargo slots instead of the paper doll,
+ * because a truck has no head, hands or camouflage to show. */
+
+// draw the cargo grid for the currently selected vehicle
+void BltVehicleStashPanel(void);
+
+// create or tear down the cargo slot mouse regions
+void CreateDestroyVehicleStashSlots(BOOLEAN fCreate);
+
 #endif

--- a/src/game/Tactical/LoadSaveObjectType.h
+++ b/src/game/Tactical/LoadSaveObjectType.h
@@ -5,6 +5,9 @@
 #include "LoadSaveData.h"
 
 
+// Bytes one OBJECTTYPE takes up in a saved game, as written by InjectObject().
+#define SIZE_OF_SAVED_OBJECTTYPE 36
+
 void ExtractObject(DataReader& d, OBJECTTYPE* o);
 
 void InjectObject(DataWriter& d, const OBJECTTYPE* o);

--- a/src/game/Tactical/LoadSaveVehicleType.cc
+++ b/src/game/Tactical/LoadSaveVehicleType.cc
@@ -3,6 +3,7 @@
 #include "Isometric_Utils.h"
 #include "LoadSaveVehicleType.h"
 #include "LoadSaveData.h"
+#include "LoadSaveObjectType.h"
 #include "SGPFile.h"
 #include "Soldier_Control.h"
 #include "Soldier_Profile.h"
@@ -73,6 +74,17 @@ void ExtractVehicleTypeFromFile(HWFILE const file, VEHICLETYPE* const v, UINT32 
 	EXTR_BOOL(d, v->fValid)
 	EXTR_SKIP(d, 2)
 	Assert(d.getConsumed() == lengthof(data));
+
+	// Cargo was added in save version 104; older saves simply have none.
+	if (savegame_version >= 104)
+	{
+		BYTE stash_data[VEHICLE_STASH_SLOTS * SIZE_OF_SAVED_OBJECTTYPE];
+		file->read(stash_data, sizeof(stash_data));
+
+		DataReader sd{stash_data};
+		for (OBJECTTYPE& o : v->stash) ExtractObject(sd, &o);
+		Assert(sd.getConsumed() == lengthof(stash_data));
+	}
 }
 
 
@@ -107,4 +119,12 @@ void InjectVehicleTypeIntoFile(HWFILE const file, VEHICLETYPE const* const v)
 	Assert(d.getConsumed() == lengthof(data));
 
 	file->write(data, sizeof(data));
+
+	BYTE stash_data[VEHICLE_STASH_SLOTS * SIZE_OF_SAVED_OBJECTTYPE];
+
+	DataWriter sd{stash_data};
+	for (OBJECTTYPE const& o : v->stash) InjectObject(sd, &o);
+	Assert(sd.getConsumed() == lengthof(stash_data));
+
+	file->write(stash_data, sizeof(stash_data));
 }

--- a/src/game/Tactical/Vehicles.cc
+++ b/src/game/Tactical/Vehicles.cc
@@ -35,6 +35,7 @@
 
 #include "ContentManager.h"
 #include "GameInstance.h"
+#include "GamePolicy.h"
 #include "ShippingDestinationModel.h"
 #include "VehicleModel.h"
 
@@ -851,6 +852,8 @@ void NewLoadVehicleMovementInfoFromSavedGameFile(HWFILE const hFile)
 
 bool VehicleHasStash(VEHICLETYPE const& v)
 {
+	if (!gamepolicy(vehicle_cargo)) return false;
+
 	return v.ubVehicleType == HUMMER || v.ubVehicleType == ICE_CREAM_TRUCK;
 }
 

--- a/src/game/Tactical/Vehicles.cc
+++ b/src/game/Tactical/Vehicles.cc
@@ -19,6 +19,7 @@
 #include "Random.h"
 #include "Text.h"
 #include "Explosion_Control.h"
+#include "Handle_Items.h"
 #include "StrategicMap.h"
 #include "Campaign_Types.h"
 #include "Sys_Globals.h"
@@ -674,6 +675,10 @@ static void HandleCriticalHitForVehicleInLocation(const UINT8 ubID, const INT16 
 		CheckForAndHandleSoldierDeath(&vs, &fMadeCorpse);
 
 		KillAllInVehicle(v);
+
+		// The cargo survives the mercs - tip it out where the wreck stands rather
+		// than deleting it silently.
+		SpillVehicleStash(v, sGridNo, vs.bLevel);
 	}
 }
 
@@ -841,6 +846,42 @@ void NewLoadVehicleMovementInfoFromSavedGameFile(HWFILE const hFile)
 {
 	//Load in the Squad movement id's
 	hFile->read(gubVehicleMovementGroups);
+}
+
+
+bool VehicleHasStash(VEHICLETYPE const& v)
+{
+	return v.ubVehicleType == HUMMER || v.ubVehicleType == ICE_CREAM_TRUCK;
+}
+
+
+VEHICLETYPE* GetStashVehicleForSoldier(SOLDIERTYPE const* const s)
+{
+	if (s == NULL)                             return NULL;
+	if (!(s->uiStatusFlags & SOLDIER_VEHICLE)) return NULL;
+
+	/* This is asked once per frame from the mapscreen render, so check the id here
+	 * rather than letting GetVehicle() throw for a vehicle that has already been
+	 * cleaned out of the list. */
+	INT32 const id = s->bVehicleID;
+	if (id < 0 || static_cast<size_t>(id) >= pVehicleList.size()) return NULL;
+
+	VEHICLETYPE& v = pVehicleList[id];
+	if (!v.fValid || v.fDestroyed) return NULL;
+
+	return VehicleHasStash(v) ? &v : NULL;
+}
+
+
+void SpillVehicleStash(VEHICLETYPE& v, INT16 const sGridNo, UINT8 const ubLevel)
+{
+	for (OBJECTTYPE& o : v.stash)
+	{
+		if (o.ubNumberOfObjects == 0) continue;
+
+		AddItemToPool(sGridNo, &o, VISIBLE, ubLevel, 0, 0);
+		o = OBJECTTYPE{};
+	}
 }
 
 

--- a/src/game/Tactical/Vehicles.h
+++ b/src/game/Tactical/Vehicles.h
@@ -1,6 +1,7 @@
 #ifndef _VEHICLES_H
 #define _VEHICLES_H
 
+#include "Item_Types.h"
 #include "JA2Types.h"
 #include "Strategic_Movement.h"
 
@@ -9,6 +10,10 @@
 
 #define MAX_VEHICLES 10
 #define MAX_PASSENGERS_IN_VEHICLE 10
+
+// Cargo slots in the vehicles that carry a stash.  The mapscreen panel lays these
+// out as a grid; see the cargo panel in Map_Screen_Interface_Map_Inventory.cc.
+#define VEHICLE_STASH_SLOTS 18
 
 // type of vehicles
 enum{
@@ -30,6 +35,7 @@ struct VEHICLETYPE
 	UINT8   ubVehicleType; // type of vehicle
 	SGPSector sSector; // position on the Stategic Map
 	SOLDIERTYPE *pPassengers[MAX_PASSENGERS_IN_VEHICLE];
+	OBJECTTYPE stash[VEHICLE_STASH_SLOTS]; // cargo; stays empty unless VehicleHasStash()
 	UINT32  uiMovementSoundID;
 	BOOLEAN fBetweenSectors; // between sectors?
 	BOOLEAN fDestroyed;
@@ -57,6 +63,17 @@ extern std::vector<VEHICLETYPE> pVehicleList;
 
 
 void SetVehicleValuesIntoSoldierType( SOLDIERTYPE *pVehicle );
+
+/* Can the mercs load cargo into this vehicle?  The hummer and the ice cream truck can:
+ * they are enterable and they have a SOLDIERTYPE to select in the mapscreen team panel.
+ * The tank is not enterable and the helicopter has no SOLDIERTYPE at all. */
+bool VehicleHasStash(VEHICLETYPE const&);
+
+// The vehicle the selected mapscreen character stands for, iff it has a stash.
+VEHICLETYPE* GetStashVehicleForSoldier(SOLDIERTYPE const*);
+
+// Tip the cargo out onto the ground when the vehicle is destroyed.
+void SpillVehicleStash(VEHICLETYPE&, INT16 sGridNo, UINT8 ubLevel);
 
 // add vehicle to list and return id value
 INT32 AddVehicleToList(const SGPSector& sMap, INT16 sGridNo, UINT8 ubType);


### PR DESCRIPTION
In 1.13, the vehicles had an inventory. Makes sense I guess, you can just put rifles, tool boxes and bottles of beer into the trunk of the car, right? I've implemented this here too. It's less cargo space than in 1.13, 18 slots here in total. This way, I could reuse the image of the sector inventory (with cropping), and didn't have to redo it. Is there any interest in this feature? It's pretty non-vanilla, so I guess it would make sense to gate it behind a game.json flag.

these 18 slots require a new array on the vehicle "character", so  the savegame version had to be incremented to 104.

Disclaimer: the code was written by claude code.

<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/d1f88bfc-07fe-492e-ae12-8d28b89c6bac" />


Below this line is an AI written summary:

---

A squad that drives everywhere still has to carry everything it owns on its backs, and the sector inventory only helps while the mercs are standing in that sector.  Let the two enterable vehicles carry cargo of their own, so kit can be parked in the truck and driven to wherever it is next needed.

The cargo lives in VEHICLETYPE rather than in the inventory of the SOLDIERTYPE that represents the vehicle.  A merc's inv[] has nineteen slots of which only four behave as big pockets - ItemSlotLimit() and CanItemFitInPosition() decide that positionally, from the slot index - so reusing it would have meant either a four slot hold or changing the pocket rules for every merc in the game.  An array on the vehicle sidesteps both: every cargo slot takes anything, and the helicopter, which has no SOLDIERTYPE at all, cannot accidentally acquire one.

Eighteen slots are written after the vehicle's fixed record in the save, read back only for save version 104 and later, so older saves load with empty holds.

The panel takes over the team panel while a vehicle is the selected character, the same slot the paper doll uses.  It draws a plain three by six grid instead, because a truck has no head, hands, armour or camouflage to show.  The slot artwork is borrowed from the sector inventory background: that lattice is baked into one big sector_inventory.sti rather than being a sub-image, so the background is blitted under a clipping rectangle with an offset that lines its lattice up with ours.  That fixes the cell size at 72x32 and is what makes the grid three columns of six.

The trash can and the key ring are painted into mapinv.sti, so they exist as pictures only while the paper doll is up.  Creating their mouse regions over the cargo grid left invisible click targets on the slots, so they now follow the selection and are absent while the cargo panel is showing.  The done button stays in both, since it is drawn and it is how the panel is closed.

Cargo is tipped out onto the ground when the vehicle is destroyed rather than being deleted with it.