### PR TITLE
Implement SGPVSurface::ShadowRect with SDL

### DIFF
--- a/src/game/Init.cc
+++ b/src/game/Init.cc
@@ -67,9 +67,6 @@ try
 	// INit shade tables
 	BuildShadeTable( );
 
-	// INit intensity tables
-	BuildIntensityTable( );
-
 	// Initailize World
 	InitializeWorld();
 

--- a/src/sgp/Shading.cc
+++ b/src/sgp/Shading.cc
@@ -5,10 +5,8 @@
 #include <algorithm>
 #include <iterator>
 
-UINT16 IntensityTable[65536];
 UINT16 ShadeTable[65536];
 UINT16 White16BPPPalette[256];
-static float guiShadePercent = 0.48f;
 
 
 /* Builds a 16-bit color shading table. This function should be called only
@@ -34,29 +32,6 @@ void BuildShadeTable(void)
 	}
 
 	std::fill(std::begin(White16BPPPalette), std::end(White16BPPPalette), UINT16_MAX);
-}
-
-
-/* Builds a 16-bit color shading table. This function should be called only
- * after the current video adapter's pixel format is known (IE:
- * GetRgbDistribution() has been called, and the globals for masks and shifts
- * have been initialized by that function), and before any blitting is done.
- */
-void BuildIntensityTable(void)
-{
-	const float dShadedPercent = 0.80f;
-
-	for (UINT16 red = 0; red < 256; red += 4)
-	{
-		for (UINT16 green = 0; green < 256; green += 4)
-		{
-			for (UINT16 blue = 0; blue < 256; blue += 4)
-			{
-				UINT16 index = Get16BPPColor(FROMRGB(red, green, blue));
-				IntensityTable[index] = Get16BPPColor(FROMRGB(red * dShadedPercent, green * dShadedPercent, blue * dShadedPercent));
-			}
-		}
-	}
 }
 
 

--- a/src/sgp/Shading.h
+++ b/src/sgp/Shading.h
@@ -3,11 +3,15 @@
 
 #include "Types.h"
 
-void BuildShadeTable(void);
-void BuildIntensityTable(void);
-void SetShadeTablePercent(float uiShadePercent);
+inline float guiShadePercent = 0.48f;
 
-extern UINT16 IntensityTable[65536];
+void BuildShadeTable(void);
+void SetShadeTablePercent(float uiShadePercent);
+static inline float GetShadeTablePercent()
+{
+	return guiShadePercent;
+}
+
 extern UINT16 ShadeTable[65536];
 extern UINT16 White16BPPPalette[256];
 

--- a/src/sgp/VObject_Blitters.cc
+++ b/src/sgp/VObject_Blitters.cc
@@ -2194,53 +2194,6 @@ BlitNonTransLoop: // blit non-transparent pixels
 }
 
 
-void Blt16BPPBufferFilterRect(UINT16* pBuffer, UINT32 uiDestPitchBYTES, const UINT16* filter_table, SGPRect* area)
-{
-INT32  width, height;
-UINT32 LineSkip;
-UINT16 *DestPtr;
-
-	// Assertions
-	Assert( pBuffer != NULL );
-
-	// Clipping
-	if( area->iLeft < ClippingRect.iLeft )
-		area->iLeft = ClippingRect.iLeft;
-	if( area->iTop < ClippingRect.iTop )
-		area->iTop = ClippingRect.iTop;
-	if( area->iRight >= ClippingRect.iRight )
-		area->iRight = ClippingRect.iRight - 1;
-	if( area->iBottom >= ClippingRect.iBottom )
-		area->iBottom = ClippingRect.iBottom - 1;
-	//CHECKF(area->iLeft >= ClippingRect.iLeft );
-	//CHECKF(area->iTop >= ClippingRect.iTop );
-	//CHECKF(area->iRight <= ClippingRect.iRight );
-	//CHECKF(area->iBottom <= ClippingRect.iBottom );
-
-	DestPtr=(pBuffer+(area->iTop*(uiDestPitchBYTES/2))+area->iLeft);
-	width=area->iRight-area->iLeft+1;
-	height=area->iBottom-area->iTop+1;
-	LineSkip=(uiDestPitchBYTES-(width*2));
-
-	CHECKV(width  >= 1);
-	CHECKV(height >= 1);
-
-	do
-	{
-		UINT32 w = width;
-
-		do
-		{
-			*DestPtr = filter_table[*DestPtr];
-			DestPtr++;
-		}
-		while (--w > 0);
-		DestPtr = (UINT16*)((UINT8*)DestPtr + LineSkip);
-	}
-	while (--height > 0);
-}
-
-
 ClipInfo::ClipInfo(SGPVObject const * hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex, SGPRect const * clipregion)
 {
 	vobject = hSrcVObject;

--- a/src/sgp/VObject_Blitters.h
+++ b/src/sgp/VObject_Blitters.h
@@ -77,10 +77,6 @@ void Blt16BPPTo16BPP(UINT16 *pDest, UINT32 uiDestPitch, UINT16 *pSrc, UINT32 uiS
 void Blt16BPPBufferHatchRect(UINT16 *pBuffer, UINT32 uiDestPitchBYTES, SGPRect *area );
 void Blt16BPPBufferLooseHatchRectWithColor(UINT16 *pBuffer, UINT32 uiDestPitchBYTES, SGPRect *area, UINT16 usColor );
 
-/* Filter a rectangular area with the given filter table.  This is used for
- * shading. */
-void Blt16BPPBufferFilterRect(UINT16* pBuffer, UINT32 uiDestPitchBYTES, const UINT16* filter_table, SGPRect* area);
-
 void Blt8BPPDataTo16BPPBufferShadow( UINT16 *pBuffer, UINT32 uiDestPitchBYTES, HVOBJECT hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex );
 
 void Blt8BPPDataTo16BPPBuffer( UINT16 *pBuffer, UINT32 uiDestPitchBYTES, SGPVSurface* hSrcVSurface, UINT8 *pSrcBuffer, INT32 iX, INT32 iY);

--- a/src/sgp/VSurface.cc
+++ b/src/sgp/VSurface.cc
@@ -14,6 +14,34 @@
 
 extern SGPVSurface* gpVSurfaceHead;
 
+namespace {
+
+// Helper class to set a SDL surface's clipping rectangle to the equivalent
+// of JA2's global clipping rectangle. Restores the previous clipping
+// rectangle when it is destroyed.
+class ApplyClippingRect
+{
+	SDL_Surface * surface;
+	SDL_Rect oldClipRect;
+
+public:
+	ApplyClippingRect(SDL_Surface * s) : surface(s)
+	{
+          SDL_GetSurfaceClipRect(s, &oldClipRect);
+
+          SGPRect clipRect = GetClippingRect();
+          SDL_Rect newClipRect{clipRect.iLeft, clipRect.iTop,
+                               clipRect.iRight - clipRect.iLeft + 1,
+                               clipRect.iBottom - clipRect.iTop + 1};
+          SDL_SetSurfaceClipRect(s, &newClipRect);
+	}
+
+	~ApplyClippingRect()
+	{
+		SDL_SetSurfaceClipRect(surface, &oldClipRect);
+	}
+};
+}
 
 SGPVSurface::SGPVSurface(UINT16 const w, UINT16 const h, UINT8 const bpp) :
 	p16BPPPalette(),
@@ -101,43 +129,30 @@ void SGPVSurface::Fill(const UINT16 colour)
 }
 
 
-static void InternalShadowVideoSurfaceRect(SGPVSurface* const dst, INT32 X1, INT32 Y1, INT32 X2, INT32 Y2, const UINT16* const filter_table)
+static void InternalShadowVideoSurfaceRect(SDL_Surface * dst, INT32 x1, INT32 y1, INT32 x2, INT32 y2, float shadeFactor)
 {
-	if (X1 < 0) X1 = 0;
-	if (X2 < 0) return;
+	ApplyClippingRect acr{ dst };
 
-	if (Y2 < 0) return;
-	if (Y1 < 0) Y1 = 0;
+	Uint8 modF = static_cast<Uint8>(255 * shadeFactor);
+	SDL_SetSurfaceColorMod(dst, modF, modF, modF);
 
-	if (X2 >= dst->Width())  X2 = dst->Width() - 1;
-	if (Y2 >= dst->Height()) Y2 = dst->Height() - 1;
+	SDL_Rect blitRect{ x1, y1, x2 - x1 + 1, y2 - y1 + 1 };
+	SDL_BlitSurface(dst, &blitRect, dst, &blitRect);
 
-	if (X1 >= dst->Width())  return;
-	if (Y1 >= dst->Height()) return;
-
-	if (X2 - X1 <= 0) return;
-	if (Y2 - Y1 <= 0) return;
-
-	SGPRect area;
-	area.iTop    = Y1;
-	area.iBottom = Y2;
-	area.iLeft   = X1;
-	area.iRight  = X2;
-
-	SGPVSurface::Lock ldst(dst);
-	Blt16BPPBufferFilterRect(ldst.Buffer<UINT16>(), ldst.Pitch(), filter_table, &area);
+	SDL_SetSurfaceColorMod(dst, 255, 255, 255);
 }
 
 
 void SGPVSurface::ShadowRect(INT32 const x1, INT32 const y1, INT32 const x2, INT32 const y2)
 {
-	InternalShadowVideoSurfaceRect(this, x1, y1, x2, y2, ShadeTable);
+	InternalShadowVideoSurfaceRect(surface_.get(), x1, y1, x2, y2, GetShadeTablePercent());
 }
 
 
 void SGPVSurface::ShadowRectUsingLowPercentTable(INT32 const x1, INT32 const y1, INT32 const x2, INT32 const y2)
 {
-	InternalShadowVideoSurfaceRect(this, x1, y1, x2, y2, IntensityTable);
+	// 0.8 is the factor that was used to compute the IntensityTable in vanilla.
+	InternalShadowVideoSurfaceRect(surface_.get(), x1, y1, x2, y2, 0.80f);
 }
 
 


### PR DESCRIPTION
The results of this function and its cousin ShadowRectUsingLowPercentTable can be achieved by calling SDL_SetSurfaceColorMod before blitting the target rectangle onto itself.

This allows us to remove the intensity table, the function that builds it and one blitter.