### PR TITLE
Clean up Fade_Screen

### DIFF
--- a/src/game/Fade_Screen.cc
+++ b/src/game/Fade_Screen.cc
@@ -13,6 +13,11 @@
 #include "UILayout.h"
 
 
+enum FadeType : INT8 {
+	FADE_OUT_REALFADE,
+	FADE_IN_REALFADE
+};
+
 static ScreenID guiExitScreen;
 BOOLEAN gfFadeInitialized = FALSE;
 INT16   gsFadeLimit;
@@ -20,12 +25,11 @@ UINT32  guiTime;
 UINT32  guiFadeDelay;
 BOOLEAN gfFirstTimeInFade = FALSE;
 INT16   gsFadeCount;
-static INT8 gbFadeType;
+static FadeType gbFadeType;
 INT16   gsFadeRealCount;
-BOOLEAN gfFadeInVideo;
 
-
-FADE_FUNCTION gFadeFunction = NULL;
+using FADE_FUNCTION = void (*)();
+static FADE_FUNCTION gFadeFunction = NULL;
 
 FADE_HOOK gFadeInDoneCallback  = NULL;
 FADE_HOOK gFadeOutDoneCallback = NULL;
@@ -50,14 +54,14 @@ void FadeOutNextFrame( )
 }
 
 
-static void BeginFade(ScreenID uiExitScreen, INT8 bFadeValue, INT8 bType, UINT32 uiDelay);
+static void BeginFade(ScreenID uiExitScreen, FadeType bType, UINT32 uiDelay);
 
 
 BOOLEAN HandleBeginFadeIn(ScreenID const uiScreenExit)
 {
 	if ( gfFadeIn )
 	{
-		BeginFade( uiScreenExit, 35, FADE_IN_REALFADE, 5 );
+		BeginFade(uiScreenExit, FADE_IN_REALFADE, 5);
 
 		gfFadeIn = FALSE;
 
@@ -73,7 +77,7 @@ BOOLEAN HandleBeginFadeOut(ScreenID const uiScreenExit)
 {
 	if ( gfFadeOut )
 	{
-		BeginFade( uiScreenExit, 35, FADE_OUT_REALFADE, 5 );
+		BeginFade(uiScreenExit, FADE_OUT_REALFADE, 5);
 
 		gfFadeOut = FALSE;
 
@@ -130,14 +134,12 @@ static void FadeFrameBufferRealFade(void);
 static void FadeInFrameBufferRealFade(void);
 
 
-static void BeginFade(ScreenID const uiExitScreen, INT8 const bFadeValue, INT8 const bType, UINT32 const uiDelay)
+static void BeginFade(ScreenID const uiExitScreen, FadeType const bType, UINT32 const uiDelay)
 {
 	//Init some paramters
 	guiExitScreen	= uiExitScreen;
 	guiFadeDelay			= uiDelay;
 	gfFadeIn = FALSE;
-	gfFadeInVideo = TRUE;
-
 
 	// Calculate step;
 	switch (bType)
@@ -146,7 +148,6 @@ static void BeginFade(ScreenID const uiExitScreen, INT8 const bFadeValue, INT8 c
 			gsFadeRealCount = -1;
 			gsFadeLimit			= 8;
 			gFadeFunction = FadeInFrameBufferRealFade;
-			gfFadeInVideo   = FALSE;
 
 			BltVideoSurface(guiSAVEBUFFER, FRAME_BUFFER, 0, 0, NULL);
 			FRAME_BUFFER->Fill(Get16BPPColor(FROMRGB(0, 0, 0)));
@@ -156,7 +157,6 @@ static void BeginFade(ScreenID const uiExitScreen, INT8 const bFadeValue, INT8 c
 			gsFadeRealCount = -1;
 			gsFadeLimit			= 10;
 			gFadeFunction = FadeFrameBufferRealFade;
-			gfFadeInVideo   = FALSE;
 			break;
 	}
 
@@ -198,18 +198,8 @@ ScreenID FadeScreenHandle()
 
 	if ( ( uiTime - guiTime ) > guiFadeDelay )
 	{
-		// Fade!
-		if ( !gfFadeIn )
-		{
-			//gFadeFunction( );
-		}
-
 		InvalidateScreen();
-
-		if ( !gfFadeInVideo )
-		{
-			gFadeFunction( );
-		}
+		gFadeFunction();
 
 		gsFadeCount++;
 
@@ -219,6 +209,8 @@ ScreenID FadeScreenHandle()
 			{
 				case FADE_OUT_REALFADE:
 					FRAME_BUFFER->Fill(Get16BPPColor(FROMRGB(0, 0, 0)));
+					break;
+				case FADE_IN_REALFADE:
 					break;
 			}
 

--- a/src/game/Fade_Screen.h
+++ b/src/game/Fade_Screen.h
@@ -4,23 +4,14 @@
 #include "ScreenIDs.h"
 #include "Types.h"
 
-#define FADE_OUT_REALFADE	5
-
-#define FADE_IN_REALFADE	12
-
 typedef void (*FADE_HOOK)( void );
 
 extern FADE_HOOK gFadeInDoneCallback;
 extern FADE_HOOK gFadeOutDoneCallback;
 
 
-typedef void (*FADE_FUNCTION)( void );
-
-
 extern BOOLEAN       gfFadeInitialized;
 extern BOOLEAN       gfFadeIn;
-extern FADE_FUNCTION gFadeFunction;
-extern BOOLEAN       gfFadeInVideo;
 
 BOOLEAN HandleBeginFadeIn(ScreenID uiScreenExit);
 BOOLEAN HandleBeginFadeOut(ScreenID uiScreenExit);

--- a/src/sgp/Video.cc
+++ b/src/sgp/Video.cc
@@ -1,6 +1,5 @@
 #include "Cursor_Control.h"
 #include "Debug.h"
-#include "Fade_Screen.h"
 #include "FPS.h"
 #include "HImage.h"
 #include "Local.h"
@@ -26,11 +25,6 @@
 #define MAX_CURSOR_HEIGHT 64
 
 #define MAX_DIRTY_REGIONS 128
-
-#define RED_MASK 0xF800
-#define GREEN_MASK 0x07E0
-#define BLUE_MASK 0x001F
-#define ALPHA_MASK 0
 
 #define OVERSAMPLING_SCALE 4
 
@@ -460,39 +454,32 @@ void RefreshScreen(void)
 
 	if (gfForceFullScreenRefresh || guiDirtyRegionCount > 0 || guiDirtyRegionExCount > 0)
 	{
-		if (gfFadeInitialized && gfFadeInVideo)
+		if (gfForceFullScreenRefresh)
 		{
-			gFadeFunction();
+			SDL_BlitSurface(FrameBuffer, NULL, ScreenBuffer, NULL);
+			ScreenTextureUpdateRect = { 0, 0, ScreenBuffer->w, ScreenBuffer->h };
 		}
 		else
 		{
-			if (gfForceFullScreenRefresh)
+			for (UINT32 i = 0; i < guiDirtyRegionCount; i++)
 			{
-				SDL_BlitSurface(FrameBuffer, NULL, ScreenBuffer, NULL);
-				ScreenTextureUpdateRect = { 0, 0, ScreenBuffer->w, ScreenBuffer->h };
+				ScreenTextureUpdateRect += DirtyRegions[i];
+				SDL_BlitSurface(FrameBuffer, &DirtyRegions[i], ScreenBuffer, &DirtyRegions[i]);
 			}
-			else
-			{
-				for (UINT32 i = 0; i < guiDirtyRegionCount; i++)
-				{
-					ScreenTextureUpdateRect += DirtyRegions[i];
-					SDL_BlitSurface(FrameBuffer, &DirtyRegions[i], ScreenBuffer, &DirtyRegions[i]);
-				}
 
-				for (UINT32 i = 0; i < guiDirtyRegionExCount; i++)
+			for (UINT32 i = 0; i < guiDirtyRegionExCount; i++)
+			{
+				SDL_Rect* r = &DirtyRegionsEx[i];
+				if (scrolling)
 				{
-					SDL_Rect* r = &DirtyRegionsEx[i];
-					if (scrolling)
+					// Check if we are completely out of bounds
+					if (r->y <= gsVIEWPORT_WINDOW_END_Y && r->y + r->h <= gsVIEWPORT_WINDOW_END_Y)
 					{
-						// Check if we are completely out of bounds
-						if (r->y <= gsVIEWPORT_WINDOW_END_Y && r->y + r->h <= gsVIEWPORT_WINDOW_END_Y)
-						{
-							continue;
-						}
+						continue;
 					}
-					ScreenTextureUpdateRect += *r;
-					SDL_BlitSurface(FrameBuffer, r, ScreenBuffer, r);
 				}
+				ScreenTextureUpdateRect += *r;
+				SDL_BlitSurface(FrameBuffer, r, ScreenBuffer, r);
 			}
 		}
 		if (scrolling)


### PR DESCRIPTION
• Remove unused (always false) gfFadeInVideo
• Move declarations from header to source file where possible
• Remove unused argument of BeginFade()

Hopefully these are the last remains of the several different fade methods that were present but never used in vanilla.