### PR TITLE
Apply the hit location modifier to hand-to-hand attacks

### DIFF
--- a/src/game/Tactical/Weapons.cc
+++ b/src/game/Tactical/Weapons.cc
@@ -1219,6 +1219,19 @@ void UseHandToHand(SOLDIERTYPE* const pSoldier, INT16 const sTargetGridNo, BOOLE
 				// CALCULATE DAMAGE!
 				iImpact = HTHImpact( pSoldier, pTargetSoldier, (iHitChance - iDiceRoll), FALSE );
 
+				// modify by hit location (as knives and bullets do); for punches this
+				// scales both breath and life damage since they are split from the same
+				// value downstream in EVENT_SoldierGotHit
+				// (the crit impact is unused here, but the helper requires it)
+				INT32 iImpactForCrits;
+				AdjustImpactByHitLocation( iImpact, pSoldier->bAimShotLocation, &iImpact, &iImpactForCrits );
+
+				// any successful hit does at LEAST 1 pt minimum damage
+				if (iImpact < 1)
+				{
+					iImpact = 1;
+				}
+
 				// Send event for getting hit
 				EV_S_WEAPONHIT SWeaponHit{};
 				SWeaponHit.usSoldierID = pTargetSoldier->ubID;


### PR DESCRIPTION
When we have show_hit_chance turned on we may notice that aiming at head while using hth attack is harder. However, it turns out that we're doing the same damage no matter what body part we're aiming. With this change it will be similar to blade attacks. 