### PR TITLE
Use a SDL palette for 8-bit surfaces

### DIFF
--- a/src/sgp/VObject_Blitters.cc
+++ b/src/sgp/VObject_Blitters.cc
@@ -1635,43 +1635,6 @@ BlitNonTransLoop: // blit non-transparent pixels
 }
 
 
-/* Blit a subrect from a flat 8 bit surface to a 16-bit buffer. */
-void Blt8BPPDataSubTo16BPPBuffer(UINT16* const buf, UINT32 const uiDestPitchBYTES, SGPVSurface* const hSrcVSurface, UINT8* const pSrcBuffer, UINT32 const src_pitch, INT32 const x, INT32 const y, SGPBox const* const rect)
-{
-	Assert(hSrcVSurface);
-	Assert(pSrcBuffer);
-	Assert(buf);
-
-	CHECKV(x >= 0);
-	CHECKV(y >= 0);
-
-	UINT32 const LeftSkip   = rect->x;
-	UINT32 const TopSkip    = rect->y * src_pitch;
-	UINT32 const BlitLength = rect->w;
-	UINT32       BlitHeight = rect->h;
-	UINT32 const src_skip   = src_pitch - BlitLength;
-
-	UINT32        const pitch     = uiDestPitchBYTES / 2;
-	UINT8  const*       src       = pSrcBuffer + TopSkip + LeftSkip;
-	UINT16*             dst       = buf + pitch * y + x;
-	UINT16 const* const pal       = hSrcVSurface->p16BPPPalette;
-	UINT32              line_skip = pitch - BlitLength;
-
-	do
-	{
-		UINT32 w = BlitLength;
-		do
-		{
-			*dst++ = pal[*src++];
-		}
-		while (--w != 0);
-		src += src_skip;
-		dst += line_skip;
-	}
-	while (--BlitHeight != 0);
-}
-
-
 /**********************************************************************************************
 Blt8BPPDataTo16BPPBuffer
 

--- a/src/sgp/VObject_Blitters.h
+++ b/src/sgp/VObject_Blitters.h
@@ -80,7 +80,6 @@ void Blt16BPPBufferLooseHatchRectWithColor(UINT16 *pBuffer, UINT32 uiDestPitchBY
 void Blt8BPPDataTo16BPPBufferShadow( UINT16 *pBuffer, UINT32 uiDestPitchBYTES, HVOBJECT hSrcVObject, INT32 iX, INT32 iY, UINT16 usIndex );
 
 void Blt8BPPDataTo16BPPBuffer( UINT16 *pBuffer, UINT32 uiDestPitchBYTES, SGPVSurface* hSrcVSurface, UINT8 *pSrcBuffer, INT32 iX, INT32 iY);
-void Blt8BPPDataSubTo16BPPBuffer(UINT16* buf, UINT32 uiDestPitchBYTES, SGPVSurface* hSrcVSurface, UINT8* pSrcBuffer, UINT32 src_pitch, INT32 iX, INT32 iY, SGPBox const* rect);
 
 // Blits from flat 8bpp source, to 16bpp dest, divides in half
 void Blt8BPPDataTo16BPPBufferHalf(UINT16* dst_buf, UINT32 uiDestPitchBYTES, SGPVSurface* src_surface, UINT8 const* src_buf, UINT32 src_pitch, INT32 x, INT32 y, SGPBox const* rect);

--- a/src/sgp/VSurface.cc
+++ b/src/sgp/VSurface.cc
@@ -3,10 +3,8 @@
 #include "Shading.h"
 #include "VObject_Blitters.h"
 #include "VSurface.h"
-#include "Logger.h"
 
 #include "SDL3/SDL.h"
-#include <SDL3/SDL_pixels.h>
 #include <string_theory/format>
 #include <string_theory/string>
 
@@ -96,13 +94,14 @@ SGPVSurface::~SGPVSurface()
 
 void SGPVSurface::SetPalette(const SGPPaletteEntry* const src_pal)
 {
-	// Create palette object if not already done so
-	if (!palette_) palette_.Allocate(256);
-	SGPPaletteEntry* const p = palette_;
-	for (UINT32 i = 0; i < 256; i++)
-	{
-		p[i] = src_pal[i];
-	}
+	// SDL's palettes are reference counted, so we can
+	// a) safely insert the newly created palette into a surface without
+	//    checking for an existing one first
+	// b) destroy the palette after doing so
+	auto * palette = SDL_CreatePalette(256);
+	SDL_SetPaletteColors(palette, src_pal, 0, 256);
+	SDL_SetSurfacePalette(surface_.get(), palette);
+	SDL_DestroyPalette(palette);
 
 	if (p16BPPPalette != NULL) delete[] p16BPPPalette;
 	p16BPPPalette = Create16BPPPalette(src_pal);
@@ -221,63 +220,21 @@ void BltVideoSurface(SGPVSurface* const dst, SGPVSurface* const src, INT32 const
 	Assert(dst);
 	Assert(src);
 
-	const UINT8 src_bpp = src->BPP();
-	const UINT8 dst_bpp = dst->BPP();
-	if (src_bpp == dst_bpp)
+	SDL_Rect* src_rect = 0;
+	SDL_Rect  r;
+	if (src_box)
 	{
-		SDL_Rect* src_rect = 0;
-		SDL_Rect  r;
-		if (src_box)
-		{
-			r.x = src_box->x;
-			r.y = src_box->y;
-			r.w = src_box->w;
-			r.h = src_box->h;
-			src_rect = &r;
-		}
-
-		SDL_Rect dstrect;
-		dstrect.x = iDestX;
-		dstrect.y = iDestY;
-		SDL_BlitSurface(src->surface_.get(), src_rect, dst->surface_.get(), &dstrect);
+		r.x = src_box->x;
+		r.y = src_box->y;
+		r.w = src_box->w;
+		r.h = src_box->h;
+		src_rect = &r;
 	}
-	else if (src_bpp < dst_bpp)
-	{
-		SGPBox const* src_rect = src_box;
-		SGPBox        r;
-		if (!src_rect)
-		{
-			// Check Sizes, SRC size MUST be <= DEST size
-			if (dst->Height() < src->Height())
-			{
-				SLOGD("Incompatible height size given in Video Surface blit");
-				return;
-			}
-			if (dst->Width() < src->Width())
-			{
-				SLOGD("Incompatible height size given in Video Surface blit");
-				return;
-			}
 
-			r.x = 0;
-			r.y = 0;
-			r.w = src->Width();
-			r.h = src->Height();
-			src_rect = &r;
-		}
-
-		SGPVSurface::Lock lsrc(src);
-		SGPVSurface::Lock ldst(dst);
-		UINT8*  const s_buf  = lsrc.Buffer<UINT8>();
-		UINT32  const spitch = lsrc.Pitch();
-		UINT16* const d_buf  = ldst.Buffer<UINT16>();
-		UINT32  const dpitch = ldst.Pitch();
-		Blt8BPPDataSubTo16BPPBuffer(d_buf, dpitch, src, s_buf, spitch, iDestX, iDestY, src_rect);
-	}
-	else
-	{
-		SLOGD("Incompatible BPP values with src and dest Video Surfaces for blitting");
-	}
+	SDL_Rect dstrect;
+	dstrect.x = iDestX;
+	dstrect.y = iDestY;
+	SDL_BlitSurface(src->surface_.get(), src_rect, dst->surface_.get(), &dstrect);
 }
 
 
@@ -359,4 +316,15 @@ void FillVideoSurfaceWithStretch(SGPVSurface* const dst, SGPVSurface* const src)
 	srcRec.set(0, 0, src->Width(), src->Height());
 	dstRec.set(0, 0, dst->Width(), dst->Height());
 	BltStretchVideoSurface(dst, src, &srcRec, &dstRec);
+}
+
+SGPPaletteEntry const * SGPVSurface::GetPalette() const
+{
+	auto * palette = SDL_GetSurfacePalette(surface_.get());
+	return palette ? palette->colors : nullptr;
+}
+
+void DeleteVideoSurface(SGPVSurface const * vs)
+{
+	delete vs;
 }

--- a/src/sgp/VSurface.h
+++ b/src/sgp/VSurface.h
@@ -1,7 +1,6 @@
 #ifndef VSURFACE_H
 #define VSURFACE_H
 
-#include "Buffer.h"
 #include "SDL_helpers.h"
 #include "Types.h"
 #include <memory>
@@ -27,7 +26,7 @@ class SGPVSurface
 	public:
 		SGPVSurface(SDL_Surface*);
 		SGPVSurface(UINT16 w, UINT16 h, UINT8 bpp);
-		virtual ~SGPVSurface();
+		~SGPVSurface();
 
 		UINT16 Width()  const { return surface_->w; }
 		UINT16 Height() const { return surface_->h; }
@@ -37,7 +36,7 @@ class SGPVSurface
 		void SetPalette(const SGPPaletteEntry* src_pal);
 
 		// Get the RGB palette entry values
-		SGPPaletteEntry const* GetPalette() const { return palette_; }
+		SGPPaletteEntry const * GetPalette() const;
 
 		void SetTransparency(COLORVAL);
 
@@ -62,7 +61,6 @@ class SGPVSurface
 
 	private:
 		SurfaceUniquePtr                           surface_;
-		SGP::Buffer<SGPPaletteEntry>               palette_;
 	public:
 		UINT16*                                    p16BPPPalette; // A 16BPP palette used for 8->16 blits
 	private:
@@ -135,10 +133,7 @@ SGPVSurface* AddVideoSurfaceFromFile(const char* Filename);
 void BltVideoSurfaceHalf(SGPVSurface* dst, SGPVSurface* src, INT32 DestX, INT32 DestY, SGPBox const* src_rect);
 
 // Deletes all data, including palettes
-static inline void DeleteVideoSurface(SGPVSurface* const vs)
-{
-	delete vs;
-}
+void DeleteVideoSurface(SGPVSurface const * vs);
 
 void BltVideoSurfaceOnce(SGPVSurface* dst, const char* filename, INT32 x, INT32 y);
 


### PR DESCRIPTION
This allows us to use SDL_BlitSurface for all 1:1 surface blits, which makes BltVideoSurface() much simpler and gets rid of one more blitter (Blt8BPPDataSubTo16BPPBuffer).

If you want to verify that this actually works, drawing the laptop's desktop background is one example of an 8-bit to 16-bit surface blit.