### PR TITLE
Reduce the number of LogMessageST overloads

### DIFF
--- a/src/sgp/Logger.h
+++ b/src/sgp/Logger.h
@@ -28,10 +28,11 @@ template <size_t p> constexpr const char* ToRelativePath(const char* filename)
 #define __FILENAME__ (ToRelativePath<SOURCE_PATH_SIZE>(__FILE__))
 
 template<typename... Args>
-constexpr void LogMessageST([[maybe_unused]] bool isAssert, LogLevel level, const char* file, Args && ... args)
+void LogMessageST([[maybe_unused]] bool isAssert, LogLevel level,
+	const char* file, const char* fmtString, Args && ... args)
 {
 	if (level <= Logger_getLevel()) {
-		Logger_log(level, ST::format(std::forward<Args>(args)...).c_str(), file);
+		Logger_log(level, ST::format(fmtString, std::forward<Args>(args)...).c_str(), file);
 	}
 
 	#ifdef ENABLE_ASSERTS


### PR DESCRIPTION
By requiring that the first argument of the SLOG macros must be a `const char *` we can help the compiler generate far fewer instances of this template. For example, with the old definition `SLOGD("abc {}", 1)` and `SLOGD("abcd {}", 1) `used two different overloads. These can now be rolled into one.

This should be perfectly save because `ST::format` already requires its first argument to be `const char *`.

According to gdb, this cuts down the number of `LogMessageST` overloads from 556 to 219. In my case, code and data size of a RelWithDebInfo executable shrunk by ~76K.